### PR TITLE
ensure that getNRandomColors always returns n colors even for n > 500

### DIFF
--- a/app/assets/javascripts/libs/color_generator.js
+++ b/app/assets/javascripts/libs/color_generator.js
@@ -1519,8 +1519,17 @@ const ColorGenerator = {
   },
 
   getNRandomColors(n: number): Array<Vector3> {
-    // Take the first n colors and shuffle these
-    return _.shuffle(rgbs.slice(0, Math.min(n, rgbs.length)));
+    let shuffledColors = [];
+    let remainingColorCount = n;
+
+    while (remainingColorCount > 0) {
+      // Take the first k colors
+      const batchSize = Math.min(remainingColorCount, rgbs.length);
+      shuffledColors = shuffledColors.concat(rgbs.slice(0, batchSize));
+      remainingColorCount -= batchSize;
+    }
+
+    return _.shuffle(shuffledColors);
   },
 };
 


### PR DESCRIPTION
### Mailable description of changes:
 - Fix shuffle colors for large tree amount

### Steps to test:
- test shuffle all tree colors for n < 500 and n > 500

### Issues:
- contributes to #2361

------
- [X] Ready for review
