### PR TITLE
Add treeName getter and setter to api

### DIFF
--- a/app/assets/javascripts/oxalis/api/api_latest.js
+++ b/app/assets/javascripts/oxalis/api/api_latest.js
@@ -18,12 +18,14 @@ import {
   createCommentAction,
   deleteNodeAction,
   setNodeRadiusAction,
+  setTreeNameAction,
 } from "oxalis/model/actions/skeletontracing_actions";
 import {
   findTreeByNodeId,
   getNodeAndTree,
   getActiveNode,
   getActiveTree,
+  getTree,
   getSkeletonTracing,
 } from "oxalis/model/accessors/skeletontracing_accessor";
 import { setActiveCellAction, setModeAction } from "oxalis/model/actions/volumetracing_actions";
@@ -211,6 +213,37 @@ class TracingApi {
         return comment != null ? comment.content : null;
       })
       .getOrElse(null);
+  }
+
+  /**
+  * Sets the name for a tree. If no tree id is given, the active tree is used.
+  *
+  * @example
+  * api.tracing.setTreeName("Special tree", 1);
+  */
+  setTreeName(name: string, treeId: ?number) {
+    const tracing = Store.getState().tracing;
+    assertSkeleton(tracing);
+    getSkeletonTracing(tracing).map(skeletonTracing => {
+      if (treeId == null) {
+        treeId = skeletonTracing.activeTreeId;
+      }
+      Store.dispatch(setTreeNameAction(name, treeId));
+    });
+  }
+
+  /**
+  * Returns the name for a given tree id. If none is given, the name of the active tree is returned.
+  *
+  * @example
+  * api.tracing.getTreeName();
+  */
+  getTreeName(treeId?: number) {
+    const tracing = Store.getState().tracing;
+    assertSkeleton(tracing);
+    return getTree(tracing, treeId)
+      .map(activeTree => activeTree.name)
+      .get();
   }
 
   /**

--- a/app/assets/javascripts/oxalis/model/actions/skeletontracing_actions.js
+++ b/app/assets/javascripts/oxalis/model/actions/skeletontracing_actions.js
@@ -49,7 +49,7 @@ type CreateTreeActionType = { type: "CREATE_TREE", timestamp: number };
 type DeleteTreeActionType = { type: "DELETE_TREE", treeId?: number, timestamp: number };
 type SetActiveTreeActionType = { type: "SET_ACTIVE_TREE", treeId: number };
 type MergeTreesActionType = { type: "MERGE_TREES", sourceNodeId: number, targetNodeId: number };
-type SetTreeNameActionType = { type: "SET_TREE_NAME", treeId?: number, name: ?string };
+type SetTreeNameActionType = { type: "SET_TREE_NAME", name: ?string, treeId: ?number };
 type SelectNextTreeActionType = { type: "SELECT_NEXT_TREE", forward: ?boolean };
 type ShuffleTreeColorActionType = { type: "SHUFFLE_TREE_COLOR", treeId?: number };
 type CreateCommentActionType = {
@@ -224,7 +224,7 @@ export const mergeTreesAction = (
 
 export const setTreeNameAction = (
   name: ?string = null,
-  treeId?: number,
+  treeId: ?number,
 ): SetTreeNameActionType => ({
   type: "SET_TREE_NAME",
   name,

--- a/app/assets/javascripts/test/api/api_skeleton_latest.spec.js
+++ b/app/assets/javascripts/test/api/api_skeleton_latest.spec.js
@@ -169,3 +169,36 @@ test("Calling a volume api function in a skeleton tracing should throw an error"
   const api = t.context.api;
   t.throws(() => api.tracing.getVolumeMode());
 });
+
+test("getTreeName should get the name of a tree", t => {
+  const api = t.context.api;
+  const name = api.tracing.getTreeName(2);
+  t.is(name, "explorative_2017-02-08_SCM_Boy_002");
+});
+
+test("getTreeName should get the name of the active tree if no treeId is specified", t => {
+  const api = t.context.api;
+  const name = api.tracing.getTreeName();
+  t.is(name, "explorative_2017-02-08_SCM_Boy_001");
+});
+
+test("getTreeName should throw an error if the supplied treeId doesn't exist", t => {
+  const api = t.context.api;
+  t.throws(() => api.tracing.getTreeName(5));
+});
+
+test("setTreeName should set the name of a tree", t => {
+  const api = t.context.api;
+  const NAME = "a tree";
+  api.tracing.setTreeName(NAME, 2);
+  const name = api.tracing.getTreeName(2);
+  t.is(name, NAME);
+});
+
+test("setTreeName should set the name of the active tree if no treeId is specified", t => {
+  const api = t.context.api;
+  const NAME = "a tree";
+  api.tracing.setTreeName(NAME);
+  const name = api.tracing.getTreeName(1);
+  t.is(name, NAME);
+});


### PR DESCRIPTION
### Mailable description of changes:
 - It is now possible to get and set tree names via the API. Have a look at the `setTreeName` and `getTreeName` functions in the docs (https://webknossos.brain.mpg.de/assets/docs/frontend-api/index.html). 

### Steps to test:
- Run the frontend tests

### Issues:
- fixes https://discuss.webknossos.org/t/setactivetreename-functionality-in-api/321/

------
- [x] Ready for review
