### PR TITLE
RGBA packing for grayscale data

### DIFF
--- a/app/assets/javascripts/libs/drawing.js
+++ b/app/assets/javascripts/libs/drawing.js
@@ -122,64 +122,6 @@ class Drawing {
     }
   }
 
-  // https://en.wikipedia.org/wiki/Midpoint_circle_algorithm
-  fillCircle(
-    x0: number,
-    y0: number,
-    radius: number,
-    scale: [number, number],
-    drawPixel: (number, number) => void,
-  ) {
-    let x = radius - 1;
-    let y = 0;
-    let dx = 1;
-    let dy = 1;
-    // Decision criterion divided by 2 evaluated at x=r, y=0
-    let decisionOver2 = dx - (radius << 1);
-    while (x >= y) {
-      this.drawLine2d(
-        -x * scale[0] + x0,
-        y * scale[1] + y0,
-        x * scale[0] + x0,
-        y * scale[1] + y0,
-        drawPixel,
-      );
-      this.drawLine2d(
-        -y * scale[0] + x0,
-        -x * scale[1] + y0,
-        -y * scale[0] + x0,
-        x * scale[1] + y0,
-        drawPixel,
-      );
-      this.drawLine2d(
-        -x * scale[0] + x0,
-        -y * scale[1] + y0,
-        x * scale[0] + x0,
-        -y * scale[1] + y0,
-        drawPixel,
-      );
-      this.drawLine2d(
-        y * scale[0] + x0,
-        -x * scale[1] + y0,
-        y * scale[0] + x0,
-        x * scale[1] + y0,
-        drawPixel,
-      );
-      if (decisionOver2 <= 0) {
-        y++;
-        // Change in decision criterion for y -> y+1
-        decisionOver2 += dy;
-        dy += 2;
-      }
-      if (decisionOver2 > 0) {
-        x--;
-        dx += 2;
-        // Change for y -> y+1, x -> x-1
-        decisionOver2 += (-radius << 1) + dx;
-      }
-    }
-  }
-
   // Source: http://will.thimbleby.net/scanline-flood-fill/
   fillArea(
     x: number,

--- a/app/assets/javascripts/libs/input.js
+++ b/app/assets/javascripts/libs/input.js
@@ -372,7 +372,9 @@ export class InputMouse {
       Utils.addEventListenerWithDelegation(document, "wheel", this.targetSelector, this.mouseWheel),
     );
 
-    this.hammerManager = new Hammer(this.domElement);
+    this.hammerManager = new Hammer(this.domElement, {
+      inputClass: Hammer.TouchInput,
+    });
     this.hammerManager.get("pan").set({ direction: Hammer.DIRECTION_ALL });
     this.hammerManager.get("pinch").set({ enable: true });
     this.hammerManager.on("panstart", (evt: HammerJsEvent) => this.mouseDown(evt.srcEvent));

--- a/app/assets/javascripts/oxalis/constants.js
+++ b/app/assets/javascripts/oxalis/constants.js
@@ -67,6 +67,10 @@ export const VolumeToolEnum = {
 };
 export type VolumeToolType = $Keys<typeof VolumeToolEnum>;
 
+export function volumeToolEnumToIndex(volumeTool: ?VolumeToolType): number {
+  return Object.keys(VolumeToolEnum).indexOf(volumeTool);
+}
+
 export const ContourModeEnum = {
   IDLE: "IDLE",
   DRAW: "DRAW",

--- a/app/assets/javascripts/oxalis/controller/scene_controller.js
+++ b/app/assets/javascripts/oxalis/controller/scene_controller.js
@@ -202,7 +202,6 @@ class SceneController {
     // though they are all looking at the same scene, some
     // things have to be changed for each cam.
 
-    let pos;
     this.cube.updateForCam(id);
     this.userBoundingBox.updateForCam(id);
     Utils.__guard__(this.taskBoundingBox, x => x.updateForCam(id));
@@ -214,7 +213,7 @@ class SceneController {
         if (planeId === id) {
           this.planes[planeId].setOriginalCrosshairColor();
           this.planes[planeId].setVisible(true);
-          pos = _.clone(getPosition(Store.getState().flycam));
+          const pos = _.clone(getPosition(Store.getState().flycam));
           ind = Dimensions.getIndices(planeId);
           // Offset the plane so the user can see the skeletonTracing behind the plane
           pos[ind[2]] +=
@@ -227,7 +226,7 @@ class SceneController {
     } else {
       this.volumeMeshes.visible = true;
       for (const planeId of OrthoViewValuesWithoutTDView) {
-        pos = getPosition(Store.getState().flycam);
+        const pos = getPosition(Store.getState().flycam);
         this.planes[planeId].setPosition(new THREE.Vector3(pos[0], pos[1], pos[2]));
         this.planes[planeId].setGrayCrosshairColor();
         this.planes[planeId].setVisible(true);

--- a/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -505,7 +505,7 @@ function threeCameraToCameraData(camera: THREE.OrthographicCamera): CameraData {
   };
 }
 
-function calculateGlobalPos(clickPos: Point2) {
+export function calculateGlobalPos(clickPos: Point2): Vector3 {
   let position;
   const state = Store.getState();
   const activeViewport = state.viewModeData.plane.activeViewport;
@@ -513,56 +513,39 @@ function calculateGlobalPos(clickPos: Point2) {
   const zoomFactor = getPlaneScalingFactor(state.flycam);
   const viewportScale = state.userConfiguration.scale;
   const planeRatio = getBaseVoxelFactors(state.dataset.scale);
+
+  const diffX =
+    (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.x) / viewportScale * zoomFactor;
+  const diffY =
+    (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.y) / viewportScale * zoomFactor;
+
   switch (activeViewport) {
     case OrthoViews.PLANE_XY:
       position = [
-        curGlobalPos[0] -
-          (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.x) /
-            viewportScale *
-            planeRatio[0] *
-            zoomFactor,
-        curGlobalPos[1] -
-          (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.y) /
-            viewportScale *
-            planeRatio[1] *
-            zoomFactor,
+        curGlobalPos[0] - diffX * planeRatio[0],
+        curGlobalPos[1] - diffY * planeRatio[1],
         curGlobalPos[2],
       ];
       break;
     case OrthoViews.PLANE_YZ:
       position = [
         curGlobalPos[0],
-        curGlobalPos[1] -
-          (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.y) /
-            viewportScale *
-            planeRatio[1] *
-            zoomFactor,
-        curGlobalPos[2] -
-          (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.x) /
-            viewportScale *
-            planeRatio[2] *
-            zoomFactor,
+        curGlobalPos[1] - diffY * planeRatio[1],
+        curGlobalPos[2] - diffX * planeRatio[2],
       ];
       break;
     case OrthoViews.PLANE_XZ:
       position = [
-        curGlobalPos[0] -
-          (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.x) /
-            viewportScale *
-            planeRatio[0] *
-            zoomFactor,
+        curGlobalPos[0] - diffX * planeRatio[0],
         curGlobalPos[1],
-        curGlobalPos[2] -
-          (constants.VIEWPORT_WIDTH * viewportScale / 2 - clickPos.y) /
-            viewportScale *
-            planeRatio[2] *
-            zoomFactor,
+        curGlobalPos[2] - diffY * planeRatio[2],
       ];
       break;
     default:
-      throw new Error(
+      console.error(
         `Trying to calculate the global position, but no viewport is active: ${activeViewport}`,
       );
+      return [0, 0, 0];
   }
 
   return position;

--- a/app/assets/javascripts/oxalis/model.js
+++ b/app/assets/javascripts/oxalis/model.js
@@ -51,9 +51,10 @@ import {
   getDataset,
   getSharingToken,
 } from "admin/admin_rest_api";
+
+import messages from "messages";
 import type Layer from "oxalis/model/binary/layers/layer";
 import type { APIAnnotationType, APIDatasetType } from "admin/api_flow_types";
-import messages from "messages";
 import type { DataTextureSizeAndCount } from "./model/binary/data_rendering_logic";
 import * as DataRenderingLogic from "./model/binary/data_rendering_logic";
 
@@ -269,7 +270,7 @@ export class OxalisModel {
     }
   }
 
-  async initializeDataset(datasetName: string) {
+  async initializeDataset(datasetName: string): Promise<Array<Vector3>> {
     const sharingToken = getSharingToken();
     const rawDataset =
       sharingToken != null

--- a/app/assets/javascripts/oxalis/model.js
+++ b/app/assets/javascripts/oxalis/model.js
@@ -122,7 +122,7 @@ export class OxalisModel {
   lowerBoundary: Vector3;
   upperBoundary: Vector3;
   isMappingSupported: boolean = true;
-  dataTextureCountPerLayer: number;
+  unpackedDataTextureCountPerLayer: number;
 
   async fetch(
     tracingType: TracingTypeTracingType,
@@ -215,7 +215,7 @@ export class OxalisModel {
     }
 
     const usedTextureSize = supportedTextureSize >= 8192 ? 8192 : 4096;
-    const dataTextureCountPerLayer = (() => {
+    const unpackedDataTextureCountPerLayer = (() => {
       const bucketCountPerPlane =
         constants.MAXIMUM_NEEDED_BUCKETS_PER_DIMENSION ** 2 + // buckets in current zoomStep
         Math.ceil(constants.MAXIMUM_NEEDED_BUCKETS_PER_DIMENSION / 2) ** 2; // buckets in fallback zoomstep;
@@ -226,7 +226,7 @@ export class OxalisModel {
 
     const lookupTextureCountPerLayer = 1;
     const necessaryTextureCount =
-      layers.length * (dataTextureCountPerLayer + lookupTextureCountPerLayer);
+      layers.length * (unpackedDataTextureCountPerLayer + lookupTextureCountPerLayer);
 
     // Count textures needed for mappings separately, because they are not strictly necessary
     let textureCountForCellMappings = 0;
@@ -245,7 +245,7 @@ export class OxalisModel {
       this.isMappingSupported = false;
     }
 
-    return [usedTextureSize, dataTextureCountPerLayer];
+    return [usedTextureSize, unpackedDataTextureCountPerLayer];
   }
 
   determineAllowedModes(settings: SettingsType) {
@@ -366,8 +366,8 @@ export class OxalisModel {
       layerInfo => new LayerClass(layerInfo, dataStore),
     );
 
-    const [textureWidth, dataTextureCountPerLayer] = this.validateSpecsForLayers(layers);
-    this.dataTextureCountPerLayer = dataTextureCountPerLayer;
+    const [textureWidth, unpackedDataTextureCountPerLayer] = this.validateSpecsForLayers(layers);
+    this.unpackedDataTextureCountPerLayer = unpackedDataTextureCountPerLayer;
 
     this.connectionInfo = new ConnectionInfo();
     this.binary = {};
@@ -382,7 +382,7 @@ export class OxalisModel {
         maxLayerZoomStep,
         this.connectionInfo,
         textureWidth,
-        dataTextureCountPerLayer,
+        unpackedDataTextureCountPerLayer,
       );
     }
 

--- a/app/assets/javascripts/oxalis/model/binary.js
+++ b/app/assets/javascripts/oxalis/model/binary.js
@@ -126,7 +126,7 @@ class Binary {
     maxZoomStep: number,
     connectionInfo: ConnectionInfo,
     textureWidth: number,
-    unpackedDataTextureCount: number,
+    dataTextureCount: number,
   ) {
     this.tracingType = Store.getState().tracing.type;
     this.layer = layer;
@@ -134,9 +134,7 @@ class Binary {
     _.extend(this, BackboneEvents);
 
     this.textureWidth = textureWidth;
-    // If the layer only holds one byte per voxel, we can pack 4 bytes using rgba channels
-    const packingDegree = this.getByteCount() === 1 ? 4 : 1;
-    this.dataTextureCount = Math.ceil(unpackedDataTextureCount / packingDegree);
+    this.dataTextureCount = dataTextureCount;
 
     this.category = this.layer.category;
     this.name = this.layer.name;

--- a/app/assets/javascripts/oxalis/model/binary/bucket.js
+++ b/app/assets/javascripts/oxalis/model/binary/bucket.js
@@ -97,11 +97,9 @@ export class DataBucket {
   }
 
   label(labelFunc: Uint8Array => void) {
-    window.requestAnimationFrame(() => {
-      labelFunc(this.getOrCreateData());
-      this.dirty = true;
-      this.throttledTriggerLabeled();
-    });
+    labelFunc(this.getOrCreateData());
+    this.dirty = true;
+    this.throttledTriggerLabeled();
   }
 
   throttledTriggerLabeled = _.throttle(() => this.trigger("bucketLabeled"), 10);

--- a/app/assets/javascripts/oxalis/model/binary/data_rendering_logic.js
+++ b/app/assets/javascripts/oxalis/model/binary/data_rendering_logic.js
@@ -64,16 +64,17 @@ export function calculateTextureSizeAndCountForLayer(
   specs: GpuSpecs,
   byteCount: number,
 ): DataTextureSizeAndCount {
-  let textureSize = specs.supportedTextureSize >= 8192 ? 8192 : 4096;
+  let textureSize = specs.supportedTextureSize; // >= 8192 ? 8192 : 4096;
   const packingDegree = getPackingDegree(byteCount);
-
-  const textureCount = getTextureCount(textureSize, packingDegree);
 
   // Try to half the texture size as long as it does not require more
   // data textures
-  while (getTextureCount(textureSize / 2, packingDegree) === 1) {
+  while (
+    getTextureCount(textureSize / 2, packingDegree) <= getTextureCount(textureSize, packingDegree)
+  ) {
     textureSize /= 2;
   }
 
+  const textureCount = getTextureCount(textureSize, packingDegree);
   return { textureSize, textureCount };
 }

--- a/app/assets/javascripts/oxalis/model/binary/data_rendering_logic.js
+++ b/app/assets/javascripts/oxalis/model/binary/data_rendering_logic.js
@@ -1,0 +1,79 @@
+// @flow
+import constants from "oxalis/constants";
+
+type GpuSpecs = {
+  supportedTextureSize: number,
+  maxTextureCount: number,
+};
+
+export function getSupportedTextureMetrics(): GpuSpecs {
+  const canvas = document.createElement("canvas");
+  const contextProvider = canvas.getContext
+    ? x => canvas.getContext(x)
+    : ctxName => ({
+        MAX_TEXTURE_SIZE: 0,
+        MAX_COMBINED_TEXTURE_IMAGE_UNITS: 1,
+        getParameter(param) {
+          return ctxName === "webgl" && param === 0 ? 4096 : 8192;
+        },
+      });
+
+  const gl = contextProvider("webgl");
+
+  if (!gl) {
+    throw new Error("WebGL context could not be constructed.");
+  }
+
+  const supportedTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+  const maxTextureCount = gl.getParameter(gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS);
+
+  return { supportedTextureSize, maxTextureCount };
+}
+
+export function validateMinimumRequirements(specs: GpuSpecs): void {
+  if (specs.supportedTextureSize < 4096 || specs.maxTextureCount < 8) {
+    throw new Error(
+      "Minimum spec is not met. GPU should support at least a texture size of 4096 and 8 textures.",
+    );
+  }
+}
+
+export type DataTextureSizeAndCount = { textureSize: number, textureCount: number };
+
+function getPackingDegree(byteCount: number) {
+  // If the layer only holds one byte per voxel, we can pack 4 bytes using rgba channels
+  return byteCount === 1 ? 4 : 1;
+}
+
+function getNecessaryVoxelCount() {
+  const bucketCountPerPlane =
+    constants.MAXIMUM_NEEDED_BUCKETS_PER_DIMENSION ** 2 + // buckets in current zoomStep
+    Math.ceil(constants.MAXIMUM_NEEDED_BUCKETS_PER_DIMENSION / 2) ** 2; // buckets in fallback zoomstep;
+  return 3 * bucketCountPerPlane * constants.BUCKET_SIZE;
+}
+
+function getAvailableVoxelCount(textureSize: number, packingDegree: number) {
+  return packingDegree * textureSize ** 2;
+}
+
+function getTextureCount(textureSize: number, packingDegree: number) {
+  return Math.ceil(getNecessaryVoxelCount() / getAvailableVoxelCount(textureSize, packingDegree));
+}
+
+export function calculateTextureSizeAndCountForLayer(
+  specs: GpuSpecs,
+  byteCount: number,
+): DataTextureSizeAndCount {
+  let textureSize = specs.supportedTextureSize >= 8192 ? 8192 : 4096;
+  const packingDegree = getPackingDegree(byteCount);
+
+  const textureCount = getTextureCount(textureSize, packingDegree);
+
+  // Try to half the texture size as long as it does not require more
+  // data textures
+  while (getTextureCount(textureSize / 2, packingDegree) === 1) {
+    textureSize /= 2;
+  }
+
+  return { textureSize, textureCount };
+}

--- a/app/assets/javascripts/oxalis/model/reducers/volumetracing_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/volumetracing_reducer.js
@@ -115,7 +115,7 @@ function VolumeTracingReducer(state: OxalisState, action: VolumeTracingActionTyp
         }
 
         case "SET_BRUSH_SIZE": {
-          const brushSize = Math.max(1, action.brushSize);
+          const brushSize = Math.max(10, action.brushSize);
           return update(state, {
             temporaryConfiguration: { brushSize: { $set: brushSize } },
           });

--- a/app/assets/javascripts/oxalis/model/volumetracing/volumelayer.js
+++ b/app/assets/javascripts/oxalis/model/volumetracing/volumelayer.js
@@ -178,7 +178,7 @@ class VolumeLayer {
     const radius = Math.round(
       this.pixelsToVoxels(Store.getState().temporaryConfiguration.brushSize) / 2,
     );
-    const width = 2 * radius + 1;
+    const width = 2 * radius;
     const height = width;
 
     const map = new Array(width);
@@ -188,22 +188,20 @@ class VolumeLayer {
         map[x][y] = false;
       }
     }
-    const coord2d = this.get2DCoordinate(position);
-    const minCoord2d = [Math.floor(coord2d[0] - radius), Math.floor(coord2d[1] - radius)];
-
-    const setMap = function(x: number, y: number, value = true): void {
-      x = Math.floor(x);
-      y = Math.floor(y);
-      map[x - minCoord2d[0]][y - minCoord2d[1]] = value;
-    };
+    const floatingCoord2d = this.get2DCoordinate(position);
+    const coord2d = [Math.floor(floatingCoord2d[0]), Math.floor(floatingCoord2d[1])];
+    const minCoord2d = [coord2d[0] - radius, coord2d[1] - radius];
 
     // Use the baseVoxelFactors to scale the circle, otherwise it'll become an ellipse
-    const baseVoxelFactors = this.get2DCoordinate(
-      getBaseVoxelFactors(Store.getState().dataset.scale),
-    );
-    Drawing.fillCircle(coord2d[0], coord2d[1], radius, baseVoxelFactors, (x, y) =>
-      setMap(x, y, true),
-    );
+    const [u, v] = this.get2DCoordinate(getBaseVoxelFactors(Store.getState().dataset.scale));
+
+    for (let x = 0; x < width; x++) {
+      for (let y = 0; y < width; y++) {
+        if (Math.sqrt(((x - radius) / u) ** 2 + ((y - radius) / v) ** 2) < radius) {
+          map[x][y] = true;
+        }
+      }
+    }
 
     const iterator = new VoxelIterator(
       map,

--- a/app/assets/javascripts/oxalis/view/input_catchers.js
+++ b/app/assets/javascripts/oxalis/view/input_catchers.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { Button } from "antd";
 import Constants, { OrthoViews } from "oxalis/constants";
 import api from "oxalis/api/internal_api";
-import type { Vector2, OrthoViewType } from "oxalis/constants";
+import type { OrthoViewType } from "oxalis/constants";
 import type { OxalisState } from "oxalis/store";
 
 const ButtonGroup = Button.Group;
@@ -13,8 +13,6 @@ const ButtonGroup = Button.Group;
 type Props = {
   scale: number,
   activeViewport: OrthoViewType,
-  brushPosition: ?Vector2,
-  brushSize: number,
 };
 
 type State = {};
@@ -26,30 +24,10 @@ class InputCatchers extends React.PureComponent<Props, State> {
       width: width / 4 - 0.5,
     };
 
-    const { brushPosition, brushSize } = this.props;
-    const brush =
-      brushPosition != null ? (
-        <div
-          id="cursor"
-          style={{
-            position: "relative",
-            left: brushPosition[0] - brushSize / 2,
-            top: brushPosition[1] - brushSize / 2,
-            width: brushSize,
-            height: brushSize,
-            borderColor: "black",
-            borderStyle: "solid",
-            borderWidth: 1,
-            borderRadius: "50%",
-            pointerEvents: "none",
-          }}
-        />
-      ) : null;
-
     const activeInputCatcher = this.props.activeViewport;
 
     return (
-      <div id="inputcatchers" style={{ cursor: brushPosition != null ? "none" : "" }}>
+      <div id="inputcatchers" style={{ cursor: false ? "none" : "" }}>
         <div
           id="inputcatcher_PLANE_XY"
           data-value={OrthoViews.PLANE_XY}
@@ -59,9 +37,7 @@ class InputCatchers extends React.PureComponent<Props, State> {
             height: width,
             borderColor: activeInputCatcher === OrthoViews.PLANE_XY ? "#ff0" : "white",
           }}
-        >
-          {activeInputCatcher === OrthoViews.PLANE_XY ? brush : null}
-        </div>
+        />
         <div
           id="inputcatcher_PLANE_YZ"
           data-value={OrthoViews.PLANE_YZ}
@@ -71,9 +47,7 @@ class InputCatchers extends React.PureComponent<Props, State> {
             height: width,
             borderColor: activeInputCatcher === OrthoViews.PLANE_YZ ? "#ff0" : "white",
           }}
-        >
-          {activeInputCatcher === OrthoViews.PLANE_YZ ? brush : null}
-        </div>
+        />
         <div
           id="inputcatcher_PLANE_XZ"
           data-value={OrthoViews.PLANE_XZ}
@@ -83,9 +57,7 @@ class InputCatchers extends React.PureComponent<Props, State> {
             height: width,
             borderColor: activeInputCatcher === OrthoViews.PLANE_XZ ? "#ff0" : "white",
           }}
-        >
-          {activeInputCatcher === OrthoViews.PLANE_XZ ? brush : null}
-        </div>
+        />
         <div
           id="inputcatcher_TDView"
           data-value={OrthoViews.TDView}
@@ -119,8 +91,6 @@ class InputCatchers extends React.PureComponent<Props, State> {
 const mapStateToProps = (state: OxalisState): Props => ({
   scale: state.userConfiguration.scale,
   activeViewport: state.viewModeData.plane.activeViewport,
-  brushPosition: state.temporaryConfiguration.brushPosition,
-  brushSize: state.temporaryConfiguration.brushSize,
 });
 
 export default connect(mapStateToProps)(InputCatchers);

--- a/app/assets/javascripts/test/helpers/apiHelpers.js
+++ b/app/assets/javascripts/test/helpers/apiHelpers.js
@@ -25,6 +25,7 @@ const ErrorHandling = {
   assertExists: _.noop,
   assert: _.noop,
 };
+
 const app = {
   vent: Object.assign({}, BackboneEvents),
 };

--- a/app/assets/javascripts/test/model/binary/data_rendering_logic.spec.js
+++ b/app/assets/javascripts/test/model/binary/data_rendering_logic.spec.js
@@ -3,7 +3,10 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"peerDependencies": true}] */
 import test from "ava";
 
-import { calculateTextureSizeAndCountForLayer } from "oxalis/model/binary/data_rendering_logic";
+import {
+  calculateTextureSizeAndCountForLayer,
+  computeDataTexturesSetup,
+} from "oxalis/model/binary/data_rendering_logic";
 
 const minSpecs = {
   supportedTextureSize: 4096,
@@ -12,12 +15,12 @@ const minSpecs = {
 
 const midSpecs = {
   supportedTextureSize: 8192,
-  maxTextureCount: 8,
+  maxTextureCount: 16,
 };
 
 const betterSpecs = {
   supportedTextureSize: 16384,
-  maxTextureCount: 8,
+  maxTextureCount: 32,
 };
 
 const grayscaleByteCount = 1;
@@ -75,4 +78,92 @@ test("calculateTextureSizeAndCountForLayer: color data + betterSpecs", t => {
   );
   t.is(textureSize, midSpecs.supportedTextureSize);
   t.is(textureCount, 1);
+});
+
+const grayscaleLayer1 = { byteCount: grayscaleByteCount };
+const grayscaleLayer2 = { byteCount: grayscaleByteCount };
+const grayscaleLayer3 = { byteCount: grayscaleByteCount };
+
+const volumeLayer1 = { byteCount: volumeByteCount };
+const getByteCount = layer => layer.byteCount;
+
+function testSupportFlags(t, supportFlags, expectedBasicSupport, expectedMappingSupport) {
+  t.is(supportFlags.isBasicRenderingSupported, expectedBasicSupport);
+  t.is(supportFlags.isMappingSupported, expectedMappingSupport);
+}
+
+function computeDataTexturesSetupCurried(spec, hasSegmentation): * {
+  return layers => computeDataTexturesSetup(spec, layers, getByteCount, hasSegmentation);
+}
+
+test("Basic support (no segmentation): all specs", t => {
+  // All specs should support up to three grayscale layers
+  for (const spec of [minSpecs, midSpecs, betterSpecs]) {
+    const computeDataTexturesSetupPartial = computeDataTexturesSetupCurried(spec, false);
+    testSupportFlags(t, computeDataTexturesSetupPartial([grayscaleLayer1]), true, true);
+
+    testSupportFlags(
+      t,
+      computeDataTexturesSetupPartial([grayscaleLayer1, grayscaleLayer2]),
+      true,
+      true,
+    );
+
+    testSupportFlags(
+      t,
+      computeDataTexturesSetupPartial([grayscaleLayer1, grayscaleLayer2, grayscaleLayer3]),
+      true,
+      true,
+    );
+  }
+});
+
+test("Basic support + volume: min specs", t => {
+  const computeDataTexturesSetupPartial = computeDataTexturesSetupCurried(minSpecs, true);
+
+  testSupportFlags(t, computeDataTexturesSetupPartial([grayscaleLayer1, volumeLayer1]), true, true);
+
+  testSupportFlags(
+    t,
+    computeDataTexturesSetupPartial([grayscaleLayer1, grayscaleLayer2, volumeLayer1]),
+    true,
+    false,
+  );
+
+  testSupportFlags(
+    t,
+    computeDataTexturesSetupPartial([
+      grayscaleLayer1,
+      grayscaleLayer2,
+      grayscaleLayer3,
+      volumeLayer1,
+    ]),
+    false,
+    false,
+  );
+});
+
+test("Basic support + volume: mid specs", t => {
+  const computeDataTexturesSetupPartial = computeDataTexturesSetupCurried(midSpecs, true);
+
+  testSupportFlags(t, computeDataTexturesSetupPartial([grayscaleLayer1, volumeLayer1]), true, true);
+
+  testSupportFlags(
+    t,
+    computeDataTexturesSetupPartial([grayscaleLayer1, grayscaleLayer2, volumeLayer1]),
+    true,
+    true,
+  );
+
+  testSupportFlags(
+    t,
+    computeDataTexturesSetupPartial([
+      grayscaleLayer1,
+      grayscaleLayer2,
+      grayscaleLayer3,
+      volumeLayer1,
+    ]),
+    true,
+    true,
+  );
 });

--- a/app/assets/javascripts/test/model/binary/data_rendering_logic.spec.js
+++ b/app/assets/javascripts/test/model/binary/data_rendering_logic.spec.js
@@ -1,0 +1,79 @@
+// @flow
+
+/* eslint import/no-extraneous-dependencies: ["error", {"peerDependencies": true}] */
+import test from "ava";
+import _ from "lodash";
+
+import { calculateTextureSizeAndCountForLayer } from "oxalis/model/binary/data_rendering_logic";
+
+const minSpecs = {
+  supportedTextureSize: 4096,
+  maxTextureCount: 8,
+};
+
+const midSpecs = {
+  supportedTextureSize: 8192,
+  maxTextureCount: 8,
+};
+
+const betterSpecs = {
+  supportedTextureSize: 16384,
+  maxTextureCount: 8,
+};
+
+const grayscaleByteCount = 1;
+const volumeByteCount = 4;
+
+test("calculateTextureSizeAndCountForLayer: grayscale data + minSpecs", t => {
+  const { textureSize, textureCount } = calculateTextureSizeAndCountForLayer(
+    minSpecs,
+    grayscaleByteCount,
+  );
+  t.is(textureSize, minSpecs.supportedTextureSize);
+  t.is(textureCount, 1);
+});
+
+test("calculateTextureSizeAndCountForLayer: grayscale data + midSpecs", t => {
+  const { textureSize, textureCount } = calculateTextureSizeAndCountForLayer(
+    midSpecs,
+    grayscaleByteCount,
+  );
+  t.is(textureSize, minSpecs.supportedTextureSize);
+  t.is(textureCount, 1);
+});
+
+test("calculateTextureSizeAndCountForLayer: grayscale data + betterSpecs", t => {
+  const { textureSize, textureCount } = calculateTextureSizeAndCountForLayer(
+    betterSpecs,
+    grayscaleByteCount,
+  );
+  t.is(textureSize, minSpecs.supportedTextureSize);
+  t.is(textureCount, 1);
+});
+
+test("calculateTextureSizeAndCountForLayer: color data + minSpecs", t => {
+  const { textureSize, textureCount } = calculateTextureSizeAndCountForLayer(
+    minSpecs,
+    volumeByteCount,
+  );
+  t.is(textureSize, minSpecs.supportedTextureSize);
+  t.is(textureCount, 3);
+});
+
+test("calculateTextureSizeAndCountForLayer: color data + midSpecs", t => {
+  const { textureSize, textureCount } = calculateTextureSizeAndCountForLayer(
+    midSpecs,
+    volumeByteCount,
+  );
+  t.is(textureSize, midSpecs.supportedTextureSize);
+  t.is(textureCount, 1);
+});
+
+test("calculateTextureSizeAndCountForLayer: color data + betterSpecs", t => {
+  const { textureSize, textureCount } = calculateTextureSizeAndCountForLayer(
+    betterSpecs,
+    volumeByteCount,
+  );
+  t.is(textureSize, midSpecs.supportedTextureSize);
+  t.is(textureCount, 1);
+});

--- a/app/assets/javascripts/test/model/binary/data_rendering_logic.spec.js
+++ b/app/assets/javascripts/test/model/binary/data_rendering_logic.spec.js
@@ -2,7 +2,6 @@
 
 /* eslint import/no-extraneous-dependencies: ["error", {"peerDependencies": true}] */
 import test from "ava";
-import _ from "lodash";
 
 import { calculateTextureSizeAndCountForLayer } from "oxalis/model/binary/data_rendering_logic";
 


### PR DESCRIPTION
This PR enables RGBA packing for grayscale data and tries to minimize texture size and count. Before this PR, grayscale data was either packed into 3 4096 textures or into 1 8192 texture. With this PR, grayscale data is always packed into 1 4096 texture.

I also refactored the logic for these calculations into an own module. Additionally, it is possible to have different data textures sizes across different layers (e.g., one 4096 texture for grayscale data and one 8192 texture (or three 4096 textures) for volume data).

I also added some tests for these calculations.

### Steps to test:
I tested multi channel data, volume data and anisotropic data while emulating different gpu specs (in `data_rendering_logic.js`, I hardcoded `supportedTextureSize` to 4096, 8192 and 16384).

### Issues:
- contributes to #2295 

------
- [X] Ready for review
