### PR TITLE
fix #1345 fix #1349 use wheel events deltaY, which works across brows…

### DIFF
--- a/app/assets/javascripts/libs/input.coffee
+++ b/app/assets/javascripts/libs/input.coffee
@@ -317,7 +317,7 @@ class Input.Mouse
   mouseWheel : (event) =>
 
     event.preventDefault()
-    delta = event.originalEvent.wheelDeltaY
+    delta = -event.originalEvent.deltaY
     if event.shiftKey
       @trigger("scroll", delta, "shift")
     else if event.altKey


### PR DESCRIPTION
Description of changes:
- Use wheel events deltaY, which works across browsers instead of chromes proprietary wheelDeltaY. This is a very small change and fixes the issue, however the numbers seem to be kind of different between wheelDeltaY (which was used before), and deltaY in chrome and in firefox. I tested both browsers and using the mousewheels feels ok, please test whether you can confirm this.
  Should be tested by someone who has a local dataset!

Steps to test:
- Scroll in tracing viewports to move in z-direction, Use "Alt+Scroll" to zoom in/out, Zoom in 3d-view

Issues:
- fixes #1345 
- fixes #1349

---
- [x] Ready for review

…ers instead of chromes proprietary wheelDeltaY


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1369/create?referer=github" target="_blank">Log Time</a>