### PR TITLE
#1746 Volume mode tracing hotfix

### DIFF
--- a/app/assets/javascripts/oxalis/model/volumetracing/volumetracing.js
+++ b/app/assets/javascripts/oxalis/model/volumetracing/volumetracing.js
@@ -109,10 +109,9 @@ class VolumeTracing {
 
 
   startEditing(planeId) {
-    // Return, if layer was actually started
-
     if (!this.restrictionHandler.updateAllowed()) { return false; }
 
+    // Return, if layer was already started
     if ((typeof this.currentLayer !== "undefined" && this.currentLayer !== null) || this.flycam.getIntegerZoomStep() > 0) {
       return false;
     }
@@ -144,6 +143,7 @@ class VolumeTracing {
     const currentLayer = this.currentLayer;
 
     if ((currentLayer == null) || currentLayer.isEmpty()) {
+      this.currentLayer = null;
       return;
     }
 


### PR DESCRIPTION
When moving in volume mode, the `volumetracing.currentLayer` was not properly reset to `null` which is assumed to be the case by other code (the `startEditing` method). This caused a subsequent volume annotation to fail on the first try and only work on second try.

Mailable description of changes (needs to be understandable by webknossos mailing list people):
- Fix tracing in volume mode after moving, which didn't work the first time.

Steps to test:
- Follow the steps seen in the video https://datashare.rzg.mpg.de/s/SkrIP871hcfU3OS

Issues:
- fixes #1746

------
- [x] Ready for review
