### PR TITLE
added 50x error page for nginx

### DIFF
--- a/buildtools/make_dist.sh
+++ b/buildtools/make_dist.sh
@@ -28,6 +28,7 @@ echo "creating root environment..."
 ROOT_ENV="rootenv"
 INSTALL_DIR="/usr/lib/${NAME}"
 mkdir -p ${ROOT_ENV}${INSTALL_DIR}
+cp ${WORKSPACE}/public/50x.html ${ROOT_ENV}${INSTALL_DIR}/50x.html
 cp -r ${APP_DIR}/* ${ROOT_ENV}${INSTALL_DIR}
 rm ${ROOT_ENV}${INSTALL_DIR}/conf/newrelic.yml
 chmod +x ${ROOT_ENV}${INSTALL_DIR}/bin/${PROJECT}

--- a/buildtools/templates/nginx_template
+++ b/buildtools/templates/nginx_template
@@ -13,6 +13,12 @@ server {
   access_log  /var/log/nginx/{{name}}.access.log;
   proxy_read_timeout 3600s;
 
+  error_page 502 /50x.html;
+  location = /50x.html {
+    root /usr/lib/{{name}};
+    internal;
+  }
+
   location / {
     {% if project != "director" and not (project == "oxalis" and branch == "dev") %}
     auth_basic            "Restricted";
@@ -38,6 +44,12 @@ server {
   listen 443 ssl http2;
   server_name  {{https_url_string}};
   access_log  /var/log/nginx/{{name}}.access.log;
+
+  error_page 502 /50x.html;
+  location = /50x.html {
+    root /usr/lib/{{name}};
+    internal;
+  }
 
   proxy_read_timeout 3600s;
 

--- a/public/50x.html
+++ b/public/50x.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>webKnossos maintenance</title>
+<style>
+  body { text-align: center; padding: 150px 30px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, Arial, sans-serif; color: #333; }
+  article { display: block; text-align: left; max-width: 700px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<article>
+  <p style="position: relative;">
+    <a href="http://thecatapi.com">
+      <img src="http://thecatapi.com/api/images/get?format=src&type=gif" alt="" style="width: 100%; max-width: 500px;">
+    </a>
+  </p>
+  <h1>We're updating webKnossos!</h1>
+  <p>Hang tight, we'll be back in a few moments. Sorry for the inconvenience.</p>
+  <p style="font-size: 13px;">If the issue persists for more than a few minutes, feel free to <a href="mailto:webknossos@scm.io">contact us</a>.</p>
+</article>


### PR DESCRIPTION
Mailable description of changes (needs to be understandable bei webknossos mailing list people):
- Fun info page while server maintenance

Steps to test:
- http://502-errorpage.oxalis.at/dashboard

Issues:
- fixes #1629 

------
- [x] Ready for review


<a href="https://timer.scm.io/repos/537237ce1a00001a003c4a14/issues/1633/create?referer=github" target="_blank">Log Time</a>