### PR TITLE
re-add woodstox dependency, making xml writer use self-closing tags

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,8 @@ object Dependencies {
   val urlHelper = "com.netaporter" %% "scala-uri" % "0.4.14"
   val webknossosWrap = "com.scalableminds" %% "webknossos-wrap" % webknossosWrapVersion
   val xmlWriter = "org.glassfish.jaxb" % "txw2" % "2.2.11"
+  val woodstoxXml = "org.codehaus.woodstox" % "wstx-asl" % "3.2.3"
+
 
   val utilDependencies = Seq(
     akkaAgent,
@@ -78,6 +80,7 @@ object Dependencies {
     silhouetteTestkit,
     specs2 % Test,
     urlHelper,
-    xmlWriter)
+    xmlWriter,
+    woodstoxXml)
 
 }


### PR DESCRIPTION
This behavior was lost in the mturk removal PR #2262 because the woodstox sbt dependency was listed under `mturk`. It being included silently modifies the behavior of the xml writer.

### Steps to test:
- download a tracing as NML (using the download button, not the frontend export)
- childless tags should be `<selfclosing />` instead of `<verbose></verbose>`

### Issues:
- fixes #2270

------
- [x] Ready for review
