### PR TITLE
if ideal thumbnail resolution does not exist, snap to closest

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/ImageThumbnail.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/ImageThumbnail.scala
@@ -18,7 +18,6 @@ object ImageThumbnail {
     val wr = math.floor(math.log(dataLayer.boundingBox.width.toDouble / width) / math.log(2)).toInt - 1
     val hr = math.floor(math.log(dataLayer.boundingBox.height.toDouble / height) / math.log(2)).toInt - 1
 
-    // TODO what about gaps in resolutions?
     math.max(0, List(wr, hr, dataLayer.resolutions.size - 1).min)
   }
 
@@ -35,7 +34,7 @@ object ImageThumbnail {
                     Point3D(centerX.get, centerY.get, centerZ.get)
                  else dataLayer.boundingBox.center
     val resolutionExponent = zoom.getOrElse(bestResolutionExponent(dataLayer, width, height))
-    val resolution = dataLayer.lookUpResolution(resolutionExponent)
+    val resolution = dataLayer.lookUpResolution(resolutionExponent, snapToClosest = true)
     val x = Math.max(0, center.x - width * resolution.x / 2)
     val y = Math.max(0, center.y - height * resolution.y / 2)
     val z = center.z

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -69,7 +69,7 @@ trait DataLayerLike {
   def lookUpResolution(resolutionExponent: Int, snapToClosest: Boolean = false): Point3D = {
     val resPower = Math.pow(2, resolutionExponent).toInt
     val matchOpt = resolutions.find(resolution => resolution.maxDim == resPower)
-    if (snapToClosest) matchOpt.getOrElse(resolutions.minBy(resolution => math.abs(resolutionExponent - (math.log(resolution.maxDim)/math.log(2)))))
+    if (snapToClosest) matchOpt.getOrElse(resolutions.minBy(resolution => math.abs(resPower - resolution.maxDim)))
     else matchOpt.getOrElse(Point3D(resPower, resPower, resPower))
   }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -66,9 +66,11 @@ trait DataLayerLike {
 
   def resolutions: List[Point3D]
 
-  def lookUpResolution(resolutionExponent: Int): Point3D = {
+  def lookUpResolution(resolutionExponent: Int, snapToClosest: Boolean = false): Point3D = {
     val resPower = Math.pow(2, resolutionExponent).toInt
-    resolutions.find(resolution => resolution.maxDim == resPower).getOrElse(Point3D(resPower, resPower, resPower))
+    val matchOpt = resolutions.find(resolution => resolution.maxDim == resPower)
+    if (snapToClosest) matchOpt.getOrElse(resolutions.minBy(resolution => math.abs(resolutionExponent - (math.log(resolution.maxDim)/math.log(2)))))
+    else matchOpt.getOrElse(Point3D(resPower, resPower, resPower))
   }
 
   def elementClass: ElementClass.Value


### PR DESCRIPTION
### Steps to test:
- create datasource with gaps in resolutions (like ```"wkwResolutions": [
        {
          "resolution": 1,
          "cubeLength": 1024
        },
        {
          "resolution": 16,
          "cubeLength": 1024
        }
      ]```)
- should still get a thumbnail

------
- [x] Ready for review
