### PR TITLE
in start script, specify which config file should be used

### DIFF
--- a/start
+++ b/start
@@ -1,4 +1,4 @@
 mongod > /dev/null &
 PID="$!"
-sbt run -mem 2048 -XX:MaxPermSize=512M
+sbt run -mem 2048 -XX:MaxPermSize=512M -Dconfig.file=conf/application.conf
 kill -9 $PID


### PR DESCRIPTION
On some machines sbt run decided to use the application.conf of the standalone-datastore subproject instead of the top-level one.

I should note that I don’t know about the mechanism that selects production settings over the application.conf so that might be disturbed by this PR.

### Steps to test:
- run wk with ./start
- view a dataset, data should load
------
- [x] Ready for review

  