### PR TITLE
Don't show zoom step warning if segmentation opacity is 0

### DIFF
--- a/app/assets/javascripts/oxalis/model.js
+++ b/app/assets/javascripts/oxalis/model.js
@@ -315,7 +315,12 @@ export class OxalisModel {
   }
 
   shouldDisplaySegmentationData(): boolean {
+    const segmentationOpacity = Store.getState().datasetConfiguration.segmentationOpacity;
+    if (segmentationOpacity === 0) {
+      return false;
+    }
     const currentViewMode = Store.getState().temporaryConfiguration.viewMode;
+
     // Currently segmentation data can only be displayed in orthogonal and volume mode
     const canModeDisplaySegmentationData = constants.MODES_PLANE.includes(currentViewMode);
     return this.getSegmentationBinary() != null && canModeDisplaySegmentationData;


### PR DESCRIPTION
### Mailable description of changes (needs to be understandable by webknossos mailing list people):
- There will be no segmentation zoom warning anymore, if the segmentation opacity is set to 0 anyway.

### Steps to test:
- Set segmentation opacity to 0 and zoom out so that the warning would appear normally.

------
- [X] Ready for review
