### PR TITLE
Fix handling of NML Uploads

### DIFF
--- a/app/assets/javascripts/dashboard/views/explorative_annotations_view.js
+++ b/app/assets/javascripts/dashboard/views/explorative_annotations_view.js
@@ -181,7 +181,7 @@ export default class ExplorativeAnnotationsView extends React.PureComponent<Prop
           const newTracings = info.fileList.map(fileInfo => fileInfo.response.annotation);
           this.setState({
             isUploadingNML: false,
-            unarchivedTracings: this.state.unarchivedTracings.concat(newTracings),
+            unarchivedTracings: newTracings.concat(this.state.unarchivedTracings),
           });
         }
       }

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -72,8 +72,9 @@ class AnnotationIOController @Inject()(val messagesApi: MessagesApi)
       for {
         annotation <- AnnotationService.createAnnotationFrom(
           request.user, nmls, parsedFiles.otherFiles, AnnotationType.Explorational, name)
+        annotationJson <- AnnotationLike.annotationLikeInfoWrites(annotation, Some(request.user), exclude = List("content"))
       } yield JsonOk(
-        Json.obj("annotation" -> Json.obj("typ" -> annotation.typ, "id" -> annotation.id)),
+        Json.obj("annotation" -> annotationJson),
         Messages("nml.file.uploadSuccess")
       )
     } else {


### PR DESCRIPTION
### Mailable description of changes:
- [Dashboard.Explorative Tracing View] Restored behavior for uploading a multiple NML files 
- Uploading a single file directly redirects the user to the tracing view to start working immediately
- Uploading multiple files will only add them to the table without any further action

### Steps to test:
1. Go to Dashboard.Explorative Tracing View
2. Upload a single NML files and be redirected
3. Upload multiple NML files and see them being added to the table (nothing more)


### Issues:
- fixes #2019 
- See https://discuss.webknossos.org/t/upload-multiple-annotations-not-possible-by-direct-selection/456/4

------
- [x] Ready for review
