### PR TITLE
#1188 Get rid of Resize event in ThreeJS Trackball Controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chokidar": "^1.4.1"
   },
   "scripts": {
-    "install": "napa georgwiese/three.js#scm-oxalis:three.js",
+    "install": "napa georgwiese/three.js#scm_oxalis:three.js",
     "test": "node_modules/jasmine-node/bin/jasmine-node --coffee app/assets/javascripts/test && sbt test",
     "prewebdriver": "npm run webdriver-update",
     "webdriver": "./node_modules/.bin/webdriver-manager start",


### PR DESCRIPTION
Description of changes:
- #1188 occurred because `TrackballControls.screen` was not updated when the 3D view was moved (e.g., when the menu was shown).
- I eliminated `TrackballControls.screen` all together and replaced it with a `getScreenBounds()` instance method that is invoked whenever `screen` was used. This might have minor performance implications.
- The changes can be tested on this branch (you'll need an `npm install` to pull the new branch), please also review [this pull Request](https://github.com/georgwiese/three.js/pull/2) in the ThreeJS repository.
- My plan is that once this PR get's an LGTM, I'll merge the PR in the ThreeJS repo and undo this PR's changes in `package.json`.

Issues:
- fixes #1188

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1264/create?referer=github" target="_blank">Log Time</a>