### PR TITLE
added tracing time to annotation

### DIFF
--- a/app/assets/javascripts/admin/models/task/annotation_collection.coffee
+++ b/app/assets/javascripts/admin/models/task/annotation_collection.coffee
@@ -1,6 +1,7 @@
 _               = require("lodash")
 backbone        = require("backbone")
 AnnotationModel = require("./annotation_model")
+FormatUtils     = require("libs/format_utils")
 
 class AnnotationCollection extends Backbone.Collection
 
@@ -10,5 +11,15 @@ class AnnotationCollection extends Backbone.Collection
 
     @url = "/api/tasks/#{taskId}/annotations"
     super()
+
+  parse : (responses) ->
+
+    return responses.map((response) ->
+
+      response.tracingTime ?= 0
+      response.formattedTracingTime = FormatUtils.formatSeconds(response.tracingTime / 1000)
+
+      return response
+    )
 
 module.exports = AnnotationCollection

--- a/app/assets/javascripts/admin/views/task/task_annotation_view.coffee
+++ b/app/assets/javascripts/admin/views/task/task_annotation_view.coffee
@@ -14,7 +14,7 @@ class TaskAnnotationView extends Marionette.View
   template : _.template("""
     <td><%- user.firstName %> <%- user.lastName %> (<%- user.email %>)</td>
     <td><%- moment(created).format("YYYY-MM-DD HH:SS") %></td>
-    <td><i class="fa fa-check-circle-o"></i><%- stateLabel %></td>
+    <td><span><i class="fa fa-check-circle-o"></i><%- stateLabel %></span><br /><span><i class="fa fa-clock-o"></i><%- formattedTracingTime %></span></td>
     <td class="nowrap">
       <div class="btn-group">
         <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -28,6 +28,7 @@ case class Annotation(
                        typ: String = AnnotationType.Explorational,
                        version: Int = 0,
                        _name: Option[String] = None,
+                       tracingTime: Option[Long] = None,
                        created : Long = System.currentTimeMillis,
                        _id: BSONObjectID = BSONObjectID.generate,
                        isActive: Boolean = true,
@@ -119,8 +120,8 @@ object Annotation {
         "name" -> annotation.name,
         "id" -> annotation.id,
         "formattedHash" -> Formatter.formatHash(annotation.id),
-        "stats" -> stats.map(_.writeAsJson).toOption
-
+        "stats" -> stats.map(_.writeAsJson).toOption,
+        "tracingTime" -> annotation.tracingTime
       )
     }
   }
@@ -198,6 +199,9 @@ object AnnotationDAO
 
     find(q).sort(Json.obj("_id" -> -1)).cursor[Annotation]().collect[List](maxDocs = limit)
   }
+
+  def logTime(time: Long, _annotation: BSONObjectID)(implicit ctx: DBAccessContext) =
+    update(Json.obj("_id" -> _annotation), Json.obj("$inc" -> Json.obj("tracingTime" -> time)))
 
   def findForWithTypeOtherThan(_user: BSONObjectID, isFinished: Option[Boolean], annotationTypes: List[AnnotationType], limit: Int)(implicit ctx: DBAccessContext) = withExceptionCatcher{
     var q = Json.obj(

--- a/app/models/annotation/AnnotationLike.scala
+++ b/app/models/annotation/AnnotationLike.scala
@@ -73,6 +73,8 @@ trait AnnotationLike extends AnnotationStatistics {
   def makeReadOnly: AnnotationLike
 
   def saveToDB(implicit ctx: DBAccessContext): Fox[AnnotationLike]
+
+  def tracingTime: Option[Long]
 }
 
 object AnnotationLike extends FoxImplicits with FilterableJson with UrlHelper{
@@ -104,7 +106,8 @@ object AnnotationLike extends FoxImplicits with FilterableJson with UrlHelper{
       "downloadUrl" +> a.relativeDownloadUrl.map(toAbsoluteUrl),
       "content" +> a.content.flatMap(AnnotationContent.writeAsJson(_)).getOrElse(JsNull),
       "contentType" +> a.content.map(_.contentType).getOrElse(""),
-      "dataSetName" +> a.dataSetName
+      "dataSetName" +> a.dataSetName,
+      "tracingTime" +> a.tracingTime
     )
   }
 }

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -190,6 +190,7 @@ object AnnotationService extends AnnotationContentProviders with BoxImplicits wi
       temporary.typ,
       temporary.version,
       temporary._name,
+      None,
       temporary.created,
       id)
 
@@ -236,6 +237,9 @@ object AnnotationService extends AnnotationContentProviders with BoxImplicits wi
           name)
     }
   }
+
+  def logTime(time: Long, _annotation: BSONObjectID)(implicit ctx: DBAccessContext) =
+    AnnotationDAO.logTime(time, _annotation)
 
   def zipAnnotations(annotations: List[Annotation], zipFileName: String)(implicit ctx: DBAccessContext) = {
     val zipped = TemporaryFile("annotationZips", normalize(zipFileName))

--- a/app/models/annotation/TemporaryAnnotation.scala
+++ b/app/models/annotation/TemporaryAnnotation.scala
@@ -41,6 +41,8 @@ case class TemporaryAnnotation(
 
   lazy val content = _content()
 
+  def tracingTime = None    // We currently do not tracing time on temporary annotations
+
   def muta = new TemporaryAnnotationMutations(this)
 
   def actions(user: Option[User]) = ResourceActionCollection()

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -8,10 +8,11 @@ import models.task.TaskService
 import play.api.Play
 import play.api.libs.concurrent.Akka
 import akka.actor.{Actor, Props}
-import models.user.{UserDAO, User}
-import models.annotation.AnnotationLike
-import com.scalableminds.util.reactivemongo.{GlobalAccessContext, DBAccessContext}
+import models.user.{User, UserDAO}
+import models.annotation.{Annotation, AnnotationLike, AnnotationService}
+import com.scalableminds.util.reactivemongo.{DBAccessContext, GlobalAccessContext}
 import scala.concurrent.duration._
+
 import net.liftweb.common.Full
 import reactivemongo.bson.BSONObjectID
 import akka.agent.Agent
@@ -91,20 +92,41 @@ object TimeSpanService extends FoxImplicits{
       timeSpan
     }
 
+    private def logTimeToAnnotation(duration: Long, annotation: Option[AnnotationLike]) = {
+      // Log time to annotation
+      annotation.map {
+        case a: Annotation =>
+          AnnotationService.logTime(duration, a._id)(GlobalAccessContext)
+        case _ =>
+        // do nothing, this is not a stored annotation
+      }
+    }
+
+    private def logTimeToTask(duration: Long, annotation: Option[AnnotationLike]) = {
+      // Log time to task
+      annotation.flatMap(_._task).foreach{ taskId =>
+        TaskService.logTime(duration, taskId)(GlobalAccessContext)
+      }
+    }
+
+    private def logTimeToUser(duration: Long, annotation: Option[AnnotationLike], _user: BSONObjectID) = {
+      // Log time to user
+      UserDAO.findOneById(_user)(GlobalAccessContext).map{ user =>
+        BrainTracing.logTime(user, duration, annotation)(GlobalAccessContext)
+      }
+    }
+
     def receive = {
       case TrackTime(timestamp, _user, annotation, ctx) =>
         val timeSpan = lastUserActivity().get(_user) match {
           case Some(last) if isNotInterrupted(timestamp, last) =>
             val duration = timestamp - last.lastUpdate
             val updated = last.copy(lastUpdate = timestamp, time = last.time + duration)
-            // Log time to task
-            annotation.flatMap(_._task).foreach{ taskId =>
-              TaskService.logTime(duration, taskId)(GlobalAccessContext)
-            }
-            // Log time to user
-            UserDAO.findOneById(_user)(GlobalAccessContext).map{ user =>
-              BrainTracing.logTime(user, duration, annotation)(GlobalAccessContext)
-            }
+
+            logTimeToTask(duration, annotation)
+            logTimeToAnnotation(duration, annotation)
+            logTimeToUser(duration, annotation, _user)
+
             TimeSpanDAO.update(updated._id, updated)(ctx)
 
             if(belongsToSameTracing(last, annotation))


### PR DESCRIPTION
Description of changes:
- Track time spend on an annotation on the annotation object

Steps to test:
- Open a task and trace
- Go to the task search page and search for the id of the task
- Unfold the annotations of the tasks, the time the user spend on the annotation should be displayed

Issues:
- fixes #1519

------
- [x] Ready for review



<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1520/create?referer=github" target="_blank">Log Time</a>