### PR TITLE
hide inactive users in user selection lists (#1903)

### DIFF
--- a/app/assets/javascripts/admin/views/project/project_create_view.js
+++ b/app/assets/javascripts/admin/views/project/project_create_view.js
@@ -184,6 +184,7 @@ class ProjectCreateView extends Marionette.View {
         modelValue() { return this.model.id; },
         modelLabel() { return `${this.model.get("lastName")}, ${this.model.get("firstName")} (${this.model.get("email")})`; },
       },
+      filter: model => model.get("isActive"),
       name: "owner",
       data: "isAdmin=true",
     });

--- a/app/assets/javascripts/admin/views/scripts/script_create_view.js
+++ b/app/assets/javascripts/admin/views/scripts/script_create_view.js
@@ -102,6 +102,7 @@ class ScriptCreateView extends Marionette.View {
         modelLabel() { return `${this.model.get("lastName")}, ${this.model.get("firstName")} (${this.model.get("email")})`; },
         defaultItem: { id: defaultUserId },
       },
+      filter: model => model.get("isActive"),
       name: "ownerId",
       data: "isAdmin=true",
     });

--- a/app/assets/javascripts/dashboard/views/task_transfer_modal_view.js
+++ b/app/assets/javascripts/dashboard/views/task_transfer_modal_view.js
@@ -48,6 +48,7 @@ class TaskTransferModalView extends ModalView {
       childViewOptions: {
         modelValue() { return `${this.model.get("lastName")}, ${this.model.get("firstName")} (${this.model.get("email")})`; },
       },
+      filter: model => model.get("isActive"),
     });
     this.showChildView("datalist", selectionView);
 


### PR DESCRIPTION
### Mailable description of changes (needs to be understandable by webknossos mailing list people):
- Hide inactive users in user selection dropdowns

### Steps to test:
- Deactivate a user, check whether the user is no longer appearing in the transfer task modal, project create and script create user list dropdowns

### Issues:
- fixes #1903

------
- [x] Ready for review
