### PR TITLE
remove preventDefault that caused text selection regression

### DIFF
--- a/app/assets/javascripts/libs/input.js
+++ b/app/assets/javascripts/libs/input.js
@@ -380,8 +380,6 @@ export class InputMouse {
   };
 
   mouseUp = (event: JQueryInputEventObject): void => {
-    event.preventDefault();
-
     this.leftMouseButton.handleMouseUp(event);
     this.rightMouseButton.handleMouseUp(event);
 
@@ -396,7 +394,6 @@ export class InputMouse {
   };
 
   mouseMove = (event: JQueryInputEventObject): void => {
-    event.preventDefault();
     let delta = null;
 
     this.position = this.getRelativeMousePosition(event);


### PR DESCRIPTION
I added these unnecessary preventDefaults in an earlier PR and forgot to remove them :(

### Mailable description of changes:
 - Fixed a bug that made it impossible to select text in the tracing view.

### Steps to test:
- Select text in the tracing view.

### Issues:
- fixes https://discuss.webknossos.org/t/text-selection-no-longer-possible-when-tracing-is-open/543

------
- [x] Ready for review
