### PR TITLE
Fix datasets for which segmentation data has multiple resolutions

### DIFF
--- a/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
@@ -202,10 +202,6 @@ class PlaneMaterialFactory extends AbstractPlaneMaterialFactory {
     }
   }
 
-  getResolutions(): Array<Vector3> {
-    return _.first(Model.getColorBinaries()).layer.resolutions;
-  }
-
   makeMaterial(options?: ShaderMaterialOptionsType): void {
     super.makeMaterial(options);
 
@@ -965,7 +961,7 @@ void main() {
       floatsPerLookUpEntry: formatNumberAsGLSLFloat(floatsPerLookUpEntry),
       formatNumberAsGLSLFloat,
       formatVector3AsVec3: vector3 => `vec3(${vector3.map(formatNumberAsGLSLFloat).join(", ")})`,
-      resolutions: this.getResolutions(),
+      resolutions: Model.getResolutions(),
       datasetScale,
       brushToolIndex: formatNumberAsGLSLFloat(volumeToolEnumToIndex(VolumeToolEnum.BRUSH)),
     });

--- a/app/assets/javascripts/oxalis/model.js
+++ b/app/assets/javascripts/oxalis/model.js
@@ -343,18 +343,12 @@ export class OxalisModel {
     this.connectionInfo = new ConnectionInfo();
     this.binary = {};
     for (const layer of layers) {
-      let maxLayerZoomStep =
-        Math.log(Math.max(...layer.resolutions.map(r => Math.max(...r)))) / Math.LN2;
-      if (layer.category === "segmentation") {
-        maxLayerZoomStep = 1;
-      }
       const textureInformation = textureInformationPerLayer.get(layer);
       if (!textureInformation) {
         throw new Error("No texture information for layer?");
       }
       this.binary[layer.name] = new Binary(
         layer,
-        maxLayerZoomStep,
         this.connectionInfo,
         textureInformation.textureSize,
         textureInformation.textureCount,
@@ -412,6 +406,7 @@ export class OxalisModel {
       return layers.map(l => ({
         ...l,
         resolutions,
+        maxZoomStep: l.resolutions.length - 1,
       }));
     }
 
@@ -443,6 +438,7 @@ export class OxalisModel {
         depth: tracing.boundingBox.depth,
       },
       resolutions,
+      maxZoomStep: resolutions.length - 1,
       elementClass: tracing.elementClass,
       mappings:
         fallbackLayer != null && fallbackLayer.mappings != null ? fallbackLayer.mappings : [],
@@ -458,7 +454,11 @@ export class OxalisModel {
       layers = layers.filter(layer => layer.category !== "segmentation");
       layers.push(tracingLayer);
     }
-    return layers;
+    return layers.map(l => ({
+      ...l,
+      resolutions,
+      maxZoomStep: l.resolutions.length - 1,
+    }));
   }
 
   shouldDisplaySegmentationData(): boolean {

--- a/app/assets/javascripts/oxalis/model/binary.js
+++ b/app/assets/javascripts/oxalis/model/binary.js
@@ -123,7 +123,6 @@ class Binary {
 
   constructor(
     layer: Layer,
-    maxZoomStep: number,
     connectionInfo: ConnectionInfo,
     textureWidth: number,
     dataTextureCount: number,
@@ -147,7 +146,12 @@ class Binary {
     this.upperBoundary = [topLeft[0] + width, topLeft[1] + height, topLeft[2] + depth];
     this.layer.upperBoundary = this.upperBoundary;
 
-    this.cube = new DataCube(this.upperBoundary, maxZoomStep + 1, this.layer.bitDepth, this.layer);
+    this.cube = new DataCube(
+      this.upperBoundary,
+      layer.maxZoomStep + 1,
+      this.layer.bitDepth,
+      this.layer,
+    );
 
     const taskQueue = new AsyncTaskQueue(Infinity);
 
@@ -288,6 +292,16 @@ class Binary {
     const isFallbackAnchorPointNew =
       isFallbackAvailable &&
       this.yieldsNewZoomedAnchorPoint(unzoomedAnchorPoint, fallbackZoomStep, "fallbackAnchorPoint");
+
+    if (logZoomStep > this.cube.MAX_ZOOM_STEP) {
+      // Don't render anything if the zoomStep is too high
+      this.textureBucketManager.setActiveBuckets(
+        [],
+        this.anchorPointCache.anchorPoint,
+        this.anchorPointCache.fallbackAnchorPoint,
+      );
+      return [this.anchorPointCache.anchorPoint, this.anchorPointCache.fallbackAnchorPoint];
+    }
 
     const subBucketLocality = getSubBucketLocality(position, this.layer.resolutions[logZoomStep]);
     const areas = getAreas(Store.getState());

--- a/app/assets/javascripts/oxalis/model/binary/layers/layer.js
+++ b/app/assets/javascripts/oxalis/model/binary/layers/layer.js
@@ -41,6 +41,7 @@ class Layer {
   mappings: Array<APIMappingType>;
   boundingBox: BoundingBoxObjectType;
   resolutions: Array<Vector3>;
+  maxZoomStep: number;
 
   constructor(layerInfo: DataLayerType, dataStoreInfo: DataStoreInfoType) {
     this.dataStoreInfo = dataStoreInfo;
@@ -51,6 +52,7 @@ class Layer {
     this.mappings = layerInfo.mappings || [];
     this.boundingBox = layerInfo.boundingBox;
     this.resolutions = layerInfo.resolutions;
+    this.maxZoomStep = layerInfo.maxZoomStep;
 
     this.bitDepth = parseInt(this.elementClass.substring(4));
   }

--- a/app/assets/javascripts/oxalis/store.js
+++ b/app/assets/javascripts/oxalis/store.js
@@ -113,6 +113,7 @@ export type DataLayerType = {
   +category: CategoryType,
   +boundingBox: BoundingBoxObjectType,
   +resolutions: Array<Vector3>,
+  +maxZoomStep: number, // denotes for which maximum zoomStep data exists
   +elementClass: ElementClassType,
   +mappings?: Array<APIMappingType>,
 };


### PR DESCRIPTION
With the new GPU rendering, multiple problems arise for datasets which have segmentation data in multiple resolutions:

- only the first resolution is considered for rendering
- if the segmentation has more zoomsteps than color data, the client throws an error when being zoomed out far enough.

This PR fixes these issues. Refactoring of `model.js` and layer handling is strongly advised though :P

### Steps to test:
- zooming out of ROI2017_wkw should show all different zoomSteps for the segmentation
- opening a dataset with more segmentation zoomSteps than color zoomSteps should not throw when zooming out (I tested that be duplicating ROI2017_wkw and removing some of the color layers).

### Issues:
- contributes to #2295 

------
- [X] Ready for review
