### PR TITLE
TreeNames are prefixed with filename for upload of multiple NMLs, fixes #557

### DIFF
--- a/app/oxalis/nml/NMLService.scala
+++ b/app/oxalis/nml/NMLService.scala
@@ -30,8 +30,16 @@ object NMLService {
   def extractFromNML(file: File): Box[NML] =
     NMLParser.parse(file)
 
-  def extractFromZip(file: File): List[Box[NML]] =
-    ZipIO.unzip(file).map(nml => NMLParser.parse(nml))
+  def extractFromZip(file: File): List[Box[NML]] = {
+    ZipIO.unzipWithFilenames(file).map{
+      case (filename, nml) =>
+        val prefix = filename.replaceAll("\\.[^.]*$", "") + "_"
+        NMLParser.parse(nml).map{
+          nml =>
+            nml.copy(trees = nml.trees.map(_.addNamePrefix(prefix)))
+        }
+    }
+  }
 
   def extractFromFile(file: File, fileName: String): List[Box[NML]] = {
     if (fileName.endsWith(".zip")) {

--- a/app/oxalis/nml/Tree.scala
+++ b/app/oxalis/nml/Tree.scala
@@ -36,6 +36,10 @@ case class Tree(treeId: Int, nodes: Set[Node], edges: Set[Edge], color: Color, n
       nodes = nodes.map(node => node.copy(id = f(node.id))),
       edges = edges.map(edge => edge.copy(source = f(edge.source), target = f(edge.target))))
   }
+
+  def addNamePrefix(prefix: String) = {
+    this.copy(name = prefix + name)
+  }
 }
 
 object Tree {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ object Dependencies{
   val akkaVersion = "2.3.5"
   val reactiveVersion = "0.10.5.0.akka23"
   val reactivePlayVersion = "0.10.5.0.akka23"
-  val braingamesVersion = "7.4.4"
+  val braingamesVersion = "7.4.5-SNAPSHOT"
 
   val restFb = "com.restfb" % "restfb" % "1.6.11"
   val commonsIo = "commons-io" % "commons-io" % "2.4"


### PR DESCRIPTION
@tmbo pls review

<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/559/create?referer=github" target="_blank">Log Time</a>
