### PR TITLE
Fix Blank Page on Dashboard 

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -124,7 +124,7 @@ class ReactRouter extends React.Component<Props> {
                   )
                 }
               />
-              <Route
+              <SecuredRoute
                 isAuthenticated={isAuthenticated}
                 path="/dashboard"
                 render={() => <DashboardView userId={null} isAdminView={false} />}


### PR DESCRIPTION
Problem: When logged out and navigating to `/dashboard` a rendering error is thrown and the page stays blank.

This is a regression introduced by PR #2387 . I am not sure if I changed [this line](https://github.com/scalableminds/webknossos/pull/2387/files#diff-23442a82e83f45a594dcfda0206ab2f2L122) on purpose or not.

@fm3 @normanrz @philippotto Can you think of any scenario where the `/dashboard` route needs to be `unsecured`?

I will add snapshot tests for the dashboard and spotlight view for logged out users as soon as PR #2395 is merged and we can authenticate as "anonymous".

### Steps to test:
- Login. Click on wK logo --> Dashboard.
- Logout. Click on wK logo --> Spotlight.
- Logout. Navigate to `/dashboard` --> Login. --> Redirect to Dashboard
- Logout. Navigate to `/` --> Spotlight.

------
- [x] Ready for review
