### PR TITLE
Redirect to spotlight for unauthorized users

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -113,13 +113,18 @@ class ReactRouter extends React.Component<Props> {
           <Navbar isAuthenticated={isAuthenticated} />
           <Content>
             <Switch>
-              <SecuredRoute
-                isAuthenticated={isAuthenticated}
+              <Route
                 exact
                 path="/"
-                render={() => <DashboardView userId={null} isAdminView={false} />}
+                render={() =>
+                  isAuthenticated ? (
+                    <DashboardView userId={null} isAdminView={false} />
+                  ) : (
+                    <Redirect to="/spotlight" />
+                  )
+                }
               />
-              <SecuredRoute
+              <Route
                 isAuthenticated={isAuthenticated}
                 path="/dashboard"
                 render={() => <DashboardView userId={null} isAdminView={false} />}


### PR DESCRIPTION
Request to the `/` route should be routed differently depending on whether one is logged in or not. Authorized users should see their dashboard. Others should be redirected to the dashboard.

This fixes a regression for the demo instance where people would always see the login screen.

### Steps to test:
- Login. Click on wK logo --> Dashboard.
- Logout. Click on wK logo --> Spotlight.

### Issues:
- fixes #2360

------
- [x] Ready for review
