### PR TITLE
blur mode switch buttons; fixes 1825

### DIFF
--- a/app/assets/javascripts/oxalis/view/action-bar/view_modes_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/view_modes_view.js
@@ -20,6 +20,10 @@ class ViewModesView extends PureComponent {
 
   _forceUpdate = () => { this.forceUpdate(); };
 
+  blurElement = (event: SyntheticInputEvent) => {
+    event.target.blur();
+  }
+
   handleChange = (event: { target: { value: ModeType } }) => {
     this.props.oldModel.setMode(event.target.value);
   };
@@ -27,9 +31,9 @@ class ViewModesView extends PureComponent {
   render() {
     return (
       <Radio.Group onChange={this.handleChange} value={this.props.oldModel.get("mode")} size="large">
-        <Radio.Button value={constants.MODE_PLANE_TRACING}>Orthogonal</Radio.Button>
-        <Radio.Button value={constants.MODE_ARBITRARY}>Flight</Radio.Button>
-        <Radio.Button value={constants.MODE_ARBITRARY_PLANE}>Oblique</Radio.Button>
+        <Radio.Button onClick={this.blurElement} value={constants.MODE_PLANE_TRACING}>Orthogonal</Radio.Button>
+        <Radio.Button onClick={this.blurElement} value={constants.MODE_ARBITRARY}>Flight</Radio.Button>
+        <Radio.Button onClick={this.blurElement} value={constants.MODE_ARBITRARY_PLANE}>Oblique</Radio.Button>
       </Radio.Group>
     );
   }


### PR DESCRIPTION
Clicking on one of the mode switch buttons gave these button elements the browser focus. Hence, all further keyboard inputs were send to these DOM elements preventing the expected behavior for most keyboard shortcuts. For instance when switching from ortho to flight mode you were not able to instantly start flying by pressing "space bar".

![image](https://cloud.githubusercontent.com/assets/1105056/25895793/baf86222-3581-11e7-9da7-bb04afeff129.png)
 
Mailable description of changes (needs to be understandable by webknossos mailing list people):
- fixes https://discuss.webknossos.org/t/window-not-active-while-moving-between-ortho-and-flight/238

Steps to test:
- Open new tracing
- Click "Flight" button to enter flight mode
- Start "flying" by pressing space without having to click into the canvas again to gain focus there

Issues:
- fixes #1825

------
- [x] Ready for review
