### PR TITLE
only hover cells if segmentation opacity is not zero

### DIFF
--- a/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
@@ -923,7 +923,11 @@ void main() {
   // Color map (<= to fight rounding mistakes)
   if ( id > 0.1 ) {
     // Increase cell opacity when cell is hovered
-    float hoverAlphaIncrement = cellIdUnderMouse == id && highlightHoveredCellId ? 0.2 : 0.0;
+    float hoverAlphaIncrement =
+      // Hover cell only if it's the active one, if the feature is enabled
+      // and if segmentation opacity is not zero
+      cellIdUnderMouse == id && highlightHoveredCellId && alpha > 0.0
+        ? 0.2 : 0.0;
     gl_FragColor = vec4(mix( data_color, convertCellIdToRGB(id), alpha + hoverAlphaIncrement ), 1.0);
   } else {
     gl_FragColor = vec4(data_color, 1.0);


### PR DESCRIPTION
### Steps to test:
- set segmentation opacity to zero and hover cells --> cells should not be highlighted

### Issues:
- fixes https://discuss.webknossos.org/t/segment-highlighting-despite-opacity-zero/860

------
- [X] Ready for review
