### PR TITLE
remove node at 0,0,0, #1711

### DIFF
--- a/app/assets/javascripts/oxalis/geometries/materials/node_shader.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/node_shader.js
@@ -7,9 +7,9 @@ import { getPlaneScalingFactor } from "oxalis/model/accessors/flycam_accessor";
 import type { UniformsType } from "oxalis/geometries/materials/abstract_plane_material_factory";
 
 export const NodeTypes = {
-  INVALID: -1.0,
-  NORMAL: 0.0,
-  BRANCH_POINT: 1.0,
+  INVALID: 0.0,
+  NORMAL: 1.0,
+  BRANCH_POINT: 2.0,
 };
 
 export const COLOR_TEXTURE_WIDTH = 1024.0;


### PR DESCRIPTION
Mailable description of changes (needs to be understandable by webknossos mailing list people):
- removes "ghost node" at 0,0,0

Steps to test:
- open any skeleton tracing and add nodes
- the ghost node should no longer be there

Issues:
- fixes part of #1711 

------
- [x] Ready for review
