### PR TITLE
Updated View Mode Informations

### DIFF
--- a/app/assets/javascripts/admin/api_flow_types.js
+++ b/app/assets/javascripts/admin/api_flow_types.js
@@ -43,7 +43,6 @@ export type APIDatasetType = {
   +name: string,
   +displayName: string,
   +owningOrganization: string,
-  +sourceType: "wkw" | "knossos",
 };
 
 export type APIDataSourceWithMessagesType = {

--- a/app/assets/javascripts/oxalis/controller/camera_controller.js
+++ b/app/assets/javascripts/oxalis/controller/camera_controller.js
@@ -53,7 +53,7 @@ class CameraController extends React.PureComponent<Props> {
   updateCamViewport(): void {
     const state = Store.getState();
     const clippingDistance = state.userConfiguration.clippingDistance;
-    const scaleFactor = getBaseVoxel(state.dataset.scale);
+    const scaleFactor = getBaseVoxel(state.dataset.dataSource.scale);
     const zoom = state.flycam.zoomStep;
     const boundary = constants.VIEWPORT_WIDTH / 2 * zoom;
     for (const planeId of OrthoViewValuesWithoutTDView) {
@@ -71,7 +71,7 @@ class CameraController extends React.PureComponent<Props> {
     const state = Store.getState();
     const gPos = getPosition(state.flycam);
     // camera position's unit is nm, so convert it.
-    const cPos = voxelToNm(state.dataset.scale, gPos);
+    const cPos = voxelToNm(state.dataset.dataSource.scale, gPos);
     const cPosVec = new THREE.Vector3(cPos[0], cPos[1], cPos[2]);
     this.props.cameras[OrthoViews.PLANE_XY].position.copy(cPosVec);
     this.props.cameras[OrthoViews.PLANE_YZ].position.copy(cPosVec);
@@ -140,8 +140,8 @@ type TweenState = {
 
 export function rotate3DViewTo(id: OrthoViewType, animate: boolean = true): void {
   const state = Store.getState();
-  const b = voxelToNm(state.dataset.scale, Model.upperBoundary);
-  const pos = voxelToNm(state.dataset.scale, getPosition(state.flycam));
+  const b = voxelToNm(state.dataset.dataSource.scale, Model.upperBoundary);
+  const pos = voxelToNm(state.dataset.dataSource.scale, getPosition(state.flycam));
 
   let to: TweenState;
   if (id === OrthoViews.TDView) {
@@ -218,7 +218,10 @@ export function rotate3DViewTo(id: OrthoViewType, animate: boolean = true): void
   }
 
   const updateCameraTDView = function(tweenState: TweenState): void {
-    const p = voxelToNm(Store.getState().dataset.scale, getPosition(Store.getState().flycam));
+    const p = voxelToNm(
+      Store.getState().dataset.dataSource.scale,
+      getPosition(Store.getState().flycam),
+    );
 
     Store.dispatch(
       setTDCameraAction({

--- a/app/assets/javascripts/oxalis/controller/scene_controller.js
+++ b/app/assets/javascripts/oxalis/controller/scene_controller.js
@@ -83,7 +83,7 @@ class SceneController {
     this.rootGroup.add(this.getRootNode());
 
     // The dimension(s) with the highest resolution will not be distorted
-    this.rootGroup.scale.copy(new THREE.Vector3(...Store.getState().dataset.scale));
+    this.rootGroup.scale.copy(new THREE.Vector3(...Store.getState().dataset.dataSource.scale));
     // Add scene to the group, all Geometries are then added to group
     this.scene.add(this.rootGroup);
   }
@@ -259,7 +259,7 @@ class SceneController {
 
   setClippingDistance(value: number): void {
     // convert nm to voxel
-    const voxelPerNMVector = getVoxelPerNM(Store.getState().dataset.scale);
+    const voxelPerNMVector = getVoxelPerNM(Store.getState().dataset.dataSource.scale);
     V3.scale(voxelPerNMVector, value, this.planeShift);
 
     app.vent.trigger("rerender");

--- a/app/assets/javascripts/oxalis/controller/viewmodes/arbitrary_controller.js
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/arbitrary_controller.js
@@ -254,7 +254,7 @@ class ArbitraryController extends React.PureComponent<Props> {
   getVoxelOffset(timeFactor: number): number {
     const state = Store.getState();
     const moveValue3d = state.userConfiguration.moveValue3d;
-    const baseVoxel = getBaseVoxel(state.dataset.scale);
+    const baseVoxel = getBaseVoxel(state.dataset.dataSource.scale);
     return moveValue3d * timeFactor / baseVoxel / constants.FPS;
   }
 

--- a/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -89,7 +89,7 @@ class PlaneController extends React.PureComponent<Props> {
     this.isStarted = false;
 
     const state = Store.getState();
-    this.oldNmPos = voxelToNm(state.dataset.scale, getPosition(state.flycam));
+    this.oldNmPos = voxelToNm(state.dataset.dataSource.scale, getPosition(state.flycam));
 
     this.planeView = new PlaneView();
 
@@ -224,14 +224,14 @@ class PlaneController extends React.PureComponent<Props> {
         return (
           state.userConfiguration.moveValue *
           timeFactor /
-          getBaseVoxel(state.dataset.scale) /
+          getBaseVoxel(state.dataset.dataSource.scale) /
           constants.FPS
         );
       }
       return (
         state.userConfiguration.moveValue *
         timeFactor /
-        getBaseVoxel(state.dataset.scale) /
+        getBaseVoxel(state.dataset.dataSource.scale) /
         constants.FPS
       );
     };
@@ -515,7 +515,7 @@ function calculateGlobalPos(clickPos: Point2) {
   const curGlobalPos = getPosition(state.flycam);
   const zoomFactor = getPlaneScalingFactor(state.flycam);
   const viewportScale = state.userConfiguration.scale;
-  const planeRatio = getBaseVoxelFactors(state.dataset.scale);
+  const planeRatio = getBaseVoxelFactors(state.dataset.dataSource.scale);
   switch (activeViewport) {
     case OrthoViews.PLANE_XY:
       position = [
@@ -574,7 +574,7 @@ function calculateGlobalPos(clickPos: Point2) {
 export function mapStateToProps(state: OxalisState, ownProps: OwnProps): Props {
   return {
     flycam: state.flycam,
-    scale: state.dataset.scale,
+    scale: state.dataset.dataSource.scale,
     onRender: ownProps.onRender,
   };
 }

--- a/app/assets/javascripts/oxalis/geometries/materials/node_shader.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/node_shader.js
@@ -39,7 +39,7 @@ class NodeShader {
       },
       datasetScale: {
         type: "f",
-        value: getBaseVoxel(state.dataset.scale),
+        value: getBaseVoxel(state.dataset.dataSource.scale),
       },
       overrideParticleSize: {
         type: "f",

--- a/app/assets/javascripts/oxalis/geometries/plane.js
+++ b/app/assets/javascripts/oxalis/geometries/plane.js
@@ -43,7 +43,7 @@ class Plane {
     // dimension with the highest resolution. In all other dimensions, the plane
     // is smaller in voxels, so that it is squared in nm.
     // --> scaleInfo.baseVoxel
-    const baseVoxelFactors = getBaseVoxelFactors(Store.getState().dataset.scale);
+    const baseVoxelFactors = getBaseVoxelFactors(Store.getState().dataset.dataSource.scale);
     const scaleArray = Dimensions.transDim(baseVoxelFactors, this.planeID);
     this.scaleVector = new THREE.Vector3(...scaleArray);
 

--- a/app/assets/javascripts/oxalis/model.js
+++ b/app/assets/javascripts/oxalis/model.js
@@ -185,7 +185,9 @@ export class OxalisModel {
     // The order of allowedModes should be independent from the server and instead be similar to ModeValues
     let allowedModes = _.intersection(ModeValues, settings.allowedModes);
 
-    const colorLayer = _.find(Store.getState().dataset.dataLayers, { category: "color" });
+    const colorLayer = _.find(Store.getState().dataset.dataSource.dataLayers, {
+      category: "color",
+    });
     if (colorLayer != null && colorLayer.elementClass !== "uint8") {
       allowedModes = allowedModes.filter(mode => !constants.MODES_ARBITRARY.includes(mode));
     }
@@ -346,7 +348,7 @@ export class OxalisModel {
 
   getLayerInfos(tracing: ?ServerTracingType) {
     // Overwrite or extend layers with volumeTracingLayer
-    let layers = _.clone(Store.getState().dataset.dataLayers);
+    let layers = _.clone(Store.getState().dataset.dataSource.dataLayers);
     // $FlowFixMe TODO Why does Flow complain about this check
     if (tracing == null || tracing.elementClass == null) {
       return layers;

--- a/app/assets/javascripts/oxalis/model/accessors/flycam_accessor.js
+++ b/app/assets/javascripts/oxalis/model/accessors/flycam_accessor.js
@@ -79,7 +79,7 @@ export function getMaxZoomStep(state: OxalisState): number {
       .map(dataset =>
         Math.max(
           0,
-          ...dataset.dataLayers.map(layer =>
+          ...dataset.dataSource.dataLayers.map(layer =>
             Math.max(0, ...layer.resolutions.map(r => Math.max(r[0], r[1], r[2]))),
           ),
         ),
@@ -107,7 +107,7 @@ export function calculateTextureBuffer(state: OxalisState): OrthoViewMapType<Vec
   // How many pixels is the texture larger than the canvas on each dimension?
   // Returns: two dimensional array with buffer[planeId][dimension], dimension: x->0, y->1
   const pixelNeeded = constants.PLANE_WIDTH * getTextureScalingFactor(state);
-  const baseVoxelFactors = scaleInfo.getBaseVoxelFactors(state.dataset.scale);
+  const baseVoxelFactors = scaleInfo.getBaseVoxelFactors(state.dataset.dataSource.scale);
   const buffer = {};
   for (const planeId of OrthoViewValues) {
     const scaleArray = Dimensions.transDim(baseVoxelFactors, planeId);
@@ -142,7 +142,7 @@ export function getRotationOrtho(planeId: OrthoViewType): Vector3 {
 export function getViewportBoundingBox(state: OxalisState): BoundingBoxType {
   const position = getPosition(state.flycam);
   const offset = getPlaneScalingFactor(state.flycam) * constants.PLANE_WIDTH / 2;
-  const baseVoxelFactors = scaleInfo.getBaseVoxelFactors(state.dataset.scale);
+  const baseVoxelFactors = scaleInfo.getBaseVoxelFactors(state.dataset.dataSource.scale);
   const min = [0, 0, 0];
   const max = [0, 0, 0];
 
@@ -182,7 +182,7 @@ export function getOffsets(state: OxalisState, planeId: OrthoViewType): Vector2 
 export function getArea(state: OxalisState, planeId: OrthoViewType): Vector4 {
   // returns [left, top, right, bottom] array
   const scaleArray = Dimensions.transDim(
-    scaleInfo.getBaseVoxelFactors(state.dataset.scale),
+    scaleInfo.getBaseVoxelFactors(state.dataset.dataSource.scale),
     planeId,
   );
   const offsets = getOffsets(state, planeId);

--- a/app/assets/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/app/assets/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -135,9 +135,9 @@ function serializeParameters(state: OxalisState): Array<string> {
           description: state.tracing.description,
         }),
         serializeTag("scale", {
-          x: state.dataset.scale[0],
-          y: state.dataset.scale[1],
-          z: state.dataset.scale[2],
+          x: state.dataset.dataSource.scale[0],
+          y: state.dataset.dataSource.scale[1],
+          z: state.dataset.dataSource.scale[2],
         }),
         serializeTag("offset", {
           x: 0,

--- a/app/assets/javascripts/oxalis/model/reducers/flycam_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/flycam_reducer.js
@@ -132,7 +132,7 @@ export function setDirectionReducer(state: OxalisState, direction: Vector3) {
 export function setRotationReducer(state: OxalisState, rotation: Vector3) {
   if (state.dataset != null) {
     const [x, y, z] = rotation;
-    let matrix = resetMatrix(state.flycam.currentMatrix, state.dataset.scale);
+    let matrix = resetMatrix(state.flycam.currentMatrix, state.dataset.dataSource.scale);
     matrix = rotateOnAxis(matrix, -z * Math.PI / 180, [0, 0, 1]);
     matrix = rotateOnAxis(matrix, -y * Math.PI / 180, [0, 1, 0]);
     matrix = rotateOnAxis(matrix, -x * Math.PI / 180, [1, 0, 0]);
@@ -216,7 +216,7 @@ function FlycamReducer(state: OxalisState, action: ActionType): OxalisState {
         const { planeId, increaseSpeedWithZoom } = action;
         const vector = Dimensions.transDim(action.vector, planeId);
         const zoomFactor = increaseSpeedWithZoom ? state.flycam.zoomStep : 1;
-        const scaleFactor = getBaseVoxelFactors(dataset.scale);
+        const scaleFactor = getBaseVoxelFactors(dataset.dataSource.scale);
         const delta = [
           vector[0] * zoomFactor * scaleFactor[0],
           vector[1] * zoomFactor * scaleFactor[1],

--- a/app/assets/javascripts/oxalis/model/reducers/settings_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/settings_reducer.js
@@ -40,7 +40,10 @@ function SettingsReducer(state: OxalisState, action: ActionType): OxalisState {
 
     case "INITIALIZE_SETTINGS": {
       // Only color layers need layer settings
-      const colorLayers = _.filter(state.dataset.dataLayers, layer => layer.category === "color");
+      const colorLayers = _.filter(
+        state.dataset.dataSource.dataLayers,
+        layer => layer.category === "color",
+      );
       const initialLayerSettings = action.initialDatasetSettings.layers;
       const layerSettingsDefaults = _.transform(
         colorLayers,
@@ -70,15 +73,8 @@ function SettingsReducer(state: OxalisState, action: ActionType): OxalisState {
     }
 
     case "SET_DATASET": {
-      const dataset = {
-        dataStore: action.dataset.dataStore,
-        name: action.dataset.dataSource.id.name,
-        scale: action.dataset.dataSource.scale,
-        dataLayers: action.dataset.dataSource.dataLayers,
-      };
-
       return update(state, {
-        dataset: { $set: dataset },
+        dataset: { $set: action.dataset },
       });
     }
 

--- a/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
+++ b/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
@@ -75,7 +75,7 @@ export function createNode(
 
   if (allowUpdate) {
     // Use the same radius as current active node or revert to default value
-    const defaultRadius = 10 * getBaseVoxel(state.dataset.scale);
+    const defaultRadius = 10 * getBaseVoxel(state.dataset.dataSource.scale);
     const radius = activeNodeMaybe.map(activeNode => activeNode.radius).getOrElse(defaultRadius);
 
     // Find new node id by increasing the max node id.

--- a/app/assets/javascripts/oxalis/model/volumetracing/volumelayer.js
+++ b/app/assets/javascripts/oxalis/model/volumetracing/volumelayer.js
@@ -199,7 +199,7 @@ class VolumeLayer {
 
     // Use the baseVoxelFactors to scale the circle, otherwise it'll become an ellipse
     const baseVoxelFactors = this.get2DCoordinate(
-      getBaseVoxelFactors(Store.getState().dataset.scale),
+      getBaseVoxelFactors(Store.getState().dataset.dataSource.scale),
     );
     Drawing.fillCircle(coord2d[0], coord2d[1], radius, baseVoxelFactors, (x, y) =>
       setMap(x, y, true),

--- a/app/assets/javascripts/oxalis/store.js
+++ b/app/assets/javascripts/oxalis/store.js
@@ -44,6 +44,7 @@ import type {
   APIScriptType,
   APITaskType,
   APIUserType,
+  APIDatasetType,
 } from "admin/api_flow_types";
 
 export type CommentType = {
@@ -325,7 +326,7 @@ export type OxalisState = {
   +datasetConfiguration: DatasetConfigurationType,
   +userConfiguration: UserConfigurationType,
   +temporaryConfiguration: TemporaryConfigurationType,
-  +dataset: DatasetType,
+  +dataset: APIDatasetType,
   +tracing: TracingType,
   +task: ?TaskType,
   +save: SaveStateType,
@@ -378,14 +379,27 @@ export const defaultState: OxalisState = {
   task: null,
   dataset: {
     name: "Test Dataset",
-    scale: [5, 5, 5],
+    created: 123,
+    dataSource: {
+      dataLayers: [],
+      scale: [5, 5, 5],
+      id: {
+        name: "Test Dataset",
+        team: "",
+      },
+    },
     isPublic: false,
+    isActive: true,
+    isEditable: true,
     dataStore: {
       name: "localhost",
       url: "http://localhost:9000",
       typ: "webknossos-store",
     },
-    dataLayers: [],
+    owningOrganization: "Connectomics department",
+    description: null,
+    displayName: "Awesome Test Dataset",
+    allowedTeams: [],
   },
   tracing: {
     annotationId: "",

--- a/app/assets/javascripts/oxalis/store.js
+++ b/app/assets/javascripts/oxalis/store.js
@@ -134,14 +134,6 @@ export type SettingsType = APISettingsType;
 
 export type DataStoreInfoType = APIDataStoreType;
 
-export type DatasetType = {
-  +name: string,
-  +dataStore: DataStoreInfoType,
-  +scale: Vector3,
-  +dataLayers: Array<DataLayerType>,
-  +isPublic: boolean,
-};
-
 export type TreeMapType = { +[number]: TreeType };
 export type TemporaryMutableTreeMapType = { [number]: TreeType };
 

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -16,11 +16,12 @@ import {
 } from "oxalis/model/actions/annotation_actions";
 import EditableTextLabel from "oxalis/view/components/editable_text_label";
 import { Table } from "antd";
-import type { OxalisState, TracingType, DatasetType, TaskType, FlycamType } from "oxalis/store";
+import type { APIDatasetType } from "admin/api_flow_types";
+import type { OxalisState, TracingType, TaskType, FlycamType } from "oxalis/store";
 
 type DatasetInfoTabStateProps = {
   tracing: TracingType,
-  dataset: DatasetType,
+  dataset: APIDatasetType,
   flycam: FlycamType,
   task: ?TaskType,
 };
@@ -84,7 +85,7 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
       throw new Error(`Model mode not recognized: ${viewMode}`);
     }
     // unit is nm
-    const baseVoxel = getBaseVoxel(this.props.dataset.scale);
+    const baseVoxel = getBaseVoxel(this.props.dataset.dataSource.scale);
     return zoom * width * baseVoxel;
   }
 
@@ -153,11 +154,23 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
   }
 
   getDatasetName(isPublicViewMode: boolean) {
-    const dataSetName = this.props.dataset.name;
-    return <p>Dataset: {dataSetName}</p>;
+    let { name: datasetName } = this.props.dataset;
+    const { displayName } = this.props.dataset;
+
+    if (isPublicViewMode && displayName) {
+      datasetName = displayName;
+    }
+
+    return <p>Dataset: {datasetName}</p>;
   }
 
   getDatasetDescription(isPublicViewMode: boolean) {
+    const { description } = this.props.tracing;
+
+    if (isPublicViewMode) {
+      return description ? <p>Description: {description}</p> : null;
+    }
+
     const tracingDescription = this.props.tracing.description || "<no comment>";
     return (
       <p>
@@ -214,11 +227,13 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
       <div className="flex-overflow">
         {this.getTracingName(isPublicViewMode)}
         {this.getDatasetName(isPublicViewMode)}
+        {this.getDatasetDescription(isPublicViewMode)}
 
         <p>Viewport Width: {this.chooseUnit(zoomLevel)}</p>
-        <p>Dataset Resolution: {TemplateHelpers.formatScale(this.props.dataset.scale)}</p>
+        <p>
+          Dataset Resolution: {TemplateHelpers.formatScale(this.props.dataset.dataSource.scale)}
+        </p>
 
-        {this.getDatasetDescription(isPublicViewMode)}
         {this.getTracingStatistics()}
         {this.getKeyboardShortcuts(isPublicViewMode)}
         {this.getOrganisationLogo()}

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -106,12 +106,80 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
     this.props.setAnnotationDescription(newDescription);
   };
 
-  render() {
-    const { tracingType, name, description } = this.props.tracing;
-    const tracingName = name || "<untitled>";
-    const tracingDescription = description || "<no comment>";
+  getTracingStatistics() {
     const statsMaybe = getStats(this.props.tracing);
+
+    return this.props.tracing.type === "skeleton" ? (
+      <div>
+        <p>Number of Trees: {statsMaybe.map(stats => stats.treeCount).getOrElse(null)}</p>
+        <p>Number of Nodes: {statsMaybe.map(stats => stats.nodeCount).getOrElse(null)}</p>
+        <p>Number of Edges: {statsMaybe.map(stats => stats.edgeCount).getOrElse(null)}</p>
+        <p>
+          Number of Branch Points: {statsMaybe.map(stats => stats.branchPointCount).getOrElse(null)}
+        </p>
+      </div>
+    ) : null;
+  }
+
+  getKeyboardShortcuts(isPublicViewMode: boolean) {
+    return isPublicViewMode ? (
+      <div>
+        <Table
+          dataSource={shortcuts}
+          columns={shortcutColumns}
+          pagination={false}
+          style={{ marginRight: 20 }}
+          size="small"
+        />
+      </div>
+    ) : null;
+  }
+
+  getOrganisationLogo() {
+    return (
+      <div>
+        <img
+          className="img-50"
+          src="/assets/images/Max-Planck-Gesellschaft.svg"
+          alt="Max Plank Geselleschaft Logo"
+        />
+        <img
+          className="img-50"
+          src="/assets/images/MPI-brain-research.svg"
+          alt="Max Plank Institute of Brain Research Logo"
+        />
+      </div>
+    );
+  }
+
+  getDatasetName(isPublicViewMode: boolean) {
+    const dataSetName = this.props.dataset.name;
+    return <p>Dataset: {dataSetName}</p>;
+  }
+
+  getDatasetDescription(isPublicViewMode: boolean) {
+    const tracingDescription = this.props.tracing.description || "<no comment>";
+    return (
+      <p>
+        <span>
+          Description:
+          <EditableTextLabel
+            value={tracingDescription}
+            onChange={this.setAnnotationDescription}
+            rows={4}
+          />
+        </span>
+      </p>
+    );
+  }
+
+  getTracingName(isPublicViewMode: boolean) {
+    if (isPublicViewMode) return null;
+
     let annotationTypeLabel;
+
+    const { tracingType, name } = this.props.tracing;
+    const tracingName = name || "<untitled>";
 
     if (this.props.task != null) {
       // In case we have a task display its id
@@ -133,61 +201,27 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
       );
     }
 
-    const zoomLevel = this.calculateZoomLevel();
-    const dataSetName = this.props.dataset.name;
+    return <p>{annotationTypeLabel}</p>;
+  }
+
+  render() {
     const isPublicViewMode =
       Store.getState().temporaryConfiguration.controlMode === ControlModeEnum.VIEW;
 
+    const zoomLevel = this.calculateZoomLevel();
+
     return (
       <div className="flex-overflow">
-        <p>{annotationTypeLabel}</p>
-        <p>Dataset: {dataSetName}</p>
+        {this.getTracingName(isPublicViewMode)}
+        {this.getDatasetName(isPublicViewMode)}
+
         <p>Viewport Width: {this.chooseUnit(zoomLevel)}</p>
         <p>Dataset Resolution: {TemplateHelpers.formatScale(this.props.dataset.scale)}</p>
-        <p>
-          <span>
-            Description:
-            <EditableTextLabel
-              value={tracingDescription}
-              onChange={this.setAnnotationDescription}
-              rows={4}
-            />
-          </span>
-        </p>
-        {this.props.tracing.type === "skeleton" ? (
-          <div>
-            <p>Number of Trees: {statsMaybe.map(stats => stats.treeCount).getOrElse(null)}</p>
-            <p>Number of Nodes: {statsMaybe.map(stats => stats.nodeCount).getOrElse(null)}</p>
-            <p>Number of Edges: {statsMaybe.map(stats => stats.edgeCount).getOrElse(null)}</p>
-            <p>
-              Number of Branch Points:{" "}
-              {statsMaybe.map(stats => stats.branchPointCount).getOrElse(null)}
-            </p>
-          </div>
-        ) : null}
-        {isPublicViewMode ? (
-          <div>
-            <Table
-              dataSource={shortcuts}
-              columns={shortcutColumns}
-              pagination={false}
-              style={{ marginRight: 20 }}
-              size="small"
-            />
-            <div>
-              <img
-                className="img-50"
-                src="/assets/images/Max-Planck-Gesellschaft.svg"
-                alt="Max Plank Geselleschaft Logo"
-              />
-              <img
-                className="img-50"
-                src="/assets/images/MPI-brain-research.svg"
-                alt="Max Plank Institute of Brain Research Logo"
-              />
-            </div>
-          </div>
-        ) : null}
+
+        {this.getDatasetDescription(isPublicViewMode)}
+        {this.getTracingStatistics()}
+        {this.getKeyboardShortcuts(isPublicViewMode)}
+        {this.getOrganisationLogo()}
       </div>
     );
   }

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -193,7 +193,7 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
         </span>
       );
     }
-    const tracingDescription = this.props.tracing.description || "<no comment>";
+    const tracingDescription = this.props.tracing.description || "<no description>";
 
     return (
       <div>

--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -124,20 +124,18 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
 
   getKeyboardShortcuts(isPublicViewMode: boolean) {
     return isPublicViewMode ? (
-      <div>
-        <Table
-          dataSource={shortcuts}
-          columns={shortcutColumns}
-          pagination={false}
-          style={{ marginRight: 20 }}
-          size="small"
-        />
-      </div>
+      <Table
+        dataSource={shortcuts}
+        columns={shortcutColumns}
+        pagination={false}
+        style={{ marginRight: 20, marginTop: 25, marginBottom: 25 }}
+        size="small"
+      />
     ) : null;
   }
 
-  getOrganisationLogo() {
-    return (
+  getOrganisationLogo(isPublicViewMode: boolean) {
+    return isPublicViewMode ? (
       <div>
         <img
           className="img-50"
@@ -150,40 +148,22 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
           alt="Max Plank Institute of Brain Research Logo"
         />
       </div>
-    );
+    ) : null;
   }
 
   getDatasetName(isPublicViewMode: boolean) {
-    let { name: datasetName } = this.props.dataset;
-    const { displayName } = this.props.dataset;
+    const { name: datasetName, displayName, description } = this.props.dataset;
 
-    if (isPublicViewMode && displayName) {
-      datasetName = displayName;
+    if (isPublicViewMode) {
+      return (
+        <div>
+          <p>Dataset: {displayName || datasetName}</p>
+          {description ? <p>{description}</p> : null}
+        </div>
+      );
     }
 
     return <p>Dataset: {datasetName}</p>;
-  }
-
-  getDatasetDescription(isPublicViewMode: boolean) {
-    const { description } = this.props.tracing;
-
-    if (isPublicViewMode) {
-      return description ? <p>Description: {description}</p> : null;
-    }
-
-    const tracingDescription = this.props.tracing.description || "<no comment>";
-    return (
-      <p>
-        <span>
-          Description:
-          <EditableTextLabel
-            value={tracingDescription}
-            onChange={this.setAnnotationDescription}
-            rows={4}
-          />
-        </span>
-      </p>
-    );
   }
 
   getTracingName(isPublicViewMode: boolean) {
@@ -213,8 +193,23 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
         </span>
       );
     }
+    const tracingDescription = this.props.tracing.description || "<no comment>";
 
-    return <p>{annotationTypeLabel}</p>;
+    return (
+      <div>
+        <p>{annotationTypeLabel}</p>
+        <p>
+          <span>
+            Description:
+            <EditableTextLabel
+              value={tracingDescription}
+              onChange={this.setAnnotationDescription}
+              rows={4}
+            />
+          </span>
+        </p>
+      </div>
+    );
   }
 
   render() {
@@ -227,7 +222,6 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
       <div className="flex-overflow">
         {this.getTracingName(isPublicViewMode)}
         {this.getDatasetName(isPublicViewMode)}
-        {this.getDatasetDescription(isPublicViewMode)}
 
         <p>Viewport Width: {this.chooseUnit(zoomLevel)}</p>
         <p>
@@ -236,7 +230,7 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
 
         {this.getTracingStatistics()}
         {this.getKeyboardShortcuts(isPublicViewMode)}
-        {this.getOrganisationLogo()}
+        {this.getOrganisationLogo(isPublicViewMode)}
       </div>
     );
   }

--- a/app/assets/javascripts/test/model/flycam_accessors.spec.js
+++ b/app/assets/javascripts/test/model/flycam_accessors.spec.js
@@ -6,15 +6,17 @@ import * as accessors from "oxalis/model/accessors/flycam_accessor";
 
 const initialState = {
   dataset: {
-    scale: [1, 1, 2],
-    dataLayers: [
-      {
-        resolutions: [[1, 1, 1], [16, 16, 16], [2, 2, 2], [4, 4, 4], [8, 8, 8]],
-      },
-      {
-        resolutions: [[1, 1, 1]],
-      },
-    ],
+    dataSource: {
+      scale: [1, 1, 2],
+      dataLayers: [
+        {
+          resolutions: [[1, 1, 1], [16, 16, 16], [2, 2, 2], [4, 4, 4], [8, 8, 8]],
+        },
+        {
+          resolutions: [[1, 1, 1]],
+        },
+      ],
+    },
   },
   datasetConfiguration: {
     quality: 0,

--- a/app/assets/javascripts/test/reducers/flycam_reducer.spec.js
+++ b/app/assets/javascripts/test/reducers/flycam_reducer.spec.js
@@ -23,7 +23,9 @@ function equalWithEpsilon(t, a, b, epsilon = 1e-10) {
 
 const initialState = {
   dataset: {
-    scale: [1, 1, 2],
+    dataSource: {
+      scale: [1, 1, 2],
+    },
   },
   userConfiguration: {
     sphericalCapRadius: 100,

--- a/app/assets/javascripts/test/reducers/skeletontracing_reducer.spec.js
+++ b/app/assets/javascripts/test/reducers/skeletontracing_reducer.spec.js
@@ -29,7 +29,9 @@ function deepEqualObjectContaining(t: Object, actual: Object, expected: Object) 
 
 const initialState = {
   dataset: {
-    scale: [5, 5, 5],
+    dataSource: {
+      scale: [5, 5, 5],
+    },
   },
   userConfiguration: {
     sortTreesByName: "timestamp",

--- a/app/assets/javascripts/test/sagas/save_saga.spec.js
+++ b/app/assets/javascripts/test/sagas/save_saga.spec.js
@@ -36,7 +36,9 @@ const {
 
 const initialState = {
   dataset: {
-    scale: [5, 5, 5],
+    dataSource: {
+      scale: [5, 5, 5],
+    },
   },
   task: {
     id: 1,

--- a/app/assets/javascripts/test/sagas/skeletontracing_saga.spec.js
+++ b/app/assets/javascripts/test/sagas/skeletontracing_saga.spec.js
@@ -40,7 +40,9 @@ function testDiffing(prevTracing, nextTracing, flycam) {
 
 const initialState = {
   dataset: {
-    scale: [5, 5, 5],
+    dataSource: {
+      scale: [5, 5, 5],
+    },
   },
   task: {
     id: 1,


### PR DESCRIPTION
I update the "info" tab to show slightly different and more relevant information when in "view mode". 

Additionally I replace the Flow Type `DatasetType` with `APIDatasetType` since the were virtually identical. Instead of saving a simplified dataset in the store wK now uses the "real" dataset object as return by the server. This allows for access to such dataset properties such as `displayName` and `description`. 


### Mailable description of changes:
 - [TracingView] Update the information shown when simply viewing a dataset. If a dataset has a display name or description they will be shown. Previously, information related to skeleton tracings was shown, which is no longer the case..

### Steps to test:
- [Dashboard] Open a dataset in "view" mode
- No information regarding "skeleton tracing" should be shown.
- On dashboard, edit a dataset. Give it a `description` and a `display name`. Bot should show up in the view mode.
- Open a skeleton tracing and make sure all the "old" information is still shown.

These problems should be fixed:
![image](https://user-images.githubusercontent.com/1105056/39245772-ebb0e93a-4894-11e8-9c0a-0628fe9c1d46.png)

Ideally, each dataset could have a custom logo of it's creator. I filed a follow up issue for that: #2522

### Issues:
- fixes #2501

------
- [x] Ready for review
