### PR TITLE
make tracing view header fixed

### DIFF
--- a/app/assets/javascripts/oxalis/view/tracing_layout_view.js
+++ b/app/assets/javascripts/oxalis/view/tracing_layout_view.js
@@ -77,7 +77,7 @@ class TracingLayoutView extends React.PureComponent {
             />
 
             <Layout className="tracing-layout">
-              <Header>
+              <Header style={{ position: "fixed", width: "100%", zIndex: 210, minHeight: 48 }}>
                 <Button
                   size="large"
                   onClick={this.handleSettingsCollapse}
@@ -88,7 +88,7 @@ class TracingLayoutView extends React.PureComponent {
                 </Button>
                 <ActionBarView />
               </Header>
-              <Layout>
+              <Layout style={{ marginTop: 64 }}>
                 <Sider
                   collapsible
                   trigger={null}


### PR DESCRIPTION
See https://discuss.webknossos.org/t/lock-tracing-options-menu-to-top-of-page/272/3

### Mailable description of changes
 - Tracing View: Locked the action bar to the top of screen while scrolling

### Steps to test:
- Open Tracing
- Scale Viewport large enough to force scroll bars
- Scroll up / down and see action bar stay on top

------
- [x] Ready for review
