### PR TITLE
fix exceptions and error toasts for anonymous users in view mode (#1873)

### DIFF
--- a/app/assets/javascripts/oxalis/model/sagas/settings_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/settings_saga.js
@@ -1,5 +1,5 @@
 // @flow
-
+import app from "app";
 import { throttle, call, select, put, take } from "redux-saga/effects";
 import Request from "libs/request";
 import { initializeSettingsAction } from "oxalis/model/actions/settings_actions";
@@ -16,11 +16,13 @@ export function* initializeSettingsAsync(): Generator<*, *, *> {
 }
 
 function* pushUserSettingsAsync() {
+  if (app.currentUser == null) return;
   const payload = yield select(state => state.userConfiguration);
   yield call(Request.sendJSONReceiveJSON, "/api/user/userConfiguration", { data: payload });
 }
 
 function* pushDatasetSettingsAsync() {
+  if (app.currentUser == null) return;
   const datasetName = yield select(state => state.dataset.name);
   const payload = yield select(state => state.datasetConfiguration);
   yield call(Request.sendJSONReceiveJSON, `/api/dataSetConfigurations/${datasetName}`, { data: payload });

--- a/app/assets/javascripts/oxalis/store.js
+++ b/app/assets/javascripts/oxalis/store.js
@@ -336,7 +336,7 @@ export const defaultState: OxalisState = {
     shouldHideAllSkeletons: false,
     viewMode: Constants.MODE_PLANE_TRACING,
     flightmodeRecording: false,
-    controlMode: ControlModeEnum.TRACE,
+    controlMode: ControlModeEnum.VIEW,
   },
   task: null,
   dataset: {

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -69,7 +69,7 @@ class DatasetInfoTabView extends Component {
     const isPublicViewMode = Store.getState().temporaryConfiguration.controlMode === ControlModeEnum.VIEW;
 
     return (
-      <div>
+      <div className="flex-overflow">
         <p>{annotationType}</p>
         <p>DataSet: {dataSetName}</p>
         <p>Viewport width: {this.chooseUnit(zoomLevel)}</p>

--- a/app/assets/javascripts/oxalis/view/right_menu_view.js
+++ b/app/assets/javascripts/oxalis/view/right_menu_view.js
@@ -44,7 +44,7 @@ class RightMenuView extends React.PureComponent {
   render() {
     return (
       <Tabs destroyInactiveTabPane defaultActiveKey="1" className="tracing-right-menu flex-column flex-column-for-ant-tabs-container">
-        <TabPane tab="Info" key="1"><DatasetInfoTabView /></TabPane>
+        <TabPane tab="Info" key="1" className="flex-column"><DatasetInfoTabView /></TabPane>
         { this.getTabs() }
       </Tabs>
     );

--- a/app/assets/javascripts/test/sagas/settings_saga.spec.js
+++ b/app/assets/javascripts/test/sagas/settings_saga.spec.js
@@ -1,12 +1,13 @@
 // @flow
 /* eslint import/no-extraneous-dependencies: ["error", {"peerDependencies": true}] */
 import test from "ava";
-
-import { initializeSettingsAsync } from "oxalis/model/sagas/settings_saga";
+import mock from "mock-require";
 import { initializeSettingsAction } from "oxalis/model/actions/settings_actions";
 import { take, put } from "redux-saga/effects";
 import { expectValueDeepEqual } from "../helpers/sagaHelpers";
-// import Request from "libs/request";
+
+mock("app", { currentUser: { firstName: "SCM", lastName: "Boy" } });
+const initializeSettingsAsync = mock.reRequire("oxalis/model/sagas/settings_saga").initializeSettingsAsync;
 
 test("settings_sagas should load initial settings into the store", (t) => {
   const datasetName = "foo";


### PR DESCRIPTION
This issue was brought up in the webknossos Slack channel after the launch of webknossos.org people testing demo.webknossos.org while not being logged in. Modifying any user or dataset setting, resulted in an exception and there was also an Error Toast displayed.
I've also fixed scrolling for the view tab, which holds more content in "View" mode, but didn't have a scrollbar before.

### Steps to test:
- Log out and view a dataset, scale the view with k/l or modify the dataset settings -> There should be no error toasts or exceptions

### Issues:
- fixes #1873

------
- [x] Ready for review
