### PR TITLE
cookies expire after 30 days instead of at browser session end

### DIFF
--- a/conf/silhouette.conf
+++ b/conf/silhouette.conf
@@ -8,6 +8,7 @@ silhouette {
   cookieAuthenticator.useFingerprinting=true
   cookieAuthenticator.authenticatorIdleTimeout=30 days
   cookieAuthenticator.authenticatorExpiry=30 days
+  cookieAuthenticator.cookieMaxAge=30 days
 
   tokenAuthenticator.headerName="X-Auth-Token"
   tokenAuthenticator.authenticatorIdleTimeout=23000 days


### PR DESCRIPTION
Sorry for yet another single-line PR…

### Mailable description of changes:
 - webKnossos now remembers logged-in users for 30 days, even after browser restart. Remember to manually sign out on unsafe machines!

### Steps to test:
- disable autoLogin
- log in to wk
- restart browser
- you should still be logged in
- browser cookie inspector should show 30-day expiration date

------
- [x] Ready for review
