### PR TITLE
make scmboy superuser by default (sees datastore token)

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -144,7 +144,8 @@ object InitialData extends GlobalDBAccess with FoxImplicits with LazyLogging {
           List(),
           loginInfo = UserService.createLoginInfo(email),
           passwordInfo = UserService.createPasswordInfo(password),
-          experiences = Map("sampleExp" -> 10))
+          experiences = Map("sampleExp" -> 10),
+          _isSuperUser = Play.configuration.getBoolean("application.authentication.defaultUser.isSuperUser"))
         )
     }
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,6 +54,7 @@ application{
     defaultUser={
       email="scmboy@scalableminds.com"
       password="secret"
+      isSuperUser=true
     }
     ssoKey="something secure"
   }


### PR DESCRIPTION
…only for local development. the dev deployment also inserts initial data, so PR 131 there disables this new setting there (already merged).

### Steps to test:
- drop local db
- start wk, look at `api/buildinfo`, token should not be `null`

### Issues:
- fixes #2436

------
- [x] Ready for review
