### PR TITLE
in main.html do not attempt autologin if it is deactivated

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="@routes.Assets.at("bundle/vendors~main.css")?nocache=@(webknossos.BuildInfo.commitHash)">
     <link rel="stylesheet" type="text/css" media="screen" href="@routes.Assets.at("bundle/main.css")?nocache=@(webknossos.BuildInfo.commitHash)">
     @Html(com.newrelic.api.agent.NewRelic.getBrowserTimingHeader)
-    @if(play.api.Play.current.configuration.getBoolean("application.authentication.enableDevAutoLogin")){
+    @if(play.api.Play.current.configuration.getBoolean("application.authentication.enableDevAutoLogin").getOrElse(false)){
       <script src="/api/auth/autoLogin"></script>
     }
     <script type="text/javascript"


### PR DESCRIPTION
In the main.html template, the `Option` value `Some(false)` was apparently always interpreted as `true`, leading to the autoLogin route being called even if it is deactivated in application.conf. It failed in the backend (as it should), leading to our most frequently reported error in NewRelic

### Steps to test:
- with `application.authentication.enableDevAutoLogin` set to `true`, autologin should still work
- with it being false (or not present), autologin should not be attempted (see network tab)

------
- [x] Ready for review
