### PR TITLE
remove unused storageFolder config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,8 +80,6 @@ braingames.binary{
 }
 
 oxalis{
-  annotation.storageFolder="data/nmls"
-
   user.time.tracingPauseInSeconds=60
 
   tasks.maxOpenPerUser = 5

--- a/conf/application_dev.conf
+++ b/conf/application_dev.conf
@@ -7,8 +7,6 @@ airbrake{
 
 http.uri="http://"${application.branch}".webknossos.xyz"
 
-oxalis.annotation.storageFolder="/srv/database/nmls/"${application.branch}
-
 application{
   insertInitialData=true
 


### PR DESCRIPTION
Removes the `oxalis.annotation.storageFolder` config option, which seems to be unused:
https://github.com/scalableminds/webknossos/search?q=storageFolder
https://github.com/scalableminds/braingames-libs/search?q=storageFolder
https://github.com/scalableminds/webknossos-datastore/search?q=storageFolder

------
- [x] Ready for review
