### PR TITLE
Select correct dataset when starting tracing in gallery view, fixes #2017

### DIFF
--- a/app/assets/javascripts/dashboard/views/gallery_dataset_view.js
+++ b/app/assets/javascripts/dashboard/views/gallery_dataset_view.js
@@ -77,11 +77,19 @@ class GalleryDatasetView extends React.PureComponent<Props, State> {
           <a href={`/datasets/${dataset.name}/view`} title="View dataset">
             <img src="/assets/images/eye.svg" alt="Eye" />
           </a>
-          <a href="#" title="Create skeleton tracing" onClick={(event) => this.submitForm(dataset.name, "skeletonTracing", event)}>
+          <a
+            href="#"
+            title="Create skeleton tracing"
+            onClick={event => this.submitForm(dataset.name, "skeletonTracing", event)}
+          >
             <img src="/assets/images/skeleton.svg" alt="Skeleton" />
           </a>
           {dataset.dataStore.typ !== "ndstore" ? (
-            <a href="#" title="Create volume tracing" onClick={(event) => this.submitForm(dataset.name, "volumeTracing", event)}>
+            <a
+              href="#"
+              title="Create volume tracing"
+              onClick={event => this.submitForm(dataset.name, "volumeTracing", event)}
+            >
               <img src="/assets/images/volume.svg" alt="Volume" />
             </a>
           ) : null}

--- a/app/assets/javascripts/dashboard/views/gallery_dataset_view.js
+++ b/app/assets/javascripts/dashboard/views/gallery_dataset_view.js
@@ -28,21 +28,14 @@ class GalleryDatasetView extends React.PureComponent<Props, State> {
 
   state = {
     contentType: "",
+    dataset: "",
   };
 
-  handleSkeletonTraceClick = (event: Event) => {
-    this.submitForm("skeletonTracing", event);
-  };
-
-  handleVolumeTraceClick = (event: Event) => {
-    this.submitForm("volumeTracing", event);
-  };
-
-  submitForm(type: string, event: Event) {
+  submitForm(dataset: string, contentType: string, event: Event) {
     event.preventDefault();
 
     if (app.currentUser != null) {
-      this.setState({ contentType: type }, () => {
+      this.setState({ contentType, dataset }, () => {
         this.form.submit();
       });
     } else {
@@ -84,11 +77,11 @@ class GalleryDatasetView extends React.PureComponent<Props, State> {
           <a href={`/datasets/${dataset.name}/view`} title="View dataset">
             <img src="/assets/images/eye.svg" alt="Eye" />
           </a>
-          <a href="#" title="Create skeleton tracing" onClick={this.handleSkeletonTraceClick}>
+          <a href="#" title="Create skeleton tracing" onClick={(event) => this.submitForm(dataset.name, "skeletonTracing", event)}>
             <img src="/assets/images/skeleton.svg" alt="Skeleton" />
           </a>
           {dataset.dataStore.typ !== "ndstore" ? (
-            <a href="#" title="Create volume tracing" onClick={this.handleVolumeTraceClick}>
+            <a href="#" title="Create volume tracing" onClick={(event) => this.submitForm(dataset.name, "volumeTracing", event)}>
               <img src="/assets/images/volume.svg" alt="Volume" />
             </a>
           ) : null}
@@ -98,7 +91,24 @@ class GalleryDatasetView extends React.PureComponent<Props, State> {
           <p>Scale: {TemplateHelpers.formatScale(dataset.dataSource.scale)}</p>
           {description}
         </div>
+      </Card>
+    );
+  }
 
+  render() {
+    return (
+      <div>
+        <Row gutter={padding}>
+          {Utils.filterWithSearchQueryAND(
+            this.props.datasets.filter(ds => ds.isActive),
+            ["name", "owningTeam", "description"],
+            this.props.searchQuery,
+          ).map(ds => (
+            <Col span={6} key={ds.name} style={{ paddingBottom: padding }}>
+              {this.renderCard(ds)}
+            </Col>
+          ))}
+        </Row>
         <form
           action={jsRoutes.controllers.AnnotationController.createExplorational().url}
           method="POST"
@@ -106,26 +116,10 @@ class GalleryDatasetView extends React.PureComponent<Props, State> {
             this.form = form;
           }}
         >
-          <input type="hidden" name="dataSetName" value={dataset.name} />
+          <input type="hidden" name="dataSetName" value={this.state.dataset} />
           <input type="hidden" name="contentType" value={this.state.contentType} />
         </form>
-      </Card>
-    );
-  }
-
-  render() {
-    return (
-      <Row gutter={padding}>
-        {Utils.filterWithSearchQueryAND(
-          this.props.datasets.filter(ds => ds.isActive),
-          ["name", "owningTeam", "description"],
-          this.props.searchQuery,
-        ).map(ds => (
-          <Col span={6} key={ds.name} style={{ paddingBottom: padding }}>
-            {this.renderCard(ds)}
-          </Col>
-        ))}
-      </Row>
+      </div>
     );
   }
 }


### PR DESCRIPTION
The issues here was, that while each `Card` has its own form, they are all assigned to the same variable `this.form` of the wrapping component. Thus, when the form is submitted, it sends whichever form was assigned to that variable last (probably the last?) and not the form for the current dataset.
I changed the code, so there is only a single form and the dataset name is passed to the `submitForm` method in the `onClick` handler similar to the tracing type.

### Mailable description of changes:
 - Bugfix: selecting the correct dataset, when starting a tracing from gallery view.

### Steps to test:
- create a skeleton tracing via gallery view
- check, that the tracing was started in the correct dataset (in contrast to master)

### Issues:
- fixes #2017

------
- [x] Ready for review
