### PR TITLE
check for tracing type in volume saga (#1912)

### DIFF
--- a/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -46,6 +46,9 @@ export function* watchVolumeTracingAsync(): Generator<*, *, *> {
 
 function* warnOfTooLowOpacity(): Generator<*, *, *> {
   yield take("INITIALIZE_SETTINGS");
+  if (yield select(state => state.tracing.type !== "volume")) {
+    return;
+  }
 
   const isOpacityTooLow = yield select(
     state => state.datasetConfiguration.segmentationOpacity < 10,


### PR DESCRIPTION
### Steps to test:
- Load a [skeleton | volume] tracing with [0 | 20] segmentation opacity and check that there is only a warning if the following is set:
   - volume and opacity 0
   - (skeleton, segmentation opacity 20 and low zoom level)

### Issues:
- This is a regression introduced regarding to #1912.

I was under the impression that volume sagas are only executed for volume tracing, but they are always executed. Maybe we should rethink this in the future.

------
- [X] Ready for review
