### PR TITLE
Improve test-speed for development by factor 6

### DIFF
--- a/buildtools/test.sh
+++ b/buildtools/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# For some reason this is necessary so that ava picks up the right files
+cd public
+
+testBundlePath="./test-bundle"
+jsPath="../app/assets/javascripts"
+
+cmd=$1
+shift;
+
+if [ $cmd == "test" ]
+then
+	lastChangedSource=$(find $jsPath -type f -printf '%T@ %p \n' | sort -n | tail -1 | awk -F'.' '{print $1}')
+	lastChangedTests=$(find $testBundlePath -type f -printf '%T@ %p \n' | sort -n | tail -1 | awk -F'.' '{print $1}')
+
+	if [ $lastChangedSource -gt $lastChangedTests ]
+	then
+		echo "Please run yarn test-prepare. The source files seem to be newer than the compiled ones."
+		exit 1
+	fi
+	
+	export NODE_PATH=$testBundlePath && BABEL_ENV=test ava $testBundlePath/test/**/*.spec.js -c 8 "$@"
+elif [ $cmd == "prepare" ]
+then
+	rm -rf $testBundlePath && BABEL_ENV=test babel $jsPath --out-dir $testBundlePath "$@"
+else
+	echo "Unknown command"
+fi

--- a/package.json
+++ b/package.json
@@ -52,10 +52,14 @@
     "webpack": "^2.5.1"
   },
   "scripts": {
-    "test": "export NODE_PATH=app/assets/javascripts && BABEL_ENV=test ava --timeout=30s",
-    "test-verbose": "export NODE_PATH=app/assets/javascripts && BABEL_ENV=test ava --timeout=60s --verbose",
-    "test-watch": "export NODE_PATH=app/assets/javascripts && BABEL_ENV=test ava --watch",
+    "test": "buildtools/test.sh prepare -q && buildtools/test.sh test --timeout=30s",
+    "test-verbose": "buildtools/test.sh prepare -q && buildtools/test.sh test --timeout=60s --verbose",
+    "test-only": "buildtools/test.sh test --timeout=30s",
+    "test-watch": "buildtools/test.sh test --watch",
+    "test-prepare": "buildtools/test.sh prepare",
+    "test-prepare-watch": "buildtools/test.sh prepare -w",
     "test-e2e": "node_modules/.bin/wdio wdio.conf.js",
+    "test-help": "echo For development it is recommended to run yarn test-prepare-watch in one terminal and yarn test-watch in another. This is the fastest way to perform incremental testing. If you are only interested in running test once, use yarn test.",
     "flow": "node_modules/.bin/flow",
     "flow-check": "node_modules/.bin/flow check",
     "lint": "node_modules/.bin/eslint --quiet app/assets/javascripts/",
@@ -111,18 +115,15 @@
   },
   "ava": {
     "files": [
-      "app/assets/javascripts/test/**/*.spec.js"
+      "./public/test-bundle/test/**/*.spec.js"
     ],
     "source": [
-      "app/assets/javascripts/**/*.{js,jsx}"
+      "./public/test-bundle/**/*.{js,jsx}"
     ],
     "modules": true,
     "failFast": true,
     "failWithoutAssertions": false,
-    "babel": "inherit",
     "powerAssert": true,
-    "require": [
-      "babel-register"
-    ]
+    "require": []
   }
 }


### PR DESCRIPTION
### Steps to test:
- Start `test-prepare-watch` and `test-watch` in two separate terminals, change some files, and watch the tests cracking like lightning through the night

Initial compilation time takes 15 seconds on my machine. For development, this has to be done only once (other builds are incremental). Initial testing takes 5 seconds (incremental tests are usually done in sub-seconds).
Running the usual `yarn test` takes < 20 seconds.