### PR TITLE
Support renaming from within tracing view

### DIFF
--- a/app/assets/javascripts/dashboard/views/explorative_tracing_list_item_view.js
+++ b/app/assets/javascripts/dashboard/views/explorative_tracing_list_item_view.js
@@ -21,17 +21,15 @@ class ExplorativeTracingListItemView extends Marionette.View {
 </td>
 <td class="explorative-name-column hover-dynamic">
   <span class="hover-hide" id="explorative-tracing-name"><%- name %></span>
-  <form action="<%- jsRoutes.controllers.AnnotationController.nameExplorativeAnnotation(typ, id).url %>"
-    method="POST" class="hover-show hide" id="explorative-name-form">
-    <div class="input-append">
-      <input class="input-medium hover-input form-control"
-             name="name"
-             id="explorative-name-input"
-             type="text"
-             value="<%- name %>"
-             autocomplete="off">
-    </div>
-  </form>
+  <div class="hover-show hide">
+    <input
+      class="hover-input form-control"
+      name="name"
+      id="explorative-name-input"
+      type="text"
+      value="<%- name %>"
+      autocomplete="off">
+  </div>
 </td>
 <td><%- dataSetName %></td>
 
@@ -73,14 +71,12 @@ class ExplorativeTracingListItemView extends Marionette.View {
 `);
 
     this.prototype.events = {
-      "submit #explorative-name-form": "nameExplorativeAnnotation",
       "click #finish-tracing": "finishOrOpenTracing",
       "click #reopen-tracing": "finishOrOpenTracing",
-      "change @ui.explorativeNameInput": "submitForm",
+      "change @ui.explorativeNameInput": "nameExplorativeAnnotation",
     };
 
     this.prototype.ui = {
-      explorativeNameForm: "#explorative-name-form",
       explorativeNameInput: "#explorative-name-input",
     };
 
@@ -91,16 +87,12 @@ class ExplorativeTracingListItemView extends Marionette.View {
     };
   }
 
-  submitForm() {
-    this.ui.explorativeNameForm.submit();
-  }
-
   nameExplorativeAnnotation(event) {
     event.preventDefault();
-    const target = event.target;
-    const url = target.action;
+    const payload = { data: { name: event.target.value } };
+    const url = `/annotations/${this.model.get("typ")}/${this.model.get("id")}/name`;
 
-    Request.sendUrlEncodedFormReceiveJSON(url, { data: $(target).serialize() }).then(response => {
+    Request.sendJSONReceiveJSON(url, payload).then(response => {
       Toast.message(response.messages);
       const newName = this.$("input[name='name']").val();
       this.model.set("name", newName);

--- a/app/assets/javascripts/oxalis/model/actions/actions.js
+++ b/app/assets/javascripts/oxalis/model/actions/actions.js
@@ -8,6 +8,7 @@ import type { SettingActionType } from "oxalis/model/actions/settings_actions";
 import type { TaskActionType } from "oxalis/model/actions/task_actions";
 import type { SaveActionType } from "oxalis/model/actions/save_actions";
 import type { ViewModeActionType } from "oxalis/model/actions/view_mode_actions";
+import type { AnnotationActionTypes } from "oxalis/model/actions/annotation_actions";
 
 export type ActionType =
   | SkeletonTracingActionType
@@ -16,7 +17,8 @@ export type ActionType =
   | SettingActionType
   | TaskActionType
   | SaveActionType
-  | ViewModeActionType;
+  | ViewModeActionType
+  | AnnotationActionTypes;
 
 export const wkReadyAction = () => ({
   type: "WK_READY",

--- a/app/assets/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/app/assets/javascripts/oxalis/model/actions/annotation_actions.js
@@ -1,0 +1,13 @@
+// @flow
+/* eslint-disable import/prefer-default-export */
+type SetTracingNameActionType = {
+  type: "SET_TRACING_NAME",
+  name: string,
+};
+
+export type AnnotationActionTypes = SetTracingNameActionType;
+
+export const setTracingNameAction = (name: string): SetTracingNameActionType => ({
+  type: "SET_TRACING_NAME",
+  name,
+});

--- a/app/assets/javascripts/oxalis/model/reducers/annotation_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/annotation_reducer.js
@@ -8,7 +8,6 @@ import type { ActionType } from "oxalis/model/actions/actions";
 function AnnotationReducer(state: OxalisState, action: ActionType): OxalisState {
   switch (action.type) {
     case "SET_TRACING_NAME": {
-      debugger;
       return update(state, {
         tracing: {
           name: { $set: action.name },

--- a/app/assets/javascripts/oxalis/model/reducers/annotation_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/annotation_reducer.js
@@ -1,0 +1,24 @@
+// @flow
+
+import update from "immutability-helper";
+
+import type { OxalisState } from "oxalis/store";
+import type { ActionType } from "oxalis/model/actions/actions";
+
+function AnnotationReducer(state: OxalisState, action: ActionType): OxalisState {
+  switch (action.type) {
+    case "SET_TRACING_NAME": {
+      debugger;
+      return update(state, {
+        tracing: {
+          name: { $set: action.name },
+        },
+      });
+    }
+
+    default:
+      return state;
+  }
+}
+
+export default AnnotationReducer;

--- a/app/assets/javascripts/oxalis/model/sagas/annotation_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/annotation_saga.js
@@ -5,7 +5,6 @@ import Request from "libs/request";
 export function* pushTracingNameAsync(): Generator<*, *, *> {
   const tracing = yield select(state => state.tracing);
   const url = `/annotations/${tracing.tracingType}/${tracing.tracingId}/name`;
-  debugger;
   yield [
     call(Request.sendJSONReceiveJSON, url, {
       data: { name: tracing.name },

--- a/app/assets/javascripts/oxalis/model/sagas/annotation_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/annotation_saga.js
@@ -1,0 +1,18 @@
+// @flow
+import { takeEvery, call, select } from "redux-saga/effects";
+import Request from "libs/request";
+
+export function* pushTracingNameAsync(): Generator<*, *, *> {
+  const tracing = yield select(state => state.tracing);
+  const url = `/annotations/${tracing.tracingType}/${tracing.tracingId}/name`;
+  debugger;
+  yield [
+    call(Request.sendJSONReceiveJSON, url, {
+      data: { name: tracing.name },
+    }),
+  ];
+}
+
+export function* watchAnnotationAsync(): Generator<*, *, *> {
+  yield takeEvery("SET_TRACING_NAME", pushTracingNameAsync);
+}

--- a/app/assets/javascripts/oxalis/model/sagas/root_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/root_saga.js
@@ -8,6 +8,7 @@ import {
   disallowVolumeTracingWarning,
   watchVolumeTracingAsync,
 } from "oxalis/model/sagas/volumetracing_saga";
+import { watchAnnotationAsync } from "oxalis/model/sagas/annotation_saga";
 import { alert } from "libs/window";
 import { fork, take, cancel } from "redux-saga/effects";
 
@@ -30,6 +31,7 @@ function* restartableSaga(): Generator<*, *, *> {
       editVolumeLayerAsync(),
       disallowVolumeTracingWarning(),
       watchVolumeTracingAsync(),
+      watchAnnotationAsync(),
     ];
   } catch (err) {
     alert(`\

--- a/app/assets/javascripts/oxalis/store.js
+++ b/app/assets/javascripts/oxalis/store.js
@@ -16,6 +16,7 @@ import VolumeTracingReducer from "oxalis/model/reducers/volumetracing_reducer";
 import ReadOnlyTracingReducer from "oxalis/model/reducers/readonlytracing_reducer";
 import FlycamReducer from "oxalis/model/reducers/flycam_reducer";
 import ViewModeReducer from "oxalis/model/reducers/view_mode_reducer";
+import AnnotationReducer from "oxalis/model/reducers/annotation_reducer";
 import rootSaga from "oxalis/model/sagas/root_saga";
 import overwriteActionMiddleware from "oxalis/model/helpers/overwrite_action_middleware";
 import Constants, { ControlModeEnum, OrthoViews } from "oxalis/constants";
@@ -453,6 +454,7 @@ const combinedReducers = reduceReducers(
   SaveReducer,
   FlycamReducer,
   ViewModeReducer,
+  AnnotationReducer,
 );
 
 const store = createStore(

--- a/app/assets/javascripts/oxalis/view/components/editable_text_label.js
+++ b/app/assets/javascripts/oxalis/view/components/editable_text_label.js
@@ -1,0 +1,64 @@
+// @flow
+
+import React from "react";
+import { Input, Icon } from "antd";
+
+type EditableTextLabelPropType = {
+  value: string,
+  onChange: Function,
+};
+
+class EditableTextLabel extends React.PureComponent {
+  props: EditableTextLabelPropType;
+
+  state: {
+    isEditing: boolean,
+    value: string,
+  } = {
+    isEditing: false,
+    value: "",
+  };
+
+  componentWillReceiveProps(newProps: EditableTextLabelPropType) {
+    this.setState({ value: newProps.value });
+  }
+
+  handleInputChange = (event: SyntheticInputEvent) => {
+    this.setState({ value: event.target.value });
+  };
+
+  handleOnChange = () => {
+    this.setState({ isEditing: false });
+    this.props.onChange(this.state.value);
+  };
+
+  render() {
+    const iconStyle = { cursor: "pointer" };
+
+    if (this.state.isEditing) {
+      return (
+        <span>
+          <Input
+            value={this.state.value}
+            onChange={this.handleInputChange}
+            onPressEnter={this.handleOnChange}
+            style={{ width: "60%", margin: "0 10px" }}
+            size="small"
+          />
+          <Icon type="check" style={iconStyle} onClick={this.handleOnChange} />
+        </span>
+      );
+    } else {
+      return (
+        <span>
+          <span style={{ margin: "0 10px" }}>
+            {this.props.value}
+          </span>
+          <Icon type="edit" style={iconStyle} onClick={() => this.setState({ isEditing: true })} />
+        </span>
+      );
+    }
+  }
+}
+
+export default EditableTextLabel;

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -5,13 +5,13 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import _ from "lodash";
-import { Input, Icon } from "antd";
 import { getBaseVoxel } from "oxalis/model/scaleinfo";
 import constants, { ControlModeEnum } from "oxalis/constants";
 import { getPlaneScalingFactor } from "oxalis/model/accessors/flycam_accessor";
 import Store from "oxalis/store";
 import TemplateHelpers from "libs/template_helpers";
 import { setTracingNameAction } from "oxalis/model/actions/annotation_actions";
+import EditableTextLabel from "oxalis/view/components/editable_text_label";
 import type { OxalisState, TracingType, DatasetType, FlycamType, TaskType } from "oxalis/store";
 
 type DatasetInfoTabStateProps = {
@@ -25,18 +25,6 @@ type DatasetInfoTabProps = DatasetInfoTabStateProps & { setTracingName: string =
 
 class DatasetInfoTabView extends Component {
   props: DatasetInfoTabProps;
-
-  state: {
-    isEditingName: boolean,
-    tracingName: string,
-  } = {
-    isEditingName: false,
-    tracingName: "",
-  };
-
-  componentWillReceiveProps(newProps: DatasetInfoTabProps) {
-    this.setState({ tracingName: newProps.tracing.name });
-  }
 
   calculateZoomLevel(): number {
     let width;
@@ -66,17 +54,13 @@ class DatasetInfoTabView extends Component {
     }
   }
 
-  handleTracingNameChange = (event: SyntheticInputEvent) => {
-    this.setState({ tracingName: event.target.value });
-  };
-
-  setTracingName = () => {
-    this.setState({ isEditingName: false });
-    this.props.setTracingName(this.state.tracingName);
+  setTracingName = (newName: string) => {
+    this.props.setTracingName(newName);
   };
 
   render() {
-    const { tracingType } = this.props.tracing;
+    const { tracingType, name } = this.props.tracing;
+    const tracingName = name || "<untitled>";
     let annotationTypeLabel;
 
     if (this.props.task != null) {
@@ -86,26 +70,12 @@ class DatasetInfoTabView extends Component {
           {tracingType} : {this.props.task.id}
         </span>
       );
-    } else if (this.state.isEditingName) {
+    } else {
       // Or display an explorative tracings name
       annotationTypeLabel = (
         <span>
           Explorational Tracing :
-          <Input
-            value={this.state.tracingName}
-            onChange={this.handleTracingNameChange}
-            onPressEnter={this.setTracingName}
-            style={{ width: "60%", margin: "0 10px" }}
-            size="small"
-          />{" "}
-          <Icon type="check" onClick={this.setTracingName} />
-        </span>
-      );
-    } else {
-      annotationTypeLabel = (
-        <span>
-          Explorational Tracing : {this.state.tracingName}
-          <Icon type="edit" onClick={() => this.setState({ isEditingName: true })} />
+          <EditableTextLabel value={tracingName} onChange={this.setTracingName} />
         </span>
       );
     }

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -14,13 +14,14 @@ import TemplateHelpers from "libs/template_helpers";
 import { setTracingNameAction } from "oxalis/model/actions/annotation_actions";
 import type { OxalisState, TracingType, DatasetType, FlycamType, TaskType } from "oxalis/store";
 
-type DatasetInfoTabProps = {
+type DatasetInfoTabStateProps = {
   tracing: TracingType,
   dataset: DatasetType,
   flycam: FlycamType,
   task: ?TaskType,
-  setTracingName: string => void,
 };
+
+type DatasetInfoTabProps = DatasetInfoTabStateProps & { setTracingName: string => void };
 
 class DatasetInfoTabView extends Component {
   props: DatasetInfoTabProps;
@@ -33,7 +34,7 @@ class DatasetInfoTabView extends Component {
     tracingName: "",
   };
 
-  propsWillChange(newProps) {
+  componentWillReceiveProps(newProps: DatasetInfoTabProps) {
     this.setState({ tracingName: newProps.tracing.name });
   }
 
@@ -70,6 +71,7 @@ class DatasetInfoTabView extends Component {
   };
 
   setTracingName = () => {
+    this.setState({ isEditingName: false });
     this.props.setTracingName(this.state.tracingName);
   };
 
@@ -88,12 +90,12 @@ class DatasetInfoTabView extends Component {
       // Or display an explorative tracings name
       annotationTypeLabel = (
         <span>
-          {tracingType} :
+          Explorational Tracing :
           <Input
             value={this.state.tracingName}
             onChange={this.handleTracingNameChange}
             onPressEnter={this.setTracingName}
-            style={{ width: "70%", margin: "0 10px" }}
+            style={{ width: "60%", margin: "0 10px" }}
             size="small"
           />{" "}
           <Icon type="check" onClick={this.setTracingName} />
@@ -102,7 +104,7 @@ class DatasetInfoTabView extends Component {
     } else {
       annotationTypeLabel = (
         <span>
-          {tracingType} : {this.state.tracingName}
+          Explorational Tracing : {this.state.tracingName}
           <Icon type="edit" onClick={() => this.setState({ isEditingName: true })} />
         </span>
       );
@@ -180,7 +182,7 @@ class DatasetInfoTabView extends Component {
   }
 }
 
-const mapStateToProps = (state: OxalisState): DatasetInfoTabProps => ({
+const mapStateToProps = (state: OxalisState): DatasetInfoTabStateProps => ({
   tracing: state.tracing,
   dataset: state.dataset,
   flycam: state.flycam,

--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -304,10 +304,10 @@ class AnnotationController @Inject()(val messagesApi: MessagesApi)
     }
   }
 
-  def nameExplorativeAnnotation(typ: String, id: String) = Authenticated.async(parse.urlFormEncoded) { implicit request =>
+  def nameExplorativeAnnotation(typ: String, id: String) = Authenticated.async(parse.json) { implicit request =>
     for {
       annotation <- AnnotationDAO.findOneById(id) ?~> Messages("annotation.notFound")
-      name <- postParameter("name") ?~> Messages("annotation.invalidName")
+      name <- (request.body \ "name").asOpt[String].toFox ?~> Messages("annotation.invalidName")
       updated <- annotation.muta.rename(name)
       renamedJSON <- Annotation.transformToJson(updated)
     } yield {


### PR DESCRIPTION
### Mailable description of changes:
 - Enabled renaming of explorative tracing within the tracing view (info tab on the right side)

![image](https://user-images.githubusercontent.com/1105056/28972571-72900b64-7930-11e7-85f5-73d80750e7cd.png)


### Steps to test:
- Open tracing
- open info tab on the right (see picture)
- click edit icon und (re)name tracing

Alternatively
- Go to dashboard --> explorative tracing
- hover of over the tracing in the "name" column
- change name

### Issues:
- see https://discuss.webknossos.org/t/show-multiple-tracings-at-once-workspaces/375/8

------
- [x] Ready for review
