### PR TITLE
Change email of users

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -230,7 +230,7 @@ class UserController @Inject()(val messagesApi: MessagesApi)
   def changeEmail(oldEmail: String, newEmail: String) = SecuredAction.async { implicit request =>
     for {
       _ <- request.identity.isAdmin ?~> Messages("notAllowed")
-      _ <- UserService.findOneByEmail(newEmail).reverse ?~> Messages("email not available")
+      _ <- UserService.findOneByEmail(newEmail).reverse ?~> Messages("new email not available")
       user <- UserService.changeEmail(oldEmail, newEmail)
     } yield {
       Ok(User.userPublicWrites(request.identity).writes(user))

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -226,4 +226,14 @@ class UserController @Inject()(val messagesApi: MessagesApi)
         }
     }
   }
+
+  def changeEmail(oldEmail: String, newEmail: String) = SecuredAction.async { implicit request =>
+    for {
+      _ <- request.identity.isAdmin ?~> Messages("notAllowed")
+      _ <- UserService.findOneByEmail(newEmail).reverse ?~> Messages("email not available")
+      user <- UserService.changeEmail(oldEmail, newEmail)
+    } yield {
+      Ok(User.userPublicWrites(request.identity).writes(user))
+    }
+  }
 }

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -197,17 +197,14 @@ object UserSQLDAO extends SQLDAO[UserSQL, UsersRow, Users] {
   def updateEmail(userId: ObjectId, newEmail: String)(implicit ctx: DBAccessContext) = {
     for {
       _ <- assertUpdateAccess(userId)
-      _ <- run(
-        sqlu"""update webknossos.users
-               set email = ${newEmail}
+      _ <- run(sqlu"""update webknossos.users set
+              email = ${newEmail},
+              logininfo_providerkey = ${newEmail}
                where _id = ${userId.id}""")
     } yield ()
   }
 
 }
-
-
-
 
 object UserTeamRolesSQLDAO extends SimpleSQLDAO {
 

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -194,6 +194,16 @@ object UserSQLDAO extends SQLDAO[UserSQL, UsersRow, Users] {
     } yield ()
   }
 
+  def updateEmail(userId: ObjectId, newEmail: String)(implicit ctx: DBAccessContext) = {
+    for {
+      _ <- assertUpdateAccess(userId)
+      _ <- run(
+        sqlu"""update webknossos.users
+               set email = ${newEmail}
+               where _id = ${userId.id}""")
+    } yield ()
+  }
+
 }
 
 
@@ -569,4 +579,12 @@ object UserDAO {
       _ <- UserSQLDAO.deleteOne(ObjectId.fromBsonId(id))
     } yield ()
 
+  def updateEmail(oldEmail: String, newEmail: String)(implicit ctx: DBAccessContext) = {
+    for {
+      user <- findOneByEmail(oldEmail)
+      id = ObjectId.fromBsonId(user._id)
+      _ <- UserSQLDAO.updateEmail(id, newEmail)
+      updated <- findOneByEmail(newEmail)
+    } yield updated
+  }
 }

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -124,4 +124,13 @@ object UserService extends FoxImplicits with IdentityService[User] {
   def createPasswordInfo(pw: String): PasswordInfo = {
     PasswordInfo("SCrypt", SCrypt.hashPassword(pw))
   }
+
+  def changeEmail(oldEmail: String, newEmail: String)(implicit ctx: DBAccessContext) = {
+    for {
+      user <- UserDAO.updateEmail(oldEmail, newEmail)
+      //change emails from tokens
+    } yield {
+      user
+    }
+  }
 }

--- a/conf/webknossos.routes
+++ b/conf/webknossos.routes
@@ -42,6 +42,7 @@ GET           /api/users/:id/tasks                                              
 GET           /api/users/:id/loggedTime                                         controllers.UserController.userLoggedTime(id: String)
 POST          /api/users/loggedTime                                             controllers.UserController.usersLoggedTime
 GET           /api/users/:id/annotations                                        controllers.UserController.userAnnotations(id: String, isFinished: Option[Boolean], limit: Option[Int])
+GET           /api/user/changeEmail                                             controllers.UserController.changeEmail(oldEmail: String, newEmail: String)
 
 # Team
 GET           /api/teams                                                        controllers.TeamController.list


### PR DESCRIPTION
### Mailable description of changes:
 - Admins are now able to to change the email of users.
- This does not change the emails of the users on braintracing!
- TODO: describe where to find the frontend option for this

### Steps to test:
- Test the backend route:
   connect to `http://localhost:9000/api/user/changeEmail?oldEmail=scmboy@scalableminds.com&newEmail=test@test.com` to change the email of scmboy to 'test@test.com'
You should receive a JSON of the changed user with the new email. Look in `webknossos.tokens` and verify that the old tokens of this user belong still to this user (referenced with the new email)
- Test the frontend:
TODO

### Issues:
- fixes #2428 

------
- [ ] Ready for review
