### PR TITLE
fix: if default config has no position field, use fallback

### DIFF
--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -46,8 +46,8 @@ class DataSetController @Inject()(val messagesApi: MessagesApi) extends Controll
         case Some(a: Array[Byte]) =>
           Fox.successful(a)
         case _ => {
-          val defaultCenterOpt = dataSet.defaultConfiguration.flatMap(c => JsonHelper.jsResultToOpt(c.configuration("position").validate[Point3D]))
-          val defaultZoomOpt = dataSet.defaultConfiguration.flatMap(c => JsonHelper.jsResultToOpt(c.configuration("zoom").validate[Int]))
+          val defaultCenterOpt = dataSet.defaultConfiguration.flatMap(c => c.configuration.get("position").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Point3D])))
+          val defaultZoomOpt = dataSet.defaultConfiguration.flatMap(c => c.configuration.get("zoom").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Int])))
           dataSet.dataStore.requestDataLayerThumbnail(dataLayerName, ThumbnailWidth, ThumbnailHeight, defaultZoomOpt, defaultCenterOpt).map {
             result =>
               Cache.set(s"thumbnail-$dataSetName*$dataLayerName",


### PR DESCRIPTION
The old code threw an exception if a default config map existed, but "position" or "zoom" were not present in it. Now, in this case it returns None, which will result in a fallback to the dataset center.

### Steps to test:
- import a dataset with the new import dialogue, do not enter position
- thumbnail should not be white

### Issues:
- fixes #2512

------
- [x] Ready for review
