### PR TITLE
properly run slick transactions

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -223,7 +223,7 @@ object AnnotationSQLDAO extends SQLDAO[AnnotationSQL, AnnotationsRow, Annotation
     } yield ()
 
     for {
-      _ <- run(actions.withTransactionIsolation(Serializable))
+      _ <- run(actions.transactionally.withTransactionIsolation(Serializable))
     } yield ()
   }
 

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -107,7 +107,7 @@ object DataSetService extends FoxImplicits with LazyLogging {
   def updateDataSources(dataStore: DataStore, dataSources: List[InboxDataSource])(implicit ctx: DBAccessContext) = {
     logger.info(s"[${dataStore.name}] Available datasets: " +
       s"${dataSources.count(_.isUsable)} (usable), ${dataSources.count(!_.isUsable)} (unusable)")
-    logger.debug(s"Found datasets: " + dataSources.map(_.id).mkString(", "))
+    //logger.debug(s"Found datasets: " + dataSources.map(_.id).mkString(", "))
     val dataStoreInfo = DataStoreInfo(dataStore.name, dataStore.url, dataStore.typ)
     Fox.serialSequence(dataSources) { dataSource =>
       DataSetService.updateDataSource(dataStoreInfo, dataSource)

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -190,7 +190,7 @@ object TaskSQLDAO extends SQLDAO[TaskSQL, TasksRow, Tasks] {
     } yield selectedTask
 
     for {
-      rList <- run(queries.withTransactionIsolation(Serializable))
+      rList <- run(queries.transactionally.withTransactionIsolation(Serializable))
       r <- rList.headOption.toFox
       parsed <- parse(r)
     } yield (parsed, annotationId)

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -277,7 +277,7 @@ object UserDataSetConfigurationsSQLDAO extends SimpleSQLDAO {
                where _user = ${userId.id} and _dataSet = ${dataSetId.id}"""
       insertQuery  = sqlu"""insert into webknossos.user_dataSetConfigurations(_user, _dataSet, configuration)
                values(${userId.id}, ${dataSetId.id}, '#${sanitize(Json.toJson(configuration).toString)}')"""
-      _ <- run(DBIO.sequence(List(deleteQuery, insertQuery)).withTransactionIsolation(Serializable))
+      _ <- run(DBIO.sequence(List(deleteQuery, insertQuery)).transactionally.withTransactionIsolation(Serializable))
     } yield ()
   }
 


### PR DESCRIPTION
- apparently, `runWithTransactionIsolation` does not itself create a transaction from the individual queries, without the `transactionally` 

------
- [x] Ready for review
