### PR TITLE
Webpack doesn't fail on errors in watch mode but in build mode

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -122,7 +122,7 @@ object AssetCompilation {
 
   private def assetsGenerationTask: Def.Initialize[Task[Unit]] = (webpackPath, baseDirectory, streams, target) map { (webpack, base, s, t) =>
     try{
-      val exitValue = startProcess(webpack, "", base) ! s.log
+      val exitValue = startProcess(webpack, "--bail", base) ! s.log
       if(exitValue != 0)
         throw new Error(s"Running webpack failed with exit code: $exitValue")
     } catch {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,6 @@ module.exports = {
   ],
   // devtool: "source-map",
   // debug: true,
-  bail: true,
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION
Description of changes:
- Webpack doesn't fail on errors in watch mode but in build mode

Steps to test:
- Build without JS errors: `sbt compile stage` should succeed
- Build with JS error: `sbt compile stage` should fail
- Start `sbt run` without JS errors, add a JS error (error should be printed in console), remove JS error again (should compile again)

Issues:
- fixes #1374

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1376/create?referer=github" target="_blank">Log Time</a>