### PR TITLE
Blacklist setMousePosition action in GA logging

### DIFF
--- a/app/assets/javascripts/oxalis/model/helpers/google_analytics_middleware.js
+++ b/app/assets/javascripts/oxalis/model/helpers/google_analytics_middleware.js
@@ -2,13 +2,17 @@
 import window from "libs/window";
 import type { Dispatch } from "redux";
 
+const blacklistedActionTypes = ["SET_MOUSE_POSITION"];
+
 export default function GoogleAnalyticsMiddleWare<A: $Subtype<{ type: $Subtype<string> }>>(): (
   next: Dispatch<A>,
 ) => Dispatch<A> {
   return (next: Dispatch<A>) => (action: A): A => {
     // Google Analytics
     if (typeof window.ga !== "undefined" && window.ga !== null) {
-      window.ga("send", "event", "ReduxAction", action.type);
+      if (!blacklistedActionTypes.includes(action.type)) {
+        window.ga("send", "event", "ReduxAction", action.type);
+      }
     }
 
     return next(action);


### PR DESCRIPTION
Due to the hover-cell feature, all mouse movements trigger an action which is logged by default to google analytics. As a hot fix, I excluded this action type from logging.

### Issues:
- contributes to #2442 

------
- [X] Ready for review
