### PR TITLE
Fix removeEventListener and getOffset in input.js

### DIFF
--- a/app/assets/javascripts/libs/utils.js
+++ b/app/assets/javascripts/libs/utils.js
@@ -381,20 +381,18 @@ const Utils = {
     delegateSelector: string,
     handlerFunc: Function,
   ) {
-    return element.addEventListener(
-      eventName,
-      function(event: Event) {
+    const wrapperFunc = function(event: Event) {
+      // $FlowFixMe Flow doesn't know native InputEvents
+      for (let target = event.target; target && target !== this; target = target.parentNode) {
         // $FlowFixMe Flow doesn't know native InputEvents
-        for (let target = event.target; target && target !== this; target = target.parentNode) {
-          // $FlowFixMe Flow doesn't know native InputEvents
-          if (target.matches(delegateSelector)) {
-            handlerFunc.call(target, event);
-            break;
-          }
+        if (target.matches(delegateSelector)) {
+          handlerFunc.call(target, event);
+          break;
         }
-      },
-      false,
-    );
+      }
+    };
+    element.addEventListener(eventName, wrapperFunc, false);
+    return { [eventName]: wrapperFunc };
   },
 
   async compress(data: Uint8Array | string): Promise<Uint8Array> {

--- a/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -77,8 +77,12 @@ class PlaneController extends React.PureComponent<Props> {
   listenTo: Function;
   stopListening: Function;
 
-  componentDidMount() {
+  constructor(...args: any) {
+    super(...args);
     _.extend(this, BackboneEvents);
+  }
+
+  componentDidMount() {
     this.input = {
       mouseControllers: {},
     };


### PR DESCRIPTION
This PR fixes the recent input related airbrake errors.
One error was caused because our eventListeners were not correctly removed.
The other was caused because `getOffset` in `input.js` returned viewport relative coordinates that were compared to document relative coordinates in the `isHit` function.
`window.pageXOffset` is just an alias of `window.scrollX` in case you're wondering, that's why I replaced it :)

### Steps to test:
- Open a skeleton tracing, switch to flight mode, switch back to orthogonal mode and zoom in the TD view -> there should be no errors
- Open a skeleton tracing, scroll down, click in the bottom of the YZ-View -> the YZ view should remain highlighted, the TD view should NOT be highlighted
- Set some nodes, select nodes and test other input related functionality

### Issues:
- fixes #2203 and another airbrake error

------
- [x] Ready for review
