### PR TITLE
Fix wrong check for ctrl key being pressed in keyboard hook

### DIFF
--- a/app/assets/javascripts/libs/input.coffee
+++ b/app/assets/javascripts/libs/input.coffee
@@ -37,7 +37,7 @@ class Input.KeyboardNoLoop
     shouldIgnore = (event) ->
       bindingHasCtrl  = key.toLowerCase().indexOf("ctrl") != -1
       bindingHasShift = key.toLowerCase().indexOf("shift") != -1
-      eventHasCtrl  = event.ctrl or event.metaKey
+      eventHasCtrl  = event.ctrlKey or event.metaKey
       eventHasShift = event.shiftKey
       return (eventHasCtrl and not bindingHasCtrl) or
         (eventHasShift and not bindingHasShift)


### PR DESCRIPTION
Description of changes:
- this properly checks for the ctrl key being pressed when handling shortcuts
- don't get confused by the branch name since it doesn't remove the shortcut

Issues:
- fixes #1342

---
- [X] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1358/create?referer=github" target="_blank">Log Time</a>