### PR TITLE
change toggle segmentation shortcut from 9 to 3

### DIFF
--- a/app/assets/javascripts/oxalis/controller.js
+++ b/app/assets/javascripts/oxalis/controller.js
@@ -238,7 +238,7 @@ class Controller extends React.PureComponent<Props, State> {
         "ctrl + y": () => Store.dispatch(redoAction()),
 
         // In the long run this should probably live in a user script
-        "9": function toggleSegmentationOpacity() {
+        "3": function toggleSegmentationOpacity() {
           // Flow cannot infer the return type of getConfiguration :(
           // Should be fixed once this is fixed: https://github.com/facebook/flow/issues/4513
           const curSegAlpha = Number(api.data.getConfiguration("segmentationOpacity"));


### PR DESCRIPTION

As per discussion in https://discuss.webknossos.org/t/button-for-toggling-segmentation/372/3

### Mailable description of changes:
 - The shortcut for toggling the segmentation is now 3 instead of 9, since the previous binding caused some conflicts with user scripts.

### Steps to test:
- press 3 to toggle the segmentation

------
- [X] Ready for review
