### PR TITLE
Fix bug where an empty tree was created after nml upload

### DIFF
--- a/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
@@ -29,7 +29,13 @@ import {
   getNodeAndTree,
 } from "oxalis/model/accessors/skeletontracing_accessor";
 import Constants from "oxalis/constants";
-import type { OxalisState, SkeletonTracingType, NodeType, BranchPointType } from "oxalis/store";
+import type {
+  OxalisState,
+  SkeletonTracingType,
+  NodeType,
+  BranchPointType,
+  TreeType,
+} from "oxalis/store";
 import type { ServerNodeType, ServerBranchPointType } from "oxalis/model";
 import type { ActionType } from "oxalis/model/actions/actions";
 import Maybe from "data.maybe";
@@ -65,17 +71,17 @@ function SkeletonTracingReducer(state: OxalisState, action: ActionType): OxalisS
       );
 
       const trees = _.keyBy(
-        action.tracing.trees.map(tree =>
-          update(tree, {
-            nodes: { $set: _.keyBy(_.map(tree.nodes, serverNodeToNode), "id") },
-            color: {
-              $set: tree.color || ColorGenerator.distinctColorForId(tree.treeId),
-            },
-            branchPoints: { $set: _.map(tree.branchPoints, serverBranchPointToBranchPoint) },
-            isVisible: { $set: true },
-            timestamp: { $set: tree.createdTimestamp },
-          }),
-        ),
+        action.tracing.trees.map((tree): TreeType => ({
+          comments: tree.comments,
+          edges: tree.edges,
+          name: tree.name,
+          treeId: tree.treeId,
+          nodes: _.keyBy(_.map(tree.nodes, serverNodeToNode), "id"),
+          color: tree.color || ColorGenerator.distinctColorForId(tree.treeId),
+          branchPoints: _.map(tree.branchPoints, serverBranchPointToBranchPoint),
+          isVisible: true,
+          timestamp: tree.createdTimestamp,
+        })),
         "treeId",
       );
 
@@ -106,7 +112,7 @@ function SkeletonTracingReducer(state: OxalisState, action: ActionType): OxalisS
         })
         .orElse(() => {
           // use last tree for active tree
-          const lastTree = Maybe.fromNullable(_.maxBy(_.values(trees), tree => tree.id));
+          const lastTree = Maybe.fromNullable(_.maxBy(_.values(trees), tree => tree.treeId));
           return lastTree.map(t => t.treeId);
         });
       const activeTreeId = Utils.toNullable(activeTreeIdMaybe);

--- a/app/assets/javascripts/oxalis/model/sagas/save_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/save_saga.js
@@ -224,9 +224,11 @@ function compactMovedNodesAndEdges(updateActions: Array<UpdateAction>) {
   for (const movedPairings of _.values(groupedMovedNodesAndEdges)) {
     const oldTreeId = movedPairings[0][1].value.treeId;
     const newTreeId = movedPairings[0][0].value.treeId;
-    const nodeIds = movedPairings
-      .filter(([createUA]) => createUA.name === "createNode")
-      .map(([createUA]) => createUA.value.id);
+    // This could be done with a .filter(...).map(...), but flow cannot comprehend that
+    const nodeIds = movedPairings.reduce((agg, [createUA]) => {
+      if (createUA.name === "createNode") agg.push(createUA.value.id);
+      return agg;
+    }, []);
     // The moveTreeComponent update action needs to be placed:
     // BEFORE the possible deleteTree update action of the oldTreeId and
     // AFTER the possible createTree update action of the newTreeId

--- a/flow-typed/npm/immutability-helper_vx.x.x.js
+++ b/flow-typed/npm/immutability-helper_vx.x.x.js
@@ -1,0 +1,3 @@
+declare module "immutability-helper" {
+  declare module.exports: <T>(arg1: T, arg2: Object) => T;
+}

--- a/flow-typed/npm/lodash_v4.x.x.js
+++ b/flow-typed/npm/lodash_v4.x.x.js
@@ -197,7 +197,8 @@ declare module 'lodash' {
     includes(str: string, value: string, fromIndex?: number): bool;
     invokeMap<T>(array: ?Array<T>, path: ((value: T) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
     invokeMap<T: Object>(object: T, path: ((value: any) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
-    keyBy<T, V>(array: ?Array<T>, iteratee?: ValueOnlyIteratee<T>): {[key: V]: T};
+    keyBy<T, V>(array: ?Array<T>, iteratee?: (value: T) => V): {[key: V]: T};
+    keyBy<T: Object, V: string>(array: ?Array<T>, iteratee?: V): {[key: $ElementType<T, V>]: T};
     keyBy<V, A, I, T: {[id: I]: A}>(object: T, iteratee?: ValueOnlyIteratee<A>): {[key: V]: ?A};
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(object: ?T, iteratee?: OMapIterator<V, T, U>): Array<U>;
@@ -410,6 +411,7 @@ declare module 'lodash' {
     unset(object?: ?Object, path?: ?Array<string>|string): bool;
     update(object: Object, path: string[]|string, updater: Function): Object;
     updateWith(object: Object, path: string[]|string, updater: Function, customizer?: Function): Object;
+    values<K,V>(object?: {[key: K]: V}): Array<V>;
     values(object?: ?Object): Array<any>;
     valuesIn(object?: ?Object): Array<any>;
 


### PR DESCRIPTION
This PR fixes the mentioned bug, by setting the proper activeTreeId while loading a tracing. It also adds flow typedefs for the immutability-helpers `update` function and fixes those for `_.keyBy` and `_.values`, so the next time this happens, flow will catch the error.

### Mailable description of changes:
 - The bug where a new empty tree was created after an NML upload, is now fixed.

### Steps to test:
- Upload an NML, no new empty tree should be created

### Issues:
- fixes #2102 

------
- [x] Ready for review
