### PR TITLE
#1176 Refactor volume mode

### DIFF
--- a/app/assets/javascripts/oxalis/controller/annotations/volumetracing_controller.coffee
+++ b/app/assets/javascripts/oxalis/controller/annotations/volumetracing_controller.coffee
@@ -1,7 +1,6 @@
 app        = require("app")
 Backbone   = require("backbone")
 Dimensions = require("oxalis/model/dimensions")
-Constants  = require("oxalis/constants")
 Input      = require("libs/input")
 
 class VolumeTracingController
@@ -21,10 +20,8 @@ class VolumeTracingController
   constructor : (@model, @volumeTracingView, @sceneController) ->
 
     @inDeleteMode = false
-    @controlMode = Constants.VOLUME_MODE_MOVE
 
     _.extend(@, Backbone.Events)
-    @listenTo(app.vent, "changeVolumeMode", @setControlMode)
 
     $('#create-cell-button').on("click", =>
       @model.volumeTracing.createCell()
@@ -32,8 +29,8 @@ class VolumeTracingController
 
     # Keyboard shortcuts
     new Input.KeyboardNoLoop(
-      "w" : => @toggleControlMode()
-      "1" : => @toggleControlMode()
+      "w" : => @model.volumeTracing.toggleMode()
+      "1" : => @model.volumeTracing.toggleMode()
     )
 
     # no merging for now
@@ -62,21 +59,6 @@ class VolumeTracingController
         $(input).keypress (event) =>
           if event.which == 13
             @merge()
-
-
-  setControlMode : (controlMode) ->
-
-    @controlMode = controlMode
-
-
-  toggleControlMode : ->
-
-    mode = if @controlMode == Constants.VOLUME_MODE_MOVE
-      Constants.VOLUME_MODE_TRACE
-    else
-      Constants.VOLUME_MODE_MOVE
-
-    app.vent.trigger("changeVolumeMode", mode)
 
 
   merge : ->

--- a/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.coffee
+++ b/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.coffee
@@ -38,7 +38,7 @@ class VolumeTracingPlaneController extends PlaneController
 
       leftDownMove : (delta, pos, plane, event) =>
 
-        if @volumeTracingController.controlMode == Constants.VOLUME_MODE_MOVE
+        if @model.volumeTracing.mode == Constants.VOLUME_MODE_MOVE
           @move [
             delta.x * @model.user.getMouseInversionX() / @planeView.scaleFactor
             delta.y * @model.user.getMouseInversionY() / @planeView.scaleFactor

--- a/app/assets/javascripts/oxalis/model/volumetracing/volumetracing.coffee
+++ b/app/assets/javascripts/oxalis/model/volumetracing/volumetracing.coffee
@@ -5,6 +5,7 @@ Dimensions               = require("../dimensions")
 RestrictionHandler       = require("../helpers/restriction_handler")
 Drawing                  = require("libs/drawing")
 VolumeTracingStateLogger = require("./volumetracing_statelogger")
+Constants                = require("../../constants")
 
 class VolumeTracing
 
@@ -14,6 +15,7 @@ class VolumeTracing
 
     @contentData  = tracing.content.contentData
     @restrictionHandler = new RestrictionHandler(tracing.restrictions)
+    @mode = Constants.VOLUME_MODE_MOVE
 
     @cells        = []
     @activeCell   = null
@@ -36,6 +38,21 @@ class VolumeTracing
     # For testing
     window.setAlpha = (v) -> Drawing.setAlpha(v)
     window.setSmoothLength = (v) -> Drawing.setSmoothLength(v)
+
+
+  setMode : (@mode) ->
+
+    @trigger("change:mode", @mode)
+
+
+  toggleMode : ->
+
+    @setMode(
+      if @mode == Constants.VOLUME_MODE_TRACE
+        Constants.VOLUME_MODE_MOVE
+      else
+        Constants.VOLUME_MODE_TRACE
+    )
 
 
   createCell : (id) ->

--- a/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.coffee
+++ b/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.coffee
@@ -6,8 +6,18 @@ class VolumeActionsView extends Marionette.ItemView
 
   template : _.template("""
     <div class="btn-group">
-      <button type="button" class="btn btn-default btn-primary" id="mode-move">Move</button>
-      <button type="button" class="btn btn-default" id="mode-trace">Trace</button>
+      <button
+        type="button"
+        class="btn btn-default <% if (isMoveMode) { %> btn-primary <% } %>"
+        id="mode-move">
+          Move
+      </button>
+      <button
+        type="button"
+        class="btn btn-default <% if (!isMoveMode) { %> btn-primary <% } %>"
+        id="mode-trace">
+          Trace
+      </button>
     </div>
     <div class="btn-group">
       <button type="button" class="btn btn-default" id="create-cell">Create new cell (C)</button>
@@ -25,7 +35,7 @@ class VolumeActionsView extends Marionette.ItemView
 
   initialize : (options) ->
 
-    @listenTo(app.vent, "changeVolumeMode", @updateForMode)
+    @listenTo(@model.volumeTracing, "change:mode", @render)
 
 
   createCell : ->
@@ -39,11 +49,11 @@ class VolumeActionsView extends Marionette.ItemView
     app.vent.trigger("changeVolumeMode", mode)
 
 
-  updateForMode : (mode) ->
+  serializeData : ->
 
-    @$("button").removeClass("btn-primary")
+    return {
+      isMoveMode : @model.volumeTracing.mode == Constants.VOLUME_MODE_MOVE
+    }
 
-    buttonId = _.invert(@modeMapping)[mode]
-    @$("##{buttonId}").addClass("btn-primary")
 
 module.exports = VolumeActionsView


### PR DESCRIPTION
Description of changes:
- Stores volume control mode (trace / move) in model instead of controller

Issues:
- fixes #1176

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1177/create?referer=github" target="_blank">Log Time</a>