### PR TITLE
in e2e tests, insert no initial data from Global.scala (only test db)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,8 +93,8 @@ services:
           -Dhttp.address=0.0.0.0
           -Ddatastore.fossildb.address=fossildb
           -Dmongodb.uri=$${MONGO_URI}
-          -Dpostgres.url=$${POSTGRES_URL}"
-          -Dapplication.insertInitialData=false
+          -Dpostgres.url=$${POSTGRES_URL}
+          -Dapplication.insertInitialData=false"
     environment:
       - MONGO_URI=mongodb://mongo:27017/webknossos-testing
       - POSTGRES_URL=jdbc:postgresql://postgres/webknossos_testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
           -Ddatastore.fossildb.address=fossildb
           -Dmongodb.uri=$${MONGO_URI}
           -Dpostgres.url=$${POSTGRES_URL}"
+          -Dapplication.insertInitialData=false
     environment:
       - MONGO_URI=mongodb://mongo:27017/webknossos-testing
       - POSTGRES_URL=jdbc:postgresql://postgres/webknossos_testing


### PR DESCRIPTION
### Steps to test:
- run e2e-tests
- no `Inserted default user scmboy` should be printed
- they should pass

### Issues:
- fixes #2411

------
- [x] Ready for review
