### PR TITLE
fix #1346 fix current tree indicator when a node is selected in the v…

### DIFF
--- a/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
+++ b/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
@@ -308,6 +308,8 @@ class SkeletonTracing
 
     @stateLogger.push()
     @trigger("newActiveNode", @activeNode.id)
+    if lastActiveTree.treeId != @activeTree.treeId
+      @trigger("newActiveTree", @activeTree.treeId)
 
     if mergeTree
       @mergeTree(lastActiveNode, lastActiveTree)

--- a/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/list_tree_item_view.coffee
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/list_tree_item_view.coffee
@@ -1,6 +1,7 @@
-Marionette     = require("backbone.marionette")
-Utils          = require("libs/utils")
-ColorConverter = require("three.color")
+Marionette             = require("backbone.marionette")
+Utils                  = require("libs/utils")
+ColorConverter         = require("three.color")
+scrollIntoViewIfNeeded = require("scroll-into-view-if-needed")
 
 class ListTreeItemView extends Marionette.ItemView
 
@@ -42,7 +43,7 @@ class ListTreeItemView extends Marionette.ItemView
   onShow : ->
 
     # scroll to active tree
-    if @model.get("treeId") == @activeTreeId and not Utils.isElementInViewport(@el)
-      @el.scrollIntoView()
+    if @model.get("treeId") == @activeTreeId
+      scrollIntoViewIfNeeded(@el)
 
 module.exports = ListTreeItemView

--- a/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/list_tree_view.coffee
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/list_tree_view.coffee
@@ -97,8 +97,11 @@ class ListTreeView extends Marionette.CompositeView
     @selectNextTree(false)
 
 
-  selectNextTree : ->
-    @selectNextTree(true)
+  selectNextTree : (next=true) ->
+
+    @model.skeletonTracing.selectNextTree(next)
+    @model.skeletonTracing.centerActiveNode()
+    @updateName()
 
 
   createNewTree : ->
@@ -140,13 +143,6 @@ class ListTreeView extends Marionette.CompositeView
     isSortedByName = @model.user.get("sortTreesByName")
     @ui.sortNameIcon.toggle(isSortedByName)
     @ui.sortTimeIcon.toggle(!isSortedByName)
-
-
-  selectNextTree : (next) ->
-
-    @model.skeletonTracing.selectNextTree(next)
-    @model.skeletonTracing.centerActiveNode()
-    @updateName()
 
 
   getActiveTree : ->


### PR DESCRIPTION
Description of changes:
- The current tree indicator in the tree list will now be updated when a node is selected in one of the viewports. This was caused by a missing "newActiveTree" event. This also fixes the current tree id that is displayed in the settings. I've also integrated the scrollIntoViewIfNeeded ponyfill, as the method we used before caused the whole window to scroll at times instead of only the tree list, which was very annoying.

I did notice (again) that the whole view is rerendered once the current tree id changes. Of course one could optimize that, but I think we agreed on redoing this view in react soon, so I didn't do anything in that regard.

Steps to test:
- Select different trees in one of the viewports. The current tree indicator in the tree list should be updated as well as the current tree id in the settings.

Issues:
- fixes #1346 

---
- [x] Ready for review

…iewport


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1393/create?referer=github" target="_blank">Log Time</a>