### PR TITLE
fix api getDataValue for already requested buckets (#1893)

### DIFF
--- a/app/assets/javascripts/oxalis/model/binary/bucket.js
+++ b/app/assets/javascripts/oxalis/model/binary/bucket.js
@@ -66,6 +66,11 @@ export class DataBucket {
   }
 
 
+  isRequested(): boolean {
+    return this.state === BucketStateEnum.REQUESTED;
+  }
+
+
   isLoaded(): boolean {
     return this.state === BucketStateEnum.LOADED;
   }

--- a/app/assets/javascripts/test/api/api_skeleton_latest.spec.js
+++ b/app/assets/javascripts/test/api/api_skeleton_latest.spec.js
@@ -88,9 +88,9 @@ test("Data Api: getBoundingBox should get the bounding box of a layer", (t) => {
   t.deepEqual(boundingBox, correctBoundingBox);
 });
 
-test("Data Api: getDataValue should throw an error if the layer name is not valid", (t) => {
+test("Data Api: getDataValue should throw an error if the layer name is not valid", async (t) => {
   const api = t.context.api;
-  t.throws(() => api.data.getDataValue("nonExistingLayer", [1, 2, 3]));
+  await t.throws(api.data.getDataValue("nonExistingLayer", [1, 2, 3]));
 });
 
 test("Data Api: getDataValue should get the data value for a layer, position and zoomstep", (t) => {


### PR DESCRIPTION
### Steps to test:
```
webknossos.apiReady(2).then(async (api) => {
  const seedPos = [3896, 4270, 2551];
  api.data.getDataValue("segmentation", seedPos).then(id => console.log(`First id: ${id}`));
  api.data.getDataValue("segmentation", seedPos).then(id => console.log(`Second id: ${id}`));
})
```

Use this script with a position where segmentation data exists, but has not loaded yet. This should log the correct segmentId for both calls to getDataValue. Before the bugfix, the second call to getDataValue resulted in the segmentId `0`, as the corresponding bucket was requested but not received yet.

### Issues:
- fixes #1893

------
- [x] Ready for review
