### PR TITLE
docker-compose: set default timezone to Berlin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - USER_NAME=${USER_NAME:-sbt-user}
       - USER_UID
       - USER_GID
-      - TZ
+      - TZ=${TZ:-"Europe/Berlin"}
     working_dir: /home/${USER_NAME:-sbt-user}/webknossos
     volumes:
       - ".:/home/${USER_NAME:-sbt-user}/webknossos"


### PR DESCRIPTION
### Steps to test:
- `docker-compose run --rm base bash -c 'echo $TZ && date'`

------
- [x] Ready for review
