### PR TITLE
Fix differenTaskType handling

### DIFF
--- a/app/assets/javascripts/oxalis/api/api_latest.js
+++ b/app/assets/javascripts/oxalis/api/api_latest.js
@@ -295,14 +295,14 @@ class TracingApi {
 
       // In some cases the page needs to be reloaded, in others the tracing can be hot-swapped
       if (isDifferentDataset || isDifferentTaskType || isDifferentScript) {
-        location.pathname = newTaskUrl;
+        location.href = newTaskUrl;
       } else {
         await this.restart(annotation.typ, annotation.id, ControlModeEnum.TRACE);
       }
     } catch (err) {
       console.error(err);
       await Utils.sleep(2000);
-      location.pathname = "/dashboard";
+      location.href = "/dashboard";
     }
   }
 


### PR DESCRIPTION
See https://discuss.webknossos.org/t/finish-and-get-a-new-task-if-task-of-new-type-is-next/653

I believe this originates from the problem that `location.pathname` escapes any GET parameters that are encoded in the url. `location.href` handles them properly. In this case we have wanted to redirect to the URL `/annotations/${annotation.typ}/${annotation.id}?differentTaskType`

### Steps to test:
- Create two tasktypes with each one task (must be same dataset)
- Get first and trace
- Finish & get next
- A message should pop up that you are now doing another tasktype

------
- [x] Ready for review
