### PR TITLE
Fix renaming in dashboard

### DIFF
--- a/app/assets/javascripts/dashboard/views/dash/explorative_annotations_view.js
+++ b/app/assets/javascripts/dashboard/views/dash/explorative_annotations_view.js
@@ -216,7 +216,7 @@ export default class ExplorativeAnnotationsView extends React.PureComponent {
         : "unarchivedTracings"]: newTracings,
     });
 
-    const url = `/annotations/${tracing.typ}/${tracing.id}/name`;
+    const url = `/annotations/${tracing.typ}/${tracing.id}/edit`;
     const payload = { data: { name } };
 
     Request.sendJSONReceiveJSON(url, payload).then(response => {


### PR DESCRIPTION
The route was renamed in the context of editing the `isPublic` flag for a tracing.

### Steps to test:
- Rename a tracing in the explorative tracing tab

------
- [X] Ready for review
