### PR TITLE
Volume tracing delete active cell

### DIFF
--- a/app/assets/javascripts/admin/help/keyboardshortcut_view.js
+++ b/app/assets/javascripts/admin/help/keyboardshortcut_view.js
@@ -168,7 +168,11 @@ const KeyboardShortcutView = () => {
     },
     {
       keybinding: "Left Mouse Drag",
-      action: "Move (move Mode) / Add To Current Cell (Trace / Brush Mode)",
+      action: "Move (Move Mode) / Add To Current Cell (Trace / Brush Mode)",
+    },
+    {
+      keybinding: "Ctrl + Left Mouse Drag",
+      action: "Add Empty Voxels To Current Cell (in Trace / Brush Mode)",
     },
     {
       keybinding: "Arrow Keys",
@@ -176,7 +180,11 @@ const KeyboardShortcutView = () => {
     },
     {
       keybinding: "Right Mouse Drag",
-      action: "Remove Voxels From Cell",
+      action: "Remove Voxels From Current Cell",
+    },
+    {
+      keybinding: "Ctrl + Right Mouse Drag",
+      action: "Remove Voxels From Any Cell",
     },
     {
       keybinding: "C",

--- a/app/assets/javascripts/oxalis/constants.js
+++ b/app/assets/javascripts/oxalis/constants.js
@@ -69,8 +69,10 @@ export type VolumeToolType = $Keys<typeof VolumeToolEnum>;
 
 export const ContourModeEnum = {
   IDLE: "IDLE",
-  ADD_TO_VOLUME: "ADD_TO_VOLUME",
-  DELETE_FROM_VOLUME: "DELETE_FROM_VOLUME",
+  DRAW: "DRAW",
+  DRAW_OVERWRITE: "DRAW_OVERWRITE",
+  DELETE_FROM_ACTIVE_CELL: "DELETE_FROM_ACTIVE_CELL",
+  DELETE_FROM_ANY_CELL: "DELETE_FROM_ANY_CELL",
 };
 export type ContourModeType = $Keys<typeof ContourModeEnum>;
 

--- a/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
@@ -126,7 +126,8 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
 
         if (
           (tool === VolumeToolEnum.TRACE || tool === VolumeToolEnum.BRUSH) &&
-          contourTracingMode === ContourModeEnum.ADD_TO_VOLUME
+          (contourTracingMode === ContourModeEnum.DRAW ||
+            contourTracingMode === ContourModeEnum.DRAW_OVERWRITE)
         ) {
           Store.dispatch(addToLayerAction(this.calculateGlobalPos(pos)));
         }
@@ -136,7 +137,11 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
         const tool = getVolumeTool(Store.getState().tracing).get();
 
         if (!event.shiftKey && (tool === VolumeToolEnum.TRACE || tool === VolumeToolEnum.BRUSH)) {
-          Store.dispatch(setContourTracingMode(ContourModeEnum.ADD_TO_VOLUME));
+          if (event.ctrlKey) {
+            Store.dispatch(setContourTracingMode(ContourModeEnum.DRAW));
+          } else {
+            Store.dispatch(setContourTracingMode(ContourModeEnum.DRAW_OVERWRITE));
+          }
           Store.dispatch(startEditingAction(this.calculateGlobalPos(pos), plane));
         }
       },
@@ -158,7 +163,8 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
 
         if (
           (tool === VolumeToolEnum.TRACE || tool === VolumeToolEnum.BRUSH) &&
-          contourTracingMode === ContourModeEnum.DELETE_FROM_VOLUME
+          (contourTracingMode === ContourModeEnum.DELETE_FROM_ACTIVE_CELL ||
+            contourTracingMode === ContourModeEnum.DELETE_FROM_ANY_CELL)
         ) {
           Store.dispatch(addToLayerAction(this.calculateGlobalPos(pos)));
         }
@@ -168,7 +174,11 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
         const tool = getVolumeTool(Store.getState().tracing).get();
 
         if (!event.shiftKey && (tool === VolumeToolEnum.TRACE || tool === VolumeToolEnum.BRUSH)) {
-          Store.dispatch(setContourTracingMode(ContourModeEnum.DELETE_FROM_VOLUME));
+          if (event.ctrlKey) {
+            Store.dispatch(setContourTracingMode(ContourModeEnum.DELETE_FROM_ANY_CELL));
+          } else {
+            Store.dispatch(setContourTracingMode(ContourModeEnum.DELETE_FROM_ACTIVE_CELL));
+          }
           Store.dispatch(startEditingAction(this.calculateGlobalPos(pos), plane));
         }
       },

--- a/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
@@ -47,7 +47,6 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
   // Extends Plane controller to add controls that are specific to Volume
   // Tracing.
 
-  prevActiveCellId: number;
   keyboardNoLoop: InputKeyboardNoLoop;
 
   componentDidMount() {
@@ -169,11 +168,6 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
         const tool = getVolumeTool(Store.getState().tracing).get();
 
         if (!event.shiftKey && (tool === VolumeToolEnum.TRACE || tool === VolumeToolEnum.BRUSH)) {
-          getActiveCellId(Store.getState().tracing).map(activeCellId => {
-            this.prevActiveCellId = activeCellId;
-          });
-
-          Store.dispatch(setActiveCellAction(0));
           Store.dispatch(setContourTracingMode(ContourModeEnum.DELETE_FROM_VOLUME));
           Store.dispatch(startEditingAction(this.calculateGlobalPos(pos), plane));
         }
@@ -186,7 +180,6 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
 
         if (tool === VolumeToolEnum.TRACE || tool === VolumeToolEnum.BRUSH) {
           Store.dispatch(finishEditingAction());
-          Store.dispatch(setActiveCellAction(this.prevActiveCellId));
           Store.dispatch(setContourTracingMode(ContourModeEnum.IDLE));
         }
       },

--- a/app/assets/javascripts/oxalis/geometries/contourgeometry.js
+++ b/app/assets/javascripts/oxalis/geometries/contourgeometry.js
@@ -28,7 +28,6 @@ class ContourGeometry {
         getVolumeTracing(Store.getState().tracing).map(tracing => {
           if (tracing.activeTool === VolumeToolEnum.TRACE) {
             const contourList = tracing.contourList;
-            console.log(tracing.contourList.length);
             if (contourList && lastContourList.length !== contourList.length) {
               // Update meshes according to the new contourList
               this.reset();

--- a/app/assets/javascripts/oxalis/geometries/contourgeometry.js
+++ b/app/assets/javascripts/oxalis/geometries/contourgeometry.js
@@ -7,7 +7,7 @@ import app from "app";
 import ResizableBuffer from "libs/resizable_buffer";
 import * as THREE from "three";
 import Store from "oxalis/store";
-import { VolumeToolEnum } from "oxalis/constants";
+import { VolumeToolEnum, ContourModeEnum } from "oxalis/constants";
 import { getVolumeTracing } from "oxalis/model/accessors/volumetracing_accessor";
 import type { Vector3 } from "oxalis/constants";
 
@@ -31,7 +31,11 @@ class ContourGeometry {
             if (contourList && lastContourList.length !== contourList.length) {
               // Update meshes according to the new contourList
               this.reset();
-              this.color = tracing.activeCellId === 0 ? COLOR_DELETE : COLOR_NORMAL;
+              this.color =
+                tracing.contourTracingMode === ContourModeEnum.DELETE_FROM_ANY_CELL ||
+                tracing.contourTracingMode === ContourModeEnum.DELETE_FROM_ACTIVE_CELL
+                  ? COLOR_DELETE
+                  : COLOR_NORMAL;
               contourList.forEach(p => this.addEdgePoint(p));
             }
             lastContourList = contourList;

--- a/app/assets/javascripts/oxalis/model/binary/data_cube.js
+++ b/app/assets/javascripts/oxalis/model/binary/data_cube.js
@@ -307,17 +307,17 @@ class DataCube {
     this.trigger("volumeLabeled");
   }
 
-  labelVoxels(iterator: VoxelIterator, label: number): void {
+  labelVoxels(iterator: VoxelIterator, label: number, activeCellId?: ?number = null): void {
     while (iterator.hasNext) {
       const voxel = iterator.getNext();
-      this.labelVoxel(voxel, label);
+      this.labelVoxel(voxel, label, activeCellId);
     }
 
     this.pushQueue.push();
     this.trigger("volumeLabeled");
   }
 
-  labelVoxel(voxel: Vector3, label: number): void {
+  labelVoxel(voxel: Vector3, label: number, activeCellId: ?number): void {
     let voxelInCube = true;
     for (let i = 0; i <= 2; i++) {
       voxelInCube = voxelInCube && voxel[i] >= 0 && voxel[i] < this.upperBoundary[i];
@@ -328,18 +328,26 @@ class DataCube {
       if (bucket instanceof DataBucket) {
         const voxelIndex = this.getVoxelIndex(voxel);
 
-        const labelFunc = (data: Uint8Array): void => {
-          // Write label in little endian order
-          for (let i = 0; i < this.BYTE_OFFSET; i++) {
-            data[voxelIndex + i] = (label >> (i * 8)) & 0xff;
-          }
-        };
-        bucket.label(labelFunc);
+        let shouldUpdateVoxel = true;
+        if (label === 0 && activeCellId != null) {
+          const voxelValue = this.getMappedDataValue(voxel);
+          shouldUpdateVoxel = activeCellId === voxelValue;
+        }
 
-        // Push bucket if it's loaded, otherwise, TemporalBucketManager will push
-        // it once it is.
-        if (bucket.isLoaded()) {
-          this.pushQueue.insert(bucket);
+        if (shouldUpdateVoxel) {
+          const labelFunc = (data: Uint8Array): void => {
+            // Write label in little endian order
+            for (let i = 0; i < this.BYTE_OFFSET; i++) {
+              data[voxelIndex + i] = (label >> (i * 8)) & 0xff;
+            }
+          };
+          bucket.label(labelFunc);
+
+          // Push bucket if it's loaded, otherwise, TemporalBucketManager will push
+          // it once it is.
+          if (bucket.isLoaded()) {
+            this.pushQueue.insert(bucket);
+          }
         }
       }
     }

--- a/app/assets/javascripts/oxalis/model/binary/data_cube.js
+++ b/app/assets/javascripts/oxalis/model/binary/data_cube.js
@@ -329,7 +329,7 @@ class DataCube {
         const voxelIndex = this.getVoxelIndex(voxel);
 
         let shouldUpdateVoxel = true;
-        if (label === 0 && activeCellId != null) {
+        if (activeCellId != null) {
           const voxelValue = this.getMappedDataValue(voxel);
           shouldUpdateVoxel = activeCellId === voxelValue;
         }

--- a/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -116,10 +116,21 @@ function* createVolumeLayer(planeId: OrthoViewType): Generator<*, *, *> {
 function* labelWithIterator(iterator, contourTracingMode): Generator<*, *, *> {
   const activeCellId = yield select(state => state.tracing.activeCellId);
   const binary = yield call([Model, Model.getSegmentationBinary]);
-  if (contourTracingMode === ContourModeEnum.DELETE_FROM_VOLUME) {
-    yield call([binary.cube, binary.cube.labelVoxels], iterator, 0, activeCellId);
-  } else {
-    yield call([binary.cube, binary.cube.labelVoxels], iterator, activeCellId);
+  switch (contourTracingMode) {
+    case ContourModeEnum.DRAW_OVERWRITE:
+      yield call([binary.cube, binary.cube.labelVoxels], iterator, activeCellId);
+      break;
+    case ContourModeEnum.DRAW:
+      yield call([binary.cube, binary.cube.labelVoxels], iterator, activeCellId, 0);
+      break;
+    case ContourModeEnum.DELETE_FROM_ACTIVE_CELL:
+      yield call([binary.cube, binary.cube.labelVoxels], iterator, 0, activeCellId);
+      break;
+    case ContourModeEnum.DELETE_FROM_ANY_CELL:
+      yield call([binary.cube, binary.cube.labelVoxels], iterator, 0);
+      break;
+    default:
+      throw new Error("Invalid volume tracing mode.");
   }
 }
 

--- a/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -115,9 +115,12 @@ function* createVolumeLayer(planeId: OrthoViewType): Generator<*, *, *> {
 
 function* labelWithIterator(iterator, contourTracingMode): Generator<*, *, *> {
   const activeCellId = yield select(state => state.tracing.activeCellId);
-  const labelValue = contourTracingMode === ContourModeEnum.DELETE_FROM_VOLUME ? 0 : activeCellId;
   const binary = yield call([Model, Model.getSegmentationBinary]);
-  yield call([binary.cube, binary.cube.labelVoxels], iterator, labelValue, activeCellId);
+  if (contourTracingMode === ContourModeEnum.DELETE_FROM_VOLUME) {
+    yield call([binary.cube, binary.cube.labelVoxels], iterator, 0, activeCellId);
+  } else {
+    yield call([binary.cube, binary.cube.labelVoxels], iterator, activeCellId);
+  }
 }
 
 function* copySegmentationLayer(action: CopySegmentationLayerActionType): Generator<*, *, *> {

--- a/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -19,13 +19,11 @@ import { updateVolumeTracing } from "oxalis/model/sagas/update_actions";
 import { V3 } from "libs/mjs";
 import Toast from "libs/toast";
 import Model from "oxalis/model";
-import Constants, { VolumeToolEnum } from "oxalis/constants";
+import Constants, { VolumeToolEnum, ContourModeEnum } from "oxalis/constants";
 import type { UpdateAction } from "oxalis/model/sagas/update_actions";
-import type { OrthoViewType, VolumeToolType } from "oxalis/constants";
+import type { OrthoViewType, VolumeToolType, ContourModeType } from "oxalis/constants";
 import type { VolumeTracingType, FlycamType } from "oxalis/store";
 import api from "oxalis/api/internal_api";
-import type { ContourModeType } from "../../constants";
-import { ContourModeEnum } from "../../constants";
 
 export function* updateIsosurface(): Generator<*, *, *> {
   const shouldDisplayIsosurface = yield select(state => state.userConfiguration.isosurfaceDisplay);

--- a/app/assets/javascripts/test/sagas/volumetracing_saga.spec.js
+++ b/app/assets/javascripts/test/sagas/volumetracing_saga.spec.js
@@ -5,11 +5,10 @@
 
 /* eslint-disable import/no-extraneous-dependencies, import/first */
 import test from "ava";
-import { ContourModeEnum } from "../../oxalis/constants";
 import { expectValueDeepEqual, execCall } from "../helpers/sagaHelpers";
 import mockRequire from "mock-require";
 import _ from "lodash";
-import { OrthoViews, VolumeToolEnum } from "oxalis/constants";
+import { OrthoViews, VolumeToolEnum, ContourModeEnum } from "oxalis/constants";
 import update from "immutability-helper";
 import { take, put, race, call } from "redux-saga/effects";
 import * as VolumeTracingActions from "oxalis/model/actions/volumetracing_actions";

--- a/app/assets/javascripts/test/sagas/volumetracing_saga.spec.js
+++ b/app/assets/javascripts/test/sagas/volumetracing_saga.spec.js
@@ -108,7 +108,7 @@ test("VolumeTracingSaga should create a volume layer (saga test)", t => {
   saga.next();
   expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
   saga.next(startEditingAction);
-  saga.next(ContourModeEnum.ADD_TO_VOLUME);
+  saga.next(ContourModeEnum.DRAW_OVERWRITE);
   const startEditingSaga = execCall(t, saga.next(false));
   startEditingSaga.next();
   const layer = startEditingSaga.next([1, 1, 1]).value;
@@ -121,7 +121,7 @@ test("VolumeTracingSaga should add values to volume layer (saga test)", t => {
   saga.next();
   expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
   saga.next(startEditingAction);
-  saga.next(ContourModeEnum.ADD_TO_VOLUME);
+  saga.next(ContourModeEnum.DRAW_OVERWRITE);
   saga.next(false);
   const volumeLayer = new VolumeLayer(OrthoViews.PLANE_XY, 10);
   saga.next(volumeLayer);
@@ -139,7 +139,7 @@ test("VolumeTracingSaga should finish a volume layer (saga test)", t => {
   saga.next();
   expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
   saga.next(startEditingAction);
-  saga.next(ContourModeEnum.ADD_TO_VOLUME);
+  saga.next(ContourModeEnum.DRAW_OVERWRITE);
   saga.next(false);
   const volumeLayer = new VolumeLayer(OrthoViews.PLANE_XY, 10);
   saga.next(volumeLayer);
@@ -149,7 +149,7 @@ test("VolumeTracingSaga should finish a volume layer (saga test)", t => {
   expectValueDeepEqual(
     t,
     saga.next({ finishEditingAction }),
-    call(finishLayer, volumeLayer, VolumeToolEnum.TRACE, ContourModeEnum.ADD_TO_VOLUME),
+    call(finishLayer, volumeLayer, VolumeToolEnum.TRACE, ContourModeEnum.DRAW_OVERWRITE),
   );
 });
 
@@ -159,7 +159,7 @@ test("VolumeTracingSaga should finish a volume layer in delete mode (saga test)"
   saga.next();
   expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
   saga.next(startEditingAction);
-  saga.next(ContourModeEnum.DELETE_FROM_VOLUME);
+  saga.next(ContourModeEnum.DELETE_FROM_ACTIVE_CELL);
   saga.next(false);
   const volumeLayer = new VolumeLayer(OrthoViews.PLANE_XY, 10);
   saga.next(volumeLayer);
@@ -169,7 +169,7 @@ test("VolumeTracingSaga should finish a volume layer in delete mode (saga test)"
   expectValueDeepEqual(
     t,
     saga.next({ finishEditingAction }),
-    call(finishLayer, volumeLayer, VolumeToolEnum.TRACE, ContourModeEnum.DELETE_FROM_VOLUME),
+    call(finishLayer, volumeLayer, VolumeToolEnum.TRACE, ContourModeEnum.DELETE_FROM_ACTIVE_CELL),
   );
 });
 

--- a/app/assets/javascripts/test/sagas/volumetracing_saga.spec.js
+++ b/app/assets/javascripts/test/sagas/volumetracing_saga.spec.js
@@ -5,6 +5,7 @@
 
 /* eslint-disable import/no-extraneous-dependencies, import/first */
 import test from "ava";
+import { ContourModeEnum } from "../../oxalis/constants";
 import { expectValueDeepEqual, execCall } from "../helpers/sagaHelpers";
 import mockRequire from "mock-require";
 import _ from "lodash";
@@ -108,6 +109,7 @@ test("VolumeTracingSaga should create a volume layer (saga test)", t => {
   saga.next();
   expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
   saga.next(startEditingAction);
+  saga.next(ContourModeEnum.ADD_TO_VOLUME);
   const startEditingSaga = execCall(t, saga.next(false));
   startEditingSaga.next();
   const layer = startEditingSaga.next([1, 1, 1]).value;
@@ -120,6 +122,7 @@ test("VolumeTracingSaga should add values to volume layer (saga test)", t => {
   saga.next();
   expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
   saga.next(startEditingAction);
+  saga.next(ContourModeEnum.ADD_TO_VOLUME);
   saga.next(false);
   const volumeLayer = new VolumeLayer(OrthoViews.PLANE_XY, 10);
   saga.next(volumeLayer);
@@ -137,6 +140,7 @@ test("VolumeTracingSaga should finish a volume layer (saga test)", t => {
   saga.next();
   expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
   saga.next(startEditingAction);
+  saga.next(ContourModeEnum.ADD_TO_VOLUME);
   saga.next(false);
   const volumeLayer = new VolumeLayer(OrthoViews.PLANE_XY, 10);
   saga.next(volumeLayer);
@@ -146,7 +150,27 @@ test("VolumeTracingSaga should finish a volume layer (saga test)", t => {
   expectValueDeepEqual(
     t,
     saga.next({ finishEditingAction }),
-    call(finishLayer, volumeLayer, VolumeToolEnum.TRACE),
+    call(finishLayer, volumeLayer, VolumeToolEnum.TRACE, ContourModeEnum.ADD_TO_VOLUME),
+  );
+});
+
+test("VolumeTracingSaga should finish a volume layer in delete mode (saga test)", t => {
+  const saga = editVolumeLayerAsync();
+  saga.next();
+  saga.next();
+  expectValueDeepEqual(t, saga.next(true), take("START_EDITING"));
+  saga.next(startEditingAction);
+  saga.next(ContourModeEnum.DELETE_FROM_VOLUME);
+  saga.next(false);
+  const volumeLayer = new VolumeLayer(OrthoViews.PLANE_XY, 10);
+  saga.next(volumeLayer);
+  saga.next(VolumeToolEnum.TRACE);
+  saga.next({ addToLayerAction: addToLayerActionFn([1, 2, 3]) });
+  // Validate that finishLayer was called
+  expectValueDeepEqual(
+    t,
+    saga.next({ finishEditingAction }),
+    call(finishLayer, volumeLayer, VolumeToolEnum.TRACE, ContourModeEnum.DELETE_FROM_VOLUME),
   );
 });
 


### PR DESCRIPTION
### Mailable description of changes:
 - New controls for Volume tracing:
   * LeftClick: Draw with overwrite (current behavior)
   * LeftClick + Ctrl: Draw (only on empty voxels)
   * RightClick: Clear (only active cell)
   * RightClick + Ctrl: Clear (all cells)

### Steps to test:
- Create Volume Tracing
- Create 2 cells
- Test all 4 mouse controls

### Issues:
- https://discuss.webknossos.org/t/only-remove-pixels-from-the-active-cell-volume-tracing/737

------
- [x] Ready for review
