### PR TITLE
make taskType preferred mode optional during creation; fixes #2126

### DIFF
--- a/app/assets/javascripts/admin/views/tasktype/task_type_create_view.js
+++ b/app/assets/javascripts/admin/views/tasktype/task_type_create_view.js
@@ -82,11 +82,7 @@ class TaskTypeCreateView extends React.PureComponent<Props, State> {
 
             <FormItem label="Team" hasFeedback>
               {getFieldDecorator("team", {
-                rules: [
-                  {
-                    required: true,
-                  },
-                ],
+                rules: [{ required: true }],
               })(
                 <Select
                   allowClear
@@ -121,21 +117,13 @@ class TaskTypeCreateView extends React.PureComponent<Props, State> {
               hasFeedback
             >
               {getFieldDecorator("description", {
-                rules: [
-                  {
-                    required: true,
-                  },
-                ],
+                rules: [{ required: true }],
               })(<TextArea rows={3} />)}
             </FormItem>
 
             <FormItem label="Allowed Modes" hasFeedback>
               {getFieldDecorator("settings.allowedModes", {
-                rules: [
-                  {
-                    required: true,
-                  },
-                ],
+                rules: [{ required: true }],
               })(
                 <Select
                   mode="multiple"
@@ -169,13 +157,7 @@ class TaskTypeCreateView extends React.PureComponent<Props, State> {
             </FormItem>
 
             <FormItem label="Preferred Mode" hasFeedback>
-              {getFieldDecorator("settings.preferredMode", {
-                rules: [
-                  {
-                    required: true,
-                  },
-                ],
-              })(
+              {getFieldDecorator("settings.preferredMode")(
                 <Select allowClear optionFilterProp="children" style={{ width: "100%" }}>
                   <Option value={null}>Any</Option>
                   <Option value="orthogonal">Orthogonal</Option>


### PR DESCRIPTION
### Mailable description of changes:
- [Admin.TaskType Creation] Fixed `preferredMode` setting. Preferred mode is optional  (=any mode is allowed)

### Steps to test:
- Create a TaskType
- Either leave preferredMode empty or select `any` --> Submit From. No error should show.

### Issues:
- fixes #2126

------
- [x] Ready for review
