### PR TITLE
improved search bar query parsing

### DIFF
--- a/app/assets/javascripts/admin/models/pagination_collection.coffee
+++ b/app/assets/javascripts/admin/models/pagination_collection.coffee
@@ -115,7 +115,8 @@ class PaginationCollection
       @state.filterQuery = ""
       @state.filter = null
     else
-      words = _.map(query.split(" "), (element) -> element.toLowerCase().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"))
+      words = _.map(query.split(" "),
+        (element) -> element.toLowerCase().replace(/[\-\[\]{}()\*\+\?\.,\\\^\$\|\#\s]/g, "\\$&"))
       uniques = _.filter(_.uniq(words), (element) -> element != '')
       pattern = "(" + uniques.join("|") + ")"
       regexp = new RegExp(pattern, "igm")


### PR DESCRIPTION
Description of changes:
- improve parsing to correctly handle searches ala `2012-09` as a single word instead of two words

Steps to test:
- Go to dashboard search for a dataset name that includes a dash or an underscore

Issues:
- fixes #1378

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1390/create?referer=github" target="_blank">Log Time</a>