### PR TITLE
fix sql syntax in project deletion access query

### DIFF
--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -76,7 +76,7 @@ object ProjectSQLDAO extends SQLDAO[ProjectSQL, ProjectsRow, Projects] {
     ))
 
   override def readAccessQ(requestingUserId: ObjectId) = s"(_team in (select _team from webknossos.user_team_roles where _user = '${requestingUserId.id}')) or _owner = '${requestingUserId.id}'"
-  override def deleteAccessQ(requestingUserId: ObjectId) = s"_owner = '${requestingUserId.id}"
+  override def deleteAccessQ(requestingUserId: ObjectId) = s"_owner = '${requestingUserId.id}'"
 
   // read operations
 


### PR DESCRIPTION
### Mailable description of changes:
 - Fix: Deletion of Projects works again

### Steps to test:
- delete a project, refresh browser, should not reappear

### Issues:
- fixes #2445

------
- [x] Ready for review
