### PR TITLE
Webpack 3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,8 @@
         "transform-async-to-generator",
         "transform-class-properties",
         "transform-flow-strip-types",
-        ["import", { libraryName: "antd" }]
+        ["import", { libraryName: "antd" }],
+        "syntax-dynamic-import"
       ],
     }
   },
@@ -43,6 +44,7 @@
     "transform-async-to-generator",
     "transform-class-properties",
     "transform-flow-strip-types",
-    ["import", { libraryName: "antd" }]
+    ["import", { libraryName: "antd" }],
+    "syntax-dynamic-import"
   ],
 }

--- a/app/assets/javascripts/admin/admin.js
+++ b/app/assets/javascripts/admin/admin.js
@@ -21,7 +21,6 @@ import WorkloadListView from "admin/views/workload/workload_list_view";
 import WorkloadCollection from "admin/models/workload/workload_collection";
 import ScriptListView from "admin/views/scripts/script_list_view";
 import ScriptCollection from "admin/models/scripts/script_collection";
-
 import ProjectCreateView from "admin/views/project/project_create_view";
 import ProjectModel from "admin/models/project/project_model";
 import ProjectEditView from "admin/views/project/project_edit_view";
@@ -64,7 +63,6 @@ export {
   DatasetListView,
   ScriptListView,
   ScriptCollection,
-
   ProjectCreateView,
   ProjectModel,
   ProjectEditView,

--- a/app/assets/javascripts/admin/admin.js
+++ b/app/assets/javascripts/admin/admin.js
@@ -5,7 +5,6 @@
 
 import DatasetListView from "dashboard/views/dataset/dataset_list_view";
 import PaginationView from "admin/views/pagination_view";
-import DatasetCollection from "admin/models/dataset/dataset_collection";
 import DatasetAddView from "admin/views/dataset/dataset_add_view";
 import UserListView from "admin/views/user/user_list_view";
 import UserCollection from "admin/models/user/user_collection";
@@ -23,6 +22,24 @@ import WorkloadCollection from "admin/models/workload/workload_collection";
 import ScriptListView from "admin/views/scripts/script_list_view";
 import ScriptCollection from "admin/models/scripts/script_collection";
 
+import ProjectCreateView from "admin/views/project/project_create_view";
+import ProjectModel from "admin/models/project/project_model";
+import ProjectEditView from "admin/views/project/project_edit_view";
+import TimeStatisticModel from "admin/models/statistic/time_statistic_model";
+import DatasetEditView from "admin/views/dataset/dataset_edit_view";
+import DatasetModel from "admin/models/dataset/dataset_model";
+import TaskQueryView from "admin/views/task/task_query_view";
+import TaskCreateView from "admin/views/task/task_create_view";
+import TaskModel from "admin/models/task/task_model";
+import TaskCreateFromView from "admin/views/task/task_create_subviews/task_create_from_view";
+import TaskTypeCreateView from "admin/views/tasktype/task_type_create_view";
+import TaskTypeModel from "admin/models/tasktype/task_type_model";
+import ScriptCreateView from "admin/views/scripts/script_create_view";
+import ScriptModel from "admin/models/scripts/script_model";
+
+import TaskOverviewView from "admin/views/task/task_overview_view";
+import TaskOverviewCollection from "admin/models/task/task_overview_collection";
+
 //
 // This exports all the modules listed above and mainly serves the purpose of
 // waiting to be combinend and minified with rjs.
@@ -30,7 +47,6 @@ import ScriptCollection from "admin/models/scripts/script_collection";
 
 export {
   PaginationView,
-  DatasetCollection,
   UserListView,
   UserCollection,
   TeamListView,
@@ -48,4 +64,21 @@ export {
   DatasetListView,
   ScriptListView,
   ScriptCollection,
-};
+
+  ProjectCreateView,
+  ProjectModel,
+  ProjectEditView,
+  TimeStatisticModel,
+  DatasetEditView,
+  DatasetModel,
+  TaskQueryView,
+  TaskCreateView,
+  TaskModel,
+  TaskCreateFromView,
+  TaskTypeCreateView,
+  TaskTypeModel,
+  ScriptCreateView,
+  ScriptModel,
+  TaskOverviewView,
+  TaskOverviewCollection,
+  };

--- a/app/assets/javascripts/admin/views/statistic/statistic_list_view.js
+++ b/app/assets/javascripts/admin/views/statistic/statistic_list_view.js
@@ -27,7 +27,7 @@ class StatisticListView extends Marionette.CompositeView {
 
   initialize() {
     // set first day of the week to monday globally
-    moment.locale("en", { week: { dow: 1 } });
+    moment.updateLocale("en", { week: { dow: 1 } });
 
     this.model = new Backbone.Model({
       startDate: moment().startOf("week"),

--- a/app/assets/javascripts/oxalis/model/accessors/skeletontracing_accessor.js
+++ b/app/assets/javascripts/oxalis/model/accessors/skeletontracing_accessor.js
@@ -10,6 +10,10 @@ export function getSkeletonTracing(tracing: TracingType): Maybe<SkeletonTracingT
   return Maybe.Nothing();
 }
 
+export function enforceSkeletonTracing(tracing: TracingType): SkeletonTracingType {
+  return getSkeletonTracing(tracing).get();
+}
+
 export function getActiveNode(tracing: TracingType) {
   return getSkeletonTracing(tracing).chain((skeletonTracing) => {
     const { activeTreeId, activeNodeId } = skeletonTracing;

--- a/app/assets/javascripts/oxalis/model/accessors/volumetracing_accessor.js
+++ b/app/assets/javascripts/oxalis/model/accessors/volumetracing_accessor.js
@@ -14,6 +14,10 @@ export function getVolumeTracing(tracing: TracingType): Maybe<VolumeTracingType>
   return Maybe.Nothing();
 }
 
+export function enforceVolumeTracing(tracing: TracingType): VolumeTracingType {
+  return getVolumeTracing(tracing).get();
+}
+
 export function getActiveCellId(tracing: TracingType): Maybe<number> {
   return getVolumeTracing(tracing).map((volumeTracing) => {
     const { activeCellId } = volumeTracing;

--- a/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -7,16 +7,19 @@ import Constants from "oxalis/constants";
 import Store from "oxalis/store";
 import { setModeAction, createCellAction } from "oxalis/model/actions/volumetracing_actions";
 import { Button, Radio } from "antd";
+import { enforceVolumeTracing } from "oxalis/model/accessors/volumetracing_accessor";
 
 // Workaround until github.com/facebook/flow/issues/1113 is fixed
 const RadioGroup = Radio.Group;
 const RadioButton = Radio.Button;
 const ButtonGroup = Button.Group;
 
+type Props = {
+  volumeTracing: VolumeTracingType,
+};
+
 class VolumeActionsView extends PureComponent {
-  props: {
-    volumeTracing: VolumeTracingType,
-  };
+  props: Props;
 
   handleSetMode = (event: { target: { value: VolumeTraceOrMoveModeType } }) => {
     Store.dispatch(setModeAction(
@@ -50,9 +53,9 @@ class VolumeActionsView extends PureComponent {
   }
 }
 
-function mapStateToProps(state: OxalisState) {
+function mapStateToProps(state: OxalisState): Props {
   return {
-    volumeTracing: state.tracing,
+    volumeTracing: enforceVolumeTracing(state.tracing),
   };
 }
 

--- a/app/assets/javascripts/oxalis/view/right-menu/comment_tab/tree_comment_list.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/comment_tab/tree_comment_list.js
@@ -9,12 +9,16 @@ import { connect } from "react-redux";
 import classNames from "classnames";
 import Comment from "oxalis/view/right-menu/comment_tab/comment";
 import type { OxalisState, TreeType, SkeletonTracingType } from "oxalis/store";
+import { enforceSkeletonTracing } from "oxalis/model/accessors/skeletontracing_accessor";
+
+type OwnProps = {
+  tree: TreeType,
+  sortOrder: "asc" | "desc",
+}
 
 type TreeCommentListProps = {
-  tree: TreeType,
   skeletonTracing: SkeletonTracingType,
-  sortOrder: "asc" | "desc";
-}
+} & OwnProps;
 
 class TreeCommentList extends React.PureComponent {
 
@@ -63,9 +67,11 @@ class TreeCommentList extends React.PureComponent {
   }
 }
 
-function mapStateToProps(state: OxalisState) {
+function mapStateToProps(state: OxalisState, ownProps: OwnProps): TreeCommentListProps {
   return {
-    skeletonTracing: state.tracing,
+    skeletonTracing: enforceSkeletonTracing(state.tracing),
+    tree: ownProps.tree,
+    sortOrder: ownProps.sortOrder,
   };
 }
 

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -9,6 +9,8 @@ import { getBaseVoxel } from "oxalis/model/scaleinfo";
 import constants, { ControlModeEnum } from "oxalis/constants";
 import ArbitraryController from "oxalis/controller/viewmodes/arbitrary_controller";
 import { getPlaneScalingFactor } from "oxalis/model/accessors/flycam_accessor";
+import { enforceSkeletonTracing } from "oxalis/model/accessors/skeletontracing_accessor";
+
 import Store from "oxalis/store";
 import TemplateHelpers from "libs/template_helpers";
 import type { OxalisState, SkeletonTracingType, DatasetType, FlycamType, TaskType } from "oxalis/store";
@@ -17,7 +19,7 @@ type DatasetInfoTabProps = {
   skeletonTracing: SkeletonTracingType,
   dataset: DatasetType,
   flycam: FlycamType,
-  task: TaskType,
+  task: ?TaskType,
 };
 
 class DatasetInfoTabView extends Component {
@@ -104,9 +106,9 @@ class DatasetInfoTabView extends Component {
   }
 }
 
-function mapStateToProps(state: OxalisState) {
+function mapStateToProps(state: OxalisState): DatasetInfoTabProps {
   return {
-    skeletonTracing: state.tracing,
+    skeletonTracing: enforceSkeletonTracing(state.tracing),
     dataset: state.dataset,
     flycam: state.flycam,
     task: state.task,

--- a/app/assets/javascripts/oxalis/view/tracing_view.js
+++ b/app/assets/javascripts/oxalis/view/tracing_view.js
@@ -19,7 +19,7 @@ import type { Dispatch } from "redux";
 class TracingView extends React.PureComponent {
   props: {
     flightmodeRecording: boolean,
-    onChangeFlightmodeRecording: (boolean) => {},
+    onChangeFlightmodeRecording: ?Function,
     viewMode: ModeType,
     scale: number,
     isVolumeTracingDisallowed: boolean,

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -14,6 +14,7 @@ import BaseRouter from "libs/base_router";
 import ReactBackboneWrapper from "libs/react_backbone_wrapper";
 import PaginationCollection from "admin/models/pagination_collection";
 
+import TracingLayoutView from "oxalis/view/tracing_layout_view";
 import DashboardView from "dashboard/views/dashboard_view";
 import UserModel from "dashboard/models/user_model";
 import SpotlightView from "dashboard/views/spotlight/spotlight_view";
@@ -74,35 +75,23 @@ class Router extends BaseRouter {
   }
 
   tracingView(type, id) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (TracingLayoutView) => {
-      TracingLayoutView = TracingLayoutView.default;
-
-      const view = new ReactBackboneWrapper(TracingLayoutView, {
-        initialTracingType: type,
-        initialTracingId: id,
-        initialControlmode: ControlModeEnum.TRACE,
-      });
-      view.forcePageReload = true;
-      this.changeView(view);
-    };
-    require(["oxalis/view/tracing_layout_view"], callback);
+    const view = new ReactBackboneWrapper(TracingLayoutView, {
+      initialTracingType: type,
+      initialTracingId: id,
+      initialControlmode: ControlModeEnum.TRACE,
+    });
+    view.forcePageReload = true;
+    this.changeView(view);
   }
 
   tracingViewPublic(id) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (TracingLayoutView) => {
-      TracingLayoutView = TracingLayoutView.default;
-
-      const view = new ReactBackboneWrapper(TracingLayoutView, {
-        initialTracingType: SkeletonTracingTypeTracingEnum.View,
-        initialTracingId: id,
-        initialControlmode: ControlModeEnum.VIEW,
-      });
-      view.forcePageReload = true;
-      this.changeView(view);
-    };
-    require(["oxalis/view/tracing_layout_view"], callback);
+    const view = new ReactBackboneWrapper(TracingLayoutView, {
+      initialTracingType: SkeletonTracingTypeTracingEnum.View,
+      initialTracingId: id,
+      initialControlmode: ControlModeEnum.VIEW,
+    });
+    view.forcePageReload = true;
+    this.changeView(view);
   }
 
 

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -115,8 +115,7 @@ class Router extends BaseRouter {
 
 
   projectEdit(projectName) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const ProjectEditView = admin.ProjectEditView;
       const ProjectModel = admin.ProjectModel;
 
@@ -127,8 +126,7 @@ class Router extends BaseRouter {
         this.changeView(view);
         this.hideLoadingSpinner();
       });
-    };
-    import(/* webpackChunkName: "admin" */ "admin/admin").then(callback);
+    });
   }
 
 

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -14,6 +14,11 @@ import BaseRouter from "libs/base_router";
 import ReactBackboneWrapper from "libs/react_backbone_wrapper";
 import PaginationCollection from "admin/models/pagination_collection";
 
+import DashboardView from "dashboard/views/dashboard_view";
+import UserModel from "dashboard/models/user_model";
+import SpotlightView from "dashboard/views/spotlight/spotlight_view";
+import DatasetCollection from "admin/models/dataset/dataset_collection";
+
 // #####
 // This Router contains all the routes for views that have been
 // refactored to Backbone.View yet. All other routes, that require HTML to be
@@ -108,9 +113,9 @@ class Router extends BaseRouter {
 
   projectCreate() {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (ProjectCreateView, ProjectModel) => {
-      ProjectCreateView = ProjectCreateView.default;
-      ProjectModel = ProjectModel.default;
+    const callback = (admin) => {
+      const ProjectCreateView = admin.ProjectCreateView;
+      const ProjectModel = admin.ProjectModel;
 
       const model = new ProjectModel();
       const view = new ProjectCreateView({ model });
@@ -118,15 +123,15 @@ class Router extends BaseRouter {
       this.changeView(view);
       this.hideLoadingSpinner();
     };
-    require(["admin/views/project/project_create_view", "admin/models/project/project_model"], callback);
+    require(["admin/admin"], callback);
   }
 
 
   projectEdit(projectName) {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (ProjectEditView, ProjectModel) => {
-      ProjectEditView = ProjectEditView.default;
-      ProjectModel = ProjectModel.default;
+    const callback = (admin) => {
+      const ProjectEditView = admin.ProjectEditView;
+      const ProjectModel = admin.ProjectModel;
 
       const model = new ProjectModel({ name: projectName });
       const view = new ProjectEditView({ model });
@@ -136,45 +141,45 @@ class Router extends BaseRouter {
         this.hideLoadingSpinner();
       });
     };
-    require(["admin/views/project/project_edit_view", "admin/models/project/project_model"], callback);
+    require(["admin/admin"], callback);
   }
 
 
   statistics() {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (StatisticsView, TimeStatisticModel) => {
-      StatisticsView = StatisticsView.default;
-      TimeStatisticModel = TimeStatisticModel.default;
+    const callback = (admin) => {
+      const StatisticView = admin.StatisticView;
+      const TimeStatisticModel = admin.TimeStatisticModel;
 
       const model = new TimeStatisticModel();
-      const view = new StatisticsView({ model });
+      const view = new StatisticView({ model });
 
       this.changeView(view);
       this.listenTo(model, "sync", () => this.hideLoadingSpinner());
     };
-    require(["admin/views/statistic/statistic_view", "admin/models/statistic/time_statistic_model"], callback);
+    require(["admin/admin"], callback);
   }
 
 
   datasetAdd() {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (DatasetAddView) => {
-      DatasetAddView = DatasetAddView.default;
+    const callback = (admin) => {
+      const DatasetAddView = admin.DatasetAddView;
 
       const view = new DatasetAddView();
 
       this.changeView(view);
       this.hideLoadingSpinner();
     };
-    require(["admin/views/dataset/dataset_add_view"], callback);
+    require(["admin/admin"], callback);
   }
 
 
   datasetEdit(datasetID) {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (DatasetEditView, DatasetModel) => {
-      DatasetEditView = DatasetEditView.default;
-      DatasetModel = DatasetModel.default;
+    const callback = (admin) => {
+      const DatasetEditView = admin.DatasetEditView;
+      const DatasetModel = admin.DatasetModel;
 
       const model = new DatasetModel({ name: datasetID });
       const view = new DatasetEditView({ model });
@@ -184,7 +189,7 @@ class Router extends BaseRouter {
         this.hideLoadingSpinner();
       });
     };
-    require(["admin/views/dataset/dataset_edit_view", "admin/models/dataset/dataset_model"], callback);
+    require(["admin/admin"], callback);
   }
 
 
@@ -200,13 +205,13 @@ class Router extends BaseRouter {
 
   taskQuery() {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (TaskQueryView) => {
-      TaskQueryView = TaskQueryView.default;
+    const callback = (admin) => {
+      const TaskQueryView = admin.TaskQueryView;
 
       const view = new TaskQueryView();
       this.changeView(view);
     };
-    require(["admin/views/task/task_query_view"], callback);
+    require(["admin/admin"], callback);
   }
 
 
@@ -239,9 +244,9 @@ class Router extends BaseRouter {
    */
   taskCreate() {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (TaskCreateView, TaskModel) => {
-      TaskCreateView = TaskCreateView.default;
-      TaskModel = TaskModel.default;
+    const callback = (admin) => {
+      const TaskCreateView = admin.TaskCreateView;
+      const TaskModel = admin.TaskModel;
 
       const model = new TaskModel();
       const view = new TaskCreateView({ model });
@@ -249,7 +254,7 @@ class Router extends BaseRouter {
       this.changeView(view);
       this.hideLoadingSpinner();
     };
-    require(["admin/views/task/task_create_view", "admin/models/task/task_model"], callback);
+    require(["admin/admin"], callback);
   }
 
   /**
@@ -257,9 +262,9 @@ class Router extends BaseRouter {
    */
   taskEdit(taskID) {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (TaskCreateFromView, TaskModel) => {
-      TaskCreateFromView = TaskCreateFromView.default;
-      TaskModel = TaskModel.default;
+    const callback = (admin) => {
+      const TaskCreateFromView = admin.TaskCreateFromView;
+      const TaskModel = admin.TaskModel;
 
       const model = new TaskModel({ id: taskID });
       const view = new TaskCreateFromView({ model, type: "from_form" });
@@ -267,82 +272,68 @@ class Router extends BaseRouter {
       this.changeView(view);
       this.hideLoadingSpinner();
     };
-    require(["admin/views/task/task_create_subviews/task_create_from_view", "admin/models/task/task_model"], callback);
+    require(["admin/admin"], callback);
   }
 
 
   taskTypesCreate(taskTypeId) {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (TaskTypeCreateView, TaskTypeModel) => {
-      TaskTypeCreateView = TaskTypeCreateView.default;
-      TaskTypeModel = TaskTypeModel.default;
+    const callback = (admin) => {
+      const TaskTypeCreateView = admin.TaskTypeCreateView;
+      const TaskTypeModel = admin.TaskTypeModel;
 
       const model = new TaskTypeModel({ id: taskTypeId });
       const view = new TaskTypeCreateView({ model });
       this.changeView(view);
       this.hideLoadingSpinner();
     };
-    require(["admin/views/tasktype/task_type_create_view", "admin/models/tasktype/task_type_model"], callback);
+    require(["admin/admin"], callback);
   }
 
   scriptsCreate(scriptId) {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (ScriptCreateView, ScriptModel) => {
-      ScriptCreateView = ScriptCreateView.default;
-      ScriptModel = ScriptModel.default;
+    const callback = (admin) => {
+      const ScriptCreateView = admin.ScriptCreateView;
+      const ScriptModel = admin.ScriptModel;
 
       const model = new ScriptModel({ id: scriptId });
       const view = new ScriptCreateView({ model });
       this.changeView(view);
       this.hideLoadingSpinner();
     };
-    require(["admin/views/scripts/script_create_view", "admin/models/scripts/script_model"], callback);
+    require(["admin/admin"], callback);
   }
 
   dashboard(userID) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (DashboardView, UserModel) => {
-      DashboardView = DashboardView.default;
-      UserModel = UserModel.default;
+    const isAdminView = userID !== null;
 
-      const isAdminView = userID !== null;
+    const model = new UserModel({ id: userID });
+    const view = new DashboardView({ model, isAdminView, userID });
 
-      const model = new UserModel({ id: userID });
-      const view = new DashboardView({ model, isAdminView, userID });
+    this.listenTo(model, "sync", () => {
+      this.changeView(view);
+      this.hideLoadingSpinner();
+    });
 
-      this.listenTo(model, "sync", () => {
-        this.changeView(view);
-        this.hideLoadingSpinner();
-      });
-
-      model.fetch();
-    };
-    require(["dashboard/views/dashboard_view", "dashboard/models/user_model"], callback);
+    model.fetch();
   }
 
 
   spotlight() {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (SpotlightView, DatasetCollection) => {
-      SpotlightView = SpotlightView.default;
-      DatasetCollection = DatasetCollection.default;
+    const collection = new DatasetCollection();
+    const paginatedCollection = new PaginationCollection([], { fullCollection: collection });
+    const view = new SpotlightView({ collection: paginatedCollection });
 
-      const collection = new DatasetCollection();
-      const paginatedCollection = new PaginationCollection([], { fullCollection: collection });
-      const view = new SpotlightView({ collection: paginatedCollection });
-
-      this.changeView(view);
-      this.listenTo(collection, "sync", this.hideLoadingSpinner);
-    };
-    require(["dashboard/views/spotlight/spotlight_view", "admin/models/dataset/dataset_collection"], callback);
+    this.changeView(view);
+    this.listenTo(collection, "sync", this.hideLoadingSpinner);
   }
 
 
   taskOverview() {
     // Webpack `require` doesn't work with inline arrow functions
-    const callback = (TaskOverviewView, TaskOverviewCollection) => {
-      TaskOverviewView = TaskOverviewView.default;
-      TaskOverviewCollection = TaskOverviewCollection.default;
+    const callback = (admin) => {
+      const TaskOverviewView = admin.TaskOverviewView;
+      const TaskOverviewCollection = admin.TaskOverviewCollection;
 
       const collection = new TaskOverviewCollection();
       const view = new TaskOverviewView({ collection });
@@ -350,7 +341,7 @@ class Router extends BaseRouter {
       this.changeView(view);
       this.listenTo(collection, "sync", this.hideLoadingSpinner);
     };
-    require(["admin/views/task/task_overview_view", "admin/models/task/task_overview_collection"], callback);
+    require(["admin/admin"], callback);
   }
 
 

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -101,8 +101,7 @@ class Router extends BaseRouter {
 
 
   projectCreate() {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const ProjectCreateView = admin.ProjectCreateView;
       const ProjectModel = admin.ProjectModel;
 
@@ -111,8 +110,7 @@ class Router extends BaseRouter {
 
       this.changeView(view);
       this.hideLoadingSpinner();
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
 
@@ -130,13 +128,12 @@ class Router extends BaseRouter {
         this.hideLoadingSpinner();
       });
     };
-    require(["admin/admin"], callback);
+    import(/* webpackChunkName: "admin" */ "admin/admin").then(callback);
   }
 
 
   statistics() {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const StatisticView = admin.StatisticView;
       const TimeStatisticModel = admin.TimeStatisticModel;
 
@@ -145,28 +142,24 @@ class Router extends BaseRouter {
 
       this.changeView(view);
       this.listenTo(model, "sync", () => this.hideLoadingSpinner());
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
 
   datasetAdd() {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const DatasetAddView = admin.DatasetAddView;
 
       const view = new DatasetAddView();
 
       this.changeView(view);
       this.hideLoadingSpinner();
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
 
   datasetEdit(datasetID) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const DatasetEditView = admin.DatasetEditView;
       const DatasetModel = admin.DatasetModel;
 
@@ -177,8 +170,7 @@ class Router extends BaseRouter {
         this.changeView(view);
         this.hideLoadingSpinner();
       });
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
 
@@ -193,14 +185,12 @@ class Router extends BaseRouter {
 
 
   taskQuery() {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const TaskQueryView = admin.TaskQueryView;
 
       const view = new TaskQueryView();
       this.changeView(view);
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
 
@@ -232,8 +222,7 @@ class Router extends BaseRouter {
    * Load layout view that shows task-creation subviews
    */
   taskCreate() {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const TaskCreateView = admin.TaskCreateView;
       const TaskModel = admin.TaskModel;
 
@@ -242,16 +231,14 @@ class Router extends BaseRouter {
 
       this.changeView(view);
       this.hideLoadingSpinner();
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
   /**
    * Load item view which displays an editable task.
    */
   taskEdit(taskID) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const TaskCreateFromView = admin.TaskCreateFromView;
       const TaskModel = admin.TaskModel;
 
@@ -260,14 +247,12 @@ class Router extends BaseRouter {
 
       this.changeView(view);
       this.hideLoadingSpinner();
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
 
   taskTypesCreate(taskTypeId) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const TaskTypeCreateView = admin.TaskTypeCreateView;
       const TaskTypeModel = admin.TaskTypeModel;
 
@@ -275,13 +260,11 @@ class Router extends BaseRouter {
       const view = new TaskTypeCreateView({ model });
       this.changeView(view);
       this.hideLoadingSpinner();
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
   scriptsCreate(scriptId) {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const ScriptCreateView = admin.ScriptCreateView;
       const ScriptModel = admin.ScriptModel;
 
@@ -289,8 +272,7 @@ class Router extends BaseRouter {
       const view = new ScriptCreateView({ model });
       this.changeView(view);
       this.hideLoadingSpinner();
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
   dashboard(userID) {
@@ -319,8 +301,7 @@ class Router extends BaseRouter {
 
 
   taskOverview() {
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       const TaskOverviewView = admin.TaskOverviewView;
       const TaskOverviewCollection = admin.TaskOverviewCollection;
 
@@ -329,16 +310,14 @@ class Router extends BaseRouter {
 
       this.changeView(view);
       this.listenTo(collection, "sync", this.hideLoadingSpinner);
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
 
   showWithPagination(view, collection, options = {}) {
     _.defaults(options, { addButtonText: null });
 
-    // Webpack `require` doesn't work with inline arrow functions
-    const callback = (admin) => {
+    import(/* webpackChunkName: "admin" */ "admin/admin").then((admin) => {
       collection = new admin[collection](null, options);
       const paginatedCollection = new PaginationCollection([], { fullCollection: collection });
       view = new admin[view]({ collection: paginatedCollection });
@@ -346,8 +325,7 @@ class Router extends BaseRouter {
 
       this.changeView(paginationView, view);
       this.listenTo(collection, "sync", () => this.hideLoadingSpinner());
-    };
-    require(["admin/admin"], callback);
+    });
   }
 
   changeView(...views) {

--- a/app/views/pageSkeleton.scala.html
+++ b/app/views/pageSkeleton.scala.html
@@ -14,7 +14,7 @@
       data-airbrake-environment-name=@play.api.Play.current.configuration.getString("airbrake.environment")></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/routes.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script type="text/javascript" src="@routes.Assets.at("bundle/manifest.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
-    <script type="text/javascript" src="@routes.Assets.at("bundle/vendor.js?nocache=@(webknossos.BuildInfo.commitHash)"></script>
+    <script type="text/javascript" src="@routes.Assets.at("bundle/vendor.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script type="text/javascript" src="@routes.Assets.at("bundle/main.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     @if(play.api.Play.current.mode == play.api.Mode.Dev) {
       <link href='@routes.Assets.at("fonts/fonts-local.css")' rel='stylesheet' type='text/css' media="screen">

--- a/app/views/pageSkeleton.scala.html
+++ b/app/views/pageSkeleton.scala.html
@@ -13,6 +13,7 @@
       data-airbrake-project-key=@play.api.Play.current.configuration.getString("airbrake.projectKey")
       data-airbrake-environment-name=@play.api.Play.current.configuration.getString("airbrake.environment")></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/routes.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
+        <script type="text/javascript" src="@routes.Assets.at("bundle/vendor.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script type="text/javascript" src="@routes.Assets.at("bundle/main.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     @if(play.api.Play.current.mode == play.api.Mode.Dev) {
       <link href='@routes.Assets.at("fonts/fonts-local.css")' rel='stylesheet' type='text/css' media="screen">

--- a/app/views/pageSkeleton.scala.html
+++ b/app/views/pageSkeleton.scala.html
@@ -13,7 +13,6 @@
       data-airbrake-project-key=@play.api.Play.current.configuration.getString("airbrake.projectKey")
       data-airbrake-environment-name=@play.api.Play.current.configuration.getString("airbrake.environment")></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/routes.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
-        <script type="text/javascript" src="@routes.Assets.at("bundle/vendor.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script type="text/javascript" src="@routes.Assets.at("bundle/main.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     @if(play.api.Play.current.mode == play.api.Mode.Dev) {
       <link href='@routes.Assets.at("fonts/fonts-local.css")' rel='stylesheet' type='text/css' media="screen">

--- a/app/views/pageSkeleton.scala.html
+++ b/app/views/pageSkeleton.scala.html
@@ -14,7 +14,7 @@
       data-airbrake-environment-name=@play.api.Play.current.configuration.getString("airbrake.environment")></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/routes.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script type="text/javascript" src="@routes.Assets.at("bundle/manifest.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
-    <script type="text/javascript" src="@routes.Assets.at("bundle/vendor.js")"></script>
+    <script type="text/javascript" src="@routes.Assets.at("bundle/vendor.js?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script type="text/javascript" src="@routes.Assets.at("bundle/main.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     @if(play.api.Play.current.mode == play.api.Mode.Dev) {
       <link href='@routes.Assets.at("fonts/fonts-local.css")' rel='stylesheet' type='text/css' media="screen">

--- a/app/views/pageSkeleton.scala.html
+++ b/app/views/pageSkeleton.scala.html
@@ -13,6 +13,8 @@
       data-airbrake-project-key=@play.api.Play.current.configuration.getString("airbrake.projectKey")
       data-airbrake-environment-name=@play.api.Play.current.configuration.getString("airbrake.environment")></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/routes.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
+    <script type="text/javascript" src="@routes.Assets.at("bundle/manifest.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
+    <script type="text/javascript" src="@routes.Assets.at("bundle/vendor.js")"></script>
     <script type="text/javascript" src="@routes.Assets.at("bundle/main.js")?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     @if(play.api.Play.current.mode == play.api.Mode.Dev) {
       <link href='@routes.Assets.at("fonts/fonts-local.css")' rel='stylesheet' type='text/css' media="screen">

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.0.0",
+    "babel-plugin-dynamic-import-webpack": "^1.0.1",
+    "babel-plugin-import": "^1.1.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
@@ -66,8 +68,6 @@
   "dependencies": {
     "airbrake-js": "^0.5.8",
     "antd": "^2.9.3",
-    "babel-plugin-dynamic-import-webpack": "^1.0.1",
-    "babel-plugin-import": "^1.1.0",
     "backbone": "1.3.3",
     "backbone-subviews": "^0.7.4",
     "backbone.marionette": "^3.0.0",
@@ -108,7 +108,6 @@
     "tween.js": "^16.3.1",
     "underscore": "^1.8.3",
     "webcola": "3.3.0",
-    "webpack-bundle-analyzer": "^2.8.2",
     "whatwg-fetch": "^1.1.0"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "wdio-selenium-standalone-service": "0.0.7",
     "wdio-spec-reporter": "0.0.3",
     "webdriverio": "^4.4.0",
-    "webpack": "^2.5.1"
+    "webpack": "^3.0.0"
   },
   "scripts": {
     "test": "export NODE_PATH=app/assets/javascripts && BABEL_ENV=test ava --timeout=30s",
@@ -107,6 +107,7 @@
     "tween.js": "^16.3.1",
     "underscore": "^1.8.3",
     "webcola": "3.3.0",
+    "webpack-bundle-analyzer": "^2.8.2",
     "whatwg-fetch": "^1.1.0"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "airbrake-js": "^0.5.8",
     "antd": "^2.9.3",
+    "babel-plugin-dynamic-import-webpack": "^1.0.1",
     "babel-plugin-import": "^1.1.0",
     "backbone": "1.3.3",
     "backbone-subviews": "^0.7.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@ module.exports = function (env = {}) {
   /* eslint no-var:0, import/no-extraneous-dependencies:0 */
   var webpack = require("webpack");
   var ExtractTextPlugin = require("extract-text-webpack-plugin");
-  var BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
   var fs = require("fs");
   var path = require("path");
 
@@ -91,7 +90,6 @@ module.exports = function (env = {}) {
         "window.jQuery": "jquery",
         _: "lodash",
       }),
-      new BundleAnalyzerPlugin(),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       new webpack.optimize.CommonsChunkPlugin({
           name: "vendor",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,6 +88,17 @@ module.exports = function (env = {}) {
       }),
       new BundleAnalyzerPlugin(),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new webpack.optimize.CommonsChunkPlugin({
+          name: 'vendor',
+          minChunks: function (module) {
+             // this assumes your vendor imports exist in the node_modules directory
+             return module.context && module.context.indexOf('node_modules') !== -1;
+          }
+      }),
+      //CommonChunksPlugin will now extract all the common modules from vendor and main bundles
+      new webpack.optimize.CommonsChunkPlugin({
+          name: 'manifest' //But since there are no more common modules between them we end up with just the runtime code included in the manifest file
+      })
     ],
   };
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = function (env = {}) {
       filename: "[name].js",
       sourceMapFilename: "[file].map",
       publicPath: "/assets/bundle/",
-      chunkFilename: env.production ? "[chunkhash].js" : "[id].js",
+      chunkFilename: env.production ? "[chunkhash].js" : "[name].js",
     },
     module: {
       // Reduce compilation time by telling webpack to not parse these libraries.
@@ -36,7 +36,12 @@ module.exports = function (env = {}) {
         {
           test: /\.js$/,
           exclude: /(node_modules|bower_components)/,
-          use: "babel-loader",
+          use: [{
+            loader: "babel-loader",
+            options: {
+              plugins: ["syntax-dynamic-import"],
+            },
+          }],
         },
         {
           test: /\.less$/,
@@ -89,16 +94,16 @@ module.exports = function (env = {}) {
       new BundleAnalyzerPlugin(),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       new webpack.optimize.CommonsChunkPlugin({
-          name: 'vendor',
+          name: "vendor",
           minChunks: function (module) {
              // this assumes your vendor imports exist in the node_modules directory
-             return module.context && module.context.indexOf('node_modules') !== -1;
+             return module.context && module.context.indexOf("node_modules") !== -1;
           }
       }),
       //CommonChunksPlugin will now extract all the common modules from vendor and main bundles
       new webpack.optimize.CommonsChunkPlugin({
-          name: 'manifest' //But since there are no more common modules between them we end up with just the runtime code included in the manifest file
-      })
+          name: "manifest" //But since there are no more common modules between them we end up with just the runtime code included in the manifest file
+      }),
     ],
   };
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ module.exports = function (env = {}) {
   /* eslint no-var:0, import/no-extraneous-dependencies:0 */
   var webpack = require("webpack");
   var ExtractTextPlugin = require("extract-text-webpack-plugin");
+  var BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
   var fs = require("fs");
   var path = require("path");
 
@@ -17,6 +18,7 @@ module.exports = function (env = {}) {
   return {
     entry: {
       main: "main.js",
+      vendor: ["c3", "d3", "moment"],
     },
     output: {
       path: `${__dirname}/public/bundle`,
@@ -83,7 +85,17 @@ module.exports = function (env = {}) {
         $: "jquery",
         jQuery: "jquery",
         "window.jQuery": "jquery",
-        _: "lodash",
+        _: "lodash"
+      }),
+      new BundleAnalyzerPlugin(),
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new webpack.optimize.CommonsChunkPlugin({
+        name: "vendor",
+        chunks: ["vendor"],
+        async: 'used-twice',
+        minChunks(module, count) {
+          return count >= 2;
+        },
       }),
     ],
   };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,12 +35,7 @@ module.exports = function (env = {}) {
         {
           test: /\.js$/,
           exclude: /(node_modules|bower_components)/,
-          use: [{
-            loader: "babel-loader",
-            options: {
-              plugins: ["syntax-dynamic-import"],
-            },
-          }],
+          use: "babel-loader",
         },
         {
           test: /\.less$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,6 @@ module.exports = function (env = {}) {
   return {
     entry: {
       main: "main.js",
-      vendor: ["c3", "d3", "moment"],
     },
     output: {
       path: `${__dirname}/public/bundle`,
@@ -85,18 +84,10 @@ module.exports = function (env = {}) {
         $: "jquery",
         jQuery: "jquery",
         "window.jQuery": "jquery",
-        _: "lodash"
+        _: "lodash",
       }),
       new BundleAnalyzerPlugin(),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-      new webpack.optimize.CommonsChunkPlugin({
-        name: "vendor",
-        chunks: ["vendor"],
-        async: 'used-twice',
-        minChunks(module, count) {
-          return count >= 2;
-        },
-      }),
     ],
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,6 +732,13 @@ babel-plugin-check-es2015-constants@^6.22.0, babel-plugin-check-es2015-constants
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-webpack@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-webpack/-/babel-plugin-dynamic-import-webpack-1.0.1.tgz#26c24a1c1c9bf49184b30d5867562a4cbfa530d1"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.16.0"
+
 babel-plugin-espower@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz#5516b8fcdb26c9f0e1d8160749f6e4c65e71271e"
@@ -1299,7 +1306,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtim
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.24.1, babel-template@^6.3.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.3.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,13 +48,6 @@ abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
 
-accepts@~1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca"
-  dependencies:
-    mime-types "~2.1.11"
-    negotiator "0.6.1"
-
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -75,7 +68,7 @@ acorn@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
-acorn@^5.0.0, acorn@^5.0.1, acorn@^5.0.3:
+acorn@^5.0.0, acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
@@ -288,10 +281,6 @@ array-find-index@^1.0.1:
 array-find@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
-
-array-flatten@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
 array-iterate@^1.0.0:
   version "1.1.0"
@@ -2017,14 +2006,6 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
-content-disposition@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
-
-content-type@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
-
 continuable-cache@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
@@ -2036,14 +2017,6 @@ convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.2.0:
 convert-to-spaces@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715"
-
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
-
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
 core-assert@^0.2.0:
   version "0.2.1"
@@ -2310,12 +2283,6 @@ debug@2.2.0, debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
-  dependencies:
-    ms "2.0.0"
-
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
@@ -2381,20 +2348,12 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.0, depd@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
-
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
-
-destroy@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
 detab@^2.0.0:
   version "2.0.0"
@@ -2562,10 +2521,6 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
-duplexer@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
-
 duplexify@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.0.tgz#1aa773002e1578457e9d9d4a50b0ccaaebcbd604"
@@ -2585,11 +2540,7 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-ee-first@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
-
-ejs@^2.5.6, ejs@~2.5.6:
+ejs@~2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
 
@@ -2623,10 +2574,6 @@ empower-core@^0.6.1:
   dependencies:
     call-signature "0.0.2"
     core-js "^2.0.0"
-
-encodeurl@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2760,10 +2707,6 @@ es6-weak-map@^2.0.1:
     es5-ext "^0.10.14"
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
-
-escape-html@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2951,10 +2894,6 @@ esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-etag@~1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
-
 event-emitter@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
@@ -3025,39 +2964,6 @@ exports-loader@^0.6.4:
   dependencies:
     loader-utils "^1.0.2"
     source-map "0.5.x"
-
-express@^4.15.2:
-  version "4.15.3"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
-  dependencies:
-    accepts "~1.3.3"
-    array-flatten "1.1.1"
-    content-disposition "0.5.2"
-    content-type "~1.0.2"
-    cookie "0.3.1"
-    cookie-signature "1.0.6"
-    debug "2.6.7"
-    depd "~1.1.0"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    etag "~1.8.0"
-    finalhandler "~1.0.3"
-    fresh "0.5.0"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.1"
-    path-to-regexp "0.1.7"
-    proxy-addr "~1.1.4"
-    qs "6.4.0"
-    range-parser "~1.2.0"
-    send "0.15.3"
-    serve-static "1.12.3"
-    setprototypeof "1.0.3"
-    statuses "~1.3.1"
-    type-is "~1.6.15"
-    utils-merge "1.0.0"
-    vary "~1.1.1"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -3164,10 +3070,6 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
-filesize@^3.5.9:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
-
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -3177,18 +3079,6 @@ fill-range@^2.1.0:
     randomatic "^1.1.3"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
-
-finalhandler@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
-  dependencies:
-    debug "2.6.7"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    on-finished "~2.3.0"
-    parseurl "~1.3.1"
-    statuses "~1.3.1"
-    unpipe "~1.0.0"
 
 find-cache-dir@^0.1.1:
   version "0.1.1"
@@ -3294,14 +3184,6 @@ formatio@1.1.1:
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
   dependencies:
     samsam "~1.1"
-
-forwarded@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
-
-fresh@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
 fs-extra@^0.30.0:
   version "0.30.0"
@@ -3566,12 +3448,6 @@ gulp-sourcemaps@1.6.0:
     through2 "^2.0.0"
     vinyl "^1.0.0"
 
-gzip-size@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
-  dependencies:
-    duplexer "^0.1.1"
-
 hammerjs@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
@@ -3720,15 +3596,6 @@ html-void-elements@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.1.tgz#f929bea267a19e3535950502ca12c159f1b559af"
 
-http-errors@~1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.1.tgz#5f8b8ed98aca545656bf572997387f904a722257"
-  dependencies:
-    depd "1.1.0"
-    inherits "2.0.3"
-    setprototypeof "1.0.3"
-    statuses ">= 1.3.1 < 2"
-
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -3837,7 +3704,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -3898,10 +3765,6 @@ invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
-
-ipaddr.js@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
 irregular-plurals@^1.0.0:
   version "1.2.0"
@@ -4651,7 +4514,7 @@ lodash@3.9.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.9.3.tgz#0159e86832feffc6d61d852b12a953b99496bd32"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.5, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4802,10 +4665,6 @@ mdast-util-toc@^2.0.0:
     mdast-util-to-string "^1.0.2"
     unist-util-visit "^1.1.0"
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-
 memory-fs@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
@@ -4832,19 +4691,11 @@ meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
-merge-descriptors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-
 merge-stream@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
   dependencies:
     readable-stream "^2.0.1"
-
-methods@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
 micromatch@^2.1.5, micromatch@^2.1.6, micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
@@ -4875,15 +4726,11 @@ mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
-
-mime@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 mime@1.3.x, mime@^1.2.11, mime@^1.3.4:
   version "1.3.6"
@@ -5006,10 +4853,6 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-negotiator@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
 node-fetch@^1.0.1:
   version "1.6.3"
@@ -5204,12 +5047,6 @@ omit.js@^0.1.0:
   dependencies:
     object-assign "^4.1.0"
 
-on-finished@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
-  dependencies:
-    ee-first "1.1.1"
-
 once@^1.3.0, once@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -5231,10 +5068,6 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
-
-opener@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 optimist@~0.6.1:
   version "0.6.1"
@@ -5414,10 +5247,6 @@ parse-url@^1.3.0:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
-parseurl@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
-
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -5469,10 +5298,6 @@ path-root@^0.1.1:
   resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
   dependencies:
     path-root-regex "^0.1.0"
-
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -5870,13 +5695,6 @@ protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.5.tgz#21de1f441c4ef7094408ed9f1c94f7a114b87557"
 
-proxy-addr@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
-  dependencies:
-    forwarded "~0.1.0"
-    ipaddr.js "1.3.0"
-
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -5907,7 +5725,7 @@ q@^1.1.2, q@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@6.4.0, qs@^6.4.0, qs@~6.4.0:
+qs@^6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
@@ -5940,10 +5758,6 @@ randomatic@^1.1.3:
 randombytes@^2.0.0, randombytes@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
-
-range-parser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 raw-body@~1.1.0:
   version "1.1.7"
@@ -6867,33 +6681,6 @@ semver-diff@^2.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-send@0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.15.3.tgz#5013f9f99023df50d1bd9892c19e3defd1d53309"
-  dependencies:
-    debug "2.6.7"
-    depd "~1.1.0"
-    destroy "~1.0.4"
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    etag "~1.8.0"
-    fresh "0.5.0"
-    http-errors "~1.6.1"
-    mime "1.3.4"
-    ms "2.0.0"
-    on-finished "~2.3.0"
-    range-parser "~1.2.0"
-    statuses "~1.3.1"
-
-serve-static@1.12.3:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.3.tgz#9f4ba19e2f3030c547f8af99107838ec38d5b1e2"
-  dependencies:
-    encodeurl "~1.0.1"
-    escape-html "~1.0.3"
-    parseurl "~1.3.1"
-    send "0.15.3"
-
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -6905,10 +6692,6 @@ set-immediate-shim@^1.0.1:
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-
-setprototypeof@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.8"
@@ -7068,10 +6851,6 @@ state-toggle@^1.0.0:
 stats.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stats.js/-/stats.js-1.0.0.tgz#ca304e56b116a3f46413acc349eb6eee19df688e"
-
-"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
 stream-array@^1.1.0:
   version "1.1.2"
@@ -7467,13 +7246,6 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.15:
-  version "1.6.15"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.15"
-
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -7510,10 +7282,6 @@ uid-number@^0.0.6:
 uid2@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
-
-ultron@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"
@@ -7618,10 +7386,6 @@ unist-util-visit@^1.0.0, unist-util-visit@^1.0.1, unist-util-visit@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.1.1.tgz#e917a3b137658b335cb4420c7da2e74d928e4e94"
 
-unpipe@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
-
 unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
@@ -7687,10 +7451,6 @@ util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
-utils-merge@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
-
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
@@ -7715,10 +7475,6 @@ validate-npm-package-license@^3.0.1:
 validator@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-7.0.0.tgz#c74deb8063512fac35547938e6f0b1504a282fd2"
-
-vary@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 
 vendors@^1.0.0:
   version "1.0.1"
@@ -7901,22 +7657,6 @@ webdriverio@^4.4.0:
     wdio-dot-reporter "~0.0.8"
     wgxpath "~1.0.0"
 
-webpack-bundle-analyzer@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.8.2.tgz#8b6240c29a9d63bc72f09d920fb050adbcce9fe8"
-  dependencies:
-    acorn "^5.0.3"
-    chalk "^1.1.3"
-    commander "^2.9.0"
-    ejs "^2.5.6"
-    express "^4.15.2"
-    filesize "^3.5.9"
-    gzip-size "^3.0.0"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    opener "^1.4.3"
-    ws "^2.3.1"
-
 webpack-sources@^0.1.0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.5.tgz#aa1f3abf0f0d74db7111c40e500b84f966640750"
@@ -8077,13 +7817,6 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
-
-ws@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
-  dependencies:
-    safe-buffer "~5.0.1"
-    ultron "~1.1.0"
 
 x-is-function@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,13 @@ abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
 
+accepts@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca"
+  dependencies:
+    mime-types "~2.1.11"
+    negotiator "0.6.1"
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -68,7 +75,7 @@ acorn@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
-acorn@^5.0.0, acorn@^5.0.1:
+acorn@^5.0.0, acorn@^5.0.1, acorn@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
@@ -82,15 +89,28 @@ airbrake-js@^0.5.8:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/airbrake-js/-/airbrake-js-0.5.9.tgz#f63aa98c412601694694ff003a4c571154cfb4e6"
 
-ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
+ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+
+ajv-keywords@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
 
 ajv@^4.11.2, ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
     co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
+ajv@^5.1.5:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.0.tgz#c1735024c5da2ef75cc190713073d44f098bf486"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^0.1.0"
+    json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
@@ -268,6 +288,10 @@ array-find-index@^1.0.1:
 array-find@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
 array-iterate@^1.0.0:
   version "1.1.0"
@@ -1986,6 +2010,14 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+
+content-type@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
+
 continuable-cache@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
@@ -1997,6 +2029,14 @@ convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.2.0:
 convert-to-spaces@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz#7e3e48bbe6d997b1417ddca2868204b4d3d85715"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
 core-assert@^0.2.0:
   version "0.2.1"
@@ -2263,6 +2303,12 @@ debug@2.2.0, debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
+debug@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
@@ -2328,12 +2374,20 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+depd@1.1.0, depd@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
 detab@^2.0.0:
   version "2.0.0"
@@ -2501,6 +2555,10 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+
 duplexify@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.0.tgz#1aa773002e1578457e9d9d4a50b0ccaaebcbd604"
@@ -2520,7 +2578,11 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-ejs@~2.5.6:
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+ejs@^2.5.6, ejs@~2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
 
@@ -2554,6 +2616,10 @@ empower-core@^0.6.1:
   dependencies:
     call-signature "0.0.2"
     core-js "^2.0.0"
+
+encodeurl@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2687,6 +2753,10 @@ es6-weak-map@^2.0.1:
     es5-ext "^0.10.14"
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2874,6 +2944,10 @@ esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+etag@~1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
+
 event-emitter@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
@@ -2945,6 +3019,39 @@ exports-loader@^0.6.4:
     loader-utils "^1.0.2"
     source-map "0.5.x"
 
+express@^4.15.2:
+  version "4.15.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
+  dependencies:
+    accepts "~1.3.3"
+    array-flatten "1.1.1"
+    content-disposition "0.5.2"
+    content-type "~1.0.2"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.7"
+    depd "~1.1.0"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.0"
+    finalhandler "~1.0.3"
+    fresh "0.5.0"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.1"
+    path-to-regexp "0.1.7"
+    proxy-addr "~1.1.4"
+    qs "6.4.0"
+    range-parser "~1.2.0"
+    send "0.15.3"
+    serve-static "1.12.3"
+    setprototypeof "1.0.3"
+    statuses "~1.3.1"
+    type-is "~1.6.15"
+    utils-merge "1.0.0"
+    vary "~1.1.1"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -2979,6 +3086,10 @@ extract-text-webpack-plugin@^2.1.0:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-deep-equal@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz#5c6f4599aba6b333ee3342e2ed978672f1001f8d"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -3046,6 +3157,10 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
+filesize@^3.5.9:
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.10.tgz#fc8fa23ddb4ef9e5e0ab6e1e64f679a24a56761f"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -3055,6 +3170,18 @@ fill-range@^2.1.0:
     randomatic "^1.1.3"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
+
+finalhandler@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
+  dependencies:
+    debug "2.6.7"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.1"
+    statuses "~1.3.1"
+    unpipe "~1.0.0"
 
 find-cache-dir@^0.1.1:
   version "0.1.1"
@@ -3160,6 +3287,14 @@ formatio@1.1.1:
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
   dependencies:
     samsam "~1.1"
+
+forwarded@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
+
+fresh@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
 fs-extra@^0.30.0:
   version "0.30.0"
@@ -3424,6 +3559,12 @@ gulp-sourcemaps@1.6.0:
     through2 "^2.0.0"
     vinyl "^1.0.0"
 
+gzip-size@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+  dependencies:
+    duplexer "^0.1.1"
+
 hammerjs@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
@@ -3572,6 +3713,15 @@ html-void-elements@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.1.tgz#f929bea267a19e3535950502ca12c159f1b559af"
 
+http-errors@~1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.1.tgz#5f8b8ed98aca545656bf572997387f904a722257"
+  dependencies:
+    depd "1.1.0"
+    inherits "2.0.3"
+    setprototypeof "1.0.3"
+    statuses ">= 1.3.1 < 2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -3680,7 +3830,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -3741,6 +3891,10 @@ invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+ipaddr.js@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
 irregular-plurals@^1.0.0:
   version "1.2.0"
@@ -4185,6 +4339,10 @@ json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
 
+json-schema-traverse@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.0.tgz#0016c0b1ca1efe46d44d37541bcdfc19dcfae0db"
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -4349,7 +4507,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.16, loader-utils@^0.2.5:
+loader-utils@^0.2.5:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -4358,7 +4516,7 @@ loader-utils@^0.2.16, loader-utils@^0.2.5:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2:
+loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -4486,7 +4644,7 @@ lodash@3.9.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.9.3.tgz#0159e86832feffc6d61d852b12a953b99496bd32"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.5, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4637,6 +4795,10 @@ mdast-util-toc@^2.0.0:
     mdast-util-to-string "^1.0.2"
     unist-util-visit "^1.1.0"
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
 memory-fs@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
@@ -4663,11 +4825,19 @@ meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
 merge-stream@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
   dependencies:
     readable-stream "^2.0.1"
+
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
 micromatch@^2.1.5, micromatch@^2.1.6, micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
@@ -4698,11 +4868,15 @@ mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-types@^2.1.12, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
+
+mime@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 mime@1.3.x, mime@^1.2.11, mime@^1.3.4:
   version "1.3.6"
@@ -4825,6 +4999,10 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+negotiator@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
 node-fetch@^1.0.1:
   version "1.6.3"
@@ -5019,6 +5197,12 @@ omit.js@^0.1.0:
   dependencies:
     object-assign "^4.1.0"
 
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  dependencies:
+    ee-first "1.1.1"
+
 once@^1.3.0, once@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -5040,6 +5224,10 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
+
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 optimist@~0.6.1:
   version "0.6.1"
@@ -5219,6 +5407,10 @@ parse-url@^1.3.0:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
+parseurl@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -5270,6 +5462,10 @@ path-root@^0.1.1:
   resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
   dependencies:
     path-root-regex "^0.1.0"
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -5667,6 +5863,13 @@ protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.5.tgz#21de1f441c4ef7094408ed9f1c94f7a114b87557"
 
+proxy-addr@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
+  dependencies:
+    forwarded "~0.1.0"
+    ipaddr.js "1.3.0"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -5697,7 +5900,7 @@ q@^1.1.2, q@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@^6.4.0, qs@~6.4.0:
+qs@6.4.0, qs@^6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
@@ -5730,6 +5933,10 @@ randomatic@^1.1.3:
 randombytes@^2.0.0, randombytes@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
+
+range-parser@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 raw-body@~1.1.0:
   version "1.1.7"
@@ -6653,6 +6860,33 @@ semver-diff@^2.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+send@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.15.3.tgz#5013f9f99023df50d1bd9892c19e3defd1d53309"
+  dependencies:
+    debug "2.6.7"
+    depd "~1.1.0"
+    destroy "~1.0.4"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.0"
+    fresh "0.5.0"
+    http-errors "~1.6.1"
+    mime "1.3.4"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.3.1"
+
+serve-static@1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.3.tgz#9f4ba19e2f3030c547f8af99107838ec38d5b1e2"
+  dependencies:
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    parseurl "~1.3.1"
+    send "0.15.3"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -6664,6 +6898,10 @@ set-immediate-shim@^1.0.1:
 setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+setprototypeof@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.8"
@@ -6736,9 +6974,9 @@ source-list-map@^0.1.7, source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
-source-list-map@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.2.tgz#9889019d1024cce55cdc069498337ef6186a11a1"
+source-list-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
 source-map-resolve@^0.3.0:
   version "0.3.1"
@@ -6823,6 +7061,10 @@ state-toggle@^1.0.0:
 stats.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stats.js/-/stats.js-1.0.0.tgz#ca304e56b116a3f46413acc349eb6eee19df688e"
+
+"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
 stream-array@^1.1.0:
   version "1.1.2"
@@ -7218,6 +7460,13 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-is@~1.6.15:
+  version "1.6.15"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.15"
+
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -7226,9 +7475,9 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.8.5:
-  version "2.8.27"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"
+uglify-js@^2.8.29:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -7239,6 +7488,14 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
+uglifyjs-webpack-plugin@^0.4.4:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz#b951f4abb6bd617e66f63eb891498e391763e309"
+  dependencies:
+    source-map "^0.5.6"
+    uglify-js "^2.8.29"
+    webpack-sources "^1.0.1"
+
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
@@ -7246,6 +7503,10 @@ uid-number@^0.0.6:
 uid2@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
+
+ultron@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
 
 unc-path-regex@^0.1.0:
   version "0.1.2"
@@ -7350,6 +7611,10 @@ unist-util-visit@^1.0.0, unist-util-visit@^1.0.1, unist-util-visit@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.1.1.tgz#e917a3b137658b335cb4420c7da2e74d928e4e94"
 
+unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
 unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
@@ -7415,6 +7680,10 @@ util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
+utils-merge@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
+
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
@@ -7439,6 +7708,10 @@ validate-npm-package-license@^3.0.1:
 validator@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-7.0.0.tgz#c74deb8063512fac35547938e6f0b1504a282fd2"
+
+vary@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 
 vendors@^1.0.0:
   version "1.0.1"
@@ -7621,6 +7894,22 @@ webdriverio@^4.4.0:
     wdio-dot-reporter "~0.0.8"
     wgxpath "~1.0.0"
 
+webpack-bundle-analyzer@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.8.2.tgz#8b6240c29a9d63bc72f09d920fb050adbcce9fe8"
+  dependencies:
+    acorn "^5.0.3"
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    ejs "^2.5.6"
+    express "^4.15.2"
+    filesize "^3.5.9"
+    gzip-size "^3.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    opener "^1.4.3"
+    ws "^2.3.1"
+
 webpack-sources@^0.1.0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.5.tgz#aa1f3abf0f0d74db7111c40e500b84f966640750"
@@ -7628,37 +7917,38 @@ webpack-sources@^0.1.0:
     source-list-map "~0.1.7"
     source-map "~0.5.3"
 
-webpack-sources@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.2.3.tgz#17c62bfaf13c707f9d02c479e0dcdde8380697fb"
+webpack-sources@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.1.tgz#c7356436a4d13123be2e2426a05d1dad9cbe65cf"
   dependencies:
-    source-list-map "^1.1.1"
+    source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.5.1.tgz#61742f0cf8af555b87460a9cd8bba2f1e3ee2fce"
+webpack@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.0.0.tgz#ee9bcebf21247f7153cb410168cab45e3a59d4d7"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
-    ajv "^4.7.0"
-    ajv-keywords "^1.1.1"
+    ajv "^5.1.5"
+    ajv-keywords "^2.0.0"
     async "^2.1.2"
     enhanced-resolve "^3.0.0"
+    escope "^3.6.0"
     interpret "^1.0.0"
     json-loader "^0.5.4"
     json5 "^0.5.1"
     loader-runner "^2.3.0"
-    loader-utils "^0.2.16"
+    loader-utils "^1.1.0"
     memory-fs "~0.4.1"
     mkdirp "~0.5.0"
     node-libs-browser "^2.0.0"
     source-map "^0.5.3"
     supports-color "^3.1.0"
     tapable "~0.2.5"
-    uglify-js "^2.8.5"
+    uglifyjs-webpack-plugin "^0.4.4"
     watchpack "^1.3.1"
-    webpack-sources "^0.2.3"
+    webpack-sources "^1.0.1"
     yargs "^6.0.0"
 
 websocket-driver@>=0.5.1:
@@ -7780,6 +8070,13 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+ws@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
+  dependencies:
+    safe-buffer "~5.0.1"
+    ultron "~1.1.0"
 
 x-is-function@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Changes:
- Updates Webpack to version 3.0 [See](https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b)
- Cleaned up webpack chunks. Instead of many different chunks for each dynamic admin module there should be only 4 modules now:
  - `main.js` chunk: includes all the oxalis tracing code
  -  `admin.js` chunk: includes all admin views + a few node_modules (ace editor, bootstrap ui components)
  - `vendor.js` chunk: includes almost all node_modules / external libs
  - `manifest.js` chunk: includes on the webpack runtime. This chunk +  `vendor` is recommended by the webpack website. [See](https://webpack.js.org/guides/code-splitting-libraries/#implicit-common-vendor-chunk)
- removed all `locales` from `momentjs` to save space. We don't need support for multiple languages / cultures.

- refactored `router` to use dynamic imports using the new standard `import()` function + magic comments for chunk renaming. [See](https://webpack.js.org/guides/code-splitting-async/#dynamic-import-import-).

Overall, the whole chunking changes have some nice benefits:
- Webpack compile time went down from 36s to 31s
- Reduced complete size of all chunks from 17MB to 10MB
- Bundling only the oxalis code files in one chunk, slims down the chunk to 28k LOC instead of 68k lines when including dependencies in the same chunk. Hopefully this helps with source maps, interpretation/compile time etc.

Before:
<img width="800" alt="screen shot 2017-06-22 at 20 07 07" src="https://user-images.githubusercontent.com/1105056/27482243-fbfa7258-5820-11e7-9482-92749cfd178b.png">

After:
<img width="800" alt="screen shot 2017-06-23 at 14 12 44" src="https://user-images.githubusercontent.com/1105056/27482247-fd41ffa0-5820-11e7-97fe-79ad2be40538.png">

------
- [x] Ready for review
