### PR TITLE
CI smoke test: don't daemonize, use circleCI background

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,23 +75,43 @@ jobs:
               docker-compose run e2e-tests && s=0 && break || s=$?
             done
             (exit $s)
+
+      - run:
+          name: Start webknossos
+          background: true
+          command: |
+            set -x
+            DOCKER_TAG=${CIRCLE_BRANCH}__${CIRCLE_BUILD_NUM} docker-compose up webknossos
       - run:
           name: Run webknossos smoke test
           command: |
             set -x
-            DOCKER_TAG=${CIRCLE_BRANCH}__${CIRCLE_BUILD_NUM} docker-compose up -d webknossos
             sleep 10
             ./test/infrastructure/deployment.bash
+      - run:
+          name: Stop webknossos
+          command: |
+            set -x
             docker-compose down --volumes --remove-orphans
 
+      - run:
+          name: Start webknossos-datastore
+          background: true
+          command: |
+            set -x
+            cd webknossos-datastore
+            DOCKER_TAG=${CIRCLE_BRANCH}__${CIRCLE_BUILD_NUM} docker-compose up webknossos-datastore
       - run:
           name: Run webknossos-datastore smoke test
           command: |
             set -x
-            cd webknossos-datastore
-            DOCKER_TAG=${CIRCLE_BRANCH}__${CIRCLE_BUILD_NUM} docker-compose up -d webknossos-datastore
             sleep 10
             curl --retry 3 --max-time 15 -v http://localhost:9090/data/health
+      - run:
+          name: Stop webknossos-datastore
+          command: |
+            set -x
+            cd webknossos-datastore
             docker-compose down --volumes --remove-orphans
 
       - run:


### PR DESCRIPTION
### Steps to test:
- [CircleCI](https://circleci.com/gh/scalableminds/webknossos/tree/ci-no-daemon) shows background information about running webknossos during the e2e tests
- e2e tests are successful

------
- [x] Ready for review
