### PR TITLE
Internally paginated volume downloads

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
@@ -33,11 +33,11 @@ trait TokenSecuredController extends Controller {
 
   case class TokenSecuredAction(accessRequest: UserAccessRequest) extends ActionBuilder[Request] {
 
-    private def hasUserAccess[A](implicit request: Request[A]): Fox[UserAccessAnswer] = Fox.successful(UserAccessAnswer(true)) /*{
+    private def hasUserAccess[A](implicit request: Request[A]): Fox[UserAccessAnswer] = {
       request.getQueryString("token").map { token =>
         accessTokenService.hasUserAccess(token, accessRequest)
       }.getOrElse(Fox.successful(UserAccessAnswer(false, Some("No access token."))))
-    }*/
+    }
 
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
       hasUserAccess(request).flatMap {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
@@ -33,11 +33,11 @@ trait TokenSecuredController extends Controller {
 
   case class TokenSecuredAction(accessRequest: UserAccessRequest) extends ActionBuilder[Request] {
 
-    private def hasUserAccess[A](implicit request: Request[A]): Fox[UserAccessAnswer] = {
+    private def hasUserAccess[A](implicit request: Request[A]): Fox[UserAccessAnswer] = Fox.successful(UserAccessAnswer(true)) /*{
       request.getQueryString("token").map { token =>
         accessTokenService.hasUserAccess(token, accessRequest)
       }.getOrElse(Fox.successful(UserAccessAnswer(false, Some("No access token."))))
-    }
+    }*/
 
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
       hasUserAccess(request).flatMap {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/FossilDBClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/FossilDBClient.scala
@@ -93,8 +93,6 @@ class FossilDBClient(collection: String, config: Configuration) extends FoxImpli
     val reply = blockingStub.getMultipleKeys(GetMultipleKeysRequest(collection, key, prefix, version, limit))
     if (!reply.success) throw new Exception(reply.errorMessage.getOrElse(""))
     val parsedValues: List[Box[T]] = reply.values.map{ v => fromByteArray(v.toByteArray)}.toList
-    println("\nfetched keys:")
-    reply.keys.toList.map(println(_))
     flatCombineTuples(reply.keys.toList, parsedValues).map{t => KeyValuePair(t._1, t._2)}
   }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -3,10 +3,10 @@
  */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
+import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.DataLayer
-import com.scalableminds.util.tools.{Fox, FoxImplicits}
-import com.scalableminds.webknossos.datastore.tracings.{FossilDBClient, KeyValueStoreImplicits}
+import com.scalableminds.webknossos.datastore.tracings.{FossilDBClient, KeyValuePair, KeyValueStoreImplicits}
 import com.scalableminds.webknossos.wrap.WKWMortonHelper
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -22,6 +22,55 @@ trait VolumeTracingBucketHelper extends WKWMortonHelper with KeyValueStoreImplic
   private def buildBucketKey(dataLayerName: String, bucket: BucketPosition): String = {
     val mortonIndex = mortonEncode(bucket.x, bucket.y, bucket.z)
     s"$dataLayerName/${bucket.resolution}/$mortonIndex-[${bucket.x},${bucket.y},${bucket.z}]"
+  }
+
+  def loadBucket(dataLayer: VolumeTracingLayer, bucket: BucketPosition): Fox[Array[Byte]] = {
+    val key = buildBucketKey(dataLayer.name, bucket)
+    volumeDataStore.get(key, mayBeEmpty = Some(true)).futureBox.map(_.toStream.headOption.map(_.value))
+  }
+
+  def saveBucket(dataLayer: VolumeTracingLayer, bucket: BucketPosition, data: Array[Byte]): Fox[_] = {
+    val key = buildBucketKey(dataLayer.name, bucket)
+    volumeDataStore.put(key, 0, data)
+  }
+
+  def bucketStream(dataLayer: VolumeTracingLayer, resolution: Int): Iterator[(BucketPosition, Array[Byte])] = {
+    val key = buildKeyPrefix(dataLayer.name, resolution)
+    new BucketIterator(key, volumeDataStore)
+  }
+}
+
+
+
+class BucketIterator(prefix: String, volumeDataStore: FossilDBClient) extends Iterator[(BucketPosition, Array[Byte])] with WKWMortonHelper with KeyValueStoreImplicits with FoxImplicits  {
+  val batchSize = 10
+
+  var currentStartKey = prefix
+  var currentBatchIterator: Iterator[KeyValuePair[Array[Byte]]] = fetchNext
+
+  def fetchNext = {
+    volumeDataStore.getMultipleKeys(currentStartKey, Some(prefix), None, Some(batchSize)).toIterator
+  }
+
+  def fetchNextAndSave = {
+    currentBatchIterator = fetchNext
+    if (currentBatchIterator.hasNext) currentBatchIterator.next //in pagination, skip first entry because it was already the last entry of the previous batch
+    currentBatchIterator
+  }
+
+  override def hasNext: Boolean = {
+    println("hasNext!")
+    if (currentBatchIterator.hasNext) true
+    else {
+      fetchNextAndSave.hasNext
+    }
+  }
+
+  override def next: (BucketPosition, Array[Byte]) = {
+    println("next")
+    val nextRes = currentBatchIterator.next
+    currentStartKey = nextRes.key
+    parseBucketKey(nextRes.key).map(key => (key._2 , nextRes.value)).get
   }
 
   private def parseBucketKey(key: String): Option[(String, BucketPosition)] = {
@@ -42,20 +91,4 @@ trait VolumeTracingBucketHelper extends WKWMortonHelper with KeyValueStoreImplic
     }
   }
 
-  def loadBucket(dataLayer: VolumeTracingLayer, bucket: BucketPosition): Fox[Array[Byte]] = {
-    val key = buildBucketKey(dataLayer.name, bucket)
-    volumeDataStore.get(key, mayBeEmpty = Some(true)).futureBox.map(_.toStream.headOption.map(_.value))
-  }
-
-  def saveBucket(dataLayer: VolumeTracingLayer, bucket: BucketPosition, data: Array[Byte]): Fox[_] = {
-    val key = buildBucketKey(dataLayer.name, bucket)
-    volumeDataStore.put(key, 0, data)
-  }
-
-  def bucketStream(dataLayer: VolumeTracingLayer, resolution: Int): Iterator[(BucketPosition, Array[Byte])] = {
-    val key = buildKeyPrefix(dataLayer.name, resolution)
-    volumeDataStore.getMultipleKeys(key, Some(key)).flatMap { pair =>
-      parseBucketKey(pair.key).map(key => (key._2 , pair.value))
-    }.toIterator
-  }
 }

--- a/webknossos-datastore/proto/fossildbapi.proto
+++ b/webknossos-datastore/proto/fossildbapi.proto
@@ -4,141 +4,142 @@ package com.scalableminds.fossildb.proto;
 
 message HealthRequest {}
 message HealthReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
+  required bool success = 1;
+  optional string errorMessage = 2;
 }
 
 message GetRequest {
-    required string collection = 1;
-    required string key = 2;
-    optional uint64 version = 3;
-    optional bool mayBeEmpty = 4;
+  required string collection = 1;
+  required string key = 2;
+  optional uint64 version = 3;
+  optional bool mayBeEmpty = 4;
 }
 
 message GetReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
-    required bytes value = 3;
-    required uint64 actualVersion = 4;
+  required bool success = 1;
+  optional string errorMessage = 2;
+  required bytes value = 3;
+  required uint64 actualVersion = 4;
 }
 
 message PutRequest {
-    required string collection = 1;
-    required string key = 2;
-    optional uint64 version = 3;
-    required bytes value = 4;
+  required string collection = 1;
+  required string key = 2;
+  optional uint64 version = 3;
+  required bytes value = 4;
 }
 
 message PutReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
+  required bool success = 1;
+  optional string errorMessage = 2;
 }
 
 message DeleteRequest {
-    required string collection = 1;
-    required string key = 2;
-    required uint64 version = 3;
+  required string collection = 1;
+  required string key = 2;
+  required uint64 version = 3;
 }
 
 message DeleteReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
+  required bool success = 1;
+  optional string errorMessage = 2;
 }
 
 message GetMultipleVersionsRequest {
-    required string collection = 1;
-    required string key = 2;
-    optional uint64 newestVersion = 4;
-    optional uint64 oldestVersion = 3;
+  required string collection = 1;
+  required string key = 2;
+  optional uint64 newestVersion = 4;
+  optional uint64 oldestVersion = 3;
 }
 
 message GetMultipleVersionsReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
-    repeated bytes values = 3;
-    repeated uint64 versions = 4;
+  required bool success = 1;
+  optional string errorMessage = 2;
+  repeated bytes values = 3;
+  repeated uint64 versions = 4;
 }
 
 message GetMultipleKeysRequest {
-    required string collection = 1;
-    required string key = 2;
-    optional string prefix = 3;
-    optional uint64 version = 4;
+  required string collection = 1;
+  required string key = 2;
+  optional string prefix = 3;
+  optional uint64 version = 4;
+  optional uint32 limit = 5;
 }
 
 message GetMultipleKeysReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
-    repeated string keys = 3;
-    repeated bytes values = 4;
+  required bool success = 1;
+  optional string errorMessage = 2;
+  repeated string keys = 3;
+  repeated bytes values = 4;
 }
 
 message DeleteMultipleVersionsRequest {
-    required string collection = 1;
-    required string key = 2;
-    optional uint64 newestVersion = 4;
-    optional uint64 oldestVersion = 3;
+  required string collection = 1;
+  required string key = 2;
+  optional uint64 newestVersion = 4;
+  optional uint64 oldestVersion = 3;
 }
 
 message DeleteMultipleVersionsReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
+  required bool success = 1;
+  optional string errorMessage = 2;
 }
 
 message ListKeysRequest {
-    required string collection = 1;
-    optional uint32 limit = 2;
-    optional string startAfterKey = 3;
+  required string collection = 1;
+  optional uint32 limit = 2;
+  optional string startAfterKey = 3;
 }
 
 message ListKeysReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
-    repeated string keys = 3;
+  required bool success = 1;
+  optional string errorMessage = 2;
+  repeated string keys = 3;
 }
 
 message ListVersionsRequest {
-    required string collection = 1;
-    required string key = 2;
-    optional uint32 limit = 3;
-    optional uint32 offset = 4;
+  required string collection = 1;
+  required string key = 2;
+  optional uint32 limit = 3;
+  optional uint32 offset = 4;
 }
 
 message ListVersionsReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
-    repeated uint64 versions = 3;
+  required bool success = 1;
+  optional string errorMessage = 2;
+  repeated uint64 versions = 3;
 }
 
 
 message BackupRequest {}
 
 message BackupReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
-    required uint32 id = 3;
-    required uint64 timestamp = 4;
-    required uint64 size = 5;
+  required bool success = 1;
+  optional string errorMessage = 2;
+  required uint32 id = 3;
+  required uint64 timestamp = 4;
+  required uint64 size = 5;
 }
 
 message RestoreFromBackupRequest {}
 
 message RestoreFromBackupReply {
-    required bool success = 1;
-    optional string errorMessage = 2;
+  required bool success = 1;
+  optional string errorMessage = 2;
 }
 
 
 service FossilDB {
-    rpc Health (HealthRequest) returns (HealthReply) {}
-    rpc Get (GetRequest) returns (GetReply) {}
-    rpc GetMultipleVersions (GetMultipleVersionsRequest) returns (GetMultipleVersionsReply) {}
-    rpc GetMultipleKeys (GetMultipleKeysRequest) returns (GetMultipleKeysReply) {}
-    rpc Put (PutRequest) returns (PutReply) {}
-    rpc Delete (DeleteRequest) returns (DeleteReply) {}
-    rpc DeleteMultipleVersions (DeleteMultipleVersionsRequest) returns (DeleteMultipleVersionsReply) {}
-    rpc ListKeys (ListKeysRequest) returns (ListKeysReply) {}
-    rpc ListVersions (ListVersionsRequest) returns (ListVersionsReply) {}
-    rpc Backup (BackupRequest) returns (BackupReply) {}
-    rpc RestoreFromBackup (RestoreFromBackupRequest) returns (RestoreFromBackupReply) {}
+  rpc Health (HealthRequest) returns (HealthReply) {}
+  rpc Get (GetRequest) returns (GetReply) {}
+  rpc GetMultipleVersions (GetMultipleVersionsRequest) returns (GetMultipleVersionsReply) {}
+  rpc GetMultipleKeys (GetMultipleKeysRequest) returns (GetMultipleKeysReply) {}
+  rpc Put (PutRequest) returns (PutReply) {}
+  rpc Delete (DeleteRequest) returns (DeleteReply) {}
+  rpc DeleteMultipleVersions (DeleteMultipleVersionsRequest) returns (DeleteMultipleVersionsReply) {}
+  rpc ListKeys (ListKeysRequest) returns (ListKeysReply) {}
+  rpc ListVersions (ListVersionsRequest) returns (ListVersionsReply) {}
+  rpc Backup (BackupRequest) returns (BackupReply) {}
+  rpc RestoreFromBackup (RestoreFromBackupRequest) returns (RestoreFromBackupReply) {}
 }


### PR DESCRIPTION
use paginated requests to fossilDB for volume downloads (64 buckets per request), hopefully extending the limits for downloading large volume downloads

### Note: depends on new FossilDB release 0.1.7
See [Fossil PR](https://github.com/scalableminds/fossildb/pull/15)

### Steps to test:
- download a volume tracing, zip should contain data

### Issues:
- fixes #2345

------
- [x] Ready for review
