### PR TITLE
use correct silhouette conf fields for token expiration time

### DIFF
--- a/conf/silhouette.conf
+++ b/conf/silhouette.conf
@@ -10,7 +10,8 @@ silhouette {
   cookieAuthenticator.authenticatorExpiry=30 days
 
   tokenAuthenticator.headerName="X-Auth-Token"
-  tokenAuthenticator.expirationDate=1000 years
+  tokenAuthenticator.authenticatorIdleTimeout=23000 days
+  tokenAuthenticator.authenticatorExpiry=23000 days //must fit as seconds in 32bit signed int
 
   # OAuth1 token secret provider settings
   oauth1TokenSecretProvider.cookieName="OAuth1TokenSecret"


### PR DESCRIPTION
### Steps to test:
- get a token
- in db, it should be valid until some time 2080

### Issues:
- fixes #2199

------
- [x] Ready for review
