### PR TITLE
Add /api/features, exposing part of the config

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,13 +2,15 @@ package controllers
 
 import javax.inject.Inject
 
+import com.typesafe.config.ConfigRenderOptions
 import oxalis.security.WebknossosSilhouette.UserAwareAction
 import models.analytics.{AnalyticsDAO, AnalyticsEntry}
 import models.binary.DataStoreHandlingStrategy
 import play.api.i18n.MessagesApi
+import play.api.Play.current
 import play.api.libs.json.Json
 
-class Application @Inject()(val messagesApi: MessagesApi) extends Controller{
+class Application @Inject()(val messagesApi: MessagesApi) extends Controller {
 
   def buildInfo = UserAwareAction { implicit request =>
     val token = request.identity.flatMap { user =>
@@ -29,4 +31,9 @@ class Application @Inject()(val messagesApi: MessagesApi) extends Controller{
         request.body))
     Ok
   }
+
+  def features = UserAwareAction { implicit request =>
+    Ok(current.configuration.underlying.getConfig("features").resolve.root.render(ConfigRenderOptions.concise()))
+  }
+
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,6 +59,11 @@ application{
   }
 }
 
+features{
+  #this part of the config is exposed as JSON via /api/features
+  sampleKey="sampleValue"
+}
+
 # Actor settings
 # ~~~~~
 actor.defaultTimeout = 10

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,7 +61,6 @@ application{
 
 features{
   #this part of the config is exposed as JSON via /api/features
-  sampleKey="sampleValue"
 }
 
 # Actor settings

--- a/conf/webknossos.routes
+++ b/conf/webknossos.routes
@@ -3,6 +3,7 @@
 # ~~~~
 
 GET           /api/buildinfo                                                    controllers.Application.buildInfo
+GET           /api/features                                                     controllers.Application.features
 POST          /api/analytics/:namespace                                         controllers.Application.analytics(namespace)
 
 # Authentication


### PR DESCRIPTION
To enable feature flags etc. in the frontend, we expose a part of the config as JSON.

### Steps to test:
- test route `api/features`

### Issues:
- fixes #2368

------
- [x] Ready for review
