### PR TITLE
Add camera position to API

### DIFF
--- a/app/assets/javascripts/oxalis/api/api_latest.js
+++ b/app/assets/javascripts/oxalis/api/api_latest.js
@@ -325,6 +325,16 @@ class TracingApi {
     .start();
   }
 
+  /**
+   * Returns the current camera position.
+   *
+   * @example
+   * const currentPosition = api.tracing.getPosition()
+   */
+  getCameraPosition(): Vector3 {
+    return getPosition(Store.getState().flycam);
+  }
+
   //  VOLUMETRACING API
 
  /**

--- a/app/assets/javascripts/test/api/api_skeleton_latest.spec.js
+++ b/app/assets/javascripts/test/api/api_skeleton_latest.spec.js
@@ -54,6 +54,11 @@ test("setCommentForNode should throw an error if the supplied nodeId doesn't exi
   t.throws(() => api.tracing.setCommentForNode("another comment", 4));
 });
 
+test("getCameraPosition should return the current camera position", (t) => {
+  const api = t.context.api;
+  const cameraPosition = api.tracing.getCameraPosition();
+  t.deepEqual(cameraPosition, [1, 2, 3]);
+});
 
 test("Data Api: getLayerNames should get an array of all layer names", (t) => {
   const api = t.context.api;


### PR DESCRIPTION
Manuel / Heiko asked for access to the current camera position through the API. I wonder whether we should expose the rotation as well? Or have combined method `getCamera`?


### Mailable description of changes (needs to be understandable by webknossos mailing list people):
- Manuel / Heiko asked for access to the current camera position through the API

### Steps to test:
- run `yarn test`

------
- [x] Ready for review
