### PR TITLE
Make it easier to select nodes when particleSize is small

### DIFF
--- a/app/assets/javascripts/oxalis/geometries/materials/node_shader.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/node_shader.js
@@ -172,7 +172,7 @@ void main() {
       // - finally, the non-fractional part of each digit is removed (since it is covered by a more significant digit)
       color = fract(floor(nodeId / vec3(255.0 * 255.0, 255.0, 1.0)) / 255.0);
       // Enlarge the nodes on mobile, so they're easier to select
-      gl_PointSize = isTouch == 1 ? max(gl_PointSize * 1.5, 30.0) : gl_PointSize * 1.5;
+      gl_PointSize = isTouch == 1 ? max(gl_PointSize * 1.5, 30.0) : max(gl_PointSize * 1.5, 10.0);
       return;
     }
 


### PR DESCRIPTION
This PR enlarges nodes during the picking process if the particleSize is very small.

### Mailable description of changes:
 - Made it easier to select nodes when the particle size is configured to be small.

### Steps to test:
- Open tracing, decrease the particle size and select nodes. Selecting nodes should be possible without ultra-precise clicks :)

### Issues:
- fixes https://discuss.webknossos.org/t/activate-a-node-in-3d-viewport/771

------
- [x] Ready for review
