### PR TITLE
Feature toggles frontend

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -26,6 +26,7 @@ import type {
   APIProjectProgressReportType,
   APIOpenTasksReportType,
   APITracingType,
+  APIFeatureToggles,
 } from "admin/api_flow_types";
 import type { QueryObjectType } from "admin/task/task_search_form";
 import type { NewTaskType, TaskCreationResponseType } from "admin/task/task_create_bulk_view";
@@ -575,4 +576,8 @@ export async function getOpenTasksReport(teamId: string): Promise<Array<APIOpenT
   const openTasksData = await Request.receiveJSON(`/api/teams/${teamId}/openTasksOverview`);
   assertResponseLimit(openTasksData);
   return openTasksData;
+}
+
+export async function getFeatureToggles(): Promise<APIFeatureToggles> {
+  return Request.receiveJSON("/api/features");
 }

--- a/app/assets/javascripts/admin/api_flow_types.js
+++ b/app/assets/javascripts/admin/api_flow_types.js
@@ -244,4 +244,8 @@ export type APIOpenTasksReportType = {
   +assignmentsByProjects: { [projectName: string]: number },
 };
 
+export type APIFeatureToggles = {
+  +discussionBoard: boolean,
+};
+
 export default {};

--- a/app/assets/javascripts/features.js
+++ b/app/assets/javascripts/features.js
@@ -1,0 +1,17 @@
+// @flow
+
+import { getFeatureToggles } from "admin/admin_rest_api";
+
+let features = null;
+
+export async function load() {
+  features = await getFeatureToggles();
+  return features;
+}
+
+export default () => {
+  if (features == null) {
+    throw new Error("Features not yet loaded.");
+  }
+  return features;
+};

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -9,6 +9,7 @@ import React from "react";
 import Router from "router";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
+import { load as loadFeatureToggles } from "features";
 import Store from "oxalis/throttled_store";
 import { setActiveUserAction } from "oxalis/model/actions/user_actions";
 
@@ -25,6 +26,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // try retreive the currently active user if logged in
   try {
+    await loadFeatureToggles();
     const user = await getActiveUser({ doNotCatch: true });
     Store.dispatch(setActiveUserAction(user));
     ErrorHandling.setCurrentUser(user);

--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -10,6 +10,7 @@ import Utils from "libs/utils";
 import LoginView from "admin/auth/login_view";
 import { logoutUserAction } from "oxalis/model/actions/user_actions";
 import Store from "oxalis/store";
+import features from "features";
 
 import type { OxalisState } from "oxalis/store";
 import type { APIUserType } from "admin/api_flow_types";
@@ -135,7 +136,7 @@ class Navbar extends React.PureComponent<Props> {
       </SubMenu>,
     );
 
-    if (isAdmin) {
+    if (isAdmin && features().discussionBoard) {
       menuItems.push(
         <Menu.Item key="13">
           <a href="https://discuss.webknossos.org" target="_blank" rel="noopener noreferrer">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,7 +61,7 @@ application{
 
 features{
   #this part of the config is exposed as JSON via /api/features
-  sampleKey="sampleValue"
+  discussionBoard=false
 }
 
 # Actor settings


### PR DESCRIPTION
Shows link to discuss only on instances that have the corresponding flag activated (e.g. mhlab only).

### Steps to test:
- Open webKnossos as admin: Link to discuss shouldn't be there
- Change `features.discussionBoard` to true. Now link should be in navbar

Depends on #2369 

------
- [x] Ready for review
