### PR TITLE
Fixed non-sequential saves #940

### DIFF
--- a/app/assets/javascripts/oxalis/controller.coffee
+++ b/app/assets/javascripts/oxalis/controller.coffee
@@ -287,7 +287,7 @@ class Controller
 
       # save the progress
       model = @model.skeletonTracing || @model.volumeTracing
-      model.stateLogger.pushImpl()
+      model.stateLogger.pushNow()
 
       modalView = new ShareModalView(_model : @model)
       el = modalView.render().el

--- a/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
+++ b/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
@@ -95,7 +95,7 @@ class SkeletonTracing
       "beforeunload"
       =>
         if !@stateLogger.stateSaved() and @stateLogger.allowUpdate
-          @stateLogger.pushImpl(false)
+          @stateLogger.pushNow(false)
           return "You haven't saved your progress, please give us 2 seconds to do so and and then leave this site."
         else
           return

--- a/app/assets/javascripts/oxalis/model/statelogger.coffee
+++ b/app/assets/javascripts/oxalis/model/statelogger.coffee
@@ -14,6 +14,7 @@ class StateLogger
   constructor : (@flycam, @version, @tracingId, @tracingType, @allowUpdate) ->
 
     _.extend(this, new EventMixin())
+    @mutexedPush = _.mutexDeferred(@pushImpl, -1)
 
     @newDiffs = []
 
@@ -57,14 +58,13 @@ class StateLogger
     # Pushes the buffered tracing to the server. Pushing happens at most
     # every 30 seconds.
 
-    saveFkt = => @pushImpl(true)
-    @pushThrottled = _.throttle(_.mutexDeferred( saveFkt, -1), @PUSH_THROTTLE_TIME)
+    @pushThrottled = _.throttle(@mutexedPush, @PUSH_THROTTLE_TIME)
     @pushThrottled()
 
 
   pushNow : ->   # Interface for view & controller
 
-    return @pushImpl(false)
+    return @mutexedPush(false)
 
 
   pushImpl : (notifyOnFailure) ->


### PR DESCRIPTION
The problem occurs because some requests are assigned the same version number. How can this happen:

Calls to statelogger.push() are protected by a Mutex and hence sends are in sequential order.
However, by calling statelogger.pushNow() a request is scheduled without going through the mutex. Both request/push retries and saving manually triggers this.

How to reproduce:
1. Set network speed to something slow (GPRS) in debug tools
2. Open a tracing and hit "Save" a couple of times.
3. Tada!

Original Issue: #940 

@normanrz Can you please review?


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/942/create?referer=github" target="_blank">Log Time</a>