### PR TITLE
Fix issue with renaming tracings

### DIFF
--- a/app/assets/javascripts/oxalis/view/components/editable_text_label.js
+++ b/app/assets/javascripts/oxalis/view/components/editable_text_label.js
@@ -24,6 +24,10 @@ class EditableTextLabel extends React.PureComponent<EditableTextLabelPropType, S
     value: "",
   };
 
+  componentDidMount() {
+    this.componentWillReceiveProps(this.props);
+  }
+
   componentWillReceiveProps(newProps: EditableTextLabelPropType) {
     this.setState({ value: newProps.value });
   }


### PR DESCRIPTION
The root cause of this issue is as follows:
- The `<EditableTextLabel>`component receives a `value` from outside as a `prop``
- When in editing mode, all typing within the `<Input>` field is saved into  the state.  This is nothing special and the default behavior of a controlled React input component.
- The problem arises because the incoming `value` prop and the internal `value` state where out of sync. Or rather the internal `value` state was never initialized to the props `value`.

### Mailable description of changes:
- Fixed an issue with editing a tracing's name / comment. Sometimes an existing tracing name was not displayed while editing.

### Steps to test:
1. Go to either Dashboard.Explorative or open any Tracing
2. Rename the tracing, so testing does not start with an empty string.
3. Reload
4. Rename the tracing. An existing name should be the value of the `<Input>`.

### Issues:
- https://discuss.webknossos.org/t/tracing-name-is-lost-when-clicking-edit-button/498

------
- [ ] Ready for review
