### PR TITLE
task search: invalid mongoIDs now lead to empty result instead of exception

### DIFF
--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -211,7 +211,7 @@ object TaskDAO extends SecuredBaseDAO[Task] with FoxImplicits with QuerySupporte
     }
 
     val idsFilter = idsOpt match {
-      case Some(ids) => Json.obj(("_id") -> Json.obj("$in" -> ids.map(id => Json.obj("$oid" -> id))))
+      case Some(ids) => Json.obj(("_id") -> Json.obj("$in" -> ids.filter(BSONObjectID.parse(_).isSuccess).map(id => Json.obj("$oid" -> id))))
       case None => Json.obj()
     }
 


### PR DESCRIPTION
### Steps to test:
- Create a few tasks
- In Admin→Tasks, search for some IDs, matching tasks should show up
- Make one of the IDs invalid by deleting some characters, one result less should show up

### Issues:
- fixes #2103

------
- [x] Ready for review
