### PR TITLE
Improve warnings about segmentation opacity

### DIFF
--- a/app/assets/javascripts/oxalis/controller.js
+++ b/app/assets/javascripts/oxalis/controller.js
@@ -46,7 +46,6 @@ class Controller extends React.PureComponent {
     viewMode: ModeType,
   };
 
-  zoomStepWarningToast: ToastType;
   keyboardNoLoop: InputKeyboardNoLoop;
   stats: Stats;
 
@@ -125,12 +124,6 @@ class Controller extends React.PureComponent {
         app.vent.trigger("rerender"),
       );
     }
-
-    listenToStoreProperty(
-      store => store.flycam.zoomStep,
-      () => this.maybeWarnAboutZoomStep(),
-      true,
-    );
 
     window.webknossos = new ApiLoader(Model);
 
@@ -238,21 +231,6 @@ class Controller extends React.PureComponent {
     }
 
     this.keyboardNoLoop = new InputKeyboardNoLoop(keyboardControls);
-  }
-
-  maybeWarnAboutZoomStep() {
-    const shouldWarn = Model.shouldDisplaySegmentationData() && !Model.canDisplaySegmentationData();
-    if (shouldWarn && this.zoomStepWarningToast == null) {
-      const toastType = Store.getState().tracing.type === "volume" ? "danger" : "info";
-      this.zoomStepWarningToast = Toast.message(
-        toastType,
-        "Segmentation data and volume tracing is only fully supported at a smaller zoom level.",
-        true,
-      );
-    } else if (!shouldWarn && this.zoomStepWarningToast != null) {
-      this.zoomStepWarningToast.remove();
-      this.zoomStepWarningToast = null;
-    }
   }
 
   updateStats = () => this.stats.update();

--- a/app/assets/javascripts/oxalis/controller.js
+++ b/app/assets/javascripts/oxalis/controller.js
@@ -27,13 +27,11 @@ import ApiLoader from "oxalis/api/api_loader";
 import { wkReadyAction } from "oxalis/model/actions/actions";
 import { saveNowAction } from "oxalis/model/actions/save_actions";
 import { setViewModeAction } from "oxalis/model/actions/settings_actions";
-import { listenToStoreProperty } from "oxalis/model/helpers/listener_helpers";
 import Model from "oxalis/model";
 import Modal from "oxalis/view/modal";
 import { connect } from "react-redux";
 import messages from "messages";
 
-import type { ToastType } from "libs/toast";
 import type { ModeType, ControlModeType } from "oxalis/constants";
 import type { OxalisState, SkeletonTracingTypeTracingType } from "oxalis/store";
 

--- a/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
@@ -7,7 +7,6 @@
 import _ from "lodash";
 import Store from "oxalis/store";
 import Utils from "libs/utils";
-import Toast from "libs/toast";
 import constants, { OrthoViews } from "oxalis/constants";
 import {
   PlaneControllerClass,
@@ -59,9 +58,6 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
     this.listenTo(Model.getSegmentationBinary().cube, "newMapping", () =>
       SceneController.renderVolumeIsosurface(lastActiveCellId),
     );
-
-    // TODO: This should be put in a saga with `take('INITIALIZE_SETTINGS')`as pre-condition
-    setTimeout(this.adjustSegmentationOpacity, 500);
   }
 
   simulateTracing = async (): Promise<void> => {
@@ -144,14 +140,6 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
         this.volumeTracingController.handleCellSelection(cellId);
       },
     });
-  }
-
-  adjustSegmentationOpacity(): void {
-    if (Store.getState().datasetConfiguration.segmentationOpacity < 10) {
-      Toast.warning(
-        'Your setting for "segmentation opacity" is set very low.<br />Increase it for better visibility while volume tracing.',
-      );
-    }
   }
 
   getKeyboardControls(): Object {

--- a/app/assets/javascripts/oxalis/model/sagas/root_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/root_saga.js
@@ -72,6 +72,7 @@ function* warnAboutSegmentationOpacity(): Generator<*, *, *> {
       "ZOOM_IN",
       "ZOOM_OUT",
       "ZOOM_BY_DELTA",
+      "SET_ZOOM_STEP",
       action =>
         action.type === "UPDATE_DATASET_SETTING" && action.propertyName === "segmentationOpacity",
     ]);

--- a/app/assets/javascripts/oxalis/model/sagas/root_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/root_saga.js
@@ -9,7 +9,9 @@ import {
   watchVolumeTracingAsync,
 } from "oxalis/model/sagas/volumetracing_saga";
 import { alert } from "libs/window";
-import { fork, take, cancel } from "redux-saga/effects";
+import { select, fork, take, cancel } from "redux-saga/effects";
+import Model from "oxalis/model";
+import Toast from "libs/toast";
 
 export default function* rootSaga(): Generator<*, *, *> {
   while (true) {
@@ -22,6 +24,7 @@ export default function* rootSaga(): Generator<*, *, *> {
 function* restartableSaga(): Generator<*, *, *> {
   try {
     yield [
+      warnAboutSegmentationOpacity(),
       initializeSettingsAsync(),
       watchPushSettingsAsync(),
       watchSkeletonTracingAsync(),
@@ -37,5 +40,41 @@ Internal error.
 Please reload the page to avoid losing data.
 
 ${err} ${err.stack}`);
+  }
+}
+
+// TODO: move this saga functionality as soon as annotation_saga.js was merged
+
+function* warnAboutSegmentationOpacity(): Generator<*, *, *> {
+  let zoomStepWarningToast;
+  const warnMaybe = function*() {
+    const shouldWarn = Model.shouldDisplaySegmentationData() && !Model.canDisplaySegmentationData();
+    if (shouldWarn && zoomStepWarningToast == null) {
+      const toastType = yield select(
+        state => (state.tracing.type === "volume" ? "danger" : "info"),
+      );
+      zoomStepWarningToast = Toast.message(
+        toastType,
+        "Segmentation data and volume tracing is only fully supported at a smaller zoom level.",
+        true,
+      );
+    } else if (!shouldWarn && zoomStepWarningToast != null) {
+      zoomStepWarningToast.remove();
+      zoomStepWarningToast = null;
+    }
+  };
+
+  yield take("INITIALIZE_SETTINGS");
+  yield* warnMaybe();
+
+  while (true) {
+    yield take([
+      "ZOOM_IN",
+      "ZOOM_OUT",
+      "ZOOM_BY_DELTA",
+      action =>
+        action.type === "UPDATE_DATASET_SETTING" && action.propertyName === "segmentationOpacity",
+    ]);
+    yield* warnMaybe();
   }
 }

--- a/app/assets/javascripts/oxalis/model/sagas/skeletontracing_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/skeletontracing_saga.js
@@ -40,7 +40,6 @@ import type {
 } from "oxalis/store";
 import type { UpdateAction } from "oxalis/model/sagas/update_actions";
 import api from "oxalis/api/internal_api";
-import Model from "oxalis/model";
 
 function* centerActiveNode() {
   getActiveNode(yield select(state => state.tracing)).map(activeNode => {
@@ -104,39 +103,7 @@ export function* watchSkeletonTracingAsync(): Generator<*, *, *> {
     ["SET_ACTIVE_TREE", "SET_ACTIVE_NODE", "DELETE_NODE", "DELETE_BRANCHPOINT", "SELECT_NEXT_TREE"],
     centerActiveNode,
   );
-  yield [watchBranchPointDeletion(), warnAboutSegmentationOpacity()];
-}
-
-function* warnAboutSegmentationOpacity(): Generator<*, *, *> {
-  let zoomStepWarningToast;
-  const warnMaybe = function() {
-    const shouldWarn = Model.shouldDisplaySegmentationData() && !Model.canDisplaySegmentationData();
-    if (shouldWarn && zoomStepWarningToast == null) {
-      const toastType = Store.getState().tracing.type === "volume" ? "danger" : "info";
-      zoomStepWarningToast = Toast.message(
-        toastType,
-        "Segmentation data and volume tracing is only fully supported at a smaller zoom level.",
-        true,
-      );
-    } else if (!shouldWarn && zoomStepWarningToast != null) {
-      zoomStepWarningToast.remove();
-      zoomStepWarningToast = null;
-    }
-  };
-
-  yield take("INITIALIZE_SETTINGS");
-  warnMaybe();
-
-  while (true) {
-    yield take([
-      "ZOOM_IN",
-      "ZOOM_OUT",
-      "ZOOM_BY_DELTA",
-      action =>
-        action.type === "UPDATE_DATASET_SETTING" && action.propertyName === "segmentationOpacity",
-    ]);
-    warnMaybe();
-  }
+  yield [watchBranchPointDeletion()];
 }
 
 function* diffNodes(

--- a/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -3,7 +3,7 @@
  * @flow
  */
 import app from "app";
-import { call, select, put, take, race, takeEvery } from "redux-saga/effects";
+import { call, select, put, take, race, takeEvery, fork } from "redux-saga/effects";
 import {
   updateDirectionAction,
   resetContourAction,
@@ -41,6 +41,20 @@ export function* updateIsosurface(): Generator<*, *, *> {
 export function* watchVolumeTracingAsync(): Generator<*, *, *> {
   yield take("WK_READY");
   yield takeEvery(["FINISH_EDITING"], updateIsosurface);
+  yield fork(warnOfTooLowOpacity);
+}
+
+function* warnOfTooLowOpacity(): Generator<*, *, *> {
+  yield take("INITIALIZE_SETTINGS");
+
+  const isOpacityTooLow = yield select(
+    state => state.datasetConfiguration.segmentationOpacity < 10,
+  );
+  if (isOpacityTooLow) {
+    Toast.warning(
+      'Your setting for "segmentation opacity" is set very low.<br />Increase it for better visibility while volume tracing.',
+    );
+  }
 }
 
 export function* editVolumeLayerAsync(): Generator<*, *, *> {


### PR DESCRIPTION
I initially tackled this in #1912, but it turned out to not work on initial page loading because the settings were not initialized yet. I turned the code into a saga and also refactored the low segmentation warning special to volume tracings.

### Mailable description of changes:
 - Zoom step warnings will not appear if the segmentation opacity is 0.

### Steps to test:
- Load a skeleton tracing, set segmentation opacity to 0 and ensure that no warning is emitted on all zoom levels
- Load a skeleton tracing, set segmentation opacity to 20 and ensure that warnings are emitted when zooming out. They should return when zooming in.
- Load a volume tracing and ensure that on page load, a warning appears if and only if the segmentation opacity is below 10

------
- [X] Ready for review
