### PR TITLE
Update flow to 0.62

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -30,3 +30,5 @@ app/assets/javascripts/flow/custom-libdefs
 [lints]
 all=error
 sketchy-null=warn
+untyped-import=off
+unclear-type=warn

--- a/app/assets/javascripts/oxalis/model.js
+++ b/app/assets/javascripts/oxalis/model.js
@@ -78,7 +78,6 @@ type ServerSkeletonTracingTreeType = {
 
 type ServerTracingBaseType = {
   id: string,
-  boundingBox?: BoundingBoxObjectType,
   userBoundingBox?: BoundingBoxObjectType,
   createdTimestamp: number,
   editPosition: Vector3,
@@ -90,6 +89,7 @@ type ServerTracingBaseType = {
 
 export type ServerSkeletonTracingType = ServerTracingBaseType & {
   activeNodeId?: number,
+  boundingBox?: BoundingBoxObjectType,
   trees: Array<ServerSkeletonTracingTreeType>,
 };
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "exports-loader": "^0.6.4",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.5",
-    "flow-bin": "^0.59.0",
+    "flow-bin": "^0.62.0",
     "flow-coverage-report": "^0.4.0",
     "himalaya": "^0.2.12",
     "imports-loader": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3513,9 +3513,9 @@ flow-annotation-check@1.3.1:
     glob "7.1.1"
     load-pkg "^3.0.1"
 
-flow-bin@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+flow-bin@^0.62.0:
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.62.0.tgz#14bca669a6e3f95c0bc0c2d1eb55ec4e98cb1d83"
 
 flow-coverage-report@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Bumped the flow version in hope of performance improvements, but still seems to be very slow :/
The flow devs added some more command line output (parsed x/1800 files and so on), but for the part that takes more than a minute for me, there is no real output that would indicate why it takes so long.
Let's still merge this version bump.

------
- [x] Ready for review
