### PR TITLE
don't render stats widget #714

### DIFF
--- a/app/assets/javascripts/oxalis/controller.coffee
+++ b/app/assets/javascripts/oxalis/controller.coffee
@@ -97,7 +97,6 @@ class Controller
 
       # FPS stats
       stats = new Stats()
-      $("body").append stats.domElement
 
       @gui = @createGui(tracing.restrictions, tracing.content.settings)
 


### PR DESCRIPTION
removed dom element append. stats are needed nonetheless. so only rendering omitted.


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/775/create?referer=github" target="_blank">Log Time</a>