### PR TITLE
removed "upload successful" message for NML uploads

### DIFF
--- a/app/assets/javascripts/dashboard/views/explorative_annotations_view.js
+++ b/app/assets/javascripts/dashboard/views/explorative_annotations_view.js
@@ -145,7 +145,6 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
   };
 
   handleNMLUpload = (response: Object) => {
-    response.messages.map(m => Toast.success(m.success));
     this.props.history.push(`/annotations/${response.annotation.typ}/${response.annotation.id}`);
   };
 

--- a/app/assets/javascripts/oxalis/model/sagas/root_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/root_saga.js
@@ -57,8 +57,12 @@ function* warnAboutSegmentationOpacity(): Generator<*, *, *> {
   const warnMaybe = function*() {
     const shouldWarn = Model.shouldDisplaySegmentationData() && !Model.canDisplaySegmentationData();
     if (shouldWarn) {
-      const toastType = yield select(state => (state.tracing.type === "volume" ? "error" : "info"));
-      Toast.message(toastType, messages["tracing.segmentation_zoom_warning"], true);
+      const isVolumeTracing = yield select(state => state.tracing.type === "volume");
+      if (isVolumeTracing) {
+        Toast.message("error", messages["tracing.segmentation_zoom_warning"], true);
+      } else {
+        Toast.message("info", messages["tracing.segmentation_zoom_warning"], false, 3000);
+      }
     } else if (!shouldWarn) {
       Toast.close(messages["tracing.segmentation_zoom_warning"]);
     }


### PR DESCRIPTION
### Mailable description of changes:
- [Dashboard] Removed "Upload successful" notification for NML uploads. Errors will still be shown.
- [Tracing View] Decreased the notification duration for `Segmentation data and volume tracing is only fully supported at a smaller zoom level.` notifications for skeleton tracings to 3s

### Steps to test:
- Upload valid NML get no toast

### Issues:
- fixes https://discuss.webknossos.org/t/notifications-toasts-hide-ui-elements/646

------
- [x] Ready for review
