### PR TITLE
write activeNode to NML in backend

### DIFF
--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -79,6 +79,11 @@ object NmlWriter {
     Xml.withinElementSync("zoomLevel") {
       writer.writeAttribute("zoom", tracing.zoomLevel.toString)
     }
+    tracing.activeNodeId.map { nodeId =>
+      Xml.withinElementSync("activeNode") {
+        writer.writeAttribute("id", nodeId.toString)
+      }
+    }
     tracing.userBoundingBox.map { b =>
       Xml.withinElementSync("userBoundingBox") {
         writer.writeAttribute("topLeftX", b.topLeft.x.toString)


### PR DESCRIPTION
### Steps to test:
- create skeleton tracing, trace a bit, download
- `parameters` section of the nml should contain a field in the form of `<activeNode id="1" />`

### Issues:
- fixes #2237 

------
- [x] Ready for review
