### PR TITLE
Update libs version to fix largestSegmentId

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object Dependencies{
   val akkaVersion = "2.4.1"
   val reactiveVersion = "0.11.13"
   val reactivePlayVersion = "0.11.13-play24"
-  val braingamesVersion = "11.1.3"
+  val braingamesVersion = "11.1.8"
 
   val twelvemonkeysVersion = "3.1.2"
 


### PR DESCRIPTION
### Mailable description of changes:
 - fixed a bug to use largestSegmentId from previous import when editing wkw datasets

### Steps to test:
- edit a wkw dataset with segmentation
- the suggested `largestSegmentId` should not be 0, but whatever is in the `datasource-properties.json` file


See the actual commit: https://github.com/scalableminds/braingames-libs/commit/429fd78033ebf486ba9152eaf23c9e196b3fd9c1

------
- [x] Ready for review
