### PR TITLE
Show webknossos token to super users

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,18 +2,22 @@ package controllers
 
 import javax.inject.Inject
 
-import oxalis.security.WebknossosSilhouette.{UserAwareAction, SecuredAction}
+import oxalis.security.WebknossosSilhouette.UserAwareAction
 import models.analytics.{AnalyticsDAO, AnalyticsEntry}
+import models.binary.DataStoreHandlingStrategy
 import play.api.i18n.MessagesApi
 import play.api.libs.json.Json
-import play.twirl.api.Html
 
 class Application @Inject()(val messagesApi: MessagesApi) extends Controller{
 
   def buildInfo = UserAwareAction { implicit request =>
+    val token = request.identity.flatMap { user =>
+      if (user.isSuperUser) Some(DataStoreHandlingStrategy.webKnossosToken) else None
+    }
     Ok(Json.obj(
       "webknossos" -> webknossos.BuildInfo.toMap.mapValues(_.toString),
-      "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString)
+      "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString),
+      "token" -> token
     ))
   }
 


### PR DESCRIPTION
Sopmetimes it is helpful to know the secret token, that wK uses to identify itself to datastores. This PR exposes the secret token to superusers (currently only 5 scm accounts).

------
- [x] Ready for review
