### PR TITLE
Allow Team Managers to edit datasets

### DIFF
--- a/app/controllers/UserTokenController.scala
+++ b/app/controllers/UserTokenController.scala
@@ -79,7 +79,7 @@ class UserTokenController @Inject()(val messagesApi: MessagesApi)
         dataset <- DataSetDAO.findOneBySourceName(dataSourceName) ?~> "datasource.notFound"
         user <- userBox.toFox
         owningOrg = dataset.owningOrganization
-        isAllowed <- user.isAdminOf(owningOrg).futureBox
+        isAllowed <- (user.isAdminOf(owningOrg) || user.isTeamManagerInOrg(owningOrg)).futureBox
       } yield {
         Full(UserAccessAnswer(isAllowed.isDefined))
       }

--- a/app/models/binary/DataSet.scala
+++ b/app/models/binary/DataSet.scala
@@ -383,7 +383,7 @@ case class DataSet(
     UriEncoding.encodePathSegment(name, "UTF-8")
 
   def isEditableBy(user: Option[User]) =
-    user.exists(_.isAdminOf(owningOrganization))
+    user.exists(u => u.isAdminOf(owningOrganization) || u.isTeamManagerInOrg(owningOrganization))
 
   lazy val dataStore: DataStoreHandlingStrategy =
     DataStoreHandlingStrategy(this)

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -347,6 +347,8 @@ case class User(
     teamManagerTeamIds.contains(_team) || isAdmin && organization == team.organization
   }
 
+  def isTeamManagerInOrg(organization: String) = teamManagerTeams.length > 0 && organization == this.organization
+
   def isAdminOf(organization: String): Boolean = isAdmin && organization == this.organization
 
   override def toString = email


### PR DESCRIPTION
### Mailable description of changes:
 - TeamManagers can now import / edit datasets

### Steps to test:
- create a test user, activate, promote to team manager
- they should be able to import datasets

### Issues:
- fixes #2503

------
- [x] Ready for review
