### PR TITLE
fix #633 center active comment even when the comment view is not active

### DIFF
--- a/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/comment_tab/comment.cjsx
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/comment_tab/comment.cjsx
@@ -15,7 +15,7 @@ Comment = React.createClass(
 
     data = @props.data
     return (
-      <li className={liClassName} id={"node-#{data.node}"} ref={ (ref) => @comment = ref }>
+      <li className={liClassName} id={"comment-tab-node-#{data.node}"} ref={ (ref) => @comment = ref }>
         <i className={iClassName}></i>
         <a href="#" onClick={@handleClick}>
           {data.node + " - " + data.content}

--- a/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/comment_tab/comment_tab_view.cjsx
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/comment_tab/comment_tab_view.cjsx
@@ -100,7 +100,7 @@ class CommentTabView extends Marionette.ItemView
   ensureActiveCommentVisible : ->
 
     activeNodeId = @getActiveNodeId()
-    comment = $("#node-#{activeNodeId}")[0]
+    comment = $("#comment-tab-node-#{activeNodeId}")[0]
     scrollIntoViewIfNeeded(comment) if comment
 
 


### PR DESCRIPTION
Description of changes:
- Center the active comment once the comment tab is activated. Had to use jQuery as React cannot really be used to manage the scroll state.

Issues:
- fixes #633 

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1359/create?referer=github" target="_blank">Log Time</a>