### PR TITLE
remove md5 hashes from users

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -2,7 +2,6 @@ import akka.actor.Props
 import com.newrelic.api.agent.NewRelic
 import com.scalableminds.util.mail.Mailer
 import com.scalableminds.util.reactivemongo.{GlobalAccessContext, GlobalDBAccess}
-import com.scalableminds.util.security.SCrypt
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
@@ -108,7 +107,6 @@ object InitialData extends GlobalDBAccess with FoxImplicits with LazyLogging {
           "SCM",
           "Boy",
           true,
-          SCrypt.md5(password),
           List(),
           loginInfo = UserService.createLoginInfo(email),
           passwordInfo = UserService.createPasswordInfo(password),

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -24,7 +24,6 @@ case class User(
                  firstName: String,
                  lastName: String,
                  isActive: Boolean = false,
-                 md5hash: String = "",
                  teams: List[TeamMembership],
                  userConfiguration: UserConfiguration = UserConfiguration.default,
                  dataSetConfigurations: Map[String, DataSetConfiguration] = Map.empty,

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -69,7 +69,7 @@ object UserService extends FoxImplicits with IdentityService[User] {
     for {
       teamOpt <- TeamDAO.findOneByName(teamName)(GlobalAccessContext).futureBox
       teamMemberships = teamOpt.map(t => TeamMembership(t.name, teamRole)).toList
-      user = User(email, firstName, lastName, isActive = isActive, md5(password), teamMemberships, loginInfo = loginInfo, passwordInfo = passwordInfo)
+      user = User(email, firstName, lastName, isActive = isActive, teamMemberships, loginInfo = loginInfo, passwordInfo = passwordInfo)
       _ <- UserDAO.insert(user)(GlobalAccessContext)
     } yield user
 

--- a/app/oxalis/thirdparty/BrainTracing.scala
+++ b/app/oxalis/thirdparty/BrainTracing.scala
@@ -46,7 +46,7 @@ object BrainTracing extends LazyLogging with FoxImplicits {
           "firstname" -> user.firstName,
           "lastname" -> user.lastName,
           "email" -> user.email,
-          "pword" -> user.md5hash)
+          "pword" -> "")
         .get()
         .map { response =>
           result complete (response.status match {

--- a/conf/evolutions/45.js
+++ b/conf/evolutions/45.js
@@ -1,0 +1,6 @@
+
+// --- !Ups
+db.getCollection('users').update({}, {$unset: {"md5hash":0}}, { multi: true });
+
+// --- !Downs
+db.getCollection('users').update({}, {$set: {"md5hash": ""}}, { multi: true });

--- a/util/src/main/scala/com/scalableminds/util/security/SCrypt.scala
+++ b/util/src/main/scala/com/scalableminds/util/security/SCrypt.scala
@@ -8,7 +8,7 @@ package com.scalableminds.util.security
  */
 object SCrypt {
 
-  import java.security.{MessageDigest, SecureRandom}
+  import java.security.SecureRandom
 
   /**
    * For readability.
@@ -55,7 +55,4 @@ object SCrypt {
     hashedPassword.compareTo(BCrypt.hashpw(plainTextPassword, hashedPassword)) == 0
   }
 
-  def md5(s: String) = {
-    MessageDigest.getInstance("MD5").digest(s.getBytes).map("%02X".format(_)).mkString
-  }
 }


### PR DESCRIPTION
### Mailable description of changes:
 - MD5 hashes are no longer stored in the database

### Steps to test:
- should still compile, create initial user

### Issues:
- fixes #2351

------
- [x] Ready for review
