### PR TITLE
Fix volume mode lag by yielding during base64 and gzip encoding

### DIFF
--- a/app/assets/javascripts/libs/utils.js
+++ b/app/assets/javascripts/libs/utils.js
@@ -7,6 +7,7 @@ import _ from "lodash";
 import type { Vector3, Vector4, Vector6, BoundingBoxType } from "oxalis/constants";
 import Maybe from "data.maybe";
 import window from "libs/window";
+import pako from "pako";
 import type { APIUserType } from "admin/api_flow_types";
 
 type Comparator<T> = (T, T) => -1 | 0 | 1;
@@ -373,6 +374,22 @@ const Utils = {
 
   minutesToMilliseconds(min: number) {
     return min * 60000;
+  },
+
+  async compress(data: Uint8Array | string): Promise<Uint8Array> {
+    const DEFLATE_PUSH_SIZE = 65536;
+
+    const deflator = new pako.Deflate({ gzip: true });
+    for (let offset = 0; offset < data.length; offset += DEFLATE_PUSH_SIZE) {
+      // The second parameter to push indicates whether this is the last chunk to be deflated
+      deflator.push(
+        data.slice(offset, offset + DEFLATE_PUSH_SIZE),
+        offset + DEFLATE_PUSH_SIZE >= data.length,
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await Utils.sleep(1);
+    }
+    return deflator.result;
   },
 };
 

--- a/app/assets/javascripts/oxalis/model/actions/save_actions.js
+++ b/app/assets/javascripts/oxalis/model/actions/save_actions.js
@@ -10,7 +10,6 @@ import type { UpdateAction } from "oxalis/model/sagas/update_actions";
 type PushSaveQueueActionType = {
   type: "PUSH_SAVE_QUEUE",
   items: Array<UpdateAction>,
-  pushNow: boolean,
 };
 type SaveNowActionType = { type: "SAVE_NOW" };
 type ShiftSaveQueueActionType = { type: "SHIFT_SAVE_QUEUE", count: number };
@@ -31,13 +30,9 @@ export type SaveActionType =
   | UndoActionType
   | RedoActionType;
 
-export const pushSaveQueueAction = (
-  items: Array<UpdateAction>,
-  pushNow?: boolean = false,
-): PushSaveQueueActionType => ({
+export const pushSaveQueueAction = (items: Array<UpdateAction>): PushSaveQueueActionType => ({
   type: "PUSH_SAVE_QUEUE",
   items,
-  pushNow,
 });
 
 export const saveNowAction = (): SaveNowActionType => ({

--- a/app/assets/javascripts/oxalis/model/binary/layers/wk_layer.js
+++ b/app/assets/javascripts/oxalis/model/binary/layers/wk_layer.js
@@ -84,13 +84,14 @@ class WkLayer extends Layer {
   }
 
   async sendToStoreImpl(batch: Array<DataBucket>): Promise<void> {
+    const YIELD_AFTER_X_BUCKETS = 3;
     let counter = 0;
     const items = [];
     for (const bucket of batch) {
       counter++;
       // Do not block the main thread for too long as Base64.fromByteArray is performance heavy
       // eslint-disable-next-line no-await-in-loop
-      if (counter % 3 === 0) await Utils.sleep(1);
+      if (counter % YIELD_AFTER_X_BUCKETS === 0) await Utils.sleep(1);
       const bucketData = bucket.getData();
       const bucketInfo = BucketBuilder.fromZoomedAddress(bucket.zoomedAddress);
       items.push(updateBucket(bucketInfo, Base64.fromByteArray(bucketData)));

--- a/app/assets/javascripts/oxalis/model/binary/layers/wk_layer.js
+++ b/app/assets/javascripts/oxalis/model/binary/layers/wk_layer.js
@@ -13,6 +13,7 @@ import Request from "libs/request";
 import Store from "oxalis/store";
 import { pushSaveQueueAction } from "oxalis/model/actions/save_actions";
 import { updateBucket } from "oxalis/model/sagas/update_actions";
+import Utils from "libs/utils";
 import type { Vector4 } from "oxalis/constants";
 import type { DataLayerType, DataStoreInfoType } from "oxalis/store";
 import type { DataBucket } from "oxalis/model/binary/bucket";
@@ -83,11 +84,17 @@ class WkLayer extends Layer {
   }
 
   async sendToStoreImpl(batch: Array<DataBucket>): Promise<void> {
-    const items = batch.map(bucket => {
+    let counter = 0;
+    const items = [];
+    for (const bucket of batch) {
+      counter++;
+      // Do not block the main thread for too long as Base64.fromByteArray is performance heavy
+      // eslint-disable-next-line no-await-in-loop
+      if (counter % 3 === 0) await Utils.sleep(1);
       const bucketData = bucket.getData();
       const bucketInfo = BucketBuilder.fromZoomedAddress(bucket.zoomedAddress);
-      return updateBucket(bucketInfo, Base64.fromByteArray(bucketData));
-    });
+      items.push(updateBucket(bucketInfo, Base64.fromByteArray(bucketData)));
+    }
     Store.dispatch(pushSaveQueueAction(items));
   }
 }

--- a/app/assets/javascripts/oxalis/model/sagas/save_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/save_saga.js
@@ -84,15 +84,20 @@ export function* pushAnnotationAsync(): Generator<*, *, *> {
   yield take(["INITIALIZE_SKELETONTRACING", "INITIALIZE_VOLUMETRACING"]);
   yield put(setLastSaveTimestampAction());
   while (true) {
-    const pushAction = yield take("PUSH_SAVE_QUEUE");
-    if (!pushAction.pushNow) {
-      yield race({
-        timeout: call(delay, PUSH_THROTTLE_TIME),
-        forcePush: take("SAVE_NOW"),
-      });
+    let saveQueue;
+    // Check whether the save queue is actually empty, the PUSH_SAVE_QUEUE action
+    // could have been triggered during the call to sendRequestToServer
+    saveQueue = yield select(state => state.save.queue);
+    if (saveQueue.length === 0) {
+      // Save queue is empty, wait for push event
+      yield take("PUSH_SAVE_QUEUE");
     }
+    yield race({
+      timeout: call(delay, PUSH_THROTTLE_TIME),
+      forcePush: take("SAVE_NOW"),
+    });
     yield put(setSaveBusyAction(true));
-    const saveQueue = yield select(state => state.save.queue);
+    saveQueue = yield select(state => state.save.queue);
     if (saveQueue.length > 0) {
       yield call(sendRequestToServer);
     }

--- a/app/assets/javascripts/test/helpers/apiHelpers.js
+++ b/app/assets/javascripts/test/helpers/apiHelpers.js
@@ -17,7 +17,6 @@ import DATASET from "../fixtures/dataset_server_object";
 const Request = {
   receiveJSON: sinon.stub(),
   sendJSONReceiveJSON: sinon.stub(),
-  sendArraybufferReceiveArraybuffer: sinon.stub(),
   always: () => Promise.resolve(),
 };
 const ErrorHandling = {
@@ -45,7 +44,7 @@ export const KeyboardJS = {
   unbind: _.noop,
 };
 mockRequire("libs/keyboard", KeyboardJS);
-mockRequire("libs/toast", { error: _.noop, warning: _.noop });
+mockRequire("libs/toast", { error: _.noop, warning: _.noop, close: _.noop });
 mockRequire("libs/window", window);
 mockRequire("libs/request", Request);
 mockRequire("libs/error_handling", ErrorHandling);

--- a/app/assets/javascripts/test/model/binary/layers/wk_layer.spec.js
+++ b/app/assets/javascripts/test/model/binary/layers/wk_layer.spec.js
@@ -171,7 +171,6 @@ test.serial("sendToStore: Request Handling should send the correct request param
         },
       },
     ],
-    pushNow: false,
   };
 
   return layer.sendToStore(batch).then(() => {

--- a/app/assets/javascripts/test/sagas/save_saga.spec.js
+++ b/app/assets/javascripts/test/sagas/save_saga.spec.js
@@ -92,14 +92,17 @@ test("SaveSaga should send update actions", t => {
   const saga = pushAnnotationAsync();
   expectValueDeepEqual(t, saga.next(), take(INIT_ACTIONS));
   saga.next(); // setLastSaveTimestampAction
-  expectValueDeepEqual(t, saga.next(), take("PUSH_SAVE_QUEUE"));
-  saga.next(SaveActions.pushSaveQueueAction(updateActions, true));
+  saga.next(); // select state
+  expectValueDeepEqual(t, saga.next([]), take("PUSH_SAVE_QUEUE"));
+  saga.next(); // race
+  saga.next(SaveActions.pushSaveQueueAction(updateActions));
   saga.next();
   expectValueDeepEqual(t, saga.next(saveQueue), call(sendRequestToServer));
   saga.next(); // SET_SAVE_BUSY
 
   // Test that loop repeats
-  expectValueDeepEqual(t, saga.next(), take("PUSH_SAVE_QUEUE"));
+  saga.next(); // select state
+  expectValueDeepEqual(t, saga.next([]), take("PUSH_SAVE_QUEUE"));
 });
 
 test("SaveSaga should send request to server", t => {
@@ -189,8 +192,10 @@ test("SaveSaga should send update actions right away", t => {
   const saga = pushAnnotationAsync();
   expectValueDeepEqual(t, saga.next(), take(INIT_ACTIONS));
   saga.next();
-  expectValueDeepEqual(t, saga.next(), take("PUSH_SAVE_QUEUE"));
-  saga.next(SaveActions.pushSaveQueueAction(updateActions, true));
+  saga.next(); // select state
+  expectValueDeepEqual(t, saga.next([]), take("PUSH_SAVE_QUEUE"));
+  saga.next(); // race
+  saga.next(SaveActions.pushSaveQueueAction(updateActions));
   saga.next(SaveActions.saveNowAction());
   saga.next(saveQueue);
   saga.next();


### PR DESCRIPTION
This PR solves the volume mode save lag, by yielding during the base64 encoding of buckets and the gzip encoding of the update actions, so the main thread is not blocked by these performance heavy computations.

For some reason in the `sendToStoreImpl` I couldn't use `await Promise.all(batch.map(async ...))` because Flow complained that the result was not the array it expected :confused: 

### Mailable description of changes:
 - Fixed lag that periodically occurred in volume mode.

### Steps to test:
- Use the `Trace` mode in a volume tracing. There should be no lag when tracing immediately after the last slice was traced and there should also be no lag during the saving of the save queue (trigger using `Ctrl/Cmd + Save`).
- Saving should not take overly long as a result of this PR

### Issues:
- fixes #2136

------
- [x] Ready for review
