### PR TITLE
Speed up unit tests by removing a deep comparison

### DIFF
--- a/app/assets/javascripts/test/geometries/skeleton.spec.js
+++ b/app/assets/javascripts/test/geometries/skeleton.spec.js
@@ -110,7 +110,8 @@ test.serial("Skeleton should initialize correctly using the store's state", t =>
       NodeShader.COLOR_TEXTURE_WIDTH * NodeShader.COLOR_TEXTURE_WIDTH * 4,
     );
     textureData.set(treeColors);
-    t.deepEqual(skeleton.treeColorTexture.image.data, textureData);
+    // Do not use t.deepEqual here, it's extremely slow and takes >15s
+    t.true(_.isEqual(skeleton.treeColorTexture.image.data, textureData));
   });
 });
 


### PR DESCRIPTION
For some reason `deepEqual` takes extremely long for big Float32Arrays (>4,000,000 entries), so I replaced it at this one spot with a faster lodash comparison.
For me the tests took ~31s before and take ~17s now :) 

### Steps to test:
- Run `yarn test` before checking out the branch and after, it should be noticeably faster afterwards

------
- [x] Ready for review
