### PR TITLE
fix update of sphericalCapRadius

### DIFF
--- a/app/assets/javascripts/oxalis/geometries/arbitrary_plane.js
+++ b/app/assets/javascripts/oxalis/geometries/arbitrary_plane.js
@@ -175,7 +175,7 @@ class ArbitraryPlane {
   });
 
   setSphericalCapRadius(sphericalCapRadius: number) {
-    if (Store.getState().viewMode === constants.MODE_ARBITRARY) {
+    if (Store.getState().temporaryConfiguration.viewMode === constants.MODE_ARBITRARY) {
       this.queryVertices = this.calculateSphereVertices(sphericalCapRadius);
       this.isDirty = true;
     }


### PR DESCRIPTION
Due to a "typo", before this PR, the sphericalCapRadius was only updated when the mode was switched.

### Steps to test:
- Change the spere radius in flight mode => should be immediately visible in the viewport

------
- [x] Ready for review
