### PR TITLE
Disable import button and show spinner in bulk task creation view

### DIFF
--- a/app/assets/javascripts/admin/views/task/task_create_subviews/task_create_bulk_import_view.coffee
+++ b/app/assets/javascripts/admin/views/task/task_create_subviews/task_create_bulk_import_view.coffee
@@ -22,7 +22,9 @@ class TaskCreateBulkImportView extends Marionette.ItemView
           </div>
           <div class="form-group">
             <div class="col-sm-offset-10 col-sm-2">
-              <button type="submit" class="form-control btn btn-primary">Import</button>
+              <button type="submit" class="form-control btn btn-primary">
+                <i class="fa fa-spinner fa-pulse fa-fw hide"></i>Import
+              </button>
             </div>
           </div>
         </form>
@@ -36,6 +38,8 @@ class TaskCreateBulkImportView extends Marionette.ItemView
 
   ui :
     "bulkText" : "textarea[name=data]"
+    "submitButton" : "button[type=submit]"
+    "submitSpinner" : ".fa-spinner"
 
   ###*
     * Submit form data as json.
@@ -58,6 +62,8 @@ class TaskCreateBulkImportView extends Marionette.ItemView
       @showSaveError
     )
 
+    @toggleSubmitButton(false)
+
     # prevent page reload
     return false
 
@@ -73,10 +79,14 @@ class TaskCreateBulkImportView extends Marionette.ItemView
       @ui.bulkText.val("")
       Toast.success("All tasks were successfully created")
 
+    @toggleSubmitButton(true)
+
 
   showSaveError : ->
 
     Toast.error("The tasks could not be created due to server errors.")
+
+    @toggleSubmitButton(true)
 
 
   showInvalidData : ->
@@ -103,6 +113,12 @@ class TaskCreateBulkImportView extends Marionette.ItemView
 
     @ui.bulkText.val(failedTasks.join("\n"))
     Toast.error(errorMessages.join("\n"))
+
+
+  toggleSubmitButton : (enabled) ->
+
+    @ui.submitButton.prop("disabled", not enabled)
+    @ui.submitSpinner.toggleClass("hide", enabled)
 
 
   splitToLines : (string) ->

--- a/app/assets/stylesheets/_bootstrap_addons.less
+++ b/app/assets/stylesheets/_bootstrap_addons.less
@@ -85,6 +85,10 @@ div[data-toggle='collapse'] {
   background-color: inherit;
 }
 
+.form-control[disabled] {
+  color: black;
+}
+
 // fix jasny-bootstrap fileinput
 // https://github.com/jasny/bootstrap/issues/263
 .fileinput-filename {


### PR DESCRIPTION
Description of changes:
- Disable import button and show spinner in bulk task creation view while waiting for the server response

Steps to test:
- get or create a valid bulk import task description and duplicate it a thousand times
- import tasks in bulk, button should be disabled while waiting for the server response, a spinner should be displayed
- button should be back to normal after the server response returned (regardless of whether it was erronous or not)

Issues:
- fixes #1429 

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1471/create?referer=github" target="_blank">Log Time</a>