### PR TITLE
fix keyboardnoloop firing constantly #1786

### DIFF
--- a/app/assets/javascripts/libs/input.js
+++ b/app/assets/javascripts/libs/input.js
@@ -66,7 +66,6 @@ export class InputKeyboardNoLoop {
   }
 
   attach(key: KeyboardKey, callback: KeyboardHandler) {
-    this.isKeyActive.add(key);
     const binding = [
       key,
       (event) => {


### PR DESCRIPTION
For keyboard handling abstract the lib "KeyboardJS". The InputKeyboardNoLoop is a lightweight wrapper that should only fire once per keypress, no matter how long you hold down the button. According to this [method definition](https://github.com/RobertWHurst/KeyboardJS/blob/master/lib/keyboard.js#L54) the third argument is used for key release events. I switched to these, since those only occur once no matter how long I hold the key. Now, this will fire actions a little later (on key release instead of keyp ress) but at least it only fires once. I don't have any other idea on how the fix the key press events to only fire once.

Mailable description of changes (needs to be understandable by webknossos mailing list people):
- Fixes a bug to make sure that shortcuts the should only invoked once per keypress are not called repeatedly
- E.g. Should fix mass deleting of branch points when holding "j"

Steps to test:
- Open skeleton tracing and test some shortcuts using the InputKeyboardNoLoop class.
- e.g. create a bunch of branchpoints and press "j".
- e.g. create a bunch of comments and cycle through them with "n"
- Please test in several browsers

Issues:
fixes #1786