### PR TITLE
Fixed position of "User" item in navbar

### DIFF
--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -123,10 +123,11 @@ td.nowrap * {
 }
 
 .pull-right {
-  float: right;
+  float: right !important;
 }
+
 .pull-left {
-  float: left;
+  float: left !important;
 }
 
 // Fixing font awesome
@@ -213,4 +214,3 @@ img.img-50 {
   padding-left: 15px;
   padding-right: 15px;
 }
-


### PR DESCRIPTION
With the recent removal of Bootstrap the CSS utility classes `pull-left`and `pull-right` were moved to our general wK LESS code. Unfortunately, there were not relevant enough for some items and hence the "User" navbar entry wasn't pulled all the way to the right:

![image](https://user-images.githubusercontent.com/1105056/33660887-ca09a434-da85-11e7-91dc-e93f27792afc.png)

### Steps to test:
- Load wk. Checkout navbar. "User" should be pull right again.

------
- [x] Ready for review
