### PR TITLE
avoid duplicate toast error messages #639

### DIFF
--- a/app/assets/javascripts/libs/toast.coffee
+++ b/app/assets/javascripts/libs/toast.coffee
@@ -23,10 +23,15 @@ $.fn.alertWithTimeout = (timeout = 3000) ->
     $(window).one "mousemove", -> $this.mouseout()
 
 
+getToasts = (type, message) ->
+
+  return $(".alert-#{type}[data-id='#{message}']")
+
+
 shouldDisplayToast = (type, message, sticky) ->
 
   # Don't show duplicate sticky toasts
-  return not sticky or $(".alert-#{type}[data-id='#{message}']").length == 0
+  return not sticky or getToasts(type, message).length == 0
 
 
 Toast =
@@ -92,3 +97,6 @@ Toast =
     )
 
 
+  delete : (type, message) ->
+
+    getToasts(type, message).alert("close")

--- a/app/assets/javascripts/oxalis/model/statelogger.coffee
+++ b/app/assets/javascripts/oxalis/model/statelogger.coffee
@@ -120,5 +120,6 @@ class StateLogger
 
   pushDoneCallback : ->
 
+    @trigger("pushDone")
     $('body').removeClass('save-error')
     @committedDiffs = []

--- a/app/assets/javascripts/oxalis/view/skeletontracing/skeletontracing_view.coffee
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/skeletontracing_view.coffee
@@ -96,10 +96,11 @@ class SkeletonTracingView extends View
         @updateCommentsSortButton()
         @updateComments()
 
+    autoSaveFailureMessage = "Auto-Save failed!"
     @model.skeletonTracing.stateLogger.on
       pushFailed : =>
         if @reloadDenied
-          Toast.error("Auto-Save failed!", true)
+          Toast.error(autoSaveFailureMessage, true)
         else
           modal.show("Several attempts to reach our server have failed. You should reload the page
             to make sure that your work won't be lost.",
@@ -109,6 +110,8 @@ class SkeletonTracingView extends View
                 => return null)
               window.location.reload() )},
             {id : "cancel-button", label : "Cancel", callback : ( => @reloadDenied = true ) } ] )
+      pushDone : =>
+        Toast.delete("danger", autoSaveFailureMessage)
 
     $("a[href=#tab-comments]").on "shown", (event) =>
       @updateActiveComment()


### PR DESCRIPTION
I think #639 can be closed afterwards as the tree recoloring was merged to dev and toast disappear once the user switches to the dashboard.


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/649/create?referer=github" target="_blank">Log Time</a>