### PR TITLE
Fix "s" in flight mode

### DIFF
--- a/app/assets/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
@@ -111,7 +111,7 @@ class SkeletonTracingPlaneController extends PlaneController {
 
       s: () => {
         this.skeletonTracingController.centerActiveNode();
-        return this.cameraController.centerTDView();
+        this.cameraController.centerTDView();
       },
     });
   }

--- a/app/assets/javascripts/oxalis/view/arbitrary_view.js
+++ b/app/assets/javascripts/oxalis/view/arbitrary_view.js
@@ -145,9 +145,9 @@ class ArbitraryView {
     this.animationRequestId = 0;
     if (!this.isRunning) { return; }
 
-    if (this.needsRerender) {
-      TWEEN.update();
+    TWEEN.update();
 
+    if (this.needsRerender) {
       this.trigger("render");
 
       const { camera, geometries, renderer, scene } = this;


### PR DESCRIPTION
During the rendering optimizations I forgot that Tween.update needs to be called in every frame, even if there is no change that requires an immediate rerender.

Steps to test:
- Press "s" in flight mode

Issues:
- fixes #1821

------
- [x] Ready for review
