### PR TITLE
#545 Make abstract tree view canvas flex-grow=1, handle resize issues

### DIFF
--- a/app/assets/javascripts/oxalis/view/right_menu_view.coffee
+++ b/app/assets/javascripts/oxalis/view/right_menu_view.coffee
@@ -1,5 +1,6 @@
 ### define
 backbone.marionette : marionette
+underscore : _
 ###
 
 class RightMenuView extends Backbone.Marionette.LayoutView
@@ -12,7 +13,7 @@ class RightMenuView extends Backbone.Marionette.LayoutView
     <ul class="nav nav-tabs">
       <% TABS.forEach(function(tab) { %>
         <li>
-          <a href="#<%= tab.id %>" data-toggle="tab"><%= tab.name %></a>
+          <a href="#<%= tab.id %>" data-toggle="tab" data-tab-id="<%= tab.id %>"><%= tab.name %></a>
         </li>
       <% }) %>
     </ul>
@@ -54,6 +55,12 @@ class RightMenuView extends Backbone.Marionette.LayoutView
 
     @TABS.forEach (tab) =>
       @[tab.id].show(tab.view)
+
+    @$('a[data-toggle="tab"]').on('shown.bs.tab', (e) =>
+      tabId = $(e.target).data("tab-id")
+      tab = _.find(@TABS, (t) -> t.id == tabId)
+      tab.view.render()
+    )
 
 
   serializeData : ->

--- a/app/assets/javascripts/oxalis/view/skeletontracing/abstract_tree_renderer.coffee
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/abstract_tree_renderer.coffee
@@ -27,16 +27,17 @@ class AbstractTreeRenderer
     @nodeList = []
 
 
-  setDimensions : ({width, height}) ->
+  setDimensions : (width, height) ->
 
-    $(@canvas).css({width, height})
     @canvas[0].width = width
     @canvas[0].height = height
 
 
   drawTree : (tree, @activeNodeId) ->
-    # clear Background
-    @ctx.clearRect(0, 0, @canvas.width(), @canvas.height())
+    width = @canvas.width()
+    height = @canvas.height()
+    @setDimensions(width, height)
+    @ctx.clearRect(0, 0, width, height)
     if app.oxalis.view.theme == Constants.THEME_BRIGHT
       @vgColor = "black"
     else
@@ -66,7 +67,7 @@ class AbstractTreeRenderer
     unless root?
       return
 
-    @nodeDistance = Math.min(@canvas.height() / (@getMaxTreeDepth(root, mode) + 1), @MAX_NODE_DISTANCE)
+    @nodeDistance = Math.min(height / (@getMaxTreeDepth(root, mode) + 1), @MAX_NODE_DISTANCE)
 
     # The algorithm works as follows:
     # A tree is given a left and right border that it can use. If
@@ -81,7 +82,7 @@ class AbstractTreeRenderer
     # by recordWidths(), the second by drawTreeWithWidths().
 
     @recordWidths(root)
-    @drawTreeWithWidths(root, @NODE_RADIUS, @canvas.width() - @NODE_RADIUS, @nodeDistance, mode)
+    @drawTreeWithWidths(root, @NODE_RADIUS, width - @NODE_RADIUS, @nodeDistance / 2, mode)
 
   drawTreeWithWidths : (tree, left, right, top, mode = @MODE_NORMAL) ->
 

--- a/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/abstract_tree_view.coffee
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/abstract_tree_view.coffee
@@ -8,7 +8,7 @@ oxalis/view/skeletontracing/abstract_tree_renderer : AbstractTreeRenderer
 class AbstractTreeView extends Backbone.Marionette.ItemView
 
   template : _.template("""
-      <canvas width="<%= width %>" height="<%= height %>" style="width: <%= width %>px; height: <%= height %>px">
+      <canvas id="abstract-tree-canvas">
     """)
 
   ui :
@@ -31,23 +31,23 @@ class AbstractTreeView extends Backbone.Marionette.ItemView
     @listenTo(@model.skeletonTracing, "deleteActiveNode" , @drawTree)
     @listenTo(@model.skeletonTracing, "newNode" , @drawTree)
 
+    @initialized = false
+    $(window).on("resize", => @drawTree())
+
     @drawTree()
 
 
   resize : ->
 
-    @width = @$el.width()
-    @height = @$el.height() - 10
-
-    #re-render with correct height/width
+    @initialized = true
     @render()
 
-    @abstractTreeRenderer = new AbstractTreeRenderer(
-      @ui.canvas,
-      @width,
-      @height
-    )
 
+  render : ->
+
+    super()
+    if @initialized
+      @abstractTreeRenderer = new AbstractTreeRenderer(@ui.canvas)
     @drawTree()
 
 
@@ -55,14 +55,6 @@ class AbstractTreeView extends Backbone.Marionette.ItemView
 
     if @model.skeletonTracing and @abstractTreeRenderer
       @abstractTreeRenderer.drawTree(@model.skeletonTracing.getTree(), @model.skeletonTracing.getActiveNodeId())
-
-
-  serializeData : ->
-
-    return {
-      width : @width || 300
-      height : @height || 300
-    }
 
 
   handleClick : (event) ->

--- a/app/assets/stylesheets/trace_view/_right_menu.less
+++ b/app/assets/stylesheets/trace_view/_right_menu.less
@@ -1,6 +1,10 @@
 // The menu items to the right side of the tracing view.
 // Currently tabs for comments / trees etc
 
+#abstract-tree-canvas {
+  flex-grow: 1;
+}
+
 #tab-trees {
   p {
     width: 260px;


### PR DESCRIPTION
Fixes #545 Tree viewer gets zero height

I removed explicit height and width setting and added callbacks if the canvas size needs to change.

As a consequence, all tab views are now rerendered when selected.

<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/546/create?referer=github" target="_blank">Log Time</a>
