### PR TITLE
Allow users to access their own time tracking data

### DIFF
--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -45,8 +45,8 @@ class TimeController @Inject()(val messagesApi: MessagesApi) extends Controller 
   def getWorkingHoursOfUser(userId: String, startDate: Long, endDate: Long) = SecuredAction.async { implicit request =>
     for {
       user <- UserService.findOneById(userId, false) ?~> Messages("user.notFound")
-      _ <- request.identity.isAdminOf(user) ?~> Messages("user.notAuthorised")
-      js <- loggedTimeForUserListByTimestamp(user,startDate, endDate)
+      _ <- request.identity.isAdminOfOrSelf(user) ?~> Messages("user.notAuthorised")
+      js <- loggedTimeForUserListByTimestamp(user, startDate, endDate)
     } yield {
       Ok(js)
     }

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -101,9 +101,12 @@ case class User(
   def isEditableBy(other: User) =
     other.hasAdminAccess && ( teams.isEmpty || teamNames.exists(other.isAdminOf))
 
-  def isAdminOf(user: User): Boolean ={
+  def isAdminOfOrSelf(other: User) =
+    other._id == _id || isAdminOf(other)
+
+  def isAdminOf(user: User): Boolean =
     user.teamNames.intersect(this.adminTeamNames).nonEmpty
-  }
+
 }
 
 object User {


### PR DESCRIPTION
(backend only)

### Steps to test:
- create multiple users, one should be admin
- have each user trace some tasks
- test route `api/time/user/<id>?startDate=<milliseconds>&endDate=<milliseconds>
- admins of the other users should see everything
- users should see only their own, otherwise access denied

### Issues:
- fixes #2347

------
- [x] Ready for review
