### PR TITLE
Fixed millisecond to minute conversion for a project's expectedTime

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -32,6 +32,35 @@ function assertResponseLimit(collection) {
   }
 }
 
+// ### Do with userToken
+
+let tokenRequestPromise;
+function requestUserToken(): Promise<string> {
+  if (tokenRequestPromise) {
+    return tokenRequestPromise;
+  }
+
+  tokenRequestPromise = Request.receiveJSON("/api/userToken/generate").then(tokenObj => {
+    tokenRequestPromise = null;
+    return tokenObj.token;
+  });
+
+  return tokenRequestPromise;
+}
+
+let tokenPromise;
+export async function doWithToken<T>(fn: (token: string) => Promise<T>): Promise<*> {
+  if (!tokenPromise) tokenPromise = requestUserToken();
+  return tokenPromise.then(fn).catch(error => {
+    if (error.status === 403) {
+      console.warn("Token expired. Requesting new token...");
+      tokenPromise = requestUserToken();
+      return doWithToken(fn);
+    }
+    throw error;
+  });
+}
+
 // ### Users
 export async function getUsers(): Promise<Array<APIUserType>> {
   const users = await Request.receiveJSON("/api/users");
@@ -166,65 +195,34 @@ export async function deleteTeam(teamId: string): Promise<void> {
 }
 
 // ### Projects
+function transformProject(response): APIProjectType {
+  return Object.assign(response, {
+    expectedTime: Utils.millisecondsToMinutes(response.expectedTime),
+  });
+}
+
 export async function getProjects(): Promise<Array<APIProjectType>> {
   const responses = await Request.receiveJSON("/api/projects");
   assertResponseLimit(responses);
 
-  const projects = responses.map(response =>
-    Object.assign(response, { expectedTime: Utils.millisecondsToMinutes(response.expectedTime) }),
-  );
-  return projects;
+  return responses.map(transformProject);
 }
 
 export async function getProjectsWithOpenAssignments(): Promise<Array<APIProjectType>> {
   const responses = await Request.receiveJSON("/api/projects/assignments");
   assertResponseLimit(responses);
 
-  const projects = responses.map(response =>
-    Object.assign(response, { expectedTime: Utils.millisecondsToMinutes(response.expectedTime) }),
-  );
-  return projects;
+  return responses.map(transformProject);
 }
 
 export async function getProject(projectName: string): Promise<APIProjectType> {
   const project = await Request.receiveJSON(`/api/projects/${projectName}`);
-  return Object.assign(project, {
-    expectedTime: Utils.millisecondsToMinutes(project.expectedTime),
-  });
+  return transformProject(project);
 }
 
 export async function deleteProject(projectName: string): Promise<void> {
   return Request.receiveJSON(`/api/projects/${projectName}`, {
     method: "DELETE",
-  });
-}
-
-// ### Do with userToken
-
-let tokenRequestPromise;
-function requestUserToken(): Promise<string> {
-  if (tokenRequestPromise) {
-    return tokenRequestPromise;
-  }
-
-  tokenRequestPromise = Request.receiveJSON("/api/userToken/generate").then(tokenObj => {
-    tokenRequestPromise = null;
-    return tokenObj.token;
-  });
-
-  return tokenRequestPromise;
-}
-
-let tokenPromise;
-export async function doWithToken<T>(fn: (token: string) => Promise<T>): Promise<*> {
-  if (!tokenPromise) tokenPromise = requestUserToken();
-  return tokenPromise.then(fn).catch(error => {
-    if (error.status === 403) {
-      console.warn("Token expired. Requesting new token...");
-      tokenPromise = requestUserToken();
-      return doWithToken(fn);
-    }
-    throw error;
   });
 }
 
@@ -253,12 +251,14 @@ export async function updateProject(
   });
 }
 
-export function pauseProject(projectName: string): Promise<void> {
-  return Request.receiveJSON(`/api/projects/${projectName}/pause`);
+export async function pauseProject(projectName: string): Promise<APIProjectType> {
+  const project = await Request.receiveJSON(`/api/projects/${projectName}/pause`);
+  return transformProject(project);
 }
 
-export function resumeProject(projectName: string): Promise<void> {
-  return Request.receiveJSON(`/api/projects/${projectName}/resume`);
+export async function resumeProject(projectName: string): Promise<APIProjectType> {
+  const project = await Request.receiveJSON(`/api/projects/${projectName}/resume`);
+  return transformProject(project);
 }
 
 // ### Tasks

--- a/app/assets/javascripts/admin/views/project/project_list_view.js
+++ b/app/assets/javascripts/admin/views/project/project_list_view.js
@@ -175,7 +175,8 @@ class ProjectListView extends React.PureComponent<{}, State> {
                 sorter={Utils.localeCompareBy((project: APIProjectType) =>
                   project.expectedTime.toString(),
                 )}
-                render={expectedTime => `${expectedTime}m`}
+                render={(expectedTime, project: APIProjectType) =>
+                  project.paused ? "<paused>" : `${expectedTime}m`}
               />
               <Column
                 title="Action"

--- a/app/assets/javascripts/admin/views/project/project_list_view.js
+++ b/app/assets/javascripts/admin/views/project/project_list_view.js
@@ -175,8 +175,7 @@ class ProjectListView extends React.PureComponent<{}, State> {
                 sorter={Utils.localeCompareBy((project: APIProjectType) =>
                   project.expectedTime.toString(),
                 )}
-                render={(expectedTime, project: APIProjectType) =>
-                  project.paused ? "<paused>" : `${expectedTime}m`}
+                render={expectedTime => `${expectedTime}m`}
               />
               <Column
                 title="Action"


### PR DESCRIPTION
### Mailable description of changes:
- [Admin.Projects] Fixed incorrect conversion of milliseconds to minutes when pausing / resuming a project

### Steps to test:
- Go to Admin --> Projects
- Create  a project
- Click on the "Pause" action on the right hand side. Expected Time should still be the same value. e.g. 60min or 90min by default
- Click on the "Resume" action on the right hand side. Expected Time should still be the same value. e.g. 60min or 90min by default

### Issues:
- fixes https://discuss.webknossos.org/t/crazy-expected-time-for-project-after-pause/570

------
- [x] Ready for review
