### PR TITLE
Task assignment: query only tasks with open instances

### DIFF
--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -113,7 +113,7 @@ class ReportController @Inject()(val messagesApi: MessagesApi) extends Controlle
   private def getAllAvailableTaskCountsAndProjects(users: Seq[User])(implicit ctx: DBAccessContext): Fox[List[OpenTasksEntry]] = {
     val foxes = users.map { user =>
       for {
-        projects <- TaskDAO.findByUserReturnOnlyProject(user).toFox
+        projects <- TaskDAO.findWithOpenByUserReturnOnlyProject(user).toFox
         assignmentCountsByProject <- getAssignmentsByProjectsFor(projects, user)
       } yield {
         OpenTasksEntry(user.name, assignmentCountsByProject.values.sum, assignmentCountsByProject)

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -295,10 +295,10 @@ object TaskDAO extends SecuredBaseDAO[Task] with FoxImplicits with QuerySupporte
     ).map{result => Json.toJson(result.firstBatch).as[List[OpenInstancesResult]].map( x => x._id -> x.openInstances).toMap }
   }
 
-  def findByUserReturnOnlyProject(user: User)(implicit ctx: DBAccessContext) = {
+  def findWithOpenByUserReturnOnlyProject(user: User)(implicit ctx: DBAccessContext) = {
     for {
       jsObjects <- findWithProjection(validPriorityQ ++ Json.obj(
-        "instances" -> Json.obj("$gt" -> 0),
+        "openInstances" -> Json.obj("$gt" -> 0),
         "team" -> Json.obj("$in" -> user.teamNames),
         "$or" -> (experienceQueryFor(user) :+ noRequiredExperience)), Json.obj("_project" -> 1, "_id" -> 0)).cursor[JsObject]().collect[List]()
     } yield {

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -270,7 +270,7 @@ object TaskDAO extends SecuredBaseDAO[Task] with FoxImplicits with QuerySupporte
       Json.obj("priority" -> -1)
 
     find(validPriorityQ ++ Json.obj(
-      "instances" -> Json.obj("$gt" -> 0),
+      "openInstances" -> Json.obj("$gt" -> 0),
       "team" -> Json.obj("$in" -> teams),
       "$or" -> (experienceQueryFor(user) :+ noRequiredExperience)))
       .sort(byPriority)


### PR DESCRIPTION
Fixes the mistake that in the task assignment (and overview page), total instances were queried instead of open instances.
This happens when you rename fields that occur in Strings…

### Steps to test:
- request a task, you should get it, even if there are other tasks with higher priority (but with 0 instances)

### Issues:
- fixes #2273

------
- [x] Ready for review
