### PR TITLE
fixes #1387

### DIFF
--- a/app/assets/javascripts/oxalis/controller/viewmodes/arbitrary_controller.coffee
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/arbitrary_controller.coffee
@@ -20,6 +20,7 @@ class ArbitraryController
   # Arbitrary Controller: Responsible for Arbitrary Modes
 
   WIDTH : 128
+  TIMETOCENTER : 200
 
   plane : null
   crosshair : null
@@ -325,7 +326,7 @@ class ArbitraryController
       waypointAnimation = new TWEEN.Tween(
         {x: curPos[0], y: curPos[1], z: curPos[2], rx: curRotation[0], ry: curRotation[1], rz: curRotation[2], cam: @cam})
       waypointAnimation.to(
-        {x: newPos[0], y: newPos[1], z: newPos[2], rx: newRotation[0], ry: newRotation[1], rz: newRotation[2]}, 200)
+        {x: newPos[0], y: newPos[1], z: newPos[2], rx: newRotation[0], ry: newRotation[1], rz: newRotation[2]}, @TIMETOCENTER)
       waypointAnimation.onUpdate( ->
         @cam.setPosition([@x, @y, @z])
         @cam.setRotation([@rx, @ry, @rz])


### PR DESCRIPTION
Description of changes:
- makes recentering speed variable in flight mode (for video creation)

Steps to test:
- trace in flight mode, execute `app.oxalis.arbitraryController.TIMETOCENTER = 1000` and press shift + space

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1388/create?referer=github" target="_blank">Log Time</a>