### PR TITLE
fix zoom step warnings and refactor code a bit

### DIFF
--- a/app/assets/javascripts/oxalis/model.js
+++ b/app/assets/javascripts/oxalis/model.js
@@ -36,7 +36,6 @@ import window from "libs/window";
 import Utils from "libs/utils";
 import Binary from "oxalis/model/binary";
 import ConnectionInfo from "oxalis/model/binarydata_connection_info";
-import { getIntegerZoomStep } from "oxalis/model/accessors/flycam_accessor";
 import constants, { Vector3Indicies, ControlModeEnum, ModeValues } from "oxalis/constants";
 import type { Vector3, ControlModeType } from "oxalis/constants";
 import Request from "libs/request";
@@ -470,14 +469,6 @@ export class OxalisModel {
     // Currently segmentation data can only be displayed in orthogonal and volume mode
     const canModeDisplaySegmentationData = constants.MODES_PLANE.includes(currentViewMode);
     return this.getSegmentationBinary() != null && canModeDisplaySegmentationData;
-  }
-
-  cantDisplaySegmentationData(): boolean {
-    return getIntegerZoomStep(Store.getState()) > 1;
-  }
-
-  displaysUnsampledVolumeData(): boolean {
-    return getIntegerZoomStep(Store.getState()) === 1;
   }
 
   computeBoundaries() {

--- a/app/assets/javascripts/oxalis/model/accessors/flycam_accessor.js
+++ b/app/assets/javascripts/oxalis/model/accessors/flycam_accessor.js
@@ -69,10 +69,6 @@ export function getMaxZoomStep(state: OxalisState): number {
   return maxZoomstep;
 }
 
-export function getIntegerZoomStep(state: OxalisState): number {
-  return Math.floor(state.flycam.zoomStep);
-}
-
 export function getRequestLogZoomStep(state: OxalisState): number {
   const maxLogZoomStep = Math.log2(getMaxZoomStep(state));
   const min = Math.min(state.datasetConfiguration.quality, maxLogZoomStep);

--- a/app/assets/javascripts/oxalis/model/accessors/volumetracing_accessor.js
+++ b/app/assets/javascripts/oxalis/model/accessors/volumetracing_accessor.js
@@ -3,7 +3,7 @@
  * @flow
  */
 import Maybe from "data.maybe";
-import { getIntegerZoomStep } from "oxalis/model/accessors/flycam_accessor";
+import { getRequestLogZoomStep } from "oxalis/model/accessors/flycam_accessor";
 import type { TracingType, VolumeTracingType, OxalisState } from "oxalis/store";
 import type { VolumeToolType, ContourModeType } from "oxalis/constants";
 
@@ -40,5 +40,9 @@ export function getContourTracingMode(tracing: TracingType): Maybe<ContourModeTy
 }
 
 export function isVolumeTracingDisallowed(state: OxalisState) {
-  return getIntegerZoomStep(state) > 1;
+  return getRequestLogZoomStep(state) > 1;
+}
+
+export function displaysUnsampledVolumeData(state: OxalisState): boolean {
+  return getRequestLogZoomStep(state) === 1;
 }

--- a/app/assets/javascripts/oxalis/model/sagas/root_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/root_saga.js
@@ -18,6 +18,10 @@ import { select, fork, take, cancel } from "redux-saga/effects";
 import Model from "oxalis/model";
 import Toast from "libs/toast";
 import messages from "messages";
+import {
+  isVolumeTracingDisallowed,
+  displaysUnsampledVolumeData,
+} from "oxalis/model/accessors/volumetracing_accessor";
 
 export default function* rootSaga(): Generator<*, *, *> {
   while (true) {
@@ -55,8 +59,9 @@ ${err} ${err.stack}`);
 function* warnAboutSegmentationOpacity(): Generator<*, *, *> {
   const warnMaybe = function* warnMaybe() {
     const shouldWarn = Model.shouldDisplaySegmentationData();
+    const isDisallowed = yield select(isVolumeTracingDisallowed);
 
-    if (shouldWarn && Model.cantDisplaySegmentationData()) {
+    if (shouldWarn && isDisallowed) {
       const isVolumeTracing = yield select(state => state.tracing.type === "volume");
       Toast.message(
         "error",
@@ -67,9 +72,9 @@ function* warnAboutSegmentationOpacity(): Generator<*, *, *> {
     } else {
       Toast.close(messages["tracing.segmentation_zoom_warning"]);
     }
-
-    if (shouldWarn && Model.displaysUnsampledVolumeData()) {
-      Toast.message("warning", messages["tracing.segmentation_downsampled_data_warning"], true);
+    const displaysUnsampled = yield select(displaysUnsampledVolumeData);
+    if (shouldWarn && displaysUnsampled) {
+      Toast.message("warning", messages["tracing.segmentation_downsampled_data_warning"]);
     } else {
       Toast.close(messages["tracing.segmentation_downsampled_data_warning"]);
     }

--- a/app/assets/javascripts/test/model/flycam_accessors.spec.js
+++ b/app/assets/javascripts/test/model/flycam_accessors.spec.js
@@ -33,10 +33,6 @@ test("Flycam Accessors should calculate the max zoom step", t => {
   t.is(accessors.getMaxZoomStep(initialState), 16);
 });
 
-test("Flycam Accessors should calculate the integer zoom step", t => {
-  t.is(accessors.getIntegerZoomStep(initialState), 1);
-});
-
 test("Flycam Accessors should calculate the request log zoom step (1/3)", t => {
   t.is(accessors.getRequestLogZoomStep(initialState), 1);
 });

--- a/app/assets/javascripts/test/reducers/volumetracing_reducer.spec.js
+++ b/app/assets/javascripts/test/reducers/volumetracing_reducer.spec.js
@@ -47,6 +47,17 @@ const initialState = update(defaultState, {
   tracing: {
     $set: volumeTracing,
   },
+  dataset: {
+    dataLayers: {
+      $set: [
+        {
+          // We need to have some resolutions. Otherwise,
+          // getRequestLogZoomStep will always return 0
+          resolutions: [[1, 1, 1], [2, 2, 2], [4, 4, 4]],
+        },
+      ],
+    },
+  },
 });
 
 test("VolumeTracing should set a new active cell", t => {
@@ -185,17 +196,6 @@ test("VolumeTracing should not allow to set trace tool if getRequestLogZoomStep(
     flycam: {
       zoomStep: { $set: 3 },
     },
-    dataset: {
-      dataLayers: {
-        $set: [
-          {
-            // We need to have some resolutions. Otherwise,
-            // getRequestLogZoomStep will always return 0
-            resolutions: [[1, 1, 1], [2, 2, 2], [4, 4, 4]],
-          },
-        ],
-      },
-    },
   });
 
   t.true(getRequestLogZoomStep(alteredState) > 1);
@@ -269,17 +269,6 @@ test("VolumeTracing should not add values to the contourList if getRequestLogZoo
   const alteredState = update(initialState, {
     flycam: {
       zoomStep: { $set: 3 },
-    },
-    dataset: {
-      dataLayers: {
-        $set: [
-          {
-            // We need to have some resolutions. Otherwise,
-            // getRequestLogZoomStep will always return 0
-            resolutions: [[1, 1, 1], [2, 2, 2], [4, 4, 4]],
-          },
-        ],
-      },
     },
   });
 

--- a/app/assets/javascripts/test/reducers/volumetracing_reducer.spec.js
+++ b/app/assets/javascripts/test/reducers/volumetracing_reducer.spec.js
@@ -12,6 +12,7 @@ import VolumeTracingReducer from "oxalis/model/reducers/volumetracing_reducer";
 import Maybe from "data.maybe";
 import { VolumeToolEnum } from "oxalis/constants";
 import type { TracingType, VolumeTracingType } from "oxalis/store";
+import { getRequestLogZoomStep } from "oxalis/model/accessors/flycam_accessor";
 
 mockRequire("app", { currentUser: { firstName: "SCM", lastName: "Boy" } });
 const { defaultState } = require("oxalis/store");
@@ -178,13 +179,26 @@ test("VolumeTracing should set trace/view tool", t => {
   });
 });
 
-test("VolumeTracing should not allow to set trace tool if the zoomStep is > 1", t => {
+test("VolumeTracing should not allow to set trace tool if getRequestLogZoomStep(zoomStep) is > 1", t => {
   const setToolAction = VolumeTracingActions.setToolAction(VolumeToolEnum.TRACE);
   const alteredState = update(initialState, {
     flycam: {
-      zoomStep: { $set: 2 },
+      zoomStep: { $set: 3 },
+    },
+    dataset: {
+      dataLayers: {
+        $set: [
+          {
+            // We need to have some resolutions. Otherwise,
+            // getRequestLogZoomStep will always return 0
+            resolutions: [[1, 1, 1], [2, 2, 2], [4, 4, 4]],
+          },
+        ],
+      },
     },
   });
+
+  t.true(getRequestLogZoomStep(alteredState) > 1);
 
   // Try to change tool to Trace
   const newState = VolumeTracingReducer(alteredState, setToolAction);
@@ -249,14 +263,27 @@ test("VolumeTracing should add values to the contourList", t => {
   });
 });
 
-test("VolumeTracing should not add values to the contourList if zoomStep > 1", t => {
+test("VolumeTracing should not add values to the contourList if getRequestLogZoomStep(zoomStep) > 1", t => {
   const contourList = [[4, 6, 9], [1, 2, 3], [9, 3, 2]];
   const addToLayerActionFn = VolumeTracingActions.addToLayerAction;
   const alteredState = update(initialState, {
     flycam: {
-      zoomStep: { $set: 2 },
+      zoomStep: { $set: 3 },
+    },
+    dataset: {
+      dataLayers: {
+        $set: [
+          {
+            // We need to have some resolutions. Otherwise,
+            // getRequestLogZoomStep will always return 0
+            resolutions: [[1, 1, 1], [2, 2, 2], [4, 4, 4]],
+          },
+        ],
+      },
     },
   });
+
+  t.true(getRequestLogZoomStep(alteredState) > 1);
 
   // Try to add positions to the contourList
   let newState = VolumeTracingReducer(alteredState, addToLayerActionFn(contourList[0]));


### PR DESCRIPTION
I noticed that segmentation related warnings were triggered a bit too early. During the calculation the zoom step was simply floored. However, we use a more sophisticated calculation of the actual zoomstep which I integrated in the logic.

### Mailable description of changes:
 - Segmentation related warnings which depend on the zoom step are now more precise.

### Steps to test:
- Zoom

### Issues:
- contributes to #2295 

------
- [X] Ready for review
