### PR TITLE
fix #1035 fix initial sorting of sorted collections in combination wi…

### DIFF
--- a/app/assets/javascripts/dashboard/views/explorative_tracing_list_item_view.coffee
+++ b/app/assets/javascripts/dashboard/views/explorative_tracing_list_item_view.coffee
@@ -115,8 +115,6 @@ class ExplorativeTracingListItemView extends Marionette.ItemView
       @toggleState(@model.attributes.state)
       @model.collection.remove(@model)
       @options.parent.render()
-    ).fail((xhr) ->
-      Toast.message(xhr.responseJSON.messages)
     )
 
 module.exports = ExplorativeTracingListItemView

--- a/app/assets/javascripts/libs/behaviors/sort_table_behavior.coffee
+++ b/app/assets/javascripts/libs/behaviors/sort_table_behavior.coffee
@@ -12,12 +12,6 @@ class SortTableBehavior extends Marionette.Behavior
   defaults :
     sortDirection : "asc"
 
-  initialize : ->
-
-    # disable auto-rerender after sorting
-    # we will deal with this manually
-    this.view.sort = false
-
 
   onDomRefresh : ->
 


### PR DESCRIPTION
…th the SortedBehavior

Issue: #1035 

I'm not sure why the SortedBehavior sets the views sort attribute to false, but this was the cause of the issue. The initial sorting of the collection (which is a SortedCollection) was not reflected in the DOM.

@hotzenklotz Do you know why sort was set to false there? I don't get the comment and it seems to work fine now.


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1039/create?referer=github" target="_blank">Log Time</a>