### PR TITLE
Change tree colors in read-only mode

### DIFF
--- a/app/assets/javascripts/oxalis/model/helpers/restriction_handler.coffee
+++ b/app/assets/javascripts/oxalis/model/helpers/restriction_handler.coffee
@@ -13,35 +13,23 @@ class RestrictionHandler
 
 
   # Should be called whenever the model is modified
-  # Returns whether the modification should be aborted
-  # ==> return if @restrictionHandler.handleUpdate()
-  handleUpdate : ->
-
-    if @restrictions.allowUpdate
-      return false
-
-    else
-      if not @issuedUpdateError
-        Toast.error(@UPDATE_ERROR)
-        @issuedUpdateError = true
-      return true
-
-
-  # Should be called whenever the model is modified
-  # but should be changed regardless of the restriction settings
-  # Returns whether the change should be persisted on the server
-  # ==> if @restrictionHandler.forceHandleUpdate()
-  #    @stateLogger.update...
-  forceHandleUpdate : ->
+  # Returns whether the modification is allowed
+  # ==> return if not @restrictionHandler.updateAllowed()
+  updateAllowed : (error=true) ->
 
     if @restrictions.allowUpdate
       return true
 
     else
-      # issue a non-persistence warning to the user
-      if not @issuedUpdateWarning
-        Toast.warning(@UPDATE_WARNING)
-        @issuedUpdateWarning = true
+      # Display error or warning if it wasn't displayed before
+      if error
+        if not @issuedUpdateError
+          Toast.error(@UPDATE_ERROR)
+          @issuedUpdateError = true
+      else
+        if not @issuedUpdateWarning
+          Toast.warning(@UPDATE_WARNING)
+          @issuedUpdateWarning = true
       return false
 
 

--- a/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
+++ b/app/assets/javascripts/oxalis/model/skeletontracing/skeletontracing.coffee
@@ -112,7 +112,7 @@ class SkeletonTracing
 
   pushBranch : ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     if @branchPointsAllowed
       if @activeNode
@@ -126,7 +126,7 @@ class SkeletonTracing
 
   popBranch : ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     reallyPopBranch = (point, tree, resolve) =>
       tree.removeBranchWithNodeId(point.id)
@@ -171,7 +171,7 @@ class SkeletonTracing
 
   addNode : (position, rotation, viewport, resolution, bitDepth, interpolation) ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     if @ensureDirection(position)
 
@@ -308,7 +308,7 @@ class SkeletonTracing
 
   setActiveNodeRadius : (radius) ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     if @activeNode?
       @activeNode.radius = Math.min( @MAX_RADIUS,
@@ -362,7 +362,7 @@ class SkeletonTracing
     tree.color = @getNewTreeColor()
 
     # force the tree color change, although it may not be persisted if the user is in read-only mode
-    if @restrictionHandler.forceHandleUpdate()
+    if @restrictionHandler.updateAllowed(false)
       @stateLogger.updateTree(tree)
 
     @trigger("newTreeColor", tree.treeId)
@@ -376,7 +376,7 @@ class SkeletonTracing
 
   createNewTree : ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     tree = new TraceTree(
       @treeIdCount++,
@@ -394,7 +394,7 @@ class SkeletonTracing
 
   deleteActiveNode : ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     unless @activeNode
       return
@@ -452,7 +452,7 @@ class SkeletonTracing
 
   deleteTree : (notify, id, notifyServer) ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     if notify
       if confirm("Do you really want to delete the whole tree?")
@@ -465,7 +465,7 @@ class SkeletonTracing
 
   reallyDeleteTree : (id, notifyServer = true) ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     unless id
       id = @activeTree.treeId
@@ -492,7 +492,7 @@ class SkeletonTracing
 
   mergeTree : (lastNode, lastTree) ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     unless lastNode
       return

--- a/app/assets/javascripts/oxalis/model/volumetracing/volumetracing.coffee
+++ b/app/assets/javascripts/oxalis/model/volumetracing/volumetracing.coffee
@@ -68,7 +68,7 @@ class VolumeTracing
   startEditing : (planeId) ->
     # Return, if layer was actually started
 
-    return false if @restrictionHandler.handleUpdate()
+    return false if not @restrictionHandler.updateAllowed()
 
     if currentLayer? or @flycam.getIntegerZoomStep() > 0
       return false
@@ -81,7 +81,7 @@ class VolumeTracing
 
   addToLayer : (pos) ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     unless @currentLayer?
       return
@@ -92,7 +92,7 @@ class VolumeTracing
 
   finishLayer : ->
 
-    return if @restrictionHandler.handleUpdate()
+    return if not @restrictionHandler.updateAllowed()
 
     if not @currentLayer? or @currentLayer.isEmpty()
       return

--- a/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/comment_tab/comment_tab_view.cjsx
+++ b/app/assets/javascripts/oxalis/view/skeletontracing/right-menu/comment_tab/comment_tab_view.cjsx
@@ -136,7 +136,7 @@ class CommentTabView extends Marionette.ItemView
 
   handleInput : (evt) ->
 
-    return if @model.skeletonTracing.restrictionHandler.handleUpdate()
+    return if not @model.skeletonTracing.restrictionHandler.updateAllowed()
 
     # add, delete or update a comment
     nodeId = @getActiveNodeId()


### PR DESCRIPTION
Description of changes:
- Add ability to change the tree color in read-only tracings, issue a persistence warning.

Steps to test:
- Open skeleton tracing, change tree colors -> no warning or error should appear
- Open read-only tracing (e.g. List task types and "View" all tracings of a specific task type), change tree color -> a one-time warning should appear that this change will not be persisted, tree colors will change 

Issues:
- fixes #1406 

---
- [x] Ready for review

…stence warning


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1470/create?referer=github" target="_blank">Log Time</a>