### PR TITLE
Add login to navbar if logged out

### DIFF
--- a/app/assets/javascripts/dashboard/views/spotlight/spotlight_view.js
+++ b/app/assets/javascripts/dashboard/views/spotlight/spotlight_view.js
@@ -15,6 +15,9 @@ class SpotlightView extends Marionette.View {
   </div>
   <div id="pagination"></div>
   <div id="datasets" class="container wide"></div>
+  <div id="spotlight-footnote">
+    Visit <a href="https://www.webknossos.org/">webknossos.org</a> to learn more about webKnossos.
+  </div>
 </div>
 <div id="credits"></div>\
 `);
@@ -36,15 +39,18 @@ class SpotlightView extends Marionette.View {
     this.collection.fetch({ data: "isActive=true" });
     this.listenTo(this.collection, "sync", function () {
       this.listenTo(this, "render", this.show);
-      return this.show();
+      this.show();
     });
   }
 
 
   show() {
-    this.showChildView("pagination", this.paginationView);
-    this.showChildView("datasets", this.spotlightDatasetListView);
-    return this.showChildView("credits", this.creditsView);
+    // Do not show the pagination and search bar if there are no datasets
+    if (this.collection.length) {
+      this.showChildView("pagination", this.paginationView);
+      this.showChildView("datasets", this.spotlightDatasetListView);
+    }
+    this.showChildView("credits", this.creditsView);
   }
 }
 SpotlightView.initClass();

--- a/app/assets/javascripts/test/pages/register_page.js
+++ b/app/assets/javascripts/test/pages/register_page.js
@@ -1,6 +1,6 @@
 export default class RegisterPage {
 
-  signupButton = "button[type=submit]"
+  signupButton = "#main-container button[type=submit]"
   alertDanger = ".alert-danger"
   modalDescription = "#modalDescription > p"
 

--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -275,6 +275,10 @@ td.nowrap * {
   }
 }
 
+#spotlight-footnote {
+  text-align: center;
+}
+
 #impressum{
   h5{
   margin-top: 2em;

--- a/app/views/mainHeader.scala.html
+++ b/app/views/mainHeader.scala.html
@@ -112,14 +112,13 @@
             </li>
           </ul>
         }.getOrElse {
-          <ul class="nav navbar-nav navbar-right">
-            <li>
-              <a href="@controllers.routes.Authentication.login(None)">Login</a>
-            </li>
-            <li>
-              <a href="@controllers.routes.Authentication.register()">Sign up</a>
-            </li>
-          </ul>
+            <a href="@controllers.routes.Authentication.register()" class="btn btn-default navbar-btn navbar-right">Sign up</a>
+            <form action="/auth/login" method="POST" class="navbar-form navbar-right">
+              <input type="email" id="email" name="email" placeholder="Email" class="form-control">
+              <input type="password" id="password" name="password" placeholder="Password" class="form-control">
+              <button type="submit" class="form-control btn btn-primary">Login</button>
+              <input type="hidden" name="redirect" value="">
+            </form>
         }
       </div>
     </div>


### PR DESCRIPTION
This PR add a login form to the navigation bar when logged out. This makes it possible to login directly from the spotlight page (and any other page). Should an error occur while logging in, the user is redirected to the original login page, where the error is then displayed. Unfortunately on the original login page, there are now two login forms (navbar and original login form), I would've liked to hide the navbar form on that route, but my Scala template skills were not sufficient.
This PR also adds a link to webknossos.org to the spotlight page as requested in internal communication.

### Mailable description of changes (needs to be understandable by webknossos mailing list people):
- Added the possibility to login from everywhere when logged out by adding a login form to the navigation bar.

### Steps to test:
- In `conf/application.conf` set `enableDevAutoLogin` to `false`
- Logout, and go to `/spotlight`, login from there with valid/invalid credentials.

### Issues:
- fixes #1914 

------
- [x] Ready for review
