### PR TITLE
Auth cleanup + Token view

### DIFF
--- a/app/assets/javascripts/admin/views/auth/auth_token_view.js
+++ b/app/assets/javascripts/admin/views/auth/auth_token_view.js
@@ -10,7 +10,7 @@ type State = {
   currentToken: string,
 };
 
-class UserTokenView extends React.PureComponent<{}, State> {
+class AuthTokenView extends React.PureComponent<{}, State> {
   state = {
     isLoading: true,
     currentToken: "",
@@ -56,7 +56,7 @@ class UserTokenView extends React.PureComponent<{}, State> {
     return (
       <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
         <Col span={8}>
-          <h3>Token</h3>
+          <h3>Auth Token</h3>
           <Form>
             <FormItem>
               <Input value={this.state.currentToken} readOnly />
@@ -73,4 +73,4 @@ class UserTokenView extends React.PureComponent<{}, State> {
   }
 }
 
-export default UserTokenView;
+export default AuthTokenView;

--- a/app/assets/javascripts/admin/views/auth/change_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/change_password_view.js
@@ -30,7 +30,7 @@ class ChangePasswordView extends React.PureComponent<Props, State> {
       if (!err) {
         Request.sendJSONReceiveJSON("/api/auth/changePassword", { data: formValues }).then(() => {
           Toast.success(messages["auth.reset_pw_confirmation"]);
-          this.props.history.push("/login");
+          this.props.history.push("/auth/login");
         });
       }
     });

--- a/app/assets/javascripts/admin/views/auth/change_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/change_password_view.js
@@ -28,7 +28,7 @@ class ChangePasswordView extends React.PureComponent<Props, State> {
 
     this.props.form.validateFieldsAndScroll((err: ?Object, formValues: Object) => {
       if (!err) {
-        Request.sendJSONReceiveJSON("/api/changepw", { data: formValues }).then(() => {
+        Request.sendJSONReceiveJSON("/api/auth/changePassword", { data: formValues }).then(() => {
           Toast.success(messages["auth.reset_pw_confirmation"]);
           this.props.history.push("/login");
         });

--- a/app/assets/javascripts/admin/views/auth/change_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/change_password_view.js
@@ -64,6 +64,7 @@ class ChangePasswordView extends React.PureComponent<Props, State> {
     return (
       <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
         <Col span={8}>
+          <h3>Change Password</h3>
           <Alert
             type="info"
             message={messages["auth.reset_logout"]}

--- a/app/assets/javascripts/admin/views/auth/finish_reset_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/finish_reset_password_view.js
@@ -28,7 +28,7 @@ class FinishResetPasswordView extends React.PureComponent<Props, State> {
 
     this.props.form.validateFieldsAndScroll((err: ?Object, formValues: Object) => {
       if (!err) {
-        Request.sendJSONReceiveJSON("/api/resetPassword", { data: formValues }).then(() => {
+        Request.sendJSONReceiveJSON("/api/auth/resetPassword", { data: formValues }).then(() => {
           Toast.success(messages["auth.reset_pw_confirmation"]);
           this.props.history.push("/login");
         });

--- a/app/assets/javascripts/admin/views/auth/finish_reset_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/finish_reset_password_view.js
@@ -30,7 +30,7 @@ class FinishResetPasswordView extends React.PureComponent<Props, State> {
       if (!err) {
         Request.sendJSONReceiveJSON("/api/auth/resetPassword", { data: formValues }).then(() => {
           Toast.success(messages["auth.reset_pw_confirmation"]);
-          this.props.history.push("/login");
+          this.props.history.push("/auth/login");
         });
       }
     });

--- a/app/assets/javascripts/admin/views/auth/finish_reset_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/finish_reset_password_view.js
@@ -64,6 +64,7 @@ class FinishResetPasswordView extends React.PureComponent<Props, State> {
     return (
       <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
         <Col span={8}>
+          <h3>Reset Password</h3>
           <Alert
             type="info"
             message={messages["auth.reset_logout"]}

--- a/app/assets/javascripts/admin/views/auth/login_view.js
+++ b/app/assets/javascripts/admin/views/auth/login_view.js
@@ -23,7 +23,7 @@ class LoginView extends React.PureComponent<Props> {
 
     this.props.form.validateFields(async (err: ?Object, formValues: Object) => {
       if (!err) {
-        await Request.sendJSONReceiveJSON("/api/login", { data: formValues });
+        await Request.sendJSONReceiveJSON("/api/auth/login", { data: formValues });
         const user = await getActiveUser();
         Store.dispatch(setActiveUserAction(user));
         this.props.history.push("/dashboard");

--- a/app/assets/javascripts/admin/views/auth/login_view.js
+++ b/app/assets/javascripts/admin/views/auth/login_view.js
@@ -75,10 +75,10 @@ class LoginView extends React.PureComponent<Props> {
               </Button>
             </FormItem>
             <FormItem>
-              <Link to="/register" style={linkStyle}>
+              <Link to="/auth/register" style={linkStyle}>
                 Register Now!
               </Link>
-              <Link to="/reset" style={Object.assign({}, linkStyle, resetStyle)}>
+              <Link to="/auth/resetPassword" style={Object.assign({}, linkStyle, resetStyle)}>
                 Forgot Password
               </Link>
             </FormItem>

--- a/app/assets/javascripts/admin/views/auth/login_view.js
+++ b/app/assets/javascripts/admin/views/auth/login_view.js
@@ -40,6 +40,7 @@ class LoginView extends React.PureComponent<Props> {
     return (
       <Row type="flex" justify="center" style={rowStyle} align="middle">
         <Col span={this.props.layout === "inline" ? 24 : 8}>
+          {this.props.layout === "horizontal" ? <h3>Login</h3> : null}
           <Form onSubmit={this.handleSubmit} layout={this.props.layout}>
             <FormItem>
               {getFieldDecorator("email", {

--- a/app/assets/javascripts/admin/views/auth/registration_view.js
+++ b/app/assets/javascripts/admin/views/auth/registration_view.js
@@ -123,8 +123,10 @@ class RegistrationView extends React.PureComponent<Props, State> {
     return (
       <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
         <Col span={8}>
+          <h3>Registration</h3>
           <Card style={{ marginBottom: 24 }}>
-            Not a member of the listed teams?<br /> Contact webknossos@scalableminds.com to get more
+            Not a member of the listed teams?<br /> Contact{" "}
+            <a href="mailto:hello@scalableminds.com">hello@scalableminds.com</a> to get more
             information about how to get to use webKnossos.
           </Card>
           <Form onSubmit={this.handleSubmit}>

--- a/app/assets/javascripts/admin/views/auth/registration_view.js
+++ b/app/assets/javascripts/admin/views/auth/registration_view.js
@@ -45,7 +45,7 @@ class RegistrationView extends React.PureComponent<Props, State> {
       if (!err) {
         Request.sendJSONReceiveJSON("/api/auth/register", { data: formValues }).then(() => {
           Toast.success(messages["auth.account_created"]);
-          this.props.history.push("/login");
+          this.props.history.push("/auth/login");
         });
       }
     });
@@ -231,7 +231,7 @@ class RegistrationView extends React.PureComponent<Props, State> {
               <Button type="primary" htmlType="submit" style={{ width: "100%" }}>
                 Register
               </Button>
-              <Link to="/login">Already have an account? Login instead.</Link>
+              <Link to="/auth/login">Already have an account? Login instead.</Link>
             </FormItem>
           </Form>
         </Col>

--- a/app/assets/javascripts/admin/views/auth/registration_view.js
+++ b/app/assets/javascripts/admin/views/auth/registration_view.js
@@ -43,7 +43,7 @@ class RegistrationView extends React.PureComponent<Props, State> {
 
     this.props.form.validateFieldsAndScroll((err: ?Object, formValues: Object) => {
       if (!err) {
-        Request.sendJSONReceiveJSON("/api/register", { data: formValues }).then(() => {
+        Request.sendJSONReceiveJSON("/api/auth/register", { data: formValues }).then(() => {
           Toast.success(messages["auth.account_created"]);
           this.props.history.push("/login");
         });

--- a/app/assets/javascripts/admin/views/auth/start_reset_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/start_reset_password_view.js
@@ -20,7 +20,7 @@ class StartResetPasswordView extends React.PureComponent<Props> {
 
     this.props.form.validateFields((err: ?Object, formValues: Object) => {
       if (!err) {
-        Request.sendJSONReceiveJSON("/api/reset", { data: formValues }).then(() => {
+        Request.sendJSONReceiveJSON("/api/startResetPassword", { data: formValues }).then(() => {
           Toast.success(messages["auth.reset_email_notification"]);
           this.props.history.push("/finishreset");
         });

--- a/app/assets/javascripts/admin/views/auth/start_reset_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/start_reset_password_view.js
@@ -22,7 +22,7 @@ class StartResetPasswordView extends React.PureComponent<Props> {
       if (!err) {
         Request.sendJSONReceiveJSON("/api/startResetPassword", { data: formValues }).then(() => {
           Toast.success(messages["auth.reset_email_notification"]);
-          this.props.history.push("/finishreset");
+          this.props.history.push("/auth/finishResetPassword");
         });
       }
     });

--- a/app/assets/javascripts/admin/views/auth/start_reset_password_view.js
+++ b/app/assets/javascripts/admin/views/auth/start_reset_password_view.js
@@ -34,6 +34,7 @@ class StartResetPasswordView extends React.PureComponent<Props> {
     return (
       <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
         <Col span={8}>
+          <h3>Reset Password</h3>
           <Form onSubmit={this.handleSubmit}>
             <FormItem>
               {getFieldDecorator("email", {

--- a/app/assets/javascripts/admin/views/auth/user_token_view.js
+++ b/app/assets/javascripts/admin/views/auth/user_token_view.js
@@ -1,25 +1,16 @@
 // @flow
 import React from "react";
-import { withRouter } from "react-router-dom";
-import { Form, Icon, Input, Button, Col, Row, Alert, Spin } from "antd";
+import { Form, Input, Button, Col, Row, Spin } from "antd";
 import Request from "libs/request";
-import messages from "messages";
-import Toast from "libs/toast";
-import { getEditableUsers, updateUser } from "admin/admin_rest_api";
-import type { ReactRouterHistoryType } from "react_router";
 
 const FormItem = Form.Item;
-
-type Props = {
-  history: ReactRouterHistoryType,
-};
 
 type State = {
   isLoading: boolean,
   currentToken: string,
 };
 
-class UserTokenView extends React.PureComponent<Props, State> {
+class UserTokenView extends React.PureComponent<{}, State> {
   state = {
     isLoading: true,
     currentToken: "",
@@ -38,6 +29,21 @@ class UserTokenView extends React.PureComponent<Props, State> {
     });
   }
 
+  async revokeToken(): Promise<void> {
+    this.setState({ isLoading: true });
+    try {
+      await Request.triggerRequest("/api/auth/token", { method: "DELETE" });
+      const { token } = await Request.receiveJSON("/api/auth/token");
+      this.setState({ currentToken: token });
+    } finally {
+      this.setState({ isLoading: false });
+    }
+  }
+
+  handleRevokeToken = () => {
+    this.revokeToken();
+  };
+
   render() {
     if (this.state.isLoading) {
       return (
@@ -50,17 +56,13 @@ class UserTokenView extends React.PureComponent<Props, State> {
     return (
       <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
         <Col span={8}>
-          <Alert
-            type="info"
-            message={messages["auth.reset_logout"]}
-            showIcon
-            style={{ marginBottom: 24 }}
-          />
+          <h3>Token</h3>
           <Form>
-            <FormItem><Input value={this.state.currentToken} readOnly />
+            <FormItem>
+              <Input value={this.state.currentToken} readOnly />
             </FormItem>
             <FormItem>
-              <Button type="primary" style={{ width: "100%" }}>
+              <Button icon="swap" onClick={this.handleRevokeToken}>
                 Revoke Token
               </Button>
             </FormItem>
@@ -71,4 +73,4 @@ class UserTokenView extends React.PureComponent<Props, State> {
   }
 }
 
-export default withRouter(Form.create()(UserTokenView));
+export default UserTokenView;

--- a/app/assets/javascripts/admin/views/auth/user_token_view.js
+++ b/app/assets/javascripts/admin/views/auth/user_token_view.js
@@ -1,0 +1,74 @@
+// @flow
+import React from "react";
+import { withRouter } from "react-router-dom";
+import { Form, Icon, Input, Button, Col, Row, Alert, Spin } from "antd";
+import Request from "libs/request";
+import messages from "messages";
+import Toast from "libs/toast";
+import { getEditableUsers, updateUser } from "admin/admin_rest_api";
+import type { ReactRouterHistoryType } from "react_router";
+
+const FormItem = Form.Item;
+
+type Props = {
+  history: ReactRouterHistoryType,
+};
+
+type State = {
+  isLoading: boolean,
+  currentToken: string,
+};
+
+class UserTokenView extends React.PureComponent<Props, State> {
+  state = {
+    isLoading: true,
+    currentToken: "",
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  async fetchData(): Promise<void> {
+    const { token } = await Request.receiveJSON("/api/auth/token");
+
+    this.setState({
+      isLoading: false,
+      currentToken: token,
+    });
+  }
+
+  render() {
+    if (this.state.isLoading) {
+      return (
+        <div className="text-center">
+          <Spin size="large" />
+        </div>
+      );
+    }
+
+    return (
+      <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
+        <Col span={8}>
+          <Alert
+            type="info"
+            message={messages["auth.reset_logout"]}
+            showIcon
+            style={{ marginBottom: 24 }}
+          />
+          <Form>
+            <FormItem><Input value={this.state.currentToken} readOnly />
+            </FormItem>
+            <FormItem>
+              <Button type="primary" style={{ width: "100%" }}>
+                Revoke Token
+              </Button>
+            </FormItem>
+          </Form>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default withRouter(Form.create()(UserTokenView));

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -140,7 +140,7 @@ class Navbar extends React.PureComponent<Props> {
                     <Link
                       to="/"
                       onClick={() => {
-                        Request.receiveJSON("/api/logout").then(() =>
+                        Request.receiveJSON("/api/auth/logout").then(() =>
                           setTimeout(() => window.location.reload(), 500),
                         );
                       }}

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -6,6 +6,7 @@ import { Link, withRouter } from "react-router-dom";
 import { Layout, Menu, Icon } from "antd";
 import { connect } from "react-redux";
 import Request from "libs/request";
+import Utils from "libs/utils";
 import LoginView from "admin/views/auth/login_view";
 
 import type { OxalisState } from "oxalis/store";
@@ -25,6 +26,12 @@ type Props = {
 } & StateProps;
 
 class Navbar extends React.PureComponent<Props> {
+  handleLogout = async () => {
+    await Request.receiveJSON("/api/auth/logout");
+    await Utils.sleep(500);
+    window.location.reload();
+  };
+
   render() {
     const navbarStyle = {
       padding: 0,
@@ -134,20 +141,13 @@ class Navbar extends React.PureComponent<Props> {
                   }
                 >
                   <Menu.Item key="resetpassword">
-                    <Link to="/changepassword">Change Password</Link>
+                    <Link to="/auth/changePassword">Change Password</Link>
                   </Menu.Item>
                   <Menu.Item key="token">
-                    <Link to="/token">Token</Link>
+                    <Link to="/auth/token">Auth Token</Link>
                   </Menu.Item>
                   <Menu.Item key="logout">
-                    <Link
-                      to="/"
-                      onClick={() => {
-                        Request.receiveJSON("/api/auth/logout").then(() =>
-                          setTimeout(() => window.location.reload(), 500),
-                        );
-                      }}
-                    >
+                    <Link to="/" onClick={this.handleLogout}>
                       Logout
                     </Link>
                   </Menu.Item>

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -136,6 +136,9 @@ class Navbar extends React.PureComponent<Props> {
                   <Menu.Item key="resetpassword">
                     <Link to="/changepassword">Change Password</Link>
                   </Menu.Item>
+                  <Menu.Item key="token">
+                    <Link to="/token">Token</Link>
+                  </Menu.Item>
                   <Menu.Item key="logout">
                     <Link
                       to="/"

--- a/app/assets/javascripts/react_router.js
+++ b/app/assets/javascripts/react_router.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable react/no-unused-prop-types */
 import React from "react";
-import { Router, Route, Switch } from "react-router-dom";
+import { Router, Route, Switch, Redirect } from "react-router-dom";
 import createBrowserHistory from "history/createBrowserHistory";
 import { connect } from "react-redux";
 import { Layout, LocaleProvider } from "antd";
@@ -21,7 +21,7 @@ import RegistrationView from "admin/views/auth/registration_view";
 import StartResetPasswordView from "admin/views/auth/start_reset_password_view";
 import FinishResetPasswordView from "admin/views/auth/finish_reset_password_view";
 import ChangePasswordView from "admin/views/auth/change_password_view";
-import UserTokenView from "admin/views/auth/user_token_view";
+import AuthTokenView from "admin/views/auth/auth_token_view";
 import DatasetImportView from "dashboard/views/dataset/dataset_import_view";
 
 // admin
@@ -304,12 +304,22 @@ class ReactRouter extends React.Component<Props> {
                   path="/timetracking"
                   component={TimeLineView}
                 />
-                <Route path="/login" render={() => <LoginView layout="horizontal" />} />
-                <Route path="/register" component={RegistrationView} />
-                <Route path="/reset" component={StartResetPasswordView} />
-                <Route path="/finishreset" component={FinishResetPasswordView} />
-                <Route path="/changepassword" component={ChangePasswordView} />
-                <Route path="/token" component={UserTokenView} />
+                <SecuredRoute
+                  isAuthenticated={isAuthenticated}
+                  path="/auth/token"
+                  component={AuthTokenView}
+                />
+                <SecuredRoute
+                  isAuthenticated={isAuthenticated}
+                  path="/auth/changePassword"
+                  component={ChangePasswordView}
+                />
+                <Route path="/login" render={() => <Redirect to="/auth/login" />} />
+                <Route path="/register" render={() => <Redirect to="/auth/register" />} />
+                <Route path="/auth/login" render={() => <LoginView layout="horizontal" />} />
+                <Route path="/auth/register" component={RegistrationView} />
+                <Route path="/auth/resetPassword" component={StartResetPasswordView} />
+                <Route path="/auth/finishResetPassword" component={FinishResetPasswordView} />
                 <Route path="/spotlight" component={SpotlightView} />
                 <Route path="/datasets/:id/view" render={this.tracingViewMode} />
               </Switch>

--- a/app/assets/javascripts/react_router.js
+++ b/app/assets/javascripts/react_router.js
@@ -21,6 +21,7 @@ import RegistrationView from "admin/views/auth/registration_view";
 import StartResetPasswordView from "admin/views/auth/start_reset_password_view";
 import FinishResetPasswordView from "admin/views/auth/finish_reset_password_view";
 import ChangePasswordView from "admin/views/auth/change_password_view";
+import UserTokenView from "admin/views/auth/user_token_view";
 import DatasetImportView from "dashboard/views/dataset/dataset_import_view";
 
 // admin
@@ -308,6 +309,7 @@ class ReactRouter extends React.Component<Props> {
                 <Route path="/reset" component={StartResetPasswordView} />
                 <Route path="/finishreset" component={FinishResetPasswordView} />
                 <Route path="/changepassword" component={ChangePasswordView} />
+                <Route path="/token" component={UserTokenView} />
                 <Route path="/spotlight" component={SpotlightView} />
                 <Route path="/datasets/:id/view" render={this.tracingViewMode} />
               </Switch>

--- a/app/controllers/Authentication.scala
+++ b/app/controllers/Authentication.scala
@@ -312,7 +312,7 @@ class Authentication @Inject()(
     for{
       maybeOldToken <- env.combinedAuthenticatorService.findByLoginInfo(request.identity.loginInfo)
       oldToken <- maybeOldToken ?~> Messages("auth.noToken")
-      result <- env.combinedAuthenticatorService.discard(oldToken, Redirect("/dashboard")) //maybe add a way to inform the user that the token was deleted
+      result <- env.combinedAuthenticatorService.discard(oldToken, Ok) //maybe add a way to inform the user that the token was deleted
     } yield {
       result
     }

--- a/app/controllers/Authentication.scala
+++ b/app/controllers/Authentication.scala
@@ -354,7 +354,7 @@ class Authentication @Inject()(
 
 object Authentication {
   def getLoginRoute() = {
-    "/login"
+    "/auth/login"
   }
 
   def getCookie(email: String)(implicit requestHeader: RequestHeader): Future[Cookie] = {

--- a/app/controllers/Authentication.scala
+++ b/app/controllers/Authentication.scala
@@ -296,10 +296,10 @@ class Authentication @Inject()(
   def getToken = SecuredAction.async { implicit request =>
     val futureOfFuture: Future[Future[Result]] = env.combinedAuthenticatorService.findByLoginInfo(request.identity.loginInfo).map {
       oldTokenOpt => {
-        if (oldTokenOpt.isDefined) Future.successful(Ok(oldTokenOpt.get.id))
+        if (oldTokenOpt.isDefined) Future.successful(Ok(Json.obj("token" -> oldTokenOpt.get.id)))
         else {
           env.combinedAuthenticatorService.createToken(request.identity.loginInfo).map {
-            newToken => Ok(newToken.id)
+            newToken => Ok(Json.obj("token" -> newToken.id))
           }
         }
       }
@@ -314,7 +314,7 @@ class Authentication @Inject()(
     for {
       oldTokenOpt <- env.combinedAuthenticatorService.findByLoginInfo(request.identity.loginInfo)
       oldToken <- oldTokenOpt ?~> Messages("auth.noToken")
-      result <- env.combinedAuthenticatorService.discard(oldToken, Ok(Messages("auth.tokenDeleted")))
+      result <- env.combinedAuthenticatorService.discard(oldToken, Ok(Json.obj("messages" -> Messages("auth.tokenDeleted"))))
     } yield {
       result
     }

--- a/app/controllers/Authentication.scala
+++ b/app/controllers/Authentication.scala
@@ -223,7 +223,7 @@ class Authentication @Inject()(
         _ <- env.authenticatorService.discard(request.authenticator, Ok) //to logout the admin
         authenticator <- env.authenticatorService.create(loginInfo)
         value <- env.authenticatorService.init(authenticator)
-        result <- env.authenticatorService.embed(value, Ok) //to login the new user
+        result <- env.authenticatorService.embed(value, Redirect("/dashboard")) //to login the new user
       } yield result
     } else {
       Logger.warn(s"User tried to switch (${request.identity.email} -> $email) but is no Superuser!")

--- a/app/oxalis/security/BearerTokenAuthenticatorDAO.scala
+++ b/app/oxalis/security/BearerTokenAuthenticatorDAO.scala
@@ -35,7 +35,7 @@ class BearerTokenAuthenticatorDAO extends AuthenticatorDAO[BearerTokenAuthentica
   }
 
   override def update(authenticator: BearerTokenAuthenticator): Future[BearerTokenAuthenticator] =
-    findAndModify(Json.obj("loginInfoParameter" -> LoginInfo(CredentialsProvider.ID, authenticator.loginInfo.providerKey)), Json.obj("$set" -> Json.obj(
+    findAndModify(Json.obj("loginInfo" -> LoginInfo(CredentialsProvider.ID, authenticator.loginInfo.providerKey)), Json.obj("$set" -> Json.obj(
       "id" -> authenticator.id,
       "lastUsedDateTime" -> authenticator.lastUsedDateTime,
       "expirationDateTime" -> authenticator.expirationDateTime,
@@ -48,6 +48,6 @@ class BearerTokenAuthenticatorDAO extends AuthenticatorDAO[BearerTokenAuthentica
   }
 
   def findByLoginInfo(loginInfo: LoginInfo): Future[Option[BearerTokenAuthenticator]] =
-    findOne("loginInfoParameter", loginInfo)(implicitly[Writes[LoginInfo]],GlobalAccessContext).futureBox.map(box => box.toOption)
+    findOne("loginInfo", loginInfo)(implicitly[Writes[LoginInfo]],GlobalAccessContext).futureBox.map(box => box.toOption)
 }
 

--- a/app/views/mail/resetPassword.scala.html
+++ b/app/views/mail/resetPassword.scala.html
@@ -4,7 +4,7 @@ Hello @name,
 your account got activated. You can start tracing at
 
 You are receiving this mail because you requested to change your password.
-To change your password go to @{uri}/finishreset and use the following token to authenticate yourself:
+To change your password go to @{uri}/auth/finishResetPassword and use the following token to authenticate yourself:
 @token
 
 Enjoy using webKnossos

--- a/app/views/pageSkeleton.scala.html
+++ b/app/views/pageSkeleton.scala.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="@routes.Assets.at("bundle/main.css")?nocache=@(webknossos.BuildInfo.commitHash)">
     @Html(com.newrelic.api.agent.NewRelic.getBrowserTimingHeader)
     @if(play.api.Play.current.configuration.getBoolean("application.authentication.enableDevAutoLogin")){
-      <script src="/autoLogin"></script>
+      <script src="/auth/autoLogin"></script>
     }
     <script type="text/javascript"
       data-airbrake-project-id=@play.api.Play.current.configuration.getString("airbrake.projectID")

--- a/conf/webknossos.routes
+++ b/conf/webknossos.routes
@@ -23,17 +23,18 @@ GET           /login                                                            
 GET           /reset                                                            controllers.Authentication.empty
 GET           /changepassword                                                   controllers.Authentication.empty
 GET           /finishreset                                                      controllers.Authentication.empty
-POST          /api/register                                                     controllers.Authentication.handleRegistration
-POST          /api/login                                                        controllers.Authentication.authenticate
+GET           /token                                                            controllers.Authentication.empty
 GET           /autoLogin                                                        controllers.Authentication.autoLogin
-GET           /api/getToken                                                     controllers.Authentication.getToken
-GET           /api/deleteToken                                                  controllers.Authentication.deleteToken
-GET           /api/switch                                                       controllers.Authentication.switchTo(to: String)
-POST          /api/reset                                                        controllers.Authentication.handleStartResetPassword
-POST          /api/changepw                                                     controllers.Authentication.changePassword
-POST          /api/resetPassword                                                controllers.Authentication.handleResetPassword
-GET           /api/logout                                                       controllers.Authentication.logout
-GET           /auth/sso                                                         controllers.Authentication.singleSignOn(sso: String, sig: String)
+POST          /api/auth/register                                                controllers.Authentication.handleRegistration
+POST          /api/auth/login                                                   controllers.Authentication.authenticate
+GET           /api/auth/token                                                   controllers.Authentication.getToken
+DELETE        /api/auth/token                                                   controllers.Authentication.deleteToken
+GET           /api/auth/switch                                                  controllers.Authentication.switchTo(to: String)
+POST          /api/auth/startResetPassword                                      controllers.Authentication.handleStartResetPassword
+POST          /api/auth/changePassword                                          controllers.Authentication.changePassword
+POST          /api/auth/resetPassword                                           controllers.Authentication.handleResetPassword
+GET           /api/auth/logout                                                  controllers.Authentication.logout
+GET           /api/auth/sso                                                     controllers.Authentication.singleSignOn(sso: String, sig: String)
 
 # Configurations
 GET           /api/userConfigurations/default                                   controllers.ConfigurationController.default

--- a/conf/webknossos.routes
+++ b/conf/webknossos.routes
@@ -20,11 +20,13 @@ GET           /help/keyboardshortcuts                                           
 # Authentication
 GET           /register                                                         controllers.Authentication.empty
 GET           /login                                                            controllers.Authentication.empty
-GET           /reset                                                            controllers.Authentication.empty
-GET           /changepassword                                                   controllers.Authentication.empty
-GET           /finishreset                                                      controllers.Authentication.empty
-GET           /token                                                            controllers.Authentication.empty
-GET           /autoLogin                                                        controllers.Authentication.autoLogin
+GET           /auth/register                                                    controllers.Authentication.empty
+GET           /auth/login                                                       controllers.Authentication.empty
+GET           /auth/resetPassword                                               controllers.Authentication.empty
+GET           /auth/changePassword                                              controllers.Authentication.empty
+GET           /auth/finishResetPassword                                         controllers.Authentication.empty
+GET           /auth/token                                                       controllers.Authentication.empty
+GET           /auth/autoLogin                                                   controllers.Authentication.autoLogin
 POST          /api/auth/register                                                controllers.Authentication.handleRegistration
 POST          /api/auth/login                                                   controllers.Authentication.authenticate
 GET           /api/auth/token                                                   controllers.Authentication.getToken


### PR DESCRIPTION
This PR cleans up the auth route naming and adds a view for getting/revoking the tokens

- Renames API and Frontend routes in a consistent manner
- All auth-related API routes now live under the prefix `/api/auth`
- Renames token API routes to `GET /api/auth/token` and `DELETE /api/auth/token`
- All auth-related frontend routes now live under the prefix `/auth`
- `/login` and `/register` have a redirect to `/auth/login` etc.
- Adds a token view `/auth/token` for viewing and revoking tokens
- `GET /api/auth/token` returns token when exists or creates a new one
- `DELETE /api/auth/token` deletes token when exists or silently does nothing
- Fixes a bug in the token mechanism

### Steps to test:
- Login, logout, register, reset password, change password
- Go to `/auth/token` and revoke

### Issues:
- fixes #2166

------
- [ ] Ready for review
