### PR TITLE
assign highest priority tasks first, not lowest...

### DIFF
--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -163,7 +163,7 @@ object TaskSQLDAO extends SQLDAO[TaskSQL, TasksRow, Tasks] {
                          and webknossos.tasks_._team in ${writeStructTupleWithQuotes(teamIds.map(t => sanitize(t.id)))}
                          and userAnnotations._task is null
                          and not webknossos.projects_.paused
-                   order by webknossos.projects_.priority
+                   order by webknossos.projects_.priority desc
                    limit 1
       """
 


### PR DESCRIPTION
this has apparently been wrong since the switch to SQL

### Mailable description of changes:
 - Fix: assign tasks of highest-priority projects first

### Steps to test:
- create multiple projects with different priorities
- task assignment should give highest-priority tasks first

### Issues:
- fixes #2497

------
- [x] Ready for review
