### PR TITLE
Add task peeking

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -46,7 +46,6 @@ function assertResponseLimit(collection) {
 }
 
 // ### Do with userToken
-
 let tokenRequestPromise;
 function requestUserToken(): Promise<string> {
   if (tokenRequestPromise) {
@@ -298,6 +297,10 @@ export async function resumeProject(projectName: string): Promise<APIProjectType
 }
 
 // ### Tasks
+export async function peekNextTasks(): Promise<Array<APITaskType>> {
+  return Request.receiveJSON("/api/user/tasks/peek");
+}
+
 export async function requestTask(): Promise<APIAnnotationType> {
   return Request.receiveJSON("/api/user/tasks/request");
 }

--- a/app/assets/javascripts/dashboard/dashboard_task_list_view.js
+++ b/app/assets/javascripts/dashboard/dashboard_task_list_view.js
@@ -13,7 +13,13 @@ import moment from "moment";
 import Toast from "libs/toast";
 import messages from "messages";
 import TransferTaskModal from "dashboard/transfer_task_modal";
-import { deleteAnnotation, resetAnnotation, finishTask } from "admin/admin_rest_api";
+import {
+  deleteAnnotation,
+  resetAnnotation,
+  finishTask,
+  requestTask,
+  peekNextTasks,
+} from "admin/admin_rest_api";
 import { getActiveUser } from "oxalis/model/accessors/user_accessor";
 import Persistence from "libs/persistence";
 import { PropTypes } from "@scalableminds/prop-types";
@@ -245,8 +251,17 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
     if (this.state.unfinishedTasks.length === 0) {
       return this.getNewTask();
     } else {
+      let modalContent = messages["task.request_new"];
+      const likelyNextTasks = await peekNextTasks();
+
+      if (likelyNextTasks.length > 0) {
+        modalContent += `\n${messages["task.peek_next"]({
+          projectName: likelyNextTasks[0].projectName,
+        })}`;
+      }
+
       return Modal.confirm({
-        content: "Do you really want another task?",
+        content: modalContent,
         onOk: () => this.getNewTask(),
       });
     }
@@ -255,7 +270,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
   async getNewTask() {
     this.setState({ isLoading: true });
     try {
-      const newTaskAnnotation = await Request.receiveJSON("/api/user/tasks/request");
+      const newTaskAnnotation = await requestTask();
 
       this.setState({
         unfinishedTasks: this.state.unfinishedTasks.concat([

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,4 +1,6 @@
 // @flow
+import _ from "lodash";
+
 export default {
   yes: "Yes",
   no: "No",
@@ -41,6 +43,10 @@ In order to restore the current window, a reload is necessary.`,
   "task.new_description": "You are now tracing a new task with the following description",
   "task.no_description": "You are now tracing a new task with no description.",
   "task.delete": "Do you really want to delete this task?",
+  "task.request_new": "Do you really want another task?",
+  "task.peek_next": _.template(
+    "The next task will most likely be part of project <%- projectName %>",
+  ),
   "task.reset_success": "Annotation was successfully reset.",
   "task.bulk_create_invalid":
     "Can not parse task specification. It includes at least one invalid task.",

--- a/start
+++ b/start
@@ -1,4 +1,4 @@
 mongod > /dev/null &
 PID="$!"
-./sbt run -mem 2048 -XX:MaxPermSize=512M -Dconfig.file=conf/application.conf
+./sbt run -mem 2048 -XX:MaxPermSize=512M -Dconfig.file=conf/application.conf -jvm-debug 5005
 kill -9 $PID


### PR DESCRIPTION
The task peeking API is currently broken on master because the Mongo Query does not work correctly. It works fine on the `slick` branch.

### Mailable description of changes:
- [Dashboard.Tasks] When clicking the "Get new Task" button the popup will include the name of the next mosts likely project if any task is available.

### Steps to test:
- Get a new task. Check the popup modal "Do you really want another task" for the name of the task.

### Issues:
- fixes #1624 

### WILL MERGE INTO SLICK BRANCH
------
- [x] Ready for review
