### PR TITLE
in project download, get skeletons in multiple smaller requests

### DIFF
--- a/util/src/main/scala/com/scalableminds/util/rpc/RPCRequest.scala
+++ b/util/src/main/scala/com/scalableminds/util/rpc/RPCRequest.scala
@@ -161,7 +161,7 @@ class RPCRequest(val id: Int, val url: String) extends FoxImplicits with LazyLog
     r.flatMap { response =>
       if (response.status == OK) {
         logger.debug(s"Successful request (ID: $id). " +
-          s"Body: '${response.body.take(100)}'")
+          s"Body: <${response.body.length} bytes of protobuf data>")
       } else {
         logger.error(s"Failed to send WS request to $url (ID: $id). " +
           s"RequestBody: '${requestBodyPreview}'. Status ${response.status}. " +


### PR DESCRIPTION
…rather than a huge one. Attempting to tackle issue #2542.

Note that these smaller requests are sent in parallel due to the asynchronous execution. Next step would be to serialize their execution.

### Steps to test:
- trace and finish some tasks of a project, download it from the project list page
- zip should contain the right amount of NMLs


------
- [x] Ready for review
