### PR TITLE
add public/test-bundle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ src/main/scala/rebel.xml
 public/bower_components
 public/bundle
 public/test-bundle
+public/docs
 public/commit.txt
 /knowledge
 conf/github.conf

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ src/main/scala/rebel.xml
 *.mtl
 public/bower_components
 public/bundle
+public/test-bundle
 public/commit.txt
 /knowledge
 conf/github.conf


### PR DESCRIPTION
Since tests are compiled into public/test-bundle, this folder should by ignored by VCS.
------
- [X] Ready for review
