### PR TITLE
#1394 Add Buckets to garbage collection only when they are pulled

### DIFF
--- a/app/assets/javascripts/oxalis/model/binary/cube.coffee
+++ b/app/assets/javascripts/oxalis/model/binary/cube.coffee
@@ -177,8 +177,9 @@ class Cube
 
     bucket = new Bucket(@BIT_DEPTH, address, @temporalBucketManager)
     bucket.on
-      bucketLoaded : => @trigger("bucketLoaded", address)
-    @addBucketToGarbageCollection(bucket)
+      bucketLoaded : =>
+        @trigger("bucketLoaded", address)
+        @addBucketToGarbageCollection(bucket)
     return bucket
 
 


### PR DESCRIPTION
Description of changes:
- Add Buckets to garbage collection only when they are pulled

Steps to test:
- Check that `app.oxalis.model.binary.color.cube.bucketCount` does not reach the limit of 5000 too quickly
- Set `Cube.MAXIMUM_BUCKET_COUNT` to something like 500 (on initialization, e.g. via breakpoint) to verify that GC still works as intended.

Issues:
- fixes #1394

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1395/create?referer=github" target="_blank">Log Time</a>