### PR TITLE
Make rendering compatible with iPad

### DIFF
--- a/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
@@ -411,8 +411,8 @@ vec4 round(vec4 a) {
   return floor(a + 0.5);
 }
 
-// Define this function for each layer, since iOS cannot handle
-// sampler2D textures[dataTextureCountPerLayer
+// Define this function for each segmentation and color layer, since iOS cannot handle
+// sampler2D textures[dataTextureCountPerLayer]
 // as a function parameter properly
 
 <% _.each(layerNamesWithSegmentation, (name) => { %>


### PR DESCRIPTION
Buckle up! Let's ride the templating train. iOS cannot handle sampler2D arrays in function parameters (it always accesses the first element of the array; silently of course).

The PR fixes this issue by not passing around the texture arrays, but instead uses a `layerIndex` to denote the desired texture array. The layer index is handled by 
`getRgbaAtXYIndex` (via an if-else-construct) which calls `getRgbaAtXYIndex_<%= layer name %>` depending on the index. `getRgbaAtXYIndex_<%= layer name %>` is defined for each layer via templates.

Hot patching on browserstack showed, that this fixes the problem. I'll test the deployed version in a bit.