### PR TITLE
fix #1389 add cancel tracing action to admin user tracings view

### DIFF
--- a/app/assets/javascripts/admin/views/task/task_annotation_view.coffee
+++ b/app/assets/javascripts/admin/views/task/task_annotation_view.coffee
@@ -28,7 +28,7 @@ class TaskAnnotationView extends Marionette.ItemView
         </li>
         <% }) %>
         <li>
-          <a href="#" class="delete-annotation"><i class="fa fa-trash-o"></i>delete</a>
+          <a href="#" class="cancel-annotation"><i class="fa fa-trash-o"></i>cancel</a>
         </li>
         </ul>
       </div>
@@ -40,7 +40,7 @@ class TaskAnnotationView extends Marionette.ItemView
 
   events :
     "click .isAjax" : "callAjax"
-    "click .delete-annotation" : "deleteAnnotation"
+    "click .cancel-annotation" : "cancelAnnotation"
 
   modelEvents :
     "change" : "render"
@@ -58,9 +58,9 @@ class TaskAnnotationView extends Marionette.ItemView
     )
 
 
-  deleteAnnotation : ->
+  cancelAnnotation : ->
 
-    if window.confirm("Do you really want to delete this annotation?")
+    if window.confirm("Do you really want to cancel this annotation?")
       @model.destroy()
 
 module.exports = TaskAnnotationView

--- a/app/assets/javascripts/dashboard/views/dashboard_task_list_item_view.coffee
+++ b/app/assets/javascripts/dashboard/views/dashboard_task_list_item_view.coffee
@@ -1,6 +1,7 @@
 _          = require("lodash")
 Marionette = require("backbone.marionette")
 Toast      = require("libs/toast")
+Request    = require("libs/request")
 
 class DashboardTaskListItemView extends Marionette.ItemView
 
@@ -36,6 +37,11 @@ class DashboardTaskListItemView extends Marionette.ItemView
             <i class="fa fa-share"></i>
             transfer
           </a>
+          </br>
+          <a href="#" id="cancel-task">
+            <i class="fa fa-trash-o"></i>
+            cancel
+          </a>
         <% } %>
         <br/>
         <a href="#" id="finish-task" class="trace-finish">
@@ -48,6 +54,7 @@ class DashboardTaskListItemView extends Marionette.ItemView
 
   events :
     "click #finish-task" : "finish"
+    "click #cancel-task" : "cancelAnnotation"
 
 
   className : ->
@@ -67,7 +74,16 @@ class DashboardTaskListItemView extends Marionette.ItemView
   finish : ->
 
     if confirm("Are you sure you want to permanently finish this tracing?")
-
       @model.finish()
+
+
+  cancelAnnotation : ->
+
+    if confirm("Do you really want to cancel this annotation?")
+      annotation = @model.get("annotation")
+      Request.triggerRequest("/annotations/#{annotation.typ}/#{annotation.id}", method : "DELETE").then( =>
+        @model.collection.fetch()
+      )
+
 
 module.exports = DashboardTaskListItemView


### PR DESCRIPTION
Description of changes:
- Add the "Cancel" action to the admin user task overview, so individual tracings can be cancelled.

Steps to test:
- Open user overview, click Show Tracings and Cancel a tracing. The tracing should be canceled and the task list should be updated.

Issues:
- fixes #1389 

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1392/create?referer=github" target="_blank">Log Time</a>