### PR TITLE
Validation scripts

### DIFF
--- a/conf/schemas/annotations.schema.js
+++ b/conf/schemas/annotations.schema.js
@@ -57,7 +57,7 @@ db.runCommand({
         $or: [{ tracingTime: { $type: "number" } }, { tracingTime: { $exists: false } }],
       },
       {
-        $or: [{ created: { $type: "number" } }, { created: { $exists: false } }],
+        created: { $type: "number", $exists: true },
       },
       {
         _id: { $type: "objectId", $exists: true },

--- a/tools/activateValidation.sh
+++ b/tools/activateValidation.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [ ! $2 ]; then
+  echo " Example of use: $0 database_name schema_dir"
+  exit 1
+fi
+
+db=$1
+schema_dir=$2
+
+host="$3"
+if [ ! $3 ]; then
+  host="localhost:27017"
+fi
+
+for schema in `ls $schema_dir`
+do
+  mongo "$host/$db" "$schema_dir/$schema"
+done

--- a/tools/import_export/import.sh
+++ b/tools/import_export/import.sh
@@ -19,5 +19,13 @@ for dump_file in `ls $dump_dir`
 do
   collection=${dump_file%.json}
   mongo "$host/$db" --eval "db.${collection}.drop()"
+  mongo "$host/$db" --eval "db.createCollection('$collection')"
+done
+
+bash ../activateValidation.sh "$db" "$dump_dir/../../conf/schemas" "$host"  
+
+for dump_file in `ls $dump_dir`
+do
+  collection=${dump_file%.json}
   mongoimport --db "$db" --host "$host" --collection "$collection" --file "$dump_dir/$dump_file"
 done

--- a/tools/import_export/import.sh
+++ b/tools/import_export/import.sh
@@ -22,7 +22,8 @@ do
   mongo "$host/$db" --eval "db.createCollection('$collection')"
 done
 
-bash ../activateValidation.sh "$db" "$dump_dir/../../conf/schemas" "$host"  
+bash ../activateValidation.sh "$db" "$dump_dir/../../conf/schemas" "$host"
+bash ../validationAction.sh "$db" "error" "$dump_dir/../../conf/schemas" "$host"
 
 for dump_file in `ls $dump_dir`
 do

--- a/tools/validationAction.sh
+++ b/tools/validationAction.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ ! $2 ]; then
-  echo " Example of use: $0 database_name schema_dir"
+  echo " Example of use: $0 error/warn database_name schema_dir"
   exit 1
 fi
 

--- a/tools/validationAction.sh
+++ b/tools/validationAction.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+if [ ! $2 ]; then
+  echo " Example of use: $0 database_name schema_dir"
+  exit 1
+fi
+
+db=$1
+schema_dir=$3
+action=$2
+
+host="$4"
+if [ ! $4 ]; then
+  host="localhost:27017"
+fi
+
+for script in `ls $schema_dir`
+do
+  collection=${script%.schema.js}
+  mongo "$host/$db" --eval "db.runCommand({ collMod: '$collection', validationAction: '$action'});"
+done


### PR DESCRIPTION
- These are the scripts to activate validation and change between `error` and `warn` validation action.
- The script for the test import is changed so the validation gets activated before the data is imported.

### Steps to test:
- bash activateValidation.sh database_name schema_dir host
- activate all validations located in schema_dir

- bash validationAction.sh error/warn database_name schema_dir host
- switches the validationAction of all validations located in schema_dir to error/warn

### Issues:
- related to #1929

------
- [x] Ready for review
