### PR TITLE
fix #1083 renew data retrieval token when it is expired

### DIFF
--- a/app/assets/javascripts/oxalis/model/binary/pullqueue.coffee
+++ b/app/assets/javascripts/oxalis/model/binary/pullqueue.coffee
@@ -102,12 +102,22 @@ class PullQueue
       ))
 
     return requestData.dataPromise().then((data) =>
-      Request.sendArraybufferReceiveArraybuffer("#{@layer.url}/data/datasets/#{@dataSetName}/layers/#{@layer.name}/data?token=#{@layer.token}",
-        data : data
-        headers :
-          "Content-Type" : "multipart/mixed; boundary=#{requestData.boundary}"
-        timeout : @MESSAGE_TIMEOUT
-        compress : true
+      @layer.tokenPromise.then( =>
+        token = @layer.token
+        Request.sendArraybufferReceiveArraybuffer("#{@layer.url}/data/datasets/#{@dataSetName}/layers/#{@layer.name}/data?token=#{token}",
+          data : data
+          headers :
+            "Content-Type" : "multipart/mixed; boundary=#{requestData.boundary}"
+          timeout : @MESSAGE_TIMEOUT
+          compress : true
+          doNotCatch : true
+        ).catch((err) =>
+          # renew token if it is invalid
+          if err.status == 403
+            @layer.renewToken(token)
+
+          throw err
+        )
       )
     ).then( (responseBuffer) ->
       responseBuffer = new Uint8Array(responseBuffer)


### PR DESCRIPTION
Description of changes:
- Renew the data token if it is invalid. The tokenRequestPromise is saved in the layer and further requests for data wait for it to be successful. One special case are data requests that begin before the token renewal and only end after the token renewal took place. Those are handled explicitly as well and don't trigger another token renewal.

Steps to test:
- for testing in model.coffee:244 replace `layer.token = dataStore.token` with `layer.token = if layer.token then dataStore.token else "1234"` so the token is invalid at first, and then gets renewed. I couldn't think of another easy way to test this.

Issues:
- fixes #1083 

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1375/create?referer=github" target="_blank">Log Time</a>