### PR TITLE
Fix KeyboardNoLoop fire callback more than once

### DIFF
--- a/app/assets/javascripts/libs/input.js
+++ b/app/assets/javascripts/libs/input.js
@@ -29,7 +29,7 @@ export type ModifierKeys = "alt" | "shift" | "ctrl";
 type KeyboardKey = string;
 type KeyboardHandler = (event: JQueryInputEventObject) => void;
 type KeyboardLoopHandler = (number, isOriginalEvent: boolean) => void;
-type KeyboardBindingPress = [KeyboardKey, KeyboardHandler];
+type KeyboardBindingPress = [KeyboardKey, null, KeyboardHandler];
 type KeyboardBindingDownUp = [KeyboardKey, KeyboardHandler, KeyboardHandler];
 type BindingMap<T: Function> = { [key: KeyboardKey]: T };
 type MouseButtonWhichType = 1 | 3;
@@ -67,6 +67,7 @@ export class InputKeyboardNoLoop {
   attach(key: KeyboardKey, callback: KeyboardHandler) {
     const binding = [
       key,
+      null,
       (event) => {
         if (!this.isStarted) { return; }
         if ($(":focus").length) { return; }


### PR DESCRIPTION
For keyboard handling abstract the lib "KeyboardJS". The `InputKeyboardNoLoop` is a lightweight wrapper that should only fire once per keypress, no matter how long you hold down the button.  According to this [method definition](https://github.com/RobertWHurst/KeyboardJS/blob/master/lib/keyboard.js#L54) The third argument is used for `key release` events. I switched to these, since those only occur once no matter how long I hold the key. Now, this will fire actions a little later (on key release instead of keyp ress) but at least it only fires once. I don't have any other idea on how the fix the key press events to only fire once.

Mailable description of changes (needs to be understandable by webknossos mailing list people):
- Fixes a bug to make sure that shortcuts the should only invoked once per keypress are not called repeatedly
- E.g. Should fix mass deleting of branch points when holding "j"

Steps to test:
- Open skeleton tracing and test some shortcuts using the `InputKeyboardNoLoop` class.
- e.g. create a bunch of branchpoints and press "j". 
- e.g. create a bunch of comments and cycle through them with "n"
- Please test in several browsers

Issues:
- fixes #1786

------
- [x] Ready for review
