### PR TITLE
removed regex that caused trouble whith _magXX in dataset names

### DIFF
--- a/app/oxalis/nml/NMLParser.scala
+++ b/app/oxalis/nml/NMLParser.scala
@@ -165,9 +165,7 @@ object NMLParser extends LazyLogging {
     }
 
     private def parseDataSetName(node: NodeSeq) = {
-      val rawDataSetName = (node \ "@name").text
-      val magRx = "_mag[0-9]*$".r
-      magRx.replaceAllIn(rawDataSetName, "")
+      (node \ "@name").text
     }
 
     private def parseDescription(node: NodeSeq) = {


### PR DESCRIPTION
### Mailable description of changes:
 - `_magXX` in dataset names in NMLs is no longer removed

### Steps to test:
see: https://discuss.webknossos.org/t/volume-tracing-doesnt-load/529/6

### Issues:

------
- [x] Ready for review
