### PR TITLE
Removed Cookie Idle Timeout

### DIFF
--- a/conf/silhouette.conf
+++ b/conf/silhouette.conf
@@ -6,9 +6,8 @@ silhouette {
   cookieAuthenticator.secureCookie=false
   cookieAuthenticator.httpOnlyCookie=true
   cookieAuthenticator.useFingerprinting=true
-  cookieAuthenticator.authenticatorIdleTimeout=30 days
   cookieAuthenticator.authenticatorExpiry=30 days
-  cookieAuthenticator.cookieMaxAge=30 days
+  cookieAuthenticator.cookieMaxAge=365 days
 
   tokenAuthenticator.headerName="X-Auth-Token"
   tokenAuthenticator.authenticatorIdleTimeout=23000 days


### PR DESCRIPTION
### Mailable description of changes:
 -  [Authentication] Increased default user cookie time. Users are authenticated for one year now.

### Steps to test:
- Checked response header for any request. It should no longer contain a `set-Cookie: authenticator=...` instruction

------
- [x] Ready for review
