### PR TITLE
build correct volume tracing bucket keys

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -22,7 +22,7 @@ trait VolumeTracingBucketHelper extends WKWMortonHelper with KeyValueStoreImplic
 
   private def buildBucketKey(dataLayerName: String, bucket: BucketPosition): String = {
     val mortonIndex = mortonEncode(bucket.x, bucket.y, bucket.z)
-    s"$dataLayerName/${bucket.resolution}/$mortonIndex-[${bucket.x},${bucket.y},${bucket.z}]"
+    s"$dataLayerName/${bucket.resolution.maxDim}/$mortonIndex-[${bucket.x},${bucket.y},${bucket.z}]"
   }
 
   def loadBucket(dataLayer: VolumeTracingLayer, bucket: BucketPosition): Fox[Array[Byte]] = {


### PR DESCRIPTION
Scale-to-resolution broke the volume tracing bucket names [(1-1-1) instead of 1]. This fixes them

### Steps to test:
- load old volume tracing from fossildb

------
- [x] Ready for review
