### PR TITLE
Set a fixed width for taskType descriptions

### DIFF
--- a/app/assets/javascripts/admin/views/tasktype/task_type_list_view.js
+++ b/app/assets/javascripts/admin/views/tasktype/task_type_list_view.js
@@ -99,6 +99,7 @@ class TaskTypeListView extends React.PureComponent<{}, State> {
                 title="ID"
                 dataIndex="id"
                 key="id"
+                width={80}
                 sorter={Utils.localeCompareBy("id")}
                 className="monospace-id"
               />
@@ -106,12 +107,14 @@ class TaskTypeListView extends React.PureComponent<{}, State> {
                 title="Team"
                 dataIndex="team"
                 key="team"
+                width={130}
                 sorter={Utils.localeCompareBy("team")}
               />
               <Column
                 title="Summary"
                 dataIndex="summary"
                 key="summary"
+                width={130}
                 sorter={Utils.localeCompareBy("summary")}
               />
               <Column
@@ -120,10 +123,7 @@ class TaskTypeListView extends React.PureComponent<{}, State> {
                 key="description"
                 sorter={Utils.localeCompareBy("description")}
                 render={description => (
-                  <div
-                    style={{ wordBreak: "break-word", maxHeight: 100, overflowY: "auto" }}
-                    className="task-type-description"
-                  >
+                  <div className="task-type-description">
                     <Markdown
                       source={description}
                       options={{ html: false, breaks: true, linkify: true }}
@@ -133,7 +133,7 @@ class TaskTypeListView extends React.PureComponent<{}, State> {
                 width={300}
               />
               <Column
-                title="Add-On Modes"
+                title="Modes"
                 dataIndex="settings"
                 key="allowedModes"
                 width={100}
@@ -164,6 +164,7 @@ class TaskTypeListView extends React.PureComponent<{}, State> {
               <Column
                 title="Action"
                 key="actions"
+                width={140}
                 render={(__, taskType: APITaskTypeType) => (
                   <span>
                     <Link to={`/annotations/CompoundTaskType/${taskType.id}`} title="View">

--- a/app/assets/javascripts/dashboard/views/dashboard_task_list_view.js
+++ b/app/assets/javascripts/dashboard/views/dashboard_task_list_view.js
@@ -299,7 +299,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
           dataIndex="type.description"
           sorter={Utils.localeCompareBy(t => t.type.description)}
           render={description => (
-            <div style={{ wordBreak: "break-word" }} className="task-type-description">
+            <div className="task-type-description">
               <Markdown
                 source={description}
                 options={{ html: false, breaks: true, linkify: true }}

--- a/app/assets/stylesheets/_dashboard.less
+++ b/app/assets/stylesheets/_dashboard.less
@@ -100,3 +100,10 @@
     }
   }
 }
+
+.task-type-description {
+  word-break: break-word;
+  max-height: 150px;
+  max-width: 300px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
The problem: https://webknossos.brain.mpg.de/taskTypes
I am not exactly sure why the table is so super messed up and misformated. I assume the taskType description was too long. Yet, the column already had a fixed width and the `<Markdown options={{breaks: true}} />` component should have dealt with that. Weird. 🙄 

### Mailable description of changes:
 - [Admin.TaskTypes] Fixed an issue with misformated task type lists. 

### Steps to test:
- Create a TaskType with a super long description. 
e.g. "Please trace the cell which occurs in the middle of your viewport. This should be an axon and therefor have NO spines. If you see spines you have made a mistake or our start-coordinate was wrong. In this case please email help@mhlab.net. IF YOU SEE A SOMA PLEASE COMMENT"soma", STOP THERE AND CONTINUE WITH THE NEXT POSITION (press "j"). Please understand what is an axon and what not: https://datashare.rzg.mpg.de/s/nOjudfxxjpF8l2N
--"
- Navigate to Admin --> Task Types. The table should look fine.


### Issues:
- fixes #2225 

------
- [x] Ready for review
