### PR TITLE
In time controller, select default end day of correct month

### DIFF
--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -63,6 +63,10 @@ class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller 
     var date = input.parse(year.toString)
     val fullYear = output.format(date).toInt
 
+    //set them here to first day of selected month so getActualMaximum below will use the correct month entry
+    startDate.set(fullYear, month - 1, 1, 0, 0, 0)
+    endDate.set(fullYear, month - 1, 1, 0, 0, 0)
+
     val sDay = startDay.getOrElse(startDate.getActualMinimum(Calendar.DAY_OF_MONTH))
     val eDay = endDay.getOrElse(endDate.getActualMaximum(Calendar.DAY_OF_MONTH))
 


### PR DESCRIPTION
### Mailable description of changes:
 - Fix: In time logging API, select correct end-day if none is specified

### Steps to test:
- if api route `api/time/allusers/2018/1` is called in february, logs should not end on 28 jan.

### Issues:
- fixes #2335

------
- [x] Ready for review
