### PR TITLE
Fix some sql queries: update tracing reference and update user dataset config

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -247,7 +247,7 @@ object AnnotationSQLDAO extends SQLDAO[AnnotationSQL, AnnotationsRow, Annotation
   def updateTracingReference(id: ObjectId, tracing: TracingReference)(implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- assertUpdateAccess(id)
-      _ <- run(sqlu"update webknossos.annotations set tracingId = ${tracing.id}, tracingTyp = '#${tracing.typ.toString}' where _id = ${id.id}")
+      _ <- run(sqlu"update webknossos.annotations set tracing_id = ${tracing.id}, tracingTyp = '#${tracing.typ.toString}' where _id = ${id.id}")
     } yield ()
 
   def updateStatistics(id: ObjectId, statistics: JsObject)(implicit ctx: DBAccessContext): Fox[Unit] =

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -189,14 +189,6 @@ object AnnotationService
     } yield true
   }
 
-  def updateAnnotationBase(task: Task, newTracingRefernce: TracingReference)(implicit ctx: DBAccessContext) = {
-    for {
-      annotationBase <- task.annotationBase
-    } yield {
-      AnnotationDAO.updateTracingRefernce(annotationBase._id, newTracingRefernce)
-    }
-  }
-
   def createFrom(
                 user: User,
                 dataSet: DataSet,

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -253,7 +253,6 @@ object UserDataSetConfigurationsSQLDAO extends SimpleSQLDAO {
   def updateDatasetConfigurationForUserAndDataset(userId: ObjectId, dataSetId: ObjectId, configuration: Map[String, JsValue])(implicit ctx: DBAccessContext): Fox[Unit] = {
     for {
       _ <- UserSQLDAO.assertUpdateAccess(userId)
-      _ <- Fox.successful(println("delete"))
       deleteQuery = sqlu"""delete from webknossos.user_dataSetConfigurations
                where _user = ${userId.id} and _dataSet = ${dataSetId.id}"""
       insertQuery  = sqlu"""insert into webknossos.user_dataSetConfigurations(_user, _dataSet, configuration)

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -253,12 +253,12 @@ object UserDataSetConfigurationsSQLDAO extends SimpleSQLDAO {
   def updateDatasetConfigurationForUserAndDataset(userId: ObjectId, dataSetId: ObjectId, configuration: Map[String, JsValue])(implicit ctx: DBAccessContext): Fox[Unit] = {
     for {
       _ <- UserSQLDAO.assertUpdateAccess(userId)
-      _ <- run(
-        sqlu"""delete from webknossos.user_dataSetConfigurations
-               where _user = ${userId.id} and _dataSet = ${dataSetId.id}""")
-      _ <- run(
-        sqlu"""insert into webknossos.user_dataSetConfigurations(_user, _dataSet, configuration)
-               values(${userId.id}, ${dataSetId.id}, '#${sanitize(Json.toJson(configuration).toString)}')""")
+      _ <- Fox.successful(println("delete"))
+      deleteQuery = sqlu"""delete from webknossos.user_dataSetConfigurations
+               where _user = ${userId.id} and _dataSet = ${dataSetId.id}"""
+      insertQuery  = sqlu"""insert into webknossos.user_dataSetConfigurations(_user, _dataSet, configuration)
+               values(${userId.id}, ${dataSetId.id}, '#${sanitize(Json.toJson(configuration).toString)}')"""
+      _ <- run(DBIO.sequence(List(deleteQuery, insertQuery)).transactionally)
     } yield ()
   }
 


### PR DESCRIPTION
* fixed updating an annotation’s tracing reference (used e.g. for revertToBase)
* running the queries for changing user dataset configurations transactionally, hopefully avoiding race conditions that lead to duplicate key errors
* removed an unused method

### Steps to test:
- change user dataset configuration (like dataset brightness), reload, should still be there
- reset an annotation to its base (`/api/annotations/:typ/:id/reset`), should now work

### Issues:
- fixes #2417

------
- [x] Ready for review
