### PR TITLE
Change libs version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object Dependencies{
   val akkaVersion = "2.4.1"
   val reactiveVersion = "0.11.13"
   val reactivePlayVersion = "0.11.13-play24"
-  val braingamesVersion = "11.1.1"
+  val braingamesVersion = "11.1.2"
 
   val twelvemonkeysVersion = "3.1.2"
 


### PR DESCRIPTION
### Mailable description of changes
- When reimporting knossos datasets with segmentation layers, their previous boundingBox was not copied from the previous import but reset. This bug is now fixed.

### Steps to test:
- reimport a knossos dataset with segmentation layer
- the suggested new boundingBox should match the previous boundingBox and not be empty

see: https://github.com/scalableminds/braingames-libs/commit/b1eba749463b620b914b356d885eaea877a701e3#diff-05101a0f4305f3c1171c66152b769bb6L24
------
- [x] Ready for review
