### PR TITLE
fix sql query to reset tasks to base

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -254,7 +254,7 @@ object AnnotationSQLDAO extends SQLDAO[AnnotationSQL, AnnotationsRow, Annotation
   def updateTracingReference(id: ObjectId, tracing: TracingReference)(implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- assertUpdateAccess(id)
-      _ <- run(sqlu"update webknossos.annotations set tracing_id = ${tracing.id}, tracingTyp = '#${tracing.typ.toString}' where _id = ${id.id}")
+      _ <- run(sqlu"update webknossos.annotations set tracing_id = ${tracing.id}, tracing_typ = '#${tracing.typ.toString}' where _id = ${id.id}")
     } yield ()
 
   def updateStatistics(id: ObjectId, statistics: JsObject)(implicit ctx: DBAccessContext): Fox[Unit] =


### PR DESCRIPTION
### Steps to test:
- create a task, trace some, then, in admin tasks view, select Actions → reset.
- should not cause an error, tracing should be reset to base

### Issues:
- fixes #2480

------
- [x] Ready for review
