### PR TITLE
Refactor save saga

### DIFF
--- a/app/assets/javascripts/oxalis/model/sagas/save_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/save_saga.js
@@ -33,7 +33,7 @@ export function* pushAnnotationAsync(): Generator<*, *, *> {
     yield put(setSaveBusyAction(true));
     const saveQueue = yield select(state => state.save.queue);
     if (saveQueue.length > 0) {
-      yield sendRequestToServer();
+      yield call(sendRequestToServer);
     }
     yield put(setSaveBusyAction(false));
   }
@@ -67,11 +67,11 @@ export function* sendRequestToServer(): Generator<*, *, *> {
       return;
     }
     yield delay(SAVE_RETRY_WAITING_TIME);
-    yield sendRequestToServer();
+    yield call(sendRequestToServer);
   }
 }
 
-function toggleErrorHighlighting(state: boolean) {
+export function toggleErrorHighlighting(state: boolean) {
   $("body").toggleClass("save-error", state);
   if (state) {
     Toast.error(messages["save.failed"], true);


### PR DESCRIPTION
I follow @philippotto's advice from #1804 to refactor the `save_saga` a little. So far so good. I need some help with the tests, though. [Here](https://github.com/scalableminds/webknossos/compare/master...ddos#diff-36dfa4e95dbfe2375794f13db7484e62R122) I am not sure how to restore the test. Also, I would like to have a test that counts the calls to `Request.sendJSONReceiveJSON` when invoking a two or three save actions. Perhaps we can use a `sinon.js` `spy` for that. @philippotto Can you help?


------
- [ ] Ready for review
