### PR TITLE
make_docker on jenkins: put cleanup in trap

### DIFF
--- a/buildtools/make_docker.sh
+++ b/buildtools/make_docker.sh
@@ -20,6 +20,15 @@ ITERATION=${4}
 pushd ${WORKSPACE}
 
 # PRE
+function cleanup {
+  docker-compose down || echo "Can not run docker-compose down"
+  docker logout || echo "Can not run docker logout"
+  popd
+}
+
+trap cleanup EXIT
+
+# PRE
 docker login -u $DOCKER_USER -p $DOCKER_PASS
 docker pull scalableminds/sbt:$SBT_VERSION_TAG
 
@@ -44,7 +53,3 @@ docker push scalableminds/oxalis:$ITERATION
 docker push scalableminds/oxalis:branch-$BRANCH
 docker push scalableminds/oxalis:commit-$COMMIT
 
-# POST
-docker logout
-
-popd


### PR DESCRIPTION
This makes sure that the most important cleanup steps are executed, even if commands in between fail (especially tests).

Steps to test:
- Look at passing and failing builds and tests on jenkins.scm.io

Issues:
- fixes review request on PR #1527

------
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1538/create?referer=github" target="_blank">Log Time</a>