### PR TITLE
ensure more db indices in code

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -123,6 +123,8 @@ object AnnotationDAO extends SecuredBaseDAO[Annotation]
 
   underlying.indexesManager.ensure(Index(Seq("isActive" -> IndexType.Ascending, "_task" -> IndexType.Ascending)))
   underlying.indexesManager.ensure(Index(Seq("isActive" -> IndexType.Ascending, "_user" -> IndexType.Ascending, "_task" -> IndexType.Ascending)))
+  underlying.indexesManager.ensure(Index(Seq("tracingReference.id" -> IndexType.Ascending)))
+  underlying.indexesManager.ensure(Index(Seq("_task" -> IndexType.Ascending, "typ" -> IndexType.Ascending)))
 
   override def find(query: JsObject = Json.obj())(implicit ctx: DBAccessContext) = {
     super.find(query ++ Json.obj("isActive" -> true))

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -150,6 +150,7 @@ object TaskDAO extends SecuredBaseDAO[Task] with FoxImplicits with QuerySupporte
   underlying.indexesManager.ensure(Index(Seq("_project" -> IndexType.Ascending)))
   underlying.indexesManager.ensure(Index(Seq("team" -> IndexType.Ascending)))
   underlying.indexesManager.ensure(Index(Seq("_taskType" -> IndexType.Ascending)))
+  underlying.indexesManager.ensure(Index(Seq("_user" -> IndexType.Ascending, "_task" -> IndexType.Ascending)))
 
   override val AccessDefinitions = new DefaultAccessDefinitions {
 

--- a/app/models/user/time/TimeSpanDAO.scala
+++ b/app/models/user/time/TimeSpanDAO.scala
@@ -15,6 +15,7 @@ object TimeSpanDAO extends SecuredBaseDAO[TimeSpan] {
   val formatter = TimeSpan.timeSpanFormat
 
   underlying.indexesManager.ensure(Index(List("timestamp" -> IndexType.Descending)))
+  underlying.indexesManager.ensure(Index(List("annotation" -> IndexType.Ascending)))
 
   def intervalFilter(start: Option[Long], end: Option[Long]) = {
 


### PR DESCRIPTION
those indices have been already created in the db, but were not yet ensured by the scala code

### Steps to test:
- run wk locally
- the db should have the same indices on touched collections as the master instance

### Issues:
- fixes #2148

------
- [x] Ready for review
