### PR TITLE
Allow multiple Datastore Auth Tokens

### DIFF
--- a/app/controllers/UserTokenController.scala
+++ b/app/controllers/UserTokenController.scala
@@ -30,7 +30,7 @@ class UserTokenController @Inject()(val messagesApi: MessagesApi)
     val context = userAwareRequestToDBAccess(request)
     val tokenFox: Fox[String] = request.identity match {
       case Some(user) =>
-        bearerTokenService.createAndInit(user.loginInfo, TokenType.DataStore).toFox
+        bearerTokenService.createAndInit(user.loginInfo, TokenType.DataStore, deleteOld = false).toFox
       case None => Fox.successful("")
     }
     for {

--- a/app/oxalis/security/BearerTokenAuthenticatorDAO.scala
+++ b/app/oxalis/security/BearerTokenAuthenticatorDAO.scala
@@ -57,12 +57,13 @@ class BearerTokenAuthenticatorDAO extends AuthenticatorDAO[BearerTokenAuthentica
   def insert(authenticator: BearerTokenAuthenticator, tokenType: TokenType.TokenTypeValue)(implicit ctx: DBAccessContext): Fox[WriteResult] =
     insert(formatter.writes(authenticator)+("tokenType" -> Json.toJson(tokenType)))
 
-  //adds the new token with the specified tokenType (and removes the old one)
-  def add(authenticator: BearerTokenAuthenticator, tokenType: TokenType.TokenTypeValue): Future[BearerTokenAuthenticator] = for {
+  def add(authenticator: BearerTokenAuthenticator, tokenType: TokenType.TokenTypeValue, deleteOld: Boolean = true): Future[BearerTokenAuthenticator] = for {
     maybeOldAuthenticator <- findByLoginInfo(authenticator.loginInfo, tokenType)
     _ <- insert(authenticator, tokenType)(GlobalAccessContext).futureBox
   } yield {
-    maybeOldAuthenticator.map(a => remove(a.id))
+    if (deleteOld) {
+      maybeOldAuthenticator.map(a => remove(a.id))
+    }
     authenticator
   }
 }

--- a/app/oxalis/security/WebknossosBearerTokenAuthenticatorService.scala
+++ b/app/oxalis/security/WebknossosBearerTokenAuthenticatorService.scala
@@ -49,18 +49,18 @@ class WebknossosBearerTokenAuthenticatorService(settings: BearerTokenAuthenticat
     }
   }
 
-  def init(authenticator: BearerTokenAuthenticator, tokenType: TokenType.TokenTypeValue)(implicit request: RequestHeader): Future[String] = {
-    dao.add(authenticator, tokenType).map { a =>
+  def init(authenticator: BearerTokenAuthenticator, tokenType: TokenType.TokenTypeValue, deleteOld: Boolean = true)(implicit request: RequestHeader): Future[String] = {
+    dao.add(authenticator, tokenType, deleteOld).map { a =>
       a.id
     }.recover {
       case e => throw new AuthenticatorInitializationException(InitError.format(ID, authenticator), e)
     }
   }
 
-  def createAndInit(loginInfo: LoginInfo, tokenType: TokenType.TokenTypeValue)(implicit request: RequestHeader): Future[String] =
+  def createAndInit(loginInfo: LoginInfo, tokenType: TokenType.TokenTypeValue, deleteOld: Boolean = true)(implicit request: RequestHeader): Future[String] =
     for {
       tokenAuthenticator <- create(loginInfo, tokenType)
-      tokenId <- init(tokenAuthenticator, tokenType)
+      tokenId <- init(tokenAuthenticator, tokenType, deleteOld)
     } yield {
       tokenId
     }


### PR DESCRIPTION
This was lost during #2311 Unify Tokens.
It is necessary to allow tracing multiple annotations simultaneously (in multiple browser tabs)

### Mailable description of changes:
 - Fix: tracing on multiple annotations simultaneously in browser tabs is possible again

### Steps to test:
- open multiple annotations in browser tabs
- trace some in all of them, save should work
- the x-auth token, however, should still be *replaced* in the db when revoked

### Issues:
- fixes #2361

------
- [x] Ready for review
