### PR TITLE
Removed dataLayer.test key from Oxalis message file

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -69,7 +69,6 @@ dataSet.import.notStarted=Dataset import couldn''t be started
 
 dataLayer.notFound=DataLayer not found
 dataLayer.forbidden=Access to this layer is not allowed.
-dataLayer.test=Test message
 
 dataToken.creationFailed=Creation of the data token failed.
 


### PR DESCRIPTION
I decided to remove it (there was any usages of this key)

<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/382/create?referer=github" target="_blank">Log Time</a>
