### PR TITLE
run task assignment without sql view

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -293,7 +293,7 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
   def peekNext = SecuredAction.async { implicit request =>
     val user = request.identity
     for {
-      (task, _) <- TaskDAO.findAssignableFor(user, user.teamIds, initializeAnnotation = false)
+      (task, _) <- TaskDAO.findAssignableFor(user, user.teamIds, initializeAnnotation = false) ?~> Messages("task.unavailable")
       taskJson <- Task.transformToJson(task)(GlobalAccessContext)
     } yield Ok(taskJson)
   }

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -149,10 +149,16 @@ object TaskSQLDAO extends SQLDAO[TaskSQL, TasksRow, Tasks] {
     val annotationId = ObjectId.generate
 
     val selectTaskQ = sql"""
+           with instances as (SELECT t._id, COUNT(annotations._id) assignedInstances, t.totalinstances - COUNT(annotations._id) openInstances
+                             FROM webknossos.tasks t
+                             left join (select * from webknossos.annotations a where typ = 'Task' and a.state != 'Cancelled' AND a.isDeleted = false) as annotations ON t._id = annotations._task
+                             GROUP BY t._id, t.totalinstances)
+
+
            select webknossos.tasks_.*
            from
              (webknossos.tasks_
-             join webknossos.task_instances on webknossos.tasks_._id = webknossos.task_instances._id)
+             join instances on webknossos.tasks_._id = instances._id)
              join
                (select *
                 from webknossos.user_experiences
@@ -160,7 +166,7 @@ object TaskSQLDAO extends SQLDAO[TaskSQL, TasksRow, Tasks] {
                as user_experiences on webknossos.tasks_.neededExperience_domain = user_experiences.domain and webknossos.tasks_.neededExperience_value <= user_experiences.value
              join webknossos.projects_ on webknossos.tasks_._project = webknossos.projects_._id
              left join (select _task from webknossos.annotations_ where _user = ${userId.id} and typ = '#${AnnotationType.Task}') as userAnnotations ON webknossos.tasks_._id = userAnnotations._task
-           where webknossos.task_instances.openInstances > 0
+           where instances.openInstances > 0
                  and webknossos.tasks_._team in #${writeStructTupleWithQuotes(teamIds.map(t => sanitize(t.id)))}
                  and userAnnotations._task is null
                  and not webknossos.projects_.paused


### PR DESCRIPTION
in the unlikely case that the sql view task_instances is somehow cached and not properly synchronized with the transaction management, this attempts to do the task assignment without it.
------
- [x] Ready for review
