### PR TITLE
treeColor no longer dependent of treeId - instead saved color is used, other minor fixes

### DIFF
--- a/app/assets/javascripts/libs/input.coffee
+++ b/app/assets/javascripts/libs/input.coffee
@@ -185,7 +185,7 @@ class Input.Mouse
     @isMouseOver = false
     @lastPosition = null
 
-    $(window).on
+    $(document).on
       "mousemove" : @mouseMove
       "mouseup"   : @mouseUp
 
@@ -201,7 +201,7 @@ class Input.Mouse
 
   unbind : ->
 
-    $(window).off
+    $(document).off
       "mousemove" : @mouseMove
       "mouseup" : @mouseUp
 

--- a/app/assets/javascripts/oxalis/controller/annotations/skeletontracing_controller.coffee
+++ b/app/assets/javascripts/oxalis/controller/annotations/skeletontracing_controller.coffee
@@ -26,7 +26,7 @@ class SkeletonTacingController
       setActiveTree : (id) => @model.skeletonTracing.setActiveTree(id)
       setActiveNode : (id) => @model.skeletonTracing.setActiveNode(id)
 
-    # Mange side bar input
+    # Manage side bar input
     $("#comment-input").on "change", (event) =>
       @model.skeletonTracing.setComment(event.target.value)
       $("#comment-input").blur()
@@ -66,7 +66,10 @@ class SkeletonTacingController
       @setActiveTree($(event.currentTarget).data("treeid"), true)
 
     $("#tree-color-shuffle").click =>
-      @model.skeletonTracing.shuffleActiveTreeColor()
+      @model.skeletonTracing.shuffleTreeColor()
+
+    $("#tree-color-shuffle-all").click =>
+      @model.skeletonTracing.shuffleAllTreeColors()
 
     $("#tree-sort").on "click", "a[data-sort]", (event) =>
       event.preventDefault()

--- a/app/assets/javascripts/oxalis/geometries/skeleton.coffee
+++ b/app/assets/javascripts/oxalis/geometries/skeleton.coffee
@@ -48,7 +48,7 @@ class Skeleton
             @loadSkeletonFromModel(trees, finishedDeferred))
           @flycam.update())
         @flycam.update()
-      newActiveTreeColor : (oldTreeId) => @updateActiveTreeColor(oldTreeId)
+      newTreeColor : (treeId) => @updateTreeColor(treeId)
 
     @model.user.on "particleSizeChanged", (particleSize) =>
       @setParticleSize(particleSize)
@@ -119,11 +119,9 @@ class Skeleton
     @flycam.update()
 
 
-  updateActiveTreeColor : (oldTreeId) ->
+  updateTreeColor : (treeId) ->
 
-    treeGeometry = @getTreeGeometry(oldTreeId)
-    newTreeId    = @skeletonTracing.getActiveTreeId()
-    treeGeometry.updateTreeColor( newTreeId )
+    @getTreeGeometry(treeId).updateTreeColor()
     @flycam.update()
 
 
@@ -131,7 +129,7 @@ class Skeleton
 
     meshes = []
     for tree in @treeGeometries
-      meshes = meshes.concat( tree.getMeshes() )
+      meshes = meshes.concat(tree.getMeshes())
     return meshes
 
   setWaypoint : (centered) =>
@@ -139,7 +137,7 @@ class Skeleton
     curGlobalPos = @flycam.getPosition()
     treeGeometry = @getTreeGeometry(@skeletonTracing.getTree().treeId)
 
-    treeGeometry.addNode( @skeletonTracing.getActiveNode() )
+    treeGeometry.addNode(@skeletonTracing.getActiveNode())
 
     # Animation to center waypoint position
     position = @skeletonTracing.getActiveNodePos()
@@ -147,7 +145,7 @@ class Skeleton
       @waypointAnimation = new TWEEN.Tween({ globalPosX: curGlobalPos[0], globalPosY: curGlobalPos[1], globalPosZ: curGlobalPos[2], flycam: @flycam})
       @waypointAnimation.to({globalPosX: position[0], globalPosY: position[1], globalPosZ: position[2]}, 200)
       @waypointAnimation.onUpdate ->
-        @flycam.setPosition [@globalPosX, @globalPosY, @globalPosZ]
+        @flycam.setPosition([@globalPosX, @globalPosY, @globalPosZ])
       @waypointAnimation.start()
 
     @flycam.update()
@@ -185,12 +183,12 @@ class Skeleton
   setActiveNode : ->
 
     if @lastActiveNode?
-      treeGeometry = @getTreeGeometry( @lastActiveNode.treeId )
-      treeGeometry?.updateNodeColor( @lastActiveNode.id, false )
+      treeGeometry = @getTreeGeometry(@lastActiveNode.treeId)
+      treeGeometry?.updateNodeColor(@lastActiveNode.id, false)
 
     if (activeNode = @model.skeletonTracing.getActiveNode())?
-      treeGeometry = @getTreeGeometry( activeNode.treeId )
-      treeGeometry?.updateNodeColor( activeNode.id, true )
+      treeGeometry = @getTreeGeometry(activeNode.treeId)
+      treeGeometry?.updateNodeColor(activeNode.id, true)
 
     @lastActiveNode = activeNode
 

--- a/app/assets/javascripts/oxalis/geometries/tree.coffee
+++ b/app/assets/javascripts/oxalis/geometries/tree.coffee
@@ -13,10 +13,10 @@ class Tree
     edgeGeometry = new THREE.BufferGeometry()
     nodeGeometry = new THREE.BufferGeometry()
 
-    edgeGeometry.addAttribute( 'position', Float32Array, 0, 3 )
-    nodeGeometry.addAttribute( 'position', Float32Array, 0, 3 )
-    nodeGeometry.addAttribute( 'size', Float32Array, 0, 1 )
-    nodeGeometry.addAttribute( 'color', Float32Array, 0, 3 )
+    edgeGeometry.addAttribute('position', Float32Array, 0, 3)
+    nodeGeometry.addAttribute('position', Float32Array, 0, 3)
+    nodeGeometry.addAttribute('size', Float32Array, 0, 1)
+    nodeGeometry.addAttribute('color', Float32Array, 0, 3)
 
     @nodeIDs = nodeGeometry.nodeIDs = new ResizableBuffer(1, 100, Int32Array)
     edgeGeometry.dynamic = true
@@ -36,9 +36,7 @@ class Tree
     )
 
     @particleMaterial = new ParticleMaterialFactory(@model).getMaterial()
-    @nodes = new THREE.ParticleSystem(
-      nodeGeometry, @particleMaterial
-    )
+    @nodes = new THREE.ParticleSystem(nodeGeometry, @particleMaterial)
 
     @id = treeId
 
@@ -61,7 +59,7 @@ class Tree
     @nodesBuffer.push(node.pos)
     @sizesBuffer.push([node.radius * 2])
     @nodeIDs.push([node.id])
-    @nodesColorBuffer.push( @getColor(node.id) )
+    @nodesColorBuffer.push(@getColor(node.id))
 
     # Add any edge from smaller IDs to the node
     # ASSUMPTION: if this node is new, it should have a
@@ -76,7 +74,7 @@ class Tree
   addNodes : (nodeList) ->
 
     for node in nodeList
-      @addNode( node )
+      @addNode(node)
 
 
   deleteNode : (node) ->
@@ -92,7 +90,7 @@ class Tree
         nodesIndex = i
         break
 
-    $.assert(nodesIndex?, "No node found.", { id: node.id, @nodeIDs })
+    $.assert(nodesIndex?, "No node found.", { id : node.id, @nodeIDs })
 
     # swap IDs and nodes
     swapLast( @nodeIDs, nodesIndex )
@@ -101,7 +99,7 @@ class Tree
     swapLast( @nodesColorBuffer, nodesIndex )
 
     # Delete Edge by finding it in the array
-    edgeArray = @getEdgeArray( node, node.neighbors[0] )
+    edgeArray = @getEdgeArray(node, node.neighbors[0])
 
     for i in [0...@edgesBuffer.getLength()]
       found = true
@@ -113,7 +111,7 @@ class Tree
 
     $.assert(found, "No edge found.", { found, edgeArray, nodesIndex })
 
-    swapLast( @edgesBuffer, edgesIndex )
+    swapLast(@edgesBuffer, edgesIndex)
 
     @updateGeometries()
 
@@ -127,7 +125,7 @@ class Tree
     merge("nodesBuffer")
     merge("edgesBuffer")
     merge("sizesBuffer")
-    @edgesBuffer.push( @getEdgeArray(lastNode, activeNode) )
+    @edgesBuffer.push(@getEdgeArray(lastNode, activeNode))
 
     @updateNodesColors()
     @updateGeometries()
@@ -154,12 +152,10 @@ class Tree
     @updateGeometries()
 
 
-  updateTreeColor : ( newTreeId ) ->
+  updateTreeColor : ->
 
-    @id = newTreeId
-
-    newColor = @model.skeletonTracing.getTree().color
-    @edges.material.color = new THREE.Color( @darkenHex( newColor ) )
+    newColor = @model.skeletonTracing.getTree(@id).color
+    @edges.material.color = new THREE.Color(@darkenHex(newColor))
 
     @updateNodesColors()
     @updateGeometries()
@@ -182,7 +178,7 @@ class Tree
 
     @nodesColorBuffer.clear()
     for i in [0..@nodeIDs.length]
-      @nodesColorBuffer.push( @getColor( @nodeIDs.get(i) ))
+      @nodesColorBuffer.push(@getColor(@nodeIDs.get(i)))
 
     @updateGeometries()
 
@@ -191,7 +187,7 @@ class Tree
 
     for i in [0..@nodeIDs.length]
       if @nodeIDs.get(i) == id
-        @nodesColorBuffer.set( @getColor( id, isActiveNode, isBranchPoint ), i )
+        @nodesColorBuffer.set(@getColor(id, isActiveNode, isBranchPoint), i)
 
     @updateGeometries()
 
@@ -200,7 +196,7 @@ class Tree
 
     for i in [0..@nodeIDs.length]
       if @nodeIDs.get(i) == id
-        @sizesBuffer.set( [radius * 2], i )
+        @sizesBuffer.set([radius * 2], i)
 
     @updateGeometries()
 
@@ -218,12 +214,12 @@ class Tree
       if isBranchPoint
         color = @invertHex(color)
 
-    return @hexToRGB( color )
+    return @hexToRGB(color)
 
 
   showRadius : (show) ->
 
-    @particleMaterial.setShowRadius( show )
+    @particleMaterial.setShowRadius(show)
 
 
   updateGeometries : ->

--- a/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
+++ b/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
@@ -27,6 +27,7 @@ class SkeletonTracing
   activeNode : null
   activeTree : null
   firstEdgeDirection : null
+  currentHue : null
 
   constructor : (tracing, @scaleInfo, @flycam, @flycam3d, @user) ->
 
@@ -417,7 +418,7 @@ class SkeletonTracing
         break
 
     diff = (if forward then 1 else -1) + trees.length
-    @setActiveTree( trees[ (i + diff) % trees.length ].treeId )
+    @setActiveTree(trees[ (i + diff) % trees.length ].treeId)
 
 
   setActiveTree : (id) ->
@@ -436,38 +437,37 @@ class SkeletonTracing
     @trigger("newActiveTree")
 
 
-  getNewTreeColor : (treeId) ->
+  getNewTreeColor : ->
 
     # this generates the most distinct colors possible, using the golden ratio
-    if treeId == 1
-      return 0xFF0000
-    else
-      currentHue = treeId * @GOLDEN_RATIO
-      currentHue %= 1
-      ColorConverter.setHSV(new THREE.Color(), currentHue, 1, 1).getHex()
+    @currentHue = @treeIdCount * @GOLDEN_RATIO % 1 unless @currentHue
+    color = ColorConverter.setHSV(new THREE.Color(), @currentHue, 1, 1).getHex()
+    @currentHue += @GOLDEN_RATIO
+    @currentHue %= 1
+    color
 
 
-  shuffleActiveTreeColor : ->
+  shuffleTreeColor : (tree) ->
 
-    oldTreeId = @activeTree.treeId
-    @activeTree.treeId = @treeIdCount++
-    @activeTree.color = @getNewTreeColor(@activeTree.treeId)
+    tree = @activeTree unless tree
+    tree.color = @getNewTreeColor()
 
-    # update tree ids
-    for node in @activeTree.nodes
-      node.treeId = @activeTree.treeId
+    @stateLogger.updateTree(tree)
 
-    @stateLogger.updateTree(@activeTree, oldTreeId)
+    @trigger("newTreeColor", tree.treeId)
 
-    @trigger("newActiveTree")
-    @trigger("newActiveTreeColor", oldTreeId)
+
+  shuffleAllTreeColors : ->
+
+    for tree in @trees
+      @shuffleTreeColor(tree)
 
 
   createNewTree : ->
 
     tree = new TraceTree(
       @treeIdCount++,
-      @getNewTreeColor(@treeIdCount-1),
+      @getNewTreeColor(),
       "Tree#{('00'+(@treeIdCount-1)).slice(-3)}",
       (new Date()).getTime())
     @trees.push(tree)

--- a/app/assets/javascripts/oxalis/model/skeletontracing/tracingparser.coffee
+++ b/app/assets/javascripts/oxalis/model/skeletontracing/tracingparser.coffee
@@ -28,7 +28,7 @@ class TracingParser
       # Create new tree
       tree = new TraceTree(
         treeData.id,
-        @skeletonTracing.getNewTreeColor(treeData.id),
+        new THREE.Color().setRGB(treeData.color...).getHex(),
         if treeData.name then treeData.name else "Tree#{('00'+treeData.id).slice(-3)}",
         treeData.timestamp)
 

--- a/app/assets/javascripts/oxalis/view/skeletontracing/skeletontracing_view.coffee
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/skeletontracing_view.coffee
@@ -61,7 +61,7 @@ class SkeletonTracingView extends View
       newNode : =>
 
         @updateActiveComment()
-        @updateTreesThrottled()
+        @updateTreesDebounced()
 
 
       newTreeName : =>
@@ -76,9 +76,9 @@ class SkeletonTracingView extends View
         @updateComments()
 
 
-      newActiveTreeColor : =>
+      newTreeColor : =>
 
-        @updateTrees()
+        @updateTreesDebounced()
 
 
       deleteActiveNode : =>
@@ -105,7 +105,7 @@ class SkeletonTracingView extends View
             [ { id : "reload-button", label : "OK, reload", callback : ( ->
               $(window).on(
                 "beforeunload"
-                =>return null)
+                => return null)
               window.location.reload() )},
             {id : "cancel-button", label : "Cancel", callback : ( => @reloadDenied = true ) } ] )
 
@@ -134,11 +134,11 @@ class SkeletonTracingView extends View
       treeId = comment.node.treeId
       if treeId != lastTreeId
         newContent.appendChild((
-          $('<li>').append($('<i>', {"class": "icon-sitemap"}),
+          $('<li>').append($('<i>', {"class": "fa fa-sitemap"}),
           $('<span>', {"data-treeid": treeId, "text": @model.skeletonTracing.getTree(treeId)?.name})))[0])
         lastTreeId = treeId
       newContent.appendChild((
-        $('<li>').append($('<i>', {"class": "icon-angle-right"}),
+        $('<li>').append($('<i>', {"class": "fa fa-angle-right"}),
         $('<a>', {"href": "#", "data-nodeid": comment.node.id, "text": comment.node.id + " - " + comment.content})))[0])
 
     commentList.append(newContent)
@@ -157,14 +157,14 @@ class SkeletonTracingView extends View
     oldIcon = $("#comment-container i.icon-arrow-right")
     if oldIcon.length
       oldIcon.toggleClass("icon-arrow-right", false)
-      oldIcon.toggleClass("icon-angle-right", true)
+      oldIcon.toggleClass("fa fa-angle-right", true)
 
     activeHref = $("#comment-container a[data-nodeid=#{@model.skeletonTracing.getActiveNodeId()}]")
     if activeHref.length
 
       newIcon = activeHref.parent("li").children("i")
       newIcon.toggleClass("icon-arrow-right", true)
-      newIcon.toggleClass("icon-angle-right", false)
+      newIcon.toggleClass("fa fa-angle-right", false)
 
       # animate scrolling to the new comment
       $("#comment-container").animate({
@@ -201,14 +201,14 @@ class SkeletonTracingView extends View
         scrollTop: newIcon.offset().top - $("#tree-list").offset().top + $("#tree-list").scrollTop()}, 250)
 
 
-  updateTreesThrottled : ->
+  updateTreesDebounced : ->
     # avoid lags caused by frequent DOM modification
 
-    @updateTreesThrottled = _.throttle(
+    @updateTreesDebounced = _.debounce(
       => @updateTrees()
-      1000
+      200
     )
-    @updateTreesThrottled()
+    @updateTreesDebounced()
 
 
   updateTrees : ->
@@ -225,7 +225,7 @@ class SkeletonTracingView extends View
         $('<li>').append($('<i>', {"class": "icon-bull"}),
           $('<a>', {"href": "#", "data-treeid": tree.treeId})
           .append($('<span>', {"title": "nodes", "text": tree.nodes.length}).css("display": "inline-block", "width": "50px"),
-          $('<i>', {"class": "icon-sign-blank"}).css(
+          $('<i>', {"class": "fa fa-circle"}).css(
             "color": "##{('000000'+tree.color.toString(16)).slice(-6)}"),
           $('<span>', {"title": "name", "text": tree.name}) )) )[0])
 

--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -324,6 +324,10 @@ body:-webkit-full-screen {
   margin-top: 10px;
   overflow-y: auto;
   white-space: normal;
+
+  ul {
+    list-style-type: none;
+  }
 }
 #abstractTreeViewer {
   height : 2*@standardViewportWidth + 20px;
@@ -441,12 +445,12 @@ body:-webkit-full-screen {
     vertical-align: top;
   }
   p {
-    width: 260px;
+    width: 290px;
     margin-top: 5px;
     margin-bottom: 5px;
   }
   input {
-    width: 203px;
+    width: 232px;
   }
 }
 

--- a/app/views/tracing/trace.scala.html
+++ b/app/views/tracing/trace.scala.html
@@ -138,8 +138,11 @@
                   <a href="#" data-sort="id"><li>by creation time <i class="fa fa-check" id= "sort-id-icon"></i></li></a>
                 </ul>
               </div>
-              <div class="inline-block pull-right">
+              <div class="btn-group inline-block">
                 <a class="btn" id="tree-color-shuffle" title="Change color"><i class="fa fa-adjust"></i></a>
+              </div>
+              <div class="btn-group inline-block">
+                <a class="btn" id="tree-color-shuffle-all" title="Shuffle all Colors"><i class="fa fa-random"></i></a>
               </div><p>
               <div id="tree-edit">
                 <button class="btn" id="tree-prev-button"><i class="fa fa-arrow-left"></i></button>


### PR DESCRIPTION
treeColor no longer dependent of treeId - instead saved color is used, added shuffleAllTreeColors button, code style, debounced DOM tree-list generation, fixed icons, fixes #127

<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/282/create?referer=github" target="_blank">Log Time</a>
