### PR TITLE
add query to list users with open tasks for project

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -236,6 +236,13 @@ object AnnotationDAO extends SecuredBaseDAO[Annotation]
         Json.obj("state.isAssigned" -> true),
         Json.obj("state.isFinished" -> true))))
 
+  def findAllUnfinishedByTaskIds(taskIds: List[BSONObjectID])(implicit ctx: DBAccessContext) = {
+    find(Json.obj(
+      "_task" -> Json.obj("$in" -> Json.toJson(taskIds)),
+      "state.isFinished" -> false
+    )).cursor[Annotation]().collect[List]()
+  }
+
   def findByTracingId(tracingId: String)(implicit ctx: DBAccessContext): Fox[Annotation] = {
     findOne(Json.obj(
       "tracingReference.id" -> tracingId

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -221,6 +221,12 @@ object UserDAO extends SecuredBaseDAO[User] {
     update(findByIdQ(_user), Json.obj("$set" -> Json.obj("pwdHash" -> hashPassword(pswd))))
   }
 
+  def findAllByIds(ids: List[BSONObjectID])(implicit ctx: DBAccessContext) = {
+    find(Json.obj(
+      "_id" -> Json.obj("$in" -> Json.toJson(ids))
+    )).cursor[User]().collect[List]()
+  }
+
   def findAllNonAnonymous(implicit ctx: DBAccessContext) = {
     find(Json.obj("_isAnonymous" -> Json.obj("$ne" -> true))).cursor[User]().collect[List]()
   }

--- a/conf/webknossos.routes
+++ b/conf/webknossos.routes
@@ -174,6 +174,7 @@ PUT           /api/projects/:name                                               
 GET           /api/projects/:name/tasks                                         controllers.ProjectController.tasksForProject(name: String)
 GET           /api/projects/:name/pause                                         controllers.ProjectController.pause(name: String)
 GET           /api/projects/:name/resume                                        controllers.ProjectController.resume(name: String)
+GET           /api/projects/:name/usersWithOpenTasks                            controllers.ProjectController.usersWithOpenTasks(name:String)
 
 # Statistics
 GET           /statistics                                                       controllers.StatisticsController.empty


### PR DESCRIPTION
### Steps to test:
- on a webknossos with at least two users and a project,
- create tasks, trace on them, don’t finish yet.
- go to `api/projects/aProject/usersWithOpenTasks`
- it should give you a json list of email adresses

### Issues:
- fixes #2140
------
- [x] Ready for review
