### PR TITLE
Fix regression in AbstractTreeViewer due to new EdgeCollection data structure

### DIFF
--- a/app/assets/javascripts/oxalis/model/edge_collection.js
+++ b/app/assets/javascripts/oxalis/model/edge_collection.js
@@ -21,10 +21,15 @@ export default class EdgeCollection {
   }
 
   getEdgesForNode(nodeId: number): Array<EdgeType> {
-    const outgoingEdges = this.outMap.getNullable(nodeId) || [];
-    const ingoingEdges = this.inMap.getNullable(nodeId) || [];
+    return this.getOutgoingEdgesForNode(nodeId).concat(this.getIngoingEdgesForNode(nodeId));
+  }
 
-    return outgoingEdges.concat(ingoingEdges);
+  getOutgoingEdgesForNode(nodeId: number): Array<EdgeType> {
+    return this.outMap.getNullable(nodeId) || [];
+  }
+
+  getIngoingEdgesForNode(nodeId: number): Array<EdgeType> {
+    return this.inMap.getNullable(nodeId) || [];
   }
 
   addEdges(edges: Array<EdgeType>, mutate: boolean = false): EdgeCollection {

--- a/app/assets/javascripts/oxalis/view/right-menu/abstract_tree_renderer.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/abstract_tree_renderer.js
@@ -106,7 +106,7 @@ class AbstractTreeRenderer {
         visitedNodes[curNodeId] = true;
       }
 
-      const edges = this.tree.edges.getEdgesForNode(curNodeId);
+      const edges = this.tree.edges.getOutgoingEdgesForNode(curNodeId);
       const childrenIds = edges.map(edge => edge.target);
       for (const childId of childrenIds) {
         const child = {


### PR DESCRIPTION
### Mailable description of changes:
 - Fix Regression in Abstract Tree Viewer

### Steps to test:
- Open a tracing with some nodes and open the abstract tree viewer

### Issues:
- fixes #2353 

------
- [X] Ready for review
