### PR TITLE
In Open Tasks report, exclude inactive users

### DIFF
--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -101,7 +101,7 @@ class ReportController @Inject()(val messagesApi: MessagesApi) extends Controlle
   def openTasksOverview(id: String) = SecuredAction.async { implicit request =>
     for {
       team <- TeamDAO.findOneById(id)(GlobalAccessContext)
-      users <- UserDAO.findByTeams(List(team.name), true)(GlobalAccessContext)
+      users <- UserDAO.findByTeams(List(team.name), includeAnonymous = true, includeInactive = false)(GlobalAccessContext)
       nonAdminUsers = users.filterNot(_.isAdminOf(team.name))
       entries: List[OpenTasksEntry] <- getAllAvailableTaskCountsAndProjects(nonAdminUsers)(GlobalAccessContext)
     } yield {

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -174,9 +174,10 @@ object UserDAO extends SecuredBaseDAO[User] {
 
   def findOneByEmail(email: String)(implicit ctx: DBAccessContext) = findOne("email", email)
 
-  def findByTeams(teams: List[String], includeAnonymous: Boolean)(implicit ctx: DBAccessContext) = withExceptionCatcher {
+  def findByTeams(teams: List[String], includeAnonymous: Boolean, includeInactive: Boolean = true)(implicit ctx: DBAccessContext) = withExceptionCatcher {
     val anonymousFilter = if(includeAnonymous) Json.obj() else Json.obj("_isAnonymous" -> Json.obj("$ne" -> true))
-    find(Json.obj("$or" -> teams.map(team => Json.obj("teams.team" -> team))) ++ anonymousFilter).cursor[User]().collect[List]()
+    val inactiveFilter = if (includeInactive) Json.obj() else Json.obj("isActive" -> true)
+    find(Json.obj("$or" -> teams.map(team => Json.obj("teams.team" -> team))) ++ anonymousFilter ++ inactiveFilter).cursor[User]().collect[List]()
   }
 
   def findByIdQ(id: BSONObjectID) = Json.obj("_id" -> id)


### PR DESCRIPTION
### Mailable description of changes:
 - Inactive users are excluded from the Open Tasks report overview page

### Steps to test:
- for local testing, multiple users that are non-admin members of a team are required,
- select that team in Statistics→Open Tasks page, all of them should be shown
- disable von in Administration→Users, now they should be excluded in the overview page

### Issues:
- fixes #2300

------
- [x] Ready for review
