### PR TITLE
deactiveate resetting the scale on datasource deactivation, #2316

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import javax.inject.Inject
 
-import oxalis.security.WebknossosSilhouette.{UserAwareRequest, UserAwareAction, SecuredRequest, SecuredAction}
+import oxalis.security.WebknossosSilhouette.{SecuredAction, SecuredRequest, UserAwareAction, UserAwareRequest}
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, SkeletonTracings}
 import com.scalableminds.webknossos.datastore.tracings.{TracingReference, TracingType}
 import com.scalableminds.util.io.{NamedEnumeratorStream, ZipIO}
@@ -117,7 +117,7 @@ class AnnotationIOController @Inject()(val messagesApi: MessagesApi)
     def skeletonToDownloadStream(dataSet: DataSet, annotation: Annotation, name: String) = {
       for {
         tracing <- dataSet.dataStore.getSkeletonTracing(annotation.tracingReference)
-        scale <- dataSet.dataSource.toUsable.map(_.scale)
+        scale <- dataSet.dataSource.scaleOpt
       } yield {
         (NmlWriter.toNmlStream(Left(tracing), annotation.description, scale), name + ".nml")
       }
@@ -126,7 +126,7 @@ class AnnotationIOController @Inject()(val messagesApi: MessagesApi)
     def volumeToDownloadStream(dataSet: DataSet, annotation: Annotation, name: String) = {
       for {
         (tracing, data) <- dataSet.dataStore.getVolumeTracing(annotation.tracingReference)
-        scale <- dataSet.dataSource.toUsable.map(_.scale)
+        scale <- dataSet.dataSource.scaleOpt
       } yield {
         (Enumerator.outputStream { outputStream =>
           ZipIO.zip(

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -266,12 +266,12 @@ object AnnotationService
     }
 
     def getScales(annotations: List[Annotation]) = {
-      val foxes = annotations.map(annotation =>
+      Fox.combined(annotations.map{ annotation =>
         for {
           dataSet <- DataSetDAO.findOneBySourceName(annotation.dataSetName)
-          dataSource <- dataSet.dataSource.toUsable
-        } yield dataSource.scale)
-      Fox.combined(foxes)
+          scale <- dataSet.dataSource.scaleOpt
+        } yield { scale }
+      })
     }
 
     def getNames(annotations: List[Annotation]) = Fox.combined(annotations.map(a => SavedTracingInformationHandler.nameForAnnotation(a).toFox))

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -95,9 +95,7 @@ object DataSetService extends FoxImplicits with LazyLogging {
           "isActive" -> false,
           "dataSource.status" -> "No longer available on datastore."),
         // we need this $unset, so the data source will not be considered imported during deserialization
-        "$unset" -> Json.obj(
-          "dataSource.dataLayers" -> "",
-          "dataSource.scale" -> "")
+        "$unset" -> Json.obj("dataSource.dataLayers" -> "")
       ),
       multi = true)
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
@@ -19,6 +19,8 @@ package object datasource {
 
     val toUsable: Option[GenericDataSource[T]] = Some(this)
 
+    val scaleOpt: Option[Scale] = Some(scale)
+
     def getDataLayer(name: String): Option[T] =
       dataLayers.find(_.name == name)
 
@@ -45,7 +47,7 @@ package object datasource {
       def writes(ds: GenericDataSource[T]) = Json.obj(
         "id" -> DataSourceId.dataSourceIdForamt.writes(ds.id),
         "dataLayers" -> ds.dataLayers.map(Json.toJson(_)),
-        "scale" -> Scale.scaleWrites. writes(ds.scale)
+        "scale" -> Scale.scaleWrites.writes(ds.scale)
       )
     }
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/InboxDataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/InboxDataSource.scala
@@ -3,6 +3,7 @@
  */
 package com.scalableminds.webknossos.datastore.models.datasource
 
+import com.scalableminds.util.geometry.Scale
 import play.api.libs.json.{Format, JsResult, JsValue, Json}
 
 package object inbox {
@@ -14,6 +15,8 @@ package object inbox {
     def toUsable: Option[GenericDataSource[T]]
 
     def isUsable: Boolean = toUsable.isDefined
+
+    def scaleOpt: Option[Scale]
   }
 
   object GenericInboxDataSource {
@@ -33,8 +36,10 @@ package object inbox {
     }
   }
 
-  case class UnusableDataSource[+T <: DataLayerLike](id: DataSourceId, status: String) extends GenericInboxDataSource[T] {
+  case class UnusableDataSource[+T <: DataLayerLike](id: DataSourceId, status: String, scale: Option[Scale] = None) extends GenericInboxDataSource[T] {
     val toUsable: Option[GenericDataSource[T]] = None
+
+    val scaleOpt: Option[Scale] = scale
   }
 
   object UnusableDataSource {
@@ -44,13 +49,15 @@ package object inbox {
         for {
           id <- (json \ "id").validate[DataSourceId]
           status <- (json \ "status").validate[String]
-        } yield UnusableDataSource(id, status)
+          scale <- (json \ "scale").validateOpt[Scale]
+        } yield UnusableDataSource(id, status, scale)
       }
 
       def writes(ds: UnusableDataSource[T]): JsValue = {
         Json.obj(
           "id" -> Json.toJson(ds.id),
-          "status" -> ds.status
+          "status" -> ds.status,
+          "scale" -> ds.scale.map(Scale.scaleWrites.writes)
         )
       }
     }
@@ -58,4 +65,5 @@ package object inbox {
 
   type InboxDataSource = GenericInboxDataSource[DataLayer]
   type InboxDataSourceLike = GenericInboxDataSource[DataLayerLike]
+  type UnusableDataSourceLike = UnusableDataSource[DataLayerLike]
 }


### PR DESCRIPTION
### Steps to test:
- create a skeleton tracing on a dataset
- make that already imported dataset unavailable (e.g. by deleting it)
- trigger an inbox check (/data/triggers/checkInbox?token=...)
- check in DB, that the scale property of that dataset is still set
- try to download tracing

### Issues:
- #2316 (step 1)

------
- [x] Ready for review
