### PR TITLE
Fix client-side downsampling for anisotropic datasets

### DIFF
--- a/app/assets/javascripts/oxalis/model/binary/bucket.js
+++ b/app/assets/javascripts/oxalis/model/binary/bucket.js
@@ -210,7 +210,6 @@ export class DataBucket {
       throw new Error("Downsampling initiated for unsupported resolution change");
     }
 
-    const halfBucketWidth = constants.BUCKET_WIDTH / 2;
     const octantExtents = [
       constants.BUCKET_WIDTH / xFactor,
       constants.BUCKET_WIDTH / yFactor,

--- a/app/assets/javascripts/oxalis/model/binary/pullqueue.js
+++ b/app/assets/javascripts/oxalis/model/binary/pullqueue.js
@@ -9,7 +9,10 @@ import type Layer from "oxalis/model/binary/layers/layer";
 import type DataCube from "oxalis/model/binary/data_cube";
 import type { Vector4 } from "oxalis/constants";
 import type { DataStoreInfoType } from "oxalis/store";
-import { zoomedAddressToAnotherZoomStep } from "oxalis/model/helpers/position_converter";
+import {
+  getResolutionsFactors,
+  zoomedAddressToAnotherZoomStep,
+} from "oxalis/model/helpers/position_converter";
 
 export type PullQueueItemType = {
   priority: number,
@@ -114,10 +117,15 @@ class PullQueue {
               zoomStep + 1,
             );
 
+            const resolutionsFactors = getResolutionsFactors(
+              this.layer.resolutions[zoomStep + 1],
+              this.layer.resolutions[zoomStep],
+            );
             const higherBucket = this.cube.getOrCreateBucket(higherAddress);
             if (higherBucket.type === "data") {
               higherBucket.downsampleFromLowerBucket(
                 bucket,
+                resolutionsFactors,
                 this.layer.category === "segmentation",
               );
             }

--- a/app/assets/javascripts/oxalis/model/helpers/position_converter.js
+++ b/app/assets/javascripts/oxalis/model/helpers/position_converter.js
@@ -49,6 +49,14 @@ export function bucketPositionToGlobalAddress(
   ];
 }
 
+export function getResolutionsFactors(resolutionA: Vector3, resolutionB: Vector3): Vector3 {
+  return [
+    resolutionA[0] / resolutionB[0],
+    resolutionA[1] / resolutionB[1],
+    resolutionA[2] / resolutionB[2],
+  ];
+}
+
 export function zoomedAddressToAnotherZoomStep(
   [x, y, z, resolutionIndex]: Vector4,
   resolutions: Array<Vector3>,
@@ -56,11 +64,12 @@ export function zoomedAddressToAnotherZoomStep(
 ): Vector4 {
   const currentResolution = resolutions[resolutionIndex];
   const targetResolution = resolutions[targetResolutionIndex];
+  const factors = getResolutionsFactors(currentResolution, targetResolution);
 
   return [
-    Math.floor(x * (currentResolution[0] / targetResolution[0])),
-    Math.floor(y * (currentResolution[1] / targetResolution[1])),
-    Math.floor(z * (currentResolution[2] / targetResolution[2])),
+    Math.floor(x * factors[0]),
+    Math.floor(y * factors[1]),
+    Math.floor(z * factors[2]),
     targetResolutionIndex,
   ];
 }

--- a/app/assets/javascripts/test/fixtures/dataset_server_object.js
+++ b/app/assets/javascripts/test/fixtures/dataset_server_object.js
@@ -7,14 +7,14 @@ export default {
         name: "color",
         category: "color",
         boundingBox: { topLeft: [0, 0, 0], width: 1024, height: 1024, depth: 1024 },
-        resolutions: [[1, 1, 1], [16, 16, 16], [2, 2, 2], [32, 32, 32], [4, 4, 4], [8, 8, 8]],
+        resolutions: [[1, 1, 1], [2, 2, 2], [32, 32, 32], [4, 4, 4], [8, 8, 8], [16, 16, 16]],
         elementClass: "uint8",
       },
       {
         name: "segmentation",
         category: "segmentation",
         boundingBox: { topLeft: [0, 0, 0], width: 1024, height: 1024, depth: 1024 },
-        resolutions: [[1, 1, 1], [16, 16, 16], [2, 2, 2], [32, 32, 32], [4, 4, 4], [8, 8, 8]],
+        resolutions: [[1, 1, 1], [2, 2, 2], [32, 32, 32], [4, 4, 4], [8, 8, 8], [16, 16, 16]],
         elementClass: "uint32",
         largestSegmentId: 1000000000,
         mappings: [


### PR DESCRIPTION
The downsampling function considered buckets always as if their resolutions were scaled uniformly. This broke volume tracing for anisotropic datasets while being zoomed out.

Instead of disabling downsampling completely for anisotropic datasets or fixing it for arbitrary anisotropic resolution changes, I went for the middle-ground and fixed the code for the kind of anisotropic data we already have (z only doubles or stays the same). For other kind of anisotropies an error will be thrown (tracing will still work, though; the only symptom is that no data is displayed at a higher zoom step).
I also refactored the code a bit.

### Steps to test:
- brush in a volume tracing and zoom out for isotropic and anisotropic datasets (before this PR, brushed voxels would be displayed at z := z/2 for anisotropic datasets; so they jumped in z direction).

- I'd love to add automated tests for the downsampling function at some point. I'll trust manual testing for now, though.

### Issues:
- contributes to #2295 

------
- [X] Ready for review
