### PR TITLE
adds an API method to trigger downloading of raw volume tracing data,…

### DIFF
--- a/app/assets/javascripts/oxalis/api/api_latest.js
+++ b/app/assets/javascripts/oxalis/api/api_latest.js
@@ -45,6 +45,7 @@ import { overwriteAction } from "oxalis/model/helpers/overwrite_action_middlewar
 import Toast from "libs/toast";
 import Request from "libs/request";
 import app from "app";
+import window from "libs/window";
 import Utils from "libs/utils";
 import { ControlModeEnum, OrthoViews } from "oxalis/constants";
 import { setPositionAction } from "oxalis/model/actions/flycam_actions";
@@ -522,6 +523,31 @@ class DataApi {
     }
     // Bucket has been loaded by now or was loaded already
     return layer.cube.getDataValue(position);
+  }
+
+  /**
+  * Download volume tracing cuboid.
+  * _Volume tracing only!_
+  *
+  * @example // Download a cuboid (from (0, 0, 0) to (100, 200, 100)) of raw data from the volume tracing layer.
+  * api.data.downloadVolumeTracingCuboid([0,0,0], [100,200,100]);
+  */
+  downloadVolumeTracingCuboid(topLeft: Vector3, bottomRight: Vector3): void {
+    assertVolume(Store.getState().tracing);
+    const dataset = Store.getState().dataset;
+    const layer = this.model.getSegmentationBinary();
+    assertExists(layer, "Segmentation layer not found!");
+
+    const downloadUrl =
+      `${dataset.dataStore.url}/data/datasets/${dataset.name}/layers/${layer.name}/data?resolution=0&` +
+      `x=${topLeft[0]}&` +
+      `y=${topLeft[1]}&` +
+      `z=${topLeft[2]}&` +
+      `width=${bottomRight[0] - topLeft[0]}&` +
+      `height=${bottomRight[1] - topLeft[1]}&` +
+      `depth=${bottomRight[2] - topLeft[2]}`
+
+    window.open(downloadUrl);
   }
 
   /**

--- a/app/assets/javascripts/test/api/api_volume_latest.spec.js
+++ b/app/assets/javascripts/test/api/api_volume_latest.spec.js
@@ -2,6 +2,7 @@
 import test from "ava";
 import "backbone.marionette";
 import sinon from "sinon";
+import mockRequire from "mock-require";
 import Constants from "oxalis/constants";
 import { setupOxalis } from "test/helpers/apiHelpers";
 import VOLUMETRACING_OBJECT from "../fixtures/volumetracing_object";
@@ -51,6 +52,16 @@ test("Data Api: labelVoxels should label a list of voxels", t => {
   t.is(cube.getDataValue([7, 8, 9]), 34);
   // Some other voxel should not
   t.not(cube.getDataValue([11, 12, 13]), 34);
+});
+
+test("Data Api: downloadVolumeTracingCuboid should open a popup with the correct URL", t => {
+  const { api } = t.context;
+  const window = mockRequire.reRequire("libs/window");
+  
+  api.data.downloadVolumeTracingCuboid([1, 2, 3], [9, 8, 7]);
+  
+  t.true(window.open.calledOnce);
+  t.true(window.open.calledWith("http://localhost:9000/data/datasets/2012-09-28_ex145_07x2/layers/64007765-cef9-4e31-b206-dba795b5be17/data?resolution=0&x=1&y=2&z=3&width=8&height=6&depth=4"));
 });
 
 test("Calling a skeleton api function in a volume tracing should throw an error", t => {

--- a/app/assets/javascripts/test/helpers/apiHelpers.js
+++ b/app/assets/javascripts/test/helpers/apiHelpers.js
@@ -23,6 +23,7 @@ const window = {
     pathname: "annotationUrl",
   },
   alert: console.log.bind(console),
+  open: sinon.spy(),
 };
 const currentUser = {
   firstName: "SCM",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,15 +1803,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
-
-chalk@^2.0.1:
+chalk@^2.0.0, chalk@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
   dependencies:
@@ -2709,10 +2701,6 @@ elliptic@^6.0.0:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
 
-emoji-regex@^6.0.0:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.3.tgz#6ac2ac58d4b78def5e39b33fcbf395688af3076c"
-
 emoji-regex@^6.1.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
@@ -3511,17 +3499,11 @@ git-url-parse@^6.0.1:
   dependencies:
     git-up "^2.0.0"
 
-github-slugger@1.1.3:
+github-slugger@1.1.3, github-slugger@^1.0.0, github-slugger@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.1.3.tgz#314a6e759a18c2b0cc5760d512ccbab549c549a7"
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
-
-github-slugger@^1.0.0, github-slugger@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.1.1.tgz#5444671f65e5a5a424cfa8ba3255cc1f7baf07ea"
-  dependencies:
-    emoji-regex "^6.0.0"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3556,7 +3538,7 @@ glob-stream@^5.3.2:
     to-absolute-glob "^0.1.1"
     unique-stream "^2.0.2"
 
-glob@7.0.5, glob@^7.0.0, glob@^7.0.3:
+glob@7.0.5, glob@^7.0.0:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
   dependencies:
@@ -3577,7 +3559,7 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.0.6, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -4389,14 +4371,14 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.8.2:
+js-yaml@^3.8.2, js-yaml@^3.8.4:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.8.4, js-yaml@^3.9.1:
+js-yaml@^3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
   dependencies:
@@ -6309,17 +6291,7 @@ rc-tree-select@~1.10.2:
     rc-trigger "1.x"
     rc-util "^4.0.2"
 
-rc-tree@^1.3.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.5.0.tgz#6b700303c4f160ad7f6c438a8fdca57de96a5dd1"
-  dependencies:
-    classnames "2.x"
-    object-assign "4.x"
-    prop-types "^15.5.8"
-    rc-animate "2.x"
-    rc-util "^4.0.2"
-
-rc-tree@~1.7.0:
+rc-tree@^1.3.0, rc-tree@~1.7.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.7.1.tgz#bb65a2bc69261cd7da3cb682fc7894c42e078256"
   dependencies:
@@ -6902,13 +6874,13 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-safe-buffer@^5.0.1, safe-buffer@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
-
-safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
 safe-json-parse@~1.0.1:
   version "1.0.1"
@@ -7274,16 +7246,9 @@ string-width@^1.0.0, string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.0.0, string-width@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.0.tgz#030664561fc146c9423ec7d978fe2457437fe6d0"
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
-string-width@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
@@ -7387,13 +7352,13 @@ supports-color@^3.2.3, supports-color@~3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0, supports-color@^4.1.0:
+supports-color@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^4.2.1:
+supports-color@^4.1.0, supports-color@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
   dependencies:


### PR DESCRIPTION
… fixes #1954

### Mailable description of changes:
 - raw volume tracing data can now be downloaded via the API

### Steps to test:
- open a volume tracing
- `webknossos.apiReady(2).then((api) => { api.data.downloadVolumeTracingCuboid([1,2,3], [4, 5, 6]) })`

### Issues:
- fixes #1954 

------
- [x] Ready for review
