### PR TITLE
Scroll to active tree in the comment tab if the active node has no comment

### DIFF
--- a/app/assets/javascripts/oxalis/view/right-menu/comment_tab/comment.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/comment_tab/comment.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from "react";
-import scrollIntoViewIfNeeded from "scroll-into-view-if-needed";
+import { scrollIntoViewIfNeeded } from "scroll-into-view-if-needed";
 import classNames from "classnames";
 import Store from "oxalis/store";
 import { setActiveNodeAction } from "oxalis/model/actions/skeletontracing_actions";

--- a/app/assets/javascripts/oxalis/view/right-menu/comment_tab/comment.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/comment_tab/comment.js
@@ -25,7 +25,7 @@ class Comment extends React.PureComponent<Props> {
   ensureVisible() {
     if (this.props.isActive) {
       // use polyfill as so far only chrome supports this functionality
-      scrollIntoViewIfNeeded(this.comment);
+      scrollIntoViewIfNeeded(this.comment, { centerIfNeeded: true });
     }
   }
 

--- a/app/assets/javascripts/oxalis/view/right-menu/comment_tab/tree_comment_list.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/comment_tab/tree_comment_list.js
@@ -9,7 +9,7 @@ import classNames from "classnames";
 import Comment from "oxalis/view/right-menu/comment_tab/comment";
 import Utils from "libs/utils";
 import { enforceSkeletonTracing } from "oxalis/model/accessors/skeletontracing_accessor";
-import scrollIntoViewIfNeeded from "scroll-into-view-if-needed";
+import { scrollIntoViewIfNeeded } from "scroll-into-view-if-needed";
 import type { OxalisState, TreeType, SkeletonTracingType } from "oxalis/store";
 
 type OwnProps = {
@@ -36,10 +36,8 @@ class TreeCommentList extends React.PureComponent<TreeCommentListProps, State> {
   }
 
   activeNodeHasComment(): boolean {
-    return this.props.tree.comments.reduce(
-      (hasComment, comment) =>
-        hasComment || comment.nodeId === this.props.skeletonTracing.activeNodeId,
-      false,
+    return this.props.tree.comments.some(
+      comment => comment.nodeId === this.props.skeletonTracing.activeNodeId,
     );
   }
 

--- a/app/assets/javascripts/oxalis/view/right-menu/comment_tab/tree_comment_list.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/comment_tab/tree_comment_list.js
@@ -27,7 +27,6 @@ type State = {
 
 class TreeCommentList extends React.PureComponent<TreeCommentListProps, State> {
   treeDomElement: ?HTMLLIElement;
-  activeNodeHasComment: boolean;
   state = {
     collapsed: false,
   };
@@ -36,11 +35,19 @@ class TreeCommentList extends React.PureComponent<TreeCommentListProps, State> {
     this.ensureVisible();
   }
 
+  activeNodeHasComment(): boolean {
+    return this.props.tree.comments.reduce(
+      (hasComment, comment) =>
+        hasComment || comment.nodeId === this.props.skeletonTracing.activeNodeId,
+      false,
+    );
+  }
+
   ensureVisible() {
     // Only scroll to this tree if this is the active tree and there is no active comment to scroll to
     if (
       this.props.tree.treeId === this.props.skeletonTracing.activeTreeId &&
-      !this.activeNodeHasComment
+      !this.activeNodeHasComment()
     ) {
       scrollIntoViewIfNeeded(this.treeDomElement, { centerIfNeeded: true });
     }
@@ -52,25 +59,20 @@ class TreeCommentList extends React.PureComponent<TreeCommentListProps, State> {
 
   render() {
     const containsActiveNode = this.props.tree.treeId === this.props.skeletonTracing.activeTreeId;
-    this.activeNodeHasComment = false;
 
     // don't render the comment nodes if the tree is collapsed
     const commentNodes = !this.state.collapsed
       ? this.props.tree.comments
           .slice(0)
           .sort(Utils.localeCompareBy("content", this.props.isSortedAscending))
-          .map(comment => {
-            const isActive = comment.nodeId === this.props.skeletonTracing.activeNodeId;
-            this.activeNodeHasComment = this.activeNodeHasComment || isActive;
-            return (
-              <Comment
-                key={comment.nodeId}
-                data={comment}
-                treeId={this.props.tree.treeId}
-                isActive={isActive}
-              />
-            );
-          })
+          .map(comment => (
+            <Comment
+              key={comment.nodeId}
+              data={comment}
+              treeId={this.props.tree.treeId}
+              isActive={comment.nodeId === this.props.skeletonTracing.activeNodeId}
+            />
+          ))
       : null;
 
     const liClassName = classNames({ bold: containsActiveNode });

--- a/app/assets/javascripts/oxalis/view/right-menu/trees_tab_item_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/trees_tab_item_view.js
@@ -5,7 +5,7 @@
 
 import _ from "lodash";
 import * as React from "react";
-import scrollIntoViewIfNeeded from "scroll-into-view-if-needed";
+import { scrollIntoViewIfNeeded } from "scroll-into-view-if-needed";
 import Store from "oxalis/store";
 import {
   toggleTreeAction,

--- a/app/assets/javascripts/oxalis/view/right-menu/trees_tab_item_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/trees_tab_item_view.js
@@ -38,7 +38,7 @@ class ListTreeItemView extends React.PureComponent<ListTreeItemViewProps> {
   ensureVisible() {
     // scroll to active tree
     if (this.props.tree.treeId === this.props.activeTreeId) {
-      scrollIntoViewIfNeeded(this.domElement);
+      scrollIntoViewIfNeeded(this.domElement, { centerIfNeeded: true });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^3.0.0",
     "redux-saga": "^0.14.3",
-    "scroll-into-view-if-needed": "^1.0.2",
+    "scroll-into-view-if-needed": "^1.4.1",
     "stats.js": "^1.0.0",
     "three": "^0.84.0",
     "tween.js": "^16.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,12 +135,6 @@ alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
 
-amator@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amator/-/amator-1.0.1.tgz#0fd3663fef5f3334d088cf68a70ba74398aa0e26"
-  dependencies:
-    bezier-easing "^2.0.3"
-
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -1435,10 +1429,6 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
-
-bezier-easing@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/bezier-easing/-/bezier-easing-2.0.3.tgz#cb493fddb7f8920ecca00973344ce0518885f17e"
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -7329,11 +7319,9 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
-scroll-into-view-if-needed@^1.0.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-1.3.0.tgz#55e35ea0efe24bdb43602c55acc2af4650e309de"
-  dependencies:
-    amator "1.0.1"
+scroll-into-view-if-needed@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-1.4.1.tgz#763580091fb8e0bd4dc2d68b475d755f66574a0e"
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
If you're looking at the code and are wondering whether `this.activeNodeHasComment` check before scrolling is actually needed, I would argue it is. When the active node has a comment we want to scroll, so that that comment is visible. Only if the active node doesn't have a comment we want to scroll, so that the tree that contains that node is visible.

### Mailable description of changes:
 - The comment list now scrolls to the active tree, even if the selected node doesn't have a comment.

### Steps to test:
- Open a tracing with many comments in different trees, select a node with a comment (that is not visible in the comment tab) in the tracing view -> the comment list should scroll to the comment
- select a node without a comment (from a tree that is not visible in the comment tab, but that has other comments) in the tracing view -> the comment list should scroll to the tree

### Issues:
- fixes #2217

------
- [x] Ready for review
