### PR TITLE
Unify the change of the node radius via mouse in different browsers

### DIFF
--- a/app/assets/javascripts/oxalis/constants.js
+++ b/app/assets/javascripts/oxalis/constants.js
@@ -94,6 +94,11 @@ const Constants = {
   MIN_SCALE: 0.5,
   MAX_SCALE: 20,
 
+  // The node radius is the actual radius of the node in nm, it's dependent on zoom and dataset scale
+  MIN_NODE_RADIUS: 1,
+  MAX_NODE_RADIUS: 5000,
+
+  // The particle size is measured in pixels - it's independent of zoom and dataset scale
   MIN_PARTICLE_SIZE: 1,
   MAX_PARTICLE_SIZE: 20,
 

--- a/app/assets/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
@@ -113,7 +113,8 @@ class SkeletonTracingPlaneController extends PlaneControllerClass {
     super.scrollPlanes(delta, type);
 
     if (type === "shift") {
-      api.tracing.setNodeRadius(delta);
+      // Different browsers send different deltas, this way the behavior is comparable
+      api.tracing.setNodeRadius(delta > 0 ? 5 : -5);
     }
   }
 

--- a/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
@@ -177,12 +177,17 @@ function SkeletonTracingReducer(state: OxalisState, action: ActionType): OxalisS
 
         case "SET_NODE_RADIUS": {
           const { radius, nodeId, treeId } = action;
+          const clampedRadius = Utils.clamp(
+            Constants.MIN_NODE_RADIUS,
+            radius,
+            Constants.MAX_NODE_RADIUS,
+          );
           return getNodeAndTree(skeletonTracing, nodeId, treeId)
             .map(([tree, node]) =>
               update(state, {
                 tracing: {
                   trees: {
-                    [tree.treeId]: { nodes: { [node.id]: { radius: { $set: radius } } } },
+                    [tree.treeId]: { nodes: { [node.id]: { radius: { $set: clampedRadius } } } },
                   },
                 },
               }),

--- a/app/assets/javascripts/oxalis/view/settings/user_settings_view.js
+++ b/app/assets/javascripts/oxalis/view/settings/user_settings_view.js
@@ -29,7 +29,6 @@ import {
 import { getMaxZoomStep } from "oxalis/model/accessors/flycam_accessor";
 import { getActiveNode } from "oxalis/model/accessors/skeletontracing_accessor";
 import { setZoomStepAction } from "oxalis/model/actions/flycam_actions";
-import Utils from "libs/utils";
 import type {
   UserConfigurationType,
   TemporaryConfigurationType,
@@ -201,9 +200,9 @@ class UserSettingsView extends PureComponent {
         this.props.tracing.activeNodeId != null ? this.props.tracing.activeNodeId : "";
       const activeTreeId =
         this.props.tracing.activeTreeId != null ? this.props.tracing.activeTreeId : "";
-      const activeNodeRadius =
-        Utils.toNullable(getActiveNode(this.props.tracing).map(activeNode => activeNode.radius)) ||
-        0;
+      const activeNodeRadius = getActiveNode(this.props.tracing)
+        .map(activeNode => activeNode.radius)
+        .getOrElse(0);
       return (
         <Panel header="Nodes & Trees" key="3">
           <NumberInputSetting

--- a/app/assets/javascripts/oxalis/view/settings/user_settings_view.js
+++ b/app/assets/javascripts/oxalis/view/settings/user_settings_view.js
@@ -27,7 +27,9 @@ import {
   LogSliderSetting,
 } from "oxalis/view/settings/setting_input_views";
 import { getMaxZoomStep } from "oxalis/model/accessors/flycam_accessor";
+import { getActiveNode } from "oxalis/model/accessors/skeletontracing_accessor";
 import { setZoomStepAction } from "oxalis/model/actions/flycam_actions";
+import Utils from "libs/utils";
 import type {
   UserConfigurationType,
   TemporaryConfigurationType,
@@ -199,6 +201,9 @@ class UserSettingsView extends PureComponent {
         this.props.tracing.activeNodeId != null ? this.props.tracing.activeNodeId : "";
       const activeTreeId =
         this.props.tracing.activeTreeId != null ? this.props.tracing.activeTreeId : "";
+      const activeNodeRadius =
+        Utils.toNullable(getActiveNode(this.props.tracing).map(activeNode => activeNode.radius)) ||
+        0;
       return (
         <Panel header="Nodes & Trees" key="3">
           <NumberInputSetting
@@ -213,12 +218,12 @@ class UserSettingsView extends PureComponent {
           />
           <LogSliderSetting
             label="Node Radius"
-            min={1}
-            max={5000}
+            min={Constants.MIN_NODE_RADIUS}
+            max={Constants.MAX_NODE_RADIUS}
             roundTo={0}
-            value={this.props.userConfiguration.radius}
+            value={activeNodeRadius}
             onChange={this.props.onChangeRadius}
-            disabled={this.props.userConfiguration.overrideNodeRadius}
+            disabled={this.props.userConfiguration.overrideNodeRadius || activeNodeRadius === 0}
           />
           <NumberSliderSetting
             label={
@@ -226,8 +231,10 @@ class UserSettingsView extends PureComponent {
                 ? "Particle Size"
                 : "Min. Particle Size"
             }
-            max={20}
+            min={Constants.MIN_PARTICLE_SIZE}
+            max={Constants.MAX_PARTICLE_SIZE}
             step={0.1}
+            roundTo={1}
             value={this.props.userConfiguration.particleSize}
             onChange={this.onChangeUser.particleSize}
           />
@@ -377,7 +384,6 @@ const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
     dispatch(setZoomStepAction(zoomStep));
   },
   onChangeRadius(radius: any) {
-    dispatch(updateUserSettingAction("radius", radius));
     dispatch(setNodeRadiusAction(radius));
   },
 });


### PR DESCRIPTION
... and fix node radius in the settings.
As Chrome and Firefox (and other browsers) send different delta values while scrolling, changing the node radius via `Shift + Scroll` was behaving weirdly in Chrome, but fine in Firefox. This PR unifies the behaviour and displays the correct node radius in the settings menu. I've also added an explanation of `node radius` and `particle size` in the code as I had already forgotten about the distinction again -.-

### Mailable description of changes:
 - Changing the node radius via `Shift + Scroll` was behaving weirdly in Chrome. This is now fixed.

### Steps to test:
- Uncheck `Override node radius` and use `Shift + Scroll` to change the node radius. This should be smooth in different browsers, the settings should be updated and it should obey the limits (min/max node radius)

### Issues:
- fixes https://discuss.webknossos.org/t/changing-node-size-with-shift-scroll-has-become-very-harsh/414/1

------
- [x] Ready for review
