### PR TITLE
Only update the TrackballControls' rotation target on demand

### DIFF
--- a/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -98,10 +98,6 @@ class PlaneController extends React.PureComponent<Props> {
     this.start();
   }
 
-  componentDidUpdate(): void {
-    this.setTargetAndFixPosition();
-  }
-
   componentWillUnmount() {
     this.stop();
   }
@@ -131,6 +127,8 @@ class PlaneController extends React.PureComponent<Props> {
       scroll: (value: number) => this.zoomTDView(Utils.clamp(-1, value, 1), true),
       over: () => {
         Store.dispatch(setViewportAction(OrthoViews.TDView));
+        // Fix the rotation target of the TrackballControls
+        this.setTargetAndFixPosition();
       },
       pinch: delta => this.zoomTDView(delta, true),
     };
@@ -169,6 +167,9 @@ class PlaneController extends React.PureComponent<Props> {
     for (let i = 0; i <= 2; i++) {
       invertedDiff.push(this.oldNmPos[i] - nmPosition[i]);
     }
+
+    if (Utils.sum(invertedDiff) === 0) return;
+
     this.oldNmPos = nmPosition;
 
     const nmVector = new THREE.Vector3(...invertedDiff);


### PR DESCRIPTION
We updated the TrackballControls' rotation target every time the position changed. Now it is only updated on demand, if the user moves his mouse to the 3d-view.

### Steps to test:
- Move through the dataset. Use rightclick-drag in the 3d-view to rotate - the rotation center should be the current position.

### Issues:
- enhances tracing performance

------
- [x] Ready for review
