### PR TITLE
prune sbt dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,51 +3,42 @@ import sbt._
 
 
 object Dependencies {
-  val playVersion = "2.4.6"
   val akkaVersion = "2.4.1"
-  val reactiveVersion = "0.11.13"
-  val reactivePlayVersion = "0.11.13-play24"
-  val twelvemonkeysVersion = "3.1.2"
   val log4jVersion = "2.0-beta9"
   val newrelicVersion = "3.44.1"
+  val playVersion = "2.4.6"
+  val reactivePlayVersion = "0.11.13-play24"
+  val reactiveVersion = "0.11.13"
   val webknossosWrapVersion = "1.1.4"
 
-  val restFb = "com.restfb" % "restfb" % "1.6.11"
-  val commonsIo = "commons-io" % "commons-io" % "2.4"
-  val commonsEmail = "org.apache.commons" % "commons-email" % "1.3.1"
-  val commonsLang = "org.apache.commons" % "commons-lang3" % "3.1"
-  val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
-  val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
-  val akkaAgent = "com.typesafe.akka" %% "akka-agent" % akkaVersion
-  val akkaRemote = "com.typesafe.akka" %% "akka-remote" % akkaVersion
-  val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
-  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
-  val jerseyClient = "com.sun.jersey" % "jersey-client" % "1.8"
-  val jerseyCore = "com.sun.jersey" % "jersey-core" % "1.8"
-  val reactivePlay = "org.reactivemongo" %% "play2-reactivemongo" % reactivePlayVersion
-  val reactiveBson = "org.reactivemongo" %% "reactivemongo-bson-macros" % reactiveVersion
-  val scalaReflect = "org.scala-lang" % "scala-reflect" % "2.11.2"
-  val scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.2"
   val airbrake = "com.scalableminds" %% "play-airbrake" % "0.5.0"
-  val urlHelper = "com.netaporter" %% "scala-uri" % "0.4.14"
-  val resourceManager = "com.jsuereth" %% "scala-arm" % "2.0"
-  val silhouette = "com.mohiva" %% "play-silhouette" % "3.0.5"
-  val playFramework = "com.typesafe.play" %% "play" % playVersion
-  val silhouetteTestkit = "com.mohiva" %% "play-silhouette-testkit" % "3.0.5" % "test"
+  val akkaAgent = "com.typesafe.akka" %% "akka-agent" % akkaVersion
+  val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
+  val akkaRemote = "com.typesafe.akka" %% "akka-remote" % akkaVersion
+  val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
   val ceedubs = "net.ceedubs" %% "ficus" % "1.1.2"
-  val scalaGuice = "net.codingwell" %% "scala-guice" % "4.0.0"
-  val webjars = "org.webjars" %% "webjars-play" % "2.4.0"
-  val rocksDB = "org.rocksdb" % "rocksdbjni" % "5.1.2"
-  val bootstrap = "com.adrianhurt" %% "play-bootstrap3" % "0.4.4-P24"
-  val log4jCore =  "org.apache.logging.log4j" % "log4j-api" % log4jVersion
-  val log4jApi = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
+  val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
+  val commonsEmail = "org.apache.commons" % "commons-email" % "1.3.1"
+  val commonsIo = "commons-io" % "commons-io" % "2.4"
+  val commonsLang = "org.apache.commons" % "commons-lang3" % "3.1"
   val liftBox = "net.liftweb" % "lift-common_2.10" % "2.6-M3"
   val liftUtil = "net.liftweb" % "lift-util_2.10" % "3.0-M1"
-  val alphanumericComparator = "se.sawano.java" % "alphanumeric-comparator" % "1.4.1"
+  val log4jApi = "org.apache.logging.log4j" % "log4j-core" % log4jVersion
+  val log4jCore =  "org.apache.logging.log4j" % "log4j-api" % log4jVersion
+  val newrelic = "com.newrelic.agent.java" % "newrelic-agent" % newrelicVersion
+  val newrelicApi = "com.newrelic.agent.java" % "newrelic-api" % newrelicVersion
+  val playFramework = "com.typesafe.play" %% "play" % playVersion
+  val reactiveBson = "org.reactivemongo" %% "reactivemongo-bson-macros" % reactiveVersion
+  val reactivePlay = "org.reactivemongo" %% "play2-reactivemongo" % reactivePlayVersion
+  val rocksDB = "org.rocksdb" % "rocksdbjni" % "5.1.2"
+  val scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.2"
+  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
   val scalapbJson = "com.scalableminds" %% "scalapb-json4s" % "0.3.2.0-scm"
-  val xmlWriter = "org.glassfish.jaxb" % "txw2" % "2.2.11"
+  val silhouette = "com.mohiva" %% "play-silhouette" % "3.0.5"
+  val silhouetteTestkit = "com.mohiva" %% "play-silhouette-testkit" % "3.0.5" % "test"
+  val urlHelper = "com.netaporter" %% "scala-uri" % "0.4.14"
   val webknossosWrap = "com.scalableminds" %% "webknossos-wrap" % webknossosWrapVersion
-  val websockets = "org.java-websocket" % "Java-WebSocket" % "1.3.0"
+  val xmlWriter = "org.glassfish.jaxb" % "txw2" % "2.2.11"
 
   // Unfortunately, we need to list all mturk dependencies seperately since mturk is not published on maven but rather
   // added to the project as a JAR. To keep the number of JARs added to this repo as small as possible, everthing that
@@ -92,94 +83,45 @@ object Dependencies {
     "org.apache.geronimo.specs" % "geronimo-javamail_1.3.1_spec" % "1.3"
   )
 
-  val tiff = Seq(
-      "com.twelvemonkeys.common" % "common-lang" % twelvemonkeysVersion,
-      "com.twelvemonkeys.common" % "common-io" % twelvemonkeysVersion,
-      "com.twelvemonkeys.common" % "common-image" % twelvemonkeysVersion,
-      "com.twelvemonkeys.imageio" %  "imageio-core" % twelvemonkeysVersion,
-      "com.twelvemonkeys.imageio" %  "imageio-metadata" % twelvemonkeysVersion,
-      "com.twelvemonkeys.imageio" % "imageio-jpeg" % twelvemonkeysVersion,
-      "com.twelvemonkeys.imageio" % "imageio-tiff" % twelvemonkeysVersion
-    )
-  val newrelic = "com.newrelic.agent.java" % "newrelic-agent" % newrelicVersion
-  val newrelicApi = "com.newrelic.agent.java" % "newrelic-api" % newrelicVersion
 
   val utilDependencies = Seq(
-    playFramework,
-    log4jCore,
-    log4jApi,
-    commonsIo,
-    commonsEmail,
-    commonsLang,
-    reactiveBson,
-    reactivePlay,
-    ws,
     akkaAgent,
     akkaRemote,
-    scalaLogging,
+    commonsEmail,
+    commonsIo,
+    commonsLang,
     liftBox,
     liftUtil,
-    scalapbJson
+    log4jApi,
+    log4jCore,
+    playFramework,
+    reactiveBson,
+    reactivePlay,
+    scalaLogging,
+    scalapbJson,
+    ws
   )
 
   val webknossosDatastoreDependencies = Seq(
-    akkaAgent,
     akkaLogging,
-    akkaRemote,
-    alphanumericComparator,
     cache,
-    commonsEmail,
-    commonsIo,
-    commonsLang,
-    liftBox,
-    liftUtil,
-    log4jApi,
-    log4jCore,
     newrelic,
     newrelicApi,
-    playFramework,
-    reactiveBson,
-    reactivePlay,
     rocksDB,
-    scalaLogging,
-    scalapbJson,
     webknossosWrap,
-    websockets,
-    ws,
-    xmlWriter,
     component("play-test")
-  ) ++ tiff
+  )
 
   val webknossosDependencies = Seq(
-    restFb,
-    commonsIo,
-    commonsEmail,
-    commonsLang,
-    commonsCodec,
-    akkaTest,
-    akkaAgent,
-    akkaRemote,
-    akkaLogging,
-    jerseyClient,
-    jerseyCore,
-    reactiveBson,
-    reactivePlay,
-    scalaReflect,
-    scalaAsync,
-    cache,
-    ws,
-    scalaLogging,
     airbrake,
-    urlHelper,
-    newrelic,
-    newrelicApi,
-    resourceManager,
+    akkaTest,
+    ceedubs,
+    commonsCodec,
+    scalaAsync,
     silhouette,
     silhouetteTestkit,
-    ceedubs,
-    scalaGuice,
-    webjars,
-    bootstrap,
-    specs2 % Test) ++ tiff ++ mturk
+    specs2 % Test,
+    urlHelper,
+    xmlWriter) ++ mturk
 
 }


### PR DESCRIPTION
Removes some unused library dependencies from our sbt build definitions.

I assume the CI tests and the compiler should have told us if something was still needed?

I also sorted the lists alphabetically and removed duplicate entries (webknossos depends on datastore depends on util)

Based on (should not be merged before) #2256 (assimilate libs)

### Issues:
- first part of #2259

------
- [x] Ready for review
