### PR TITLE
only show active datasets in gallery

### DIFF
--- a/app/assets/javascripts/admin/models/dataset/dataset_collection.coffee
+++ b/app/assets/javascripts/admin/models/dataset/dataset_collection.coffee
@@ -8,3 +8,7 @@ class DatasetCollection extends PaginationView
 
   url : "/api/datasets"
   model : DatasetModel
+
+  getActiveDatasets : ->
+
+    return new DatasetCollection(@filter("isActive"))

--- a/app/assets/javascripts/admin/views/dataset/dataset_switch_view.coffee
+++ b/app/assets/javascripts/admin/views/dataset/dataset_switch_view.coffee
@@ -48,7 +48,8 @@ class DatasetSwitchView extends Backbone.Marionette.LayoutView
   showGalleryView : ->
 
     @toggleSwitchButtons()
-    datasetGalleryView = new SpotlightDatasetListView(collection : @model)
+    activeDatasets = @model.getActiveDatasets()
+    datasetGalleryView = new SpotlightDatasetListView(collection : activeDatasets)
     @datasetPane.show(datasetGalleryView)
 
     @pagination.empty()
@@ -57,6 +58,7 @@ class DatasetSwitchView extends Backbone.Marionette.LayoutView
   showAdvancedView : ->
 
     @toggleSwitchButtons()
+
     datasetListView = new DatasetListView(collection: @model)
     @datasetPane.show(datasetListView)
 


### PR DESCRIPTION
Only show “active” datasets on the ‘featured’ / ‘gallery’ dataset view. 

Show all datasets in ‘Advanced view’


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/652/create?referer=github" target="_blank">Log Time</a>