### PR TITLE
Adds scriptId to bulk task creation

### DIFF
--- a/app/assets/javascripts/admin/views/scripts/script_list_item_view.js
+++ b/app/assets/javascripts/admin/views/scripts/script_list_item_view.js
@@ -6,6 +6,7 @@ class ScriptListItemView extends Marionette.View {
   static initClass() {
     this.prototype.tagName = "tr";
     this.prototype.template = _.template(`\
+    <td class="monospace-id"><%- id %></td>
     <td><%- name %></td>
     <td><%- owner.firstName %> <%- owner.lastName %></td>
     <td><a href="<%- gist %>" target="_blank"><%- gist %></td>\

--- a/app/assets/javascripts/admin/views/scripts/script_list_view.js
+++ b/app/assets/javascripts/admin/views/scripts/script_list_view.js
@@ -16,6 +16,7 @@ class ScriptListView extends Marionette.CompositeView {
 <table class="table table-striped table-details">
   <thead>
     <tr>
+      <th>#</th>
       <th>Name</th>
       <th>Owner</th>
       <th>Gist URL</th>

--- a/app/assets/javascripts/admin/views/task/task_create_subviews/task_create_bulk_import_view.js
+++ b/app/assets/javascripts/admin/views/task/task_create_subviews/task_create_bulk_import_view.js
@@ -18,7 +18,7 @@ class TaskCreateBulkImportView extends Marionette.View {
   <div class="col-sm-12">
     <div class="well">
       One line for each task. The values are seperated by ','. Format: <br>
-      dataSet, <a href="/taskTypes">taskTypeId</a>, experienceDomain, minExperience, x, y, z, rotX, rotY, rotZ, instances, team, minX, minY, minZ, width, height, depth, project<br><br>
+      dataSet, <a href="/taskTypes">taskTypeId</a>, experienceDomain, minExperience, x, y, z, rotX, rotY, rotZ, instances, team, minX, minY, minZ, width, height, depth, project[, <a href="/scripts">scriptId</a>]<br><br>
       <form action="" method="POST" class="form-horizontal" onSubmit="return false;">
         <div class="form-group">
           <div class="col-sm-12">
@@ -199,11 +199,13 @@ class TaskCreateBulkImportView extends Marionette.View {
     const height = parseInt(words[16]);
     const depth = parseInt(words[17]);
     const projectName = words[18];
+    const scriptId = words[19] || null;
 
     return {
       dataSet,
       team,
       taskTypeId,
+      scriptId,
       neededExperience: {
         value: minExperience,
         domain: experienceDomain,

--- a/app/assets/javascripts/admin/views/task/task_create_subviews/task_create_bulk_import_view.js
+++ b/app/assets/javascripts/admin/views/task/task_create_subviews/task_create_bulk_import_view.js
@@ -199,7 +199,7 @@ class TaskCreateBulkImportView extends Marionette.View {
     const height = parseInt(words[16]);
     const depth = parseInt(words[17]);
     const projectName = words[18];
-    const scriptId = words[19] || null;
+    const scriptId = words[19] || undefined;
 
     return {
       dataSet,


### PR DESCRIPTION
### Mailable description of changes
 - Script IDs can be added to tasks in bulk task creation

### Steps to test:
- Create a `test` project
- Assign `test` experience level 10 to SCM Boy
- Create a script, e.g. `mergerMode` https://gist.githubusercontent.com/heikowissler/d5ff5d490ab381af9405c9078096c723
- [Find the id of the script](http://localhost:9000/scripts)
- Find a [taskType](http://localhost:9000/taskTypes)
- Try to create a bulk task with script `2012-09-28_ex145_07x2,<taskTypeId>,test,1,4020,3584,1728,2,0,0,10,Connectomics department,0,0,0,8120,5584,2728,test,<scriptId>`
- Verify that the task has a script attached to it: [with the task id and the network tab](http://localhost:9000/tasks)
- Also try to create a bulk task without script `2012-09-28_ex145_07x2,<taskTypeId>,test,1,4020,3584,1728,2,0,0,10,Connectomics department,0,0,0,8120,5584,2728,test`


### Issues:
- fixes #1917

------
- [x] Ready for review
