### PR TITLE
Do not sbt clean in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,12 @@ jobs:
           command: docker-compose run base yarn run docs
       - run:
           name: Build webknossos (sbt and webpack)
-          command: docker-compose run base sbt compile stage
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker-compose run base sbt clean compile stage
+            else
+              docker-compose run base sbt compile stage
+            fi
       - run:
           name: Build webknossos-datastore (sbt)
           command: docker-compose run base sbt "project webknossosDatastore" compile stage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
           command: docker-compose run base yarn run docs
       - run:
           name: Build webknossos (sbt and webpack)
-          command: docker-compose run base sbt clean compile stage
+          command: docker-compose run base sbt compile stage
       - run:
           name: Build webknossos-datastore (sbt)
-          command: docker-compose run base sbt "project webknossosDatastore" clean compile stage
+          command: docker-compose run base sbt "project webknossosDatastore" compile stage
 
       - save_cache:
           key: cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: docker-compose run base sbt "project webknossosDatastore" compile stage
 
       - save_cache:
-          key: cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}
+          key: cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}-{{ .Revision }}
           paths:
             - "project/target"
             - "target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: docker-compose pull base
       - run:
           name: Prepare dependency folders
-          command: mkdir -p project/target ~/.m2 ~/.ivy2 ~/.sbt ~/.yarn-cache
+          command: mkdir -p project/target target ~/.m2 ~/.ivy2 ~/.sbt ~/.yarn-cache
       - restore_cache:
           keys:
             - cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}
@@ -37,6 +37,7 @@ jobs:
           key: cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}
           paths:
             - "project/target"
+            - "target"
             - "~/.m2"
             - "~/.ivy2"
             - "~/.sbt"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: docker-compose pull base
       - run:
           name: Prepare dependency folders
-          command: mkdir -p ~/.m2 ~/.ivy2 ~/.sbt ~/.yarn-cache
+          command: mkdir -p project/target ~/.m2 ~/.ivy2 ~/.sbt ~/.yarn-cache
       - restore_cache:
           keys:
             - cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}
@@ -36,6 +36,7 @@ jobs:
       - save_cache:
           key: cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}
           paths:
+            - "project/target"
             - "~/.m2"
             - "~/.ivy2"
             - "~/.sbt"


### PR DESCRIPTION
This removes the sbt `clean` part in the CI, except for the master.
Also, caching is fixed, as branch-caches were never overwritten before.

### Steps to test:
- CI is faster for sbt steps
- `clean` is run on the master

### Issues:
- related to #2285

------
- [x] Ready for review
