### PR TITLE
Disable task limit for admins, fixes #2042

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -230,7 +230,7 @@ class TaskController @Inject() (val messagesApi: MessagesApi) extends Controller
 
   def ensureMaxNumberOfOpenTasks(user: User)(implicit ctx: DBAccessContext): Fox[Int] = {
     AnnotationService.countOpenTasks(user).flatMap{ numberOfOpen =>
-      if (numberOfOpen < MAX_OPEN_TASKS)
+      if (numberOfOpen < MAX_OPEN_TASKS || user.hasAdminAccess)
         Fox.successful(numberOfOpen)
       else
         Fox.failure(Messages("task.tooManyOpenOnes"))


### PR DESCRIPTION
### Mailable description of changes:
 - admins can now request an infinite number of tasks

### Steps to test:
- create a second non-admin user
- create a project
- create > 5 tasks with >= 2 instances
- set experience for both scmboy and new user
- requests tasks for both users
- non-admin user shuld only get 5 tasks, scmboy should get all tasks

### Issues:
- fixes #2042

------
- [x] Ready for review
