### PR TITLE
on multi-nml upload (not only zip): add file name as prefix to trees

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -63,8 +63,10 @@ class AnnotationIOController @Inject()(val messagesApi: MessagesApi)
       case (acc, next) => acc.combineWith(NmlService.extractFromFile(next.ref.file, next.filename))
     }
 
+    val parseResultsPrefixed = NmlService.addPrefixesToTreeNames(parsedFiles.parseResults)
+
     if (!parsedFiles.isEmpty) {
-      val parseSuccess = parsedFiles.parseResults.filter(_.succeeded)
+      val parseSuccess = parseResultsPrefixed.filter(_.succeeded)
       val fileNames = parseSuccess.map(_.fileName)
       val tracings = parseSuccess.flatMap(_.tracing)
       val (skeletonTracings, volumeTracings) = NmlService.splitVolumeAndSkeletonTracings(tracings)

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -9,8 +9,8 @@ import com.scalableminds.braingames.datastore.tracings.{ProtoGeometryImplicits, 
 import com.scalableminds.util.geometry.{BoundingBox, Point3D, Vector3D}
 import com.scalableminds.util.reactivemongo.DBAccessContext
 import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper, TimeLogger}
-import models.annotation.{AnnotationDAO, AnnotationService, AnnotationType}
 import models.annotation.nml.NmlService
+import models.annotation.{AnnotationDAO, AnnotationService, AnnotationType}
 import models.binary.DataSetDAO
 import models.project.{Project, ProjectDAO}
 import models.task._
@@ -21,7 +21,6 @@ import play.api.Play.current
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.iteratee._
-import play.api.libs.json.Json._
 import play.api.libs.json._
 import play.api.mvc.Result
 import play.twirl.api.Html
@@ -107,8 +106,10 @@ class TaskController @Inject() (val messagesApi: MessagesApi) extends Controller
   private def parseResultToSkeletonTracingFox(parseResult: NmlService.NmlParseResult): Fox[SkeletonTracing] = parseResult match {
     case NmlService.NmlParseFailure(fileName, error) =>
       Fox.failure(Messages("nml.file.invalid", fileName, error))
-    case NmlService.NmlParseSuccess(fileName, tracing) =>
-      Fox.successful(tracing.asInstanceOf[SkeletonTracing])
+    case NmlService.NmlParseSuccess(fileName, (Left(skeletonTracing), description)) =>
+      Fox.successful(skeletonTracing)
+    case _ =>
+      Fox.failure(Messages("nml.file.invalid"))
   }
 
   private def buildFullParams(nmlParams: NmlTaskParameters, tracing: SkeletonTracing) = {

--- a/app/models/annotation/nml/NmlService.scala
+++ b/app/models/annotation/nml/NmlService.scala
@@ -78,10 +78,10 @@ object NmlService extends LazyLogging {
         otherFiles += (filename.toString -> tempFile)
       }
     }
-    ZipParseResult(addPrefixesToTreeNames(parseResults), otherFiles)
+    ZipParseResult(parseResults, otherFiles)
   }
 
-  private def addPrefixesToTreeNames(parseResults: List[NmlParseResult]): List[NmlParseResult] = {
+  def addPrefixesToTreeNames(parseResults: List[NmlParseResult]): List[NmlParseResult] = {
     def renameTrees(name: String, tracing: SkeletonTracing): SkeletonTracing = {
       val prefix = name.replaceAll("\\.[^.]*$", "") + "_"
       tracing.copy(trees = tracing.trees.map(tree => tree.copy(name = prefix + tree.name)))


### PR DESCRIPTION
Sequel to PR [2101](https://github.com/scalableminds/webknossos/pull/2101): When uploading multiple NMLs (this time not as zip), the trees are be renamed, with the respective NML names as prefixes. (This was already the behavior before bnw)

### Steps to test:
- upload two NMLs containing trees
- trees of the merged tracing should have the respective NML filenames as prefixes

### Issues:
- fixes #2100

------
- [x] Ready for review
