### PR TITLE
Update TimeTracking view for arbitrary date ranges

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -445,17 +445,15 @@ export async function getActiveUser(options: Object = {}) {
 }
 
 // ### TimeTracking
-export async function getTimeTrackingForUserByDay(
+export async function getTimeTrackingForUserByMonth(
   userEmail: string,
   day: moment$Moment,
 ): Promise<Array<APITimeTrackingType>> {
   const month = day.format("M");
   const year = day.format("YYYY");
-  const startDay = day.format("D");
-  const endDay = parseInt(startDay) + 1;
 
   const timeTrackingData = await Request.receiveJSON(
-    `/api/time/userlist/${year}/${month}?email=${userEmail}&startDay=${startDay}&endDay=${endDay}`,
+    `/api/time/userlist/${year}/${month}?email=${userEmail}`,
   );
 
   const timelogs = timeTrackingData[0].timelogs;

--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -1,5 +1,4 @@
 // @flow
-import moment from "moment";
 import Request from "libs/request";
 import Toast from "libs/toast";
 import Utils from "libs/utils";
@@ -448,12 +447,11 @@ export async function getActiveUser(options: Object = {}) {
 // ### TimeTracking
 export async function getTimeTrackingForUserByDay(
   userEmail: string,
-  day: Date,
+  day: moment$Moment,
 ): Promise<Array<APITimeTrackingType>> {
-  const momentDate = moment(day);
-  const month = momentDate.format("M");
-  const year = momentDate.format("YYYY");
-  const startDay = momentDate.format("D");
+  const month = day.format("M");
+  const year = day.format("YYYY");
+  const startDay = day.format("D");
   const endDay = parseInt(startDay) + 1;
 
   const timeTrackingData = await Request.receiveJSON(

--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -461,3 +461,19 @@ export async function getTimeTrackingForUserByMonth(
 
   return timelogs;
 }
+
+export async function getTimeTrackingForUser(
+  userId: string,
+  startDate: moment$Moment,
+  endDate: moment$Moment,
+): Promise<Array<APITimeTrackingType>> {
+  const timeTrackingData = await Request.receiveJSON(
+    `/api/time/user/${userId}?startDate=${startDate.unix() * 1000}&endDate=${endDate.unix() *
+      1000}`,
+  );
+
+  const timelogs = timeTrackingData.timelogs;
+  assertResponseLimit(timelogs);
+
+  return timelogs;
+}

--- a/app/assets/javascripts/admin/views/time/time_line_view.js
+++ b/app/assets/javascripts/admin/views/time/time_line_view.js
@@ -138,7 +138,8 @@ class TimeLineView extends React.PureComponent<*, State> {
 
     return (
       <div className="container wide">
-        <Card title={<h4>Time Tracking </h4>}>
+        <h3>Time Tracking</h3>
+        <Card>
           <Row gutter={40}>
             <Col span={12}>
               <FormItem {...formItemLayout} label="User">

--- a/app/assets/javascripts/admin/views/time/time_line_view.js
+++ b/app/assets/javascripts/admin/views/time/time_line_view.js
@@ -4,6 +4,8 @@ import * as React from "react";
 import moment from "moment";
 import { Select, Card, Form, Row, Col, DatePicker } from "antd";
 import { Chart } from "react-google-charts";
+import Toast from "libs/toast";
+import messages from "messages";
 import FormatUtils from "libs/format_utils";
 import { getUsers, getTimeTrackingForUser } from "admin/admin_rest_api";
 
@@ -100,6 +102,12 @@ class TimeLineView extends React.PureComponent<*, State> {
   };
 
   handleDateChange = async (dates: DateRangeType) => {
+    // to ease the load on the server restrict date range selection to a month
+    if (dates[0].diff(dates[1], "days") > 31) {
+      Toast.error(messages["timetracking.date_range_too_long"]);
+      return;
+    }
+
     // for same day use start and end timestamps
     const dateRange = dates[0].isSame(dates[1], "day")
       ? [dates[0].startOf("day"), dates[1].endOf("day")]

--- a/app/assets/javascripts/admin/views/time/time_line_view.js
+++ b/app/assets/javascripts/admin/views/time/time_line_view.js
@@ -142,11 +142,6 @@ class TimeLineView extends React.PureComponent<*, State> {
     return (
       <div className="container wide">
         <Card title={<h4>Time Tracking </h4>}>
-          <p>
-            The time tracking information display here only includes data acquired when working on
-            &quot;tasks&quot;.
-          </p>
-          <hr />
           <Row gutter={40}>
             <Col span={12}>
               <FormItem {...formItemLayout} label="User">
@@ -191,6 +186,8 @@ class TimeLineView extends React.PureComponent<*, State> {
                   </ul>
                 </Col>
               </Row>
+              The time tracking information display here only includes data acquired when working on
+              &quot;tasks&quot; and not explorative tracings.
             </Col>
           </Row>
         </Card>
@@ -209,7 +206,7 @@ class TimeLineView extends React.PureComponent<*, State> {
             />
           ) : (
             <div style={{ textAlign: "center" }}>
-              No Time Tracking Data for the Selected User or Day.
+              No Time Tracking Data for the Selected User or Date Range.
             </div>
           )}
         </div>

--- a/app/assets/javascripts/libs/format_utils.js
+++ b/app/assets/javascripts/libs/format_utils.js
@@ -5,6 +5,10 @@
 import moment from "moment";
 
 class FormatUtils {
+  static formatMilliseconds(durationMilliSeconds: number): string {
+    return FormatUtils.formatSeconds(durationMilliSeconds / 1000);
+  }
+
   static formatSeconds(durationSeconds: number): string {
     const t = moment.duration(durationSeconds, "seconds");
     const [days, hours, minutes, seconds] = [t.days(), t.hours(), t.minutes(), t.seconds()];

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -82,4 +82,5 @@ In order to restore the current window, a reload is necessary.`,
   "auth.error_no_user": "No active user is logged in.",
   "request.max_item_count_alert":
     "Your request returned more than 1000 results. More results might be available on the server but were omitted for technical reasons.",
+  "timetracking.date_range_too_long": "Please specify a date range of 31 days or less.",
 };

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -1,25 +1,20 @@
 package controllers
 
+import java.text.SimpleDateFormat
 import java.util.Calendar
 import javax.inject.Inject
 
-import com.scalableminds.util.mail.Send
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
-import models.annotation.{AnnotationDAO}
-import models.project.{Project, ProjectDAO}
+import models.annotation.AnnotationDAO
+import models.project.ProjectDAO
 import models.task.{Task, TaskService, TaskTypeDAO}
 import models.user.time.{TimeSpan, TimeSpanDAO}
 import models.user.{User, UserDAO, UserService}
-import oxalis.security.WebknossosSilhouette.{UserAwareAction, UserAwareRequest, SecuredRequest, SecuredAction}
-import play.api.i18n.MessagesApi
+import oxalis.security.WebknossosSilhouette.{SecuredAction, SecuredRequest}
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.AnyContent
-import play.api.i18n.{Messages, MessagesApi}
-import java.text.SimpleDateFormat
-
-import scala.concurrent.Future
-import scala.util.Failure
 
 class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller with FoxImplicits {
 
@@ -87,12 +82,7 @@ class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller 
     sDate.setTimeInMillis(startDate)
     eDate.setTimeInMillis(endDate)
 
-    for {
-      js <- getUserHours(user, sDate, eDate)
-    } yield {
-      js
-    }
-    // Json.toJson(js))
+    getUserHours(user, sDate, eDate)
   }
 
   def getUserHours(user: User, startDate: Calendar, endDate: Calendar)(implicit request: SecuredRequest[AnyContent]): Fox[JsObject] = {

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -30,7 +30,7 @@ class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller 
     for {
       users <- UserDAO.findAll
       filteredUsers = users.filter(user => request.identity.isAdminOf(user))
-      js <- loggedTimeForUserList(filteredUsers, year, month, startDay, endDay)
+      js <- loggedTimeForUserListByMonth(filteredUsers, year, month, startDay, endDay)
     } yield {
       Ok(js)
     }
@@ -41,7 +41,17 @@ class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller 
     for {
       users <- Fox.combined(userString.split(",").toList.map(email => UserService.findOneByEmail(email))) ?~> Messages("user.email.invalid")
       _ <- users.forall(u => request.identity.isAdminOf(u)) ?~> Messages("user.notAuthorised")
-      js <- loggedTimeForUserList(users, year, month, startDay, endDay)
+      js <- loggedTimeForUserListByMonth(users, year, month, startDay, endDay)
+    } yield {
+      Ok(js)
+    }
+  }
+
+  def getWorkingHoursOfUser(userId: String, startDate: Long, endDate: Long) = SecuredAction.async { implicit request =>
+    for {
+      user <- UserService.findOneById(userId, false) ?~> Messages("user.notFound")
+      _ <- request.identity.isAdminOf(user) ?~> Messages("user.notAuthorised")
+      js <- loggedTimeForUserListByTimestamp(user,startDate, endDate)
     } yield {
       Ok(js)
     }
@@ -49,7 +59,7 @@ class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller 
 
   //helper methods
 
-  def loggedTimeForUserList(users: List[User], year: Int, month: Int, startDay: Option[Int], endDay: Option[Int]) (implicit request: SecuredRequest[AnyContent]): Fox[JsValue] =  {
+  def loggedTimeForUserListByMonth(users: List[User], year: Int, month: Int, startDay: Option[Int], endDay: Option[Int]) (implicit request: SecuredRequest[AnyContent]): Fox[JsValue] =  {
     lazy val startDate = Calendar.getInstance()
     lazy val endDate = Calendar.getInstance()
 
@@ -68,6 +78,21 @@ class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller 
 
     val futureJsObjects = users.map(user => getUserHours(user, startDate, endDate))
     Fox.combined(futureJsObjects).map(jsObjectList => Json.toJson(jsObjectList))
+  }
+
+  def loggedTimeForUserListByTimestamp(user: User, startDate: Long, endDate: Long) (implicit request: SecuredRequest[AnyContent]): Fox[JsValue] =  {
+    lazy val sDate = Calendar.getInstance()
+    lazy val eDate = Calendar.getInstance()
+
+    sDate.setTimeInMillis(startDate)
+    eDate.setTimeInMillis(endDate)
+
+    for {
+      js <- getUserHours(user, sDate, eDate)
+    } yield {
+      js
+    }
+    // Json.toJson(js))
   }
 
   def getUserHours(user: User, startDate: Calendar, endDate: Calendar)(implicit request: SecuredRequest[AnyContent]): Fox[JsObject] = {

--- a/conf/webknossos.routes
+++ b/conf/webknossos.routes
@@ -198,3 +198,4 @@ GET           /assets/*file                                                     
 GET           /timetracking                                                     controllers.Authentication.empty
 GET           /api/time/allusers/:year/:month                                   controllers.TimeController.getWorkingHoursOfAllUsers(year: Int, month: Int, startDay: Option[Int], endDay: Option[Int])
 GET           /api/time/userlist/:year/:month                                   controllers.TimeController.getWorkingHoursOfUsers(email: String, year: Int, month: Int, startDay: Option[Int], endDay: Option[Int])
+GET           /api/time/user/:userId                                            controllers.TimeController.getWorkingHoursOfUser(userId: String, startDate: Long, endDate: Long)

--- a/flow-typed/npm/moment_v2.x.x.js
+++ b/flow-typed/npm/moment_v2.x.x.js
@@ -2,28 +2,28 @@
 // flow-typed version: b96843401b/moment_v2.x.x/flow_>=v0.28.x
 
 type moment$MomentOptions = {
-  y?: number|string,
-  year?: number|string,
-  years?: number|string,
-  M?: number|string,
-  month?: number|string,
-  months?: number|string,
-  d?: number|string,
-  day?: number|string,
-  days?: number|string,
-  date?: number|string,
-  h?: number|string,
-  hour?: number|string,
-  hours?: number|string,
-  m?: number|string,
-  minute?: number|string,
-  minutes?: number|string,
-  s?: number|string,
-  second?: number|string,
-  seconds?: number|string,
-  ms?: number|string,
-  millisecond?: number|string,
-  milliseconds?: number|string,
+  y?: number | string,
+  year?: number | string,
+  years?: number | string,
+  M?: number | string,
+  month?: number | string,
+  months?: number | string,
+  d?: number | string,
+  day?: number | string,
+  days?: number | string,
+  date?: number | string,
+  h?: number | string,
+  hour?: number | string,
+  hours?: number | string,
+  m?: number | string,
+  minute?: number | string,
+  minutes?: number | string,
+  s?: number | string,
+  second?: number | string,
+  seconds?: number | string,
+  ms?: number | string,
+  millisecond?: number | string,
+  milliseconds?: number | string,
 };
 
 type moment$MomentObject = {
@@ -40,8 +40,8 @@ type moment$MomentCreationData = {
   input: string,
   format: string,
   locale: Object,
-  isUTC: bool,
-  strict: bool,
+  isUTC: boolean,
+  strict: boolean,
 };
 
 type moment$CalendarFormats = {
@@ -62,10 +62,18 @@ declare class moment$LocaleData {
   weekdaysMin(moment: moment$Moment): string;
   weekdaysParse(weekDay: string): number;
   longDateFormat(dateFormat: string): string;
-  isPM(date: string): bool;
-  meridiem(hours: number, minutes: number, isLower: bool): string;
-  calendar(key: 'sameDay'|'nextDay'|'lastDay'|'nextWeek'|'prevWeek'|'sameElse', moment: moment$Moment): string;
-  relativeTime(number: number, withoutSuffix: bool, key: 's'|'m'|'mm'|'h'|'hh'|'d'|'dd'|'M'|'MM'|'y'|'yy', isFuture: bool): string;
+  isPM(date: string): boolean;
+  meridiem(hours: number, minutes: number, isLower: boolean): string;
+  calendar(
+    key: "sameDay" | "nextDay" | "lastDay" | "nextWeek" | "prevWeek" | "sameElse",
+    moment: moment$Moment,
+  ): string;
+  relativeTime(
+    number: number,
+    withoutSuffix: boolean,
+    key: "s" | "m" | "mm" | "h" | "hh" | "d" | "dd" | "M" | "MM" | "y" | "yy",
+    isFuture: boolean,
+  ): string;
   pastFuture(diff: any, relTime: string): string;
   ordinal(number: number): string;
   preparse(str: string): any;
@@ -76,7 +84,7 @@ declare class moment$LocaleData {
   firstDayOfYear(): number;
 }
 declare class moment$MomentDuration {
-  humanize(suffix?: bool): string;
+  humanize(suffix?: boolean): string;
   milliseconds(): number;
   asMilliseconds(): number;
   seconds(): number;
@@ -91,8 +99,8 @@ declare class moment$MomentDuration {
   asMonths(): number;
   years(): number;
   asYears(): number;
-  add(value: number|moment$MomentDuration|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|Object, unit?: string): this;
+  add(value: number | moment$MomentDuration | Object, unit?: string): this;
+  subtract(value: number | moment$MomentDuration | Object, unit?: string): this;
   as(unit: string): number;
   get(unit: string): number;
   toJSON(): string;
@@ -100,17 +108,24 @@ declare class moment$MomentDuration {
 }
 declare class moment$Moment {
   static ISO_8601: string;
-  static (string?: string, format?: string|Array<string>, locale?: string, strict?: bool): moment$Moment;
-  static (initDate: ?Object|number|Date|Array<number>|moment$Moment|string): moment$Moment;
+  static (
+    string?: string,
+    format?: string | Array<string>,
+    locale?: string,
+    strict?: boolean,
+  ): moment$Moment;
+  static (
+    initDate: ?Object | number | Date | Array<number> | moment$Moment | string,
+  ): moment$Moment;
   static unix(seconds: number): moment$Moment;
   static utc(): moment$Moment;
-  static utc(number: number|Array<number>): moment$Moment;
-  static utc(str: string, str2?: string|Array<string>, str3?: string): moment$Moment;
+  static utc(number: number | Array<number>): moment$Moment;
+  static utc(str: string, str2?: string | Array<string>, str3?: string): moment$Moment;
   static utc(moment: moment$Moment): moment$Moment;
   static utc(date: Date): moment$Moment;
   static parseZone(rawDate: string): moment$Moment;
-  isValid(): bool;
-  invalidAt(): 0|1|2|3|4|5|6;
+  isValid(): boolean;
+  invalidAt(): 0 | 1 | 2 | 3 | 4 | 5 | 6;
   creationData(): moment$MomentCreationData;
   millisecond(number: number): this;
   milliseconds(number: number): this;
@@ -132,8 +147,8 @@ declare class moment$Moment {
   dates(number: number): this;
   date(): number;
   dates(): number;
-  day(day: number|string): this;
-  days(day: number|string): this;
+  day(day: number | string): this;
+  days(day: number | string): this;
   day(): number;
   days(): number;
   weekday(number: number): this;
@@ -173,21 +188,31 @@ declare class moment$Moment {
   static max(dates: Array<moment$Moment>): moment$Moment;
   static min(...dates: Array<moment$Moment>): moment$Moment;
   static min(dates: Array<moment$Moment>): moment$Moment;
-  add(value: number|moment$MomentDuration|moment$Moment|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|moment$Moment|string|Object, unit?: string): this;
+  add(value: number | moment$MomentDuration | moment$Moment | Object, unit?: string): this;
+  subtract(
+    value: number | moment$MomentDuration | moment$Moment | string | Object,
+    unit?: string,
+  ): this;
   startOf(unit: string): this;
   endOf(unit: string): this;
   local(): this;
   utc(): this;
-  utcOffset(offset: number|string): void;
-  utcOffset(): number|string;
+  utcOffset(offset: number | string): void;
+  utcOffset(): number | string;
   format(format?: string): string;
-  fromNow(removeSuffix?: bool): string;
-  from(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
-  toNow(removePrefix?: bool): string;
-  to(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
+  fromNow(removeSuffix?: boolean): string;
+  from(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean,
+  ): string;
+  toNow(removePrefix?: boolean): string;
+  to(value: moment$Moment | string | number | Date | Array<number>, removePrefix?: boolean): string;
   calendar(refTime?: any, formats?: moment$CalendarFormats): string;
-  diff(date: moment$Moment|string|number|Date|Array<number>, format?: string, floating?: bool): number;
+  diff(
+    date: moment$Moment | string | number | Date | Array<number>,
+    format?: string,
+    floating?: boolean,
+  ): number;
   valueOf(): number;
   unix(): number;
   daysInMonth(): number;
@@ -196,22 +221,25 @@ declare class moment$Moment {
   toJSON(): string;
   toISOString(): string;
   toObject(): moment$MomentObject;
-  isBefore(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isSame(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isAfter(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrBefore(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrAfter(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isBetween(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isDST(): bool;
-  isDSTShifted(): bool;
-  isLeapYear(): bool;
+  isBefore(date?: moment$Moment | string | number | Date | Array<number>, ?string): boolean;
+  isSame(date?: moment$Moment | string | number | Date | Array<number>, ?string): boolean;
+  isAfter(date?: moment$Moment | string | number | Date | Array<number>, ?string): boolean;
+  isSameOrBefore(date?: moment$Moment | string | number | Date | Array<number>, ?string): boolean;
+  isSameOrAfter(date?: moment$Moment | string | number | Date | Array<number>, ?string): boolean;
+  isBetween(
+    date1: moment$Moment | string | number | Date | Array<number>,
+    date2: moment$Moment | string | number | Date | Array<number>,
+  ): boolean;
+  isDST(): boolean;
+  isDSTShifted(): boolean;
+  isLeapYear(): boolean;
   clone(): moment$Moment;
-  static isMoment(obj: any): bool;
-  static isDate(obj: any): bool;
+  static isMoment(obj: any): boolean;
+  static isDate(obj: any): boolean;
   static locale(locale: string, localeData?: Object): string;
   static updateLocale(locale: string, localeData?: ?Object): void;
   static locale(locales: Array<string>): string;
-  locale(locale: string, customization?: Object|null): moment$Moment;
+  locale(locale: string, customization?: Object | null): moment$Moment;
   locale(): string;
   static months(): Array<string>;
   static monthsShort(): Array<string>;
@@ -224,12 +252,12 @@ declare class moment$Moment {
   static weekdaysShort(): string;
   static weekdaysMin(): string;
   static localeData(key?: string): moment$LocaleData;
-  static duration(value: number|Object|string, unit?: string): moment$MomentDuration;
-  static isDuration(obj: any): bool;
+  static duration(value: number | Object | string, unit?: string): moment$MomentDuration;
+  static isDuration(obj: any): boolean;
   static normalizeUnits(unit: string): string;
   static invalid(object: any): moment$Moment;
 }
 
-declare module 'moment' {
+declare module "moment" {
   declare module.exports: Class<moment$Moment>;
 }


### PR DESCRIPTION
### Mailable description of changes:
- [Admin.TimeTracking] Extended the time tracking view to include more statistics and support arbitrary 31 day date ranges

### Steps to test:
- Go to `localhost:9000/timetracking`
- Select a date range and user --> See charts
- Select a date range > 31 --> error
- Try to break it

### Issues:
- fixes #2180 

------
- [x] Ready for review
