### PR TITLE
fix redirect after finish

### DIFF
--- a/app/assets/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -1,10 +1,9 @@
 // @flow
 import React, { PureComponent } from "react";
-import { withRouter } from "react-router-dom";
 import Model from "oxalis/model";
 import Store from "oxalis/store";
 import { connect } from "react-redux";
-import { Button, Dropdown, Menu, Icon } from "antd";
+import { Button, Dropdown, Menu, Icon, Modal } from "antd";
 import Constants from "oxalis/constants";
 import MergeModalView from "oxalis/view/action-bar/merge_modal_view";
 import ShareModalView from "oxalis/view/action-bar/share_modal_view";
@@ -18,7 +17,6 @@ import { copyAnnotationToUserAccount } from "admin/admin_rest_api";
 import { location } from "libs/window";
 import type { OxalisState, RestrictionsType, SettingsType, TaskType } from "oxalis/store";
 import type { APIUserType } from "admin/api_flow_types";
-import type { ReactRouterHistoryType } from "react_router";
 
 type StateProps = {
   tracingType: string,
@@ -28,17 +26,13 @@ type StateProps = {
   activeUser: ?APIUserType,
 };
 
-type Props = {
-  history: ReactRouterHistoryType,
-} & StateProps;
-
 type State = {
   isShareModalOpen: boolean,
   isMergeModalOpen: boolean,
   isUserScriptsModalOpen: boolean,
 };
 
-class TracingActionsView extends PureComponent<Props, State> {
+class TracingActionsView extends PureComponent<StateProps, State> {
   state = {
     isShareModalOpen: false,
     isMergeModalOpen: false,
@@ -77,9 +71,13 @@ class TracingActionsView extends PureComponent<Props, State> {
       this.props.annotationId
     }/finishAndRedirect`;
     await this.handleSave();
-    if (confirm(messages["annotation.finish"])) {
-      this.props.history.push(url);
-    }
+
+    Modal.confirm({
+      title: messages["annotation.finish"],
+      onOk: () => {
+        location.href = url;
+      },
+    });
   };
 
   handleShareOpen = () => {
@@ -267,4 +265,4 @@ function mapStateToProps(state: OxalisState): StateProps {
   };
 }
 
-export default withRouter(connect(mapStateToProps)(TracingActionsView));
+export default connect(mapStateToProps)(TracingActionsView);


### PR DESCRIPTION
Fixed the "finish" button for a tracing. In order to finish a tracing we send a request to the server and wait for the server to redirect the user back to the dashboard. Server redirection broke because of the react router update.

### Mailable description of changes:
- [Tracing View] Fixed issue with "finish" button not redirecting to dashboard

### Steps to test:
- Open a task annotation
- Click Finish from the dropdown next the save button
- Confirm the modal
- Be redirected to dashboard. Amaze!
- Navigate back to the annotation to double check that it is indeed finished

### Issues:
- fixes https://discuss.webknossos.org/t/task-finish-broken/619/1

------
- [x] Ready for review
