### PR TITLE
reduce datastore access token check cache time

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object Dependencies{
   val akkaVersion = "2.4.1"
   val reactiveVersion = "0.11.13"
   val reactivePlayVersion = "0.11.13-play24"
-  val braingamesVersion = "11.3.6"
+  val braingamesVersion = "11.3.7"
 
   val twelvemonkeysVersion = "3.1.2"
 


### PR DESCRIPTION
The datastore always asks webknossos if a user request (like sending updates, loading data) is allowed. To reduce the number of such check requests, a cache is used. This PR reduces the cache time from 30min to 2min in order to reduce the delay after some permissions actually change. The request count should still be relatively low. 
Example: after a finished annotation is un-finished in wk, this check continues forbidding updates now only for 2 minutes instead of 30.

### Code changes
- https://github.com/scalableminds/braingames-libs/commit/7d6e823e69e10477d3ffa5933de6b06bde025428

### Steps to test:
- create annotation, finish it. updates to it should now be refused.
- un-finish the annotation, soon thereafter, updates should be accepted again

------
- [x] Ready for review
