### PR TITLE
Fix tree sorting in tracing view

### DIFF
--- a/app/assets/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -130,9 +130,9 @@ class TreesTabView extends React.PureComponent<Props, State> {
     const activeMenuKey = this.props.userConfiguration.sortTreesByName
       ? "sortByName"
       : "sortByTime";
-
+    console.log("activeMenuKey", activeMenuKey);
     return (
-      <Menu defaultSelectedKeys={[activeMenuKey]} onSelect={this.handleDropdownClick}>
+      <Menu selectedKeys={[activeMenuKey]} onClick={this.handleDropdownClick}>
         <Menu.Item key="sortByName">by name</Menu.Item>
         <Menu.Item key="sortByTime">by creation time</Menu.Item>
       </Menu>

--- a/app/assets/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -130,7 +130,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
     const activeMenuKey = this.props.userConfiguration.sortTreesByName
       ? "sortByName"
       : "sortByTime";
-    console.log("activeMenuKey", activeMenuKey);
+
     return (
       <Menu selectedKeys={[activeMenuKey]} onClick={this.handleDropdownClick}>
         <Menu.Item key="sortByName">by name</Menu.Item>


### PR DESCRIPTION
Apparently, antd's menu only works with onClick even though the documentation says otherwise :thinking: 

It's not clear whether this completely resolves #2376, since the inconsistency could not be reproduced yet (I think it was always sorted by creation time).

### Mailable description of changes:
 - Sorting trees by creation time or name works again

### Steps to test:
- Load a tracing with a few trees and sort them by creation time and name

### Issues:
- contributes to #2376 

------
- [X] Ready for review
