### PR TITLE
implemented dynamic loading of hit template from file

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -15,7 +15,7 @@ import com.scalableminds.util.mail.Mailer
 import play.api.libs.concurrent.Execution.Implicits._
 import com.typesafe.config.Config
 import models.annotation.AnnotationStore
-import oxalis.mturk.MTurkNotificationHandler
+import oxalis.mturk.MTurkNotificationReceiver
 import play.api.libs.json.Json
 import play.api.mvc._
 import scala.concurrent.duration._
@@ -41,7 +41,7 @@ object Global extends GlobalSettings {
       name = "mailActor")
 
     // We need to delay the start of the notification handle, since the database needs to be available first
-    MTurkNotificationHandler.startDelayed(app, 2.seconds)
+    MTurkNotificationReceiver.startDelayed(app, 2.seconds)
 
     if (conf.getBoolean("workload.active")) {
       Akka.system(app).actorOf(

--- a/app/assets/javascripts/admin/views/project/project_create_view.coffee
+++ b/app/assets/javascripts/admin/views/project/project_create_view.coffee
@@ -95,6 +95,16 @@ class ProjectCreateView extends Marionette.LayoutView
                 <div class="col-sm-9">
                   <input type="number" class="form-control" name="assignmentConfiguration[autoApprovalDelayInSeconds]" value="60000" disabled required>
                 </div>
+              </div>  
+
+              <div class="form-group">
+                <label class="col-sm-2 control-label" for="template">HIT Template</label>
+                <div class="col-sm-9">
+                  <select class="form-control" name="assignmentConfiguration[template]" disabled>
+                    <option value="default_template" selected>Default flight template</option>
+                    <option value="branchpoint_template">Branchpoint template</option>
+                  </select>
+                </div>
               </div>
 
               <div class="form-group">

--- a/app/models/mturk/MTurkAssignmentConfig.scala
+++ b/app/models/mturk/MTurkAssignmentConfig.scala
@@ -12,7 +12,7 @@ import play.api.libs.json._
   * @param assignmentDurationInSeconds the maximum time a worker has to complete an assignment before it will get
   *                                    closed automatically
   * @param rewardInDollar              amount of money the worker can earn by completing the task
-  * @param requiredQualification       Indentifier for one of the predefined webknossos qualifications.
+  * @param requiredQualification       Identifier for one of the predefined webknossos qualifications.
   *                                    Allows to restrict mturk workers to specific group (e.g. mturk masters, workers
   *                                    with high acceptance rate)
   * @param title                       Title to be displayed on mturk
@@ -26,6 +26,7 @@ case class MTurkAssignmentConfig(
   requiredQualification: MTurkAssignmentQualification,
   title: String,
   keywords: String,
+  template: Option[String],
   description: String) extends AssignmentConfig {
 
   def id = MTurkAssignmentConfig.id

--- a/app/oxalis/mturk/MTurkNotificationReceiver.scala
+++ b/app/oxalis/mturk/MTurkNotificationReceiver.scala
@@ -20,7 +20,7 @@ import play.api.libs.json._
   * its notifications to the persitant SQS service. After that, we can request the notifications from SQS and
   * delete them after we have processed them (this allows fail safty and ensures that we will never miss a notification)
   */
-object MTurkNotificationHandler extends LazyLogging with FoxImplicits {
+object MTurkNotificationReceiver extends LazyLogging with FoxImplicits {
 
   lazy val sqsConfiguration = SQSConfiguration.fromConfig(current.configuration)
 
@@ -30,7 +30,7 @@ object MTurkNotificationHandler extends LazyLogging with FoxImplicits {
       notificationUrl.map { url =>
         logger.info("Using Amazon SQS notification url: " + url)
         Akka.system(app).actorOf(
-          Props(classOf[MTurkNotificationReceiver], url),
+          Props(classOf[MTurkNotificationActor], url),
           name = "mturkNotificationReceiver")
       }.futureBox.map {
         case f: Failure =>
@@ -57,7 +57,7 @@ object MTurkNotificationHandler extends LazyLogging with FoxImplicits {
   /**
     * Actor which will periodically retrieve notifications from SQS
     */
-  class MTurkNotificationReceiver(queueUrl: String) extends Actor with LazyLogging with FoxImplicits {
+  class MTurkNotificationActor(queueUrl: String) extends Actor with LazyLogging with FoxImplicits {
 
     import MTurkNotifications._
 

--- a/app/oxalis/mturk/MTurkService.scala
+++ b/app/oxalis/mturk/MTurkService.scala
@@ -1,5 +1,6 @@
 package oxalis.mturk
 
+import java.nio.file.Paths
 import java.util.UUID
 
 import scala.collection.JavaConversions._
@@ -23,22 +24,35 @@ import net.liftweb.common.{Empty, Failure, Full}
 import play.api.Play._
 import play.api.libs.concurrent.Execution.Implicits._
 
-object MTurkService extends LazyLogging with FoxImplicits {
+/**
+  * Service handling all the communication with the mturk api.
+  *
+  * This includes creating HITTypes for projects, HIT's for tasks and to act on notifications comming
+  * from the mturk API
+  */
+object MTurkService extends MTurkNotificationHandlers with LazyLogging with FoxImplicits {
 
   type HITTypeId = String
 
   val conf = current.configuration
 
+  // Underlying MTURK API implementation
   lazy val service = new RequesterService(loadConfig)
 
-  val questionFile = conf.getString("amazon.mturk.questionFile").get
+  // If no template of a HITType is specified on creation this will be the default HTML template for the HITs
+  val questionTemplateBaseDir = conf.getString("amazon.mturk.questionTemplateBaseDir").get
 
+  // Flag indicating the use of the mturk sandbox instead of the production environment
   val isSandboxed = conf.getBoolean("amazon.mturk.sandbox").get
 
-  val submissionUrl = if(isSandboxed) conf.getString("amazon.mturk.submissionUrl.sandbox").get
+  // HIT template contains a form, this is the submission url this form gets submitted to
+  val submissionUrl = if (isSandboxed) conf.getString("amazon.mturk.submissionUrl.sandbox").get
                       else conf.getString("amazon.mturk.submissionUrl.production").get
 
   val serverBaseUrl = conf.getString("http.uri").get
+
+  // Max lifetime of a HIT on mturk. After that time the hit gets closed even if it was not finished
+  val defaultHITLifetime = 7.days.toSeconds
 
   private def loadConfig = {
     val cfg = new ClientConfig()
@@ -47,14 +61,36 @@ object MTurkService extends LazyLogging with FoxImplicits {
     cfg.setRetriableErrors(conf.getStringList("amazon.mturk.retriableErrors").get.toSet.asJava)
     cfg.setRetryAttempts(conf.getInt("amazon.mturk.retryAttempts").get)
     cfg.setRetryDelayMillis(conf.getInt("amazon.mturk.retryDelayMillis").get)
-    if(isSandboxed)
+    if (isSandboxed)
       cfg.setServiceURL(conf.getString("amazon.mturk.serviceUrl.sandbox").get)
     else
       cfg.setServiceURL(conf.getString("amazon.mturk.serviceUrl.production").get)
     cfg
   }
 
-  def ensureEnoughFunds(neededFunds: Double): Future[Boolean] = Future {
+  /**
+    * HIT descriptions are based on file templates. Default template is 'default_template.question'
+    *
+    * @param templateNameOpt template to load
+    * @return HIT question
+    */
+  private def questionTemplateFromFile(templateNameOpt: Option[String]) = {
+    // Loading the question (QAP) file. HITQuestion is a helper class that
+    // contains the QAP of the HIT defined in the external file. This feature
+    // allows you to write the entire QAP externally as a file and be able to
+    // modify it without recompiling your code.
+    val templateName = templateNameOpt.getOrElse("default_template")
+    val templateFileName = Paths.get(questionTemplateBaseDir, templateName + ".question")
+    new HITQuestion(templateFileName.toString)
+  }
+
+  /**
+    * Request funds of account from amazon and compare to needed funds
+    *
+    * @param neededFunds required amount of money in account
+    * @return true if account has enough money
+    */
+  private def ensureEnoughFunds(neededFunds: Double): Future[Boolean] = Future {
     blocking {
       val balance = service.getAccountBalance
       logger.info("Got account balance: " + RequesterService.formatCurrency(balance))
@@ -62,81 +98,67 @@ object MTurkService extends LazyLogging with FoxImplicits {
     }
   }
 
-  def handleSubmittedAssignment(assignmentId: String, hitId: String) = {
-    def finishIfAnnotationExists(assignment: MTurkAssignment) = {
-      assignment.annotations.find(_.assignmentId == assignmentId) match {
-        case Some(reference) =>
-          for{
-            annotation <- AnnotationDAO.findOneById(reference._annotation)(GlobalAccessContext)
-            _ <- AnnotationService.finish(annotation)(GlobalAccessContext)
-          } yield true
-        case None            =>
-          logger.warn(s"Tried to finish non existent annotation. Hit: $hitId Assignment: $assignmentId")
-          Fox.successful(true)
-      }
-    }
-
-    for {
-      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
-      result <- finishIfAnnotationExists(assignment)
-      _ <- MTurkProjectDAO.decreaseNumberOfOpen(assignment._project, 1)(GlobalAccessContext)
-      _ <- MTurkAssignmentDAO.decreaseNumberInProgress(hitId, 1)(GlobalAccessContext)
-    } yield result
-  }
-
-  def handleAcceptedAssignment(assignmentId: String, hitId: String) = {
-    for {
-      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
-      _ <- MTurkAssignmentDAO.decreaseNumberOfOpen(hitId, 1)(GlobalAccessContext)
-      _ <- MTurkAssignmentDAO.increaseNumberInProgress(hitId, 1)(GlobalAccessContext)
-    } yield true
-  }
-
-  def handleHITExpired(hitId: String) = {
-    for {
-      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
-      _ <- MTurkAssignmentDAO.decreaseNumberOfOpen(hitId,  assignment.numberOfUnfinished)(GlobalAccessContext)
-      _ <- MTurkProjectDAO.decreaseNumberOfOpen(hitId, assignment.numberOfUnfinished)(GlobalAccessContext)
-    } yield true
-  }
-
-  def handleAbandonedAssignment(assignmentId: String, hitId: String) = {
-    def cancelIfAnnotationExists(assignment: MTurkAssignment) = {
-      assignment.annotations.find(_.assignmentId == assignmentId) match {
-        case Some(reference) =>
-          for {
-            annotation <- AnnotationDAO.findOneById(reference._annotation)(GlobalAccessContext)
-            _ <- annotation.muta.cancelTask()(GlobalAccessContext)
-          } yield true
-        case None            =>
-          logger.warn(s"Tried to cancel non existent annotation. Hit: $hitId Assignment: $assignmentId")
-          Fox.successful(true)
-      }
-    }
-
-    for {
-      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
-      _ <- MTurkAssignmentDAO.increaseNumberOfOpen(hitId, 1)(GlobalAccessContext)
-      _ <- MTurkAssignmentDAO.decreaseNumberInProgress(hitId, 1)(GlobalAccessContext)
-      result <- cancelIfAnnotationExists(assignment)
-    } yield result
-  }
-
+  /**
+    * Project on wk got created --> create HitType on mturk
+    *
+    * @param project wk project
+    * @param config  hit config
+    * @return success indicator
+    */
   def handleProjectCreation(project: Project, config: MTurkAssignmentConfig): Fox[Boolean] = {
     for {
       hitTypeId <- createHITType(config, Integer.toHexString(project.name.hashCode)).toFox
-      notificationUrl <- MTurkNotificationHandler.notificationUrl
+      notificationUrl <- MTurkNotificationReceiver.notificationUrl
       _ <- setupNotifications(hitTypeId, notificationUrl)
       _ <- MTurkProjectDAO.insert(MTurkProject(project.name, hitTypeId, project.team, 0))(GlobalAccessContext)
     } yield true
   }
 
+  /**
+    * Remove mturk HITs that belong to a certain wk task
+    *
+    * @param task wk task
+    * @return success indicator
+    */
+  def removeByTask(task: Task) = {
+    def disable(hitId: String): Fox[Boolean] = Future {
+      blocking {
+        try {
+          service.forceExpireHIT(hitId)
+          Full(true)
+        } catch {
+          case e: ObjectDoesNotExistException =>
+            // Task is not there any more, so lets assume it is already deleted. This mostly is only the case if
+            // one switches from sandbox to production and tries to delete tasks created in sandbox.
+            Full(true)
+          case e: Exception                   =>
+            logger.error("Failed to disable HIT. Error: " + e.getMessage, e)
+            Failure("Failed to disable HIT. Error: " + e.getMessage, Full(e), Empty)
+        }
+      }
+    }
+
+    MTurkAssignmentDAO.findOneByTask(task._id)(GlobalAccessContext).futureBox.flatMap {
+      case Full(mtAssignment) =>
+        disable(mtAssignment.hitId)
+      case _                  =>
+        Fox.successful(true)
+    }
+  }
+
+  /**
+    * Create HITs for a task
+    *
+    * @param project project of task
+    * @param task    task
+    * @return mturk assignments
+    */
   def createHITs(project: Project, task: Task): Fox[MTurkAssignment] = {
     for {
       mtProject <- MTurkProjectDAO.findByProject(project.name)(GlobalAccessContext)
       projectConfig <- project.assignmentConfiguration.asOpt[MTurkAssignmentConfig] ?~> "project.config.notMturk"
       _ <- ensureEnoughFunds(projectConfig.rewardInDollar) ?~> "mturk.notEnoughFunds"
-      (hitId, key) <- createHIT(mtProject.hitTypeId, task.instances)
+      (hitId, key) <- createHIT(mtProject.hitTypeId, projectConfig.template, task.instances)
       assignment = MTurkAssignment(task._id, task.team, mtProject._project, hitId, key, task.instances, 0)
       _ <- MTurkAssignmentDAO.insert(assignment)(GlobalAccessContext)
       _ <- MTurkProjectDAO.increaseNumberOfOpen(project.name, task.instances)(GlobalAccessContext)
@@ -146,13 +168,14 @@ object MTurkService extends LazyLogging with FoxImplicits {
   }
 
   private def setupNotifications(hITTypeId: HITTypeId, url: String): Fox[Boolean] = {
-    logger.info(s"Creating hit notifications for '$hITTypeId'. SQS: $url")
+    logger.debug(s"Creating hit notifications for '$hITTypeId'. SQS: $url")
+    // Need to specify all events we are going to handle here
     val eventTypes = Array[EventType](
       EventType.AssignmentAbandoned, EventType.AssignmentAccepted, EventType.AssignmentReturned,
       EventType.AssignmentSubmitted, EventType.AssignmentRejected, EventType.HITExpired)
     val notification = new NotificationSpecification(url, NotificationTransport.SQS, "2014-08-15", eventTypes)
 
-    Future(blocking{
+    Future(blocking {
       try {
         service.setHITTypeNotification(hITTypeId, notification, true)
         Full(true)
@@ -189,7 +212,7 @@ object MTurkService extends LazyLogging with FoxImplicits {
         qualificationRequirement.setComparator(Comparator.LessThanOrEqualTo)
         qualificationRequirement.setIntegerValue(Array(10000))
         Array(qualificationRequirement)
-      case MPIBranchPoint =>
+      case MPIBranchPoint             =>
         val qualificationRequirement = new QualificationRequirement
         qualificationRequirement.setQualificationTypeId(MPIBranchPoint.qualificationId)
         qualificationRequirement.setComparator(Comparator.GreaterThan)
@@ -213,23 +236,19 @@ object MTurkService extends LazyLogging with FoxImplicits {
           Full(id)
         } catch {
           case e: Exception =>
-            logger.error("Failed to create hittype. Eror: "+ e.getMessage, e)
-            Failure("Failed to create hittype. Eror: "+ e.getMessage, Full(e), Empty)
+            logger.error("Failed to create hittype. Eror: " + e.getMessage, e)
+            Failure("Failed to create hittype. Eror: " + e.getMessage, Full(e), Empty)
         }
       }
     }
   }
 
-  private def createHIT(hitType: String, numAssignments: Int): Fox[(String, String)] = {
-    // Loading the question (QAP) file. HITQuestion is a helper class that
-    // contains the QAP of the HIT defined in the external file. This feature
-    // allows you to write the entire QAP externally as a file and be able to
-    // modify it without recompiling your code.
-    val questionTemplate = new HITQuestion(questionFile)
+  private def createHIT(hitType: String, templateFile: Option[String], numAssignments: Int): Fox[(String, String)] = {
+    val questionTemplate = questionTemplateFromFile(templateFile)
 
     val requesterAnnotation = UUID.randomUUID().toString
 
-    val lifetimeInSeconds = 7.days.toSeconds
+    val lifetimeInSeconds = defaultHITLifetime
 
     val question = questionTemplate.getQuestion(Map(
       "webknossosUrl" -> s"$serverBaseUrl/hits/$requesterAnnotation?",
@@ -240,11 +259,9 @@ object MTurkService extends LazyLogging with FoxImplicits {
       Future {
         blocking {
           try {
-            val hit = service.createHIT(hitType,
-              null, null, null, question,
-              null, null, null, lifetimeInSeconds,
-              numAssignments, requesterAnnotation,
-              null, null)
+            val hit = service.createHIT(
+              hitType, null, null, null, question, null, null, null, lifetimeInSeconds,
+              numAssignments, requesterAnnotation, null, null)
             Full(hit)
           } catch {
             case e: Exception =>
@@ -255,38 +272,100 @@ object MTurkService extends LazyLogging with FoxImplicits {
       }
 
     hitF.map { hit =>
-
-      logger.debug("Created HIT: " + hit.getHITId)
-
-      logger.debug(service.getWebsiteURL + "/mturk/preview?groupId=" + hit.getHITTypeId)
-
+      logger.debug(s"Created HIT: ${hit.getHITId} ${service.getWebsiteURL}/mturk/preview?groupId=${hit.getHITTypeId}")
       hit.getHITId -> requesterAnnotation
     }
   }
+}
 
-  def removeByTask(task: Task) = {
-    def disable(hitId: String): Fox[Boolean] = Future{
-      blocking{
-        try {
-          service.forceExpireHIT(hitId)
-          Full(true)
-        } catch {
-          case e: ObjectDoesNotExistException =>
-            // Task is not there any more, so lets assume it is already deleted. This mostly is only the case if
-            // one switches from sandbox to production and tries to delete tasks created in sandbox.
-            Full(true)
-          case e: Exception =>
-            logger.error("Failed to disable HIT. Error: " + e.getMessage, e)
-            Failure("Failed to disable HIT. Error: " + e.getMessage, Full(e), Empty)
-        }
+/**
+  * Handle notifications from MTurk service
+  */
+trait MTurkNotificationHandlers extends LazyLogging {
+  /**
+    * HIT on mturk got submitted. Time to finish annotation and update counters.
+    *
+    * @param assignmentId mturk assignment
+    * @param hitId        mturk hit
+    * @return success indicator
+    */
+  def handleSubmittedAssignment(assignmentId: String, hitId: String) = {
+    def finishIfAnnotationExists(assignment: MTurkAssignment) = {
+      assignment.annotations.find(_.assignmentId == assignmentId) match {
+        case Some(reference) =>
+          for {
+            annotation <- AnnotationDAO.findOneById(reference._annotation)(GlobalAccessContext)
+            _ <- AnnotationService.finish(annotation)(GlobalAccessContext)
+          } yield true
+        case None            =>
+          logger.warn(s"Tried to finish non existent annotation. Hit: $hitId Assignment: $assignmentId")
+          Fox.successful(true)
       }
     }
 
-    MTurkAssignmentDAO.findOneByTask(task._id)(GlobalAccessContext).futureBox.flatMap{
-      case Full(mtAssignment ) =>
-        disable(mtAssignment.hitId)
-      case _ =>
-        Fox.successful(true)
+    for {
+      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
+      result <- finishIfAnnotationExists(assignment)
+      _ <- MTurkProjectDAO.decreaseNumberOfOpen(assignment._project, 1)(GlobalAccessContext)
+      _ <- MTurkAssignmentDAO.decreaseNumberInProgress(hitId, 1)(GlobalAccessContext)
+    } yield result
+  }
+
+  /**
+    * HIT on mturk got accepted by mturker. Update counts
+    *
+    * @param assignmentId mturk assignment
+    * @param hitId        mturk hit
+    * @return success indicator
+    */
+  def handleAcceptedAssignment(assignmentId: String, hitId: String) = {
+    for {
+      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
+      _ <- MTurkAssignmentDAO.decreaseNumberOfOpen(hitId, 1)(GlobalAccessContext)
+      _ <- MTurkAssignmentDAO.increaseNumberInProgress(hitId, 1)(GlobalAccessContext)
+    } yield true
+  }
+
+  /**
+    * HIT on mturk expired. Update counts
+    *
+    * @param hitId mturk hit
+    * @return success indicator
+    */
+  def handleHITExpired(hitId: String) = {
+    for {
+      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
+      _ <- MTurkAssignmentDAO.decreaseNumberOfOpen(hitId, assignment.numberOfUnfinished)(GlobalAccessContext)
+      _ <- MTurkProjectDAO.decreaseNumberOfOpen(hitId, assignment.numberOfUnfinished)(GlobalAccessContext)
+    } yield true
+  }
+
+  /**
+    * Mturker didn't finish his assignment of a HIT in time. Cancel annotation on WK and update counts.
+    *
+    * @param assignmentId mturk assignment
+    * @param hitId        mturk hit
+    * @return success indicator
+    */
+  def handleAbandonedAssignment(assignmentId: String, hitId: String) = {
+    def cancelIfAnnotationExists(assignment: MTurkAssignment) = {
+      assignment.annotations.find(_.assignmentId == assignmentId) match {
+        case Some(reference) =>
+          for {
+            annotation <- AnnotationDAO.findOneById(reference._annotation)(GlobalAccessContext)
+            _ <- annotation.muta.cancelTask()(GlobalAccessContext)
+          } yield true
+        case None            =>
+          logger.warn(s"Tried to cancel non existent annotation. Hit: $hitId Assignment: $assignmentId")
+          Fox.successful(true)
+      }
     }
+
+    for {
+      assignment <- MTurkAssignmentDAO.findByHITId(hitId)(GlobalAccessContext)
+      _ <- MTurkAssignmentDAO.increaseNumberOfOpen(hitId, 1)(GlobalAccessContext)
+      _ <- MTurkAssignmentDAO.decreaseNumberInProgress(hitId, 1)(GlobalAccessContext)
+      result <- cancelIfAnnotationExists(assignment)
+    } yield result
   }
 }

--- a/conf/mturk/branchpoint_template.question
+++ b/conf/mturk/branchpoint_template.question
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <HTMLQuestion xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2011-11-11/HTMLQuestion.xsd">
   <HTMLContent><![CDATA[
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'/>
-    <script type='text/javascript' src='https://s3.amazonaws.com/mturk-public/externalHIT_v1.js'></script>
-  </head>
-  <body>
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'/>
+      <script type='text/javascript' src='https://s3.amazonaws.com/mturk-public/externalHIT_v1.js'></script>
+    </head>
+    <body>
     <!-- Bootstrap v3.0.3 -->
     <link href="https://s3.amazonaws.com/mturk-public/bs30/css/bootstrap.min.css" rel="stylesheet" />
     <section class="container" id="Other" style="margin-bottom:15px; padding: 10px 10px; font-family: Verdana, Geneva, sans-serif; color:#333333; font-size:0.9em;">
@@ -75,9 +75,9 @@
         margin-bottom: 5px;
       }
       #div-intro {
-         margin-bottom: 10px;
-         margin-top: -10px;
-         text-align: center;
+        margin-bottom: 10px;
+        margin-top: -10px;
+        text-align: center;
       }
       #iframe-intro {
         display: block;
@@ -85,9 +85,9 @@
         margin-right: auto;
       }
     </style>
-  </body>
-</html>
-]]>
+    </body>
+    </html>
+    ]]>
   </HTMLContent>
   <FrameHeight>960</FrameHeight>
 </HTMLQuestion>

--- a/conf/mturk/default_template.question
+++ b/conf/mturk/default_template.question
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<HTMLQuestion xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2011-11-11/HTMLQuestion.xsd">
+  <HTMLContent><![CDATA[
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'/>
+      <script type='text/javascript' src='https://s3.amazonaws.com/mturk-public/externalHIT_v1.js'></script>
+    </head>
+    <body>
+    <!-- Bootstrap v3.0.3 -->
+    <link href="https://s3.amazonaws.com/mturk-public/bs30/css/bootstrap.min.css" rel="stylesheet" />
+    <section class="container" id="Other" style="margin-bottom:15px; padding: 10px 10px; font-family: Verdana, Geneva, sans-serif; color:#333333; font-size:0.9em;">
+      <div class="row col-xs-12 col-md-12">
+        <!-- Instructions -->
+        <div class="panel panel-primary">
+          <div class="panel-heading"><strong>Instructions</strong></div>
+          <div class="panel-body">
+            <p>Hello dear annotator:</p>
+            <ul>
+              <li>You should start by watching the 3min video below <br />
+                (Even if you saw a similar video a couple of months ago, this has changed!)
+              </li>
+              <li>
+                <div id="myelementLink" style="display: inline; font-family: Verdana;"><tt>URL not shown because there is an error with Javascript on your computer. To perform this HIT, you must have Javascript and cookies enabled on your browser.</tt></div>
+              </li>
+              <li><strong>Follow the cell by moving forward until the screen turns black or the time is over.</strong></li>
+              <li>After you are done following the cell, please return and fill out the feedback question before submitting the HIT.</li>
+            </ul>
+          </div>
+          <div id="div-intro" style="padding-bottom: 15px;">
+            <iframe id="iframe-intro" allowfullscreen="" frameborder="0" height="500px" src="https://www.youtube.com/embed/xbVfx-OjS3w" width="600px"></iframe>
+          </div>
+        </div>
+        <!-- End Instructions --><!-- Content Body -->
+        <div>&nbsp;</div>
+        <section>
+          <form name='mturk_form' method='post' id='mturk_form' action='${mturkSubmissionUrl}'>
+            <input type='hidden' value='' name='assignmentId' id='assignmentId'/>
+            <fieldset><span style="font-weight: bold; font-size: 0.9em; line-height: 1.6em;">Feedback: What would help you to perform the assignment faster or what did you not understand about the assignment?</span></fieldset>
+            <fieldset><textarea class="form-control" cols="120" name="Q6MultiLineTextInput" rows="3"></textarea></fieldset>
+            <p><input type='submit' id='submitButton' value='Submit' /></p>
+          </form>
+        </section>
+        <script type="text/javascript" language="JavaScript">
+          var assignment_id_field = document.getElementById('myelementLink');
+          var paramstr = window.location.search.substring(1);
+          var parampairs = paramstr.split("&");
+          var mturkworkerID = "";
+          var assignmentID = "";
+          for (i in parampairs) {
+            var pair = parampairs[i].split("=");
+            if (pair[0] == "workerId")
+              mturkworkerID = pair[1];
+            if (pair[0] == "assignmentId")
+              assignmentID = pair[1];
+          }
+          if (mturkworkerID == "" ) {
+            assignment_id_field.innerHTML = 'We will provide you with a link to the assignment which looks like the one in the video after you have accepted the HIT.';
+          } else {
+            assignment_id_field.innerHTML = '<span style="font-family: Verdana, Geneva, sans-serif; font-size: 11.7px; line-height: 20.8px;">Use&nbsp;</span><a target="_blank" href="${webknossosUrl}workerId=' + mturkworkerID + '&assignmentId='+ assignmentID+'"><b>this Link</b></a> to start following your assigned cell.';
+          }
+
+          turkSetAssignmentID();
+        </script>
+        <!-- End Content Body -->
+      </div>
+    </section>
+    <!-- close container -->
+    <style type="text/css">
+      fieldset {
+        padding: 10px;
+        background: #fbfbfb;
+        border-radius: 5px;
+        margin-bottom: 5px;
+      }
+      #div-intro {
+        margin-bottom: 10px;
+        margin-top: -10px;
+        text-align: center;
+      }
+      #iframe-intro {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+      }
+    </style>
+    </body>
+    </html>
+    ]]>
+  </HTMLContent>
+  <FrameHeight>960</FrameHeight>
+</HTMLQuestion>
+

--- a/conf/mturk/mturk.conf
+++ b/conf/mturk/mturk.conf
@@ -12,5 +12,5 @@ amazon.mturk {
   retryAttempts = 10
   retryDelayMillis = 1000
   sandbox = true
-  questionFile = "conf/mturk/project_hit_template.question"
+  questionTemplateBaseDir = "conf/mturk/"
 }


### PR DESCRIPTION
Description of changes:
- dynamically load HIT question template from file depending on selected template name during project creation
- added comments to mturk service

Steps to test:
- Create a new project, choose the "branchpoint template"
- Create a task for that project
- Check if HIT got created in mturk sandbox (https://requestersandbox.mturk.com/)

Issues:
- fixes #1478

---
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1479/create?referer=github" target="_blank">Log Time</a>