### PR TITLE
add tooltip to task status icons

### DIFF
--- a/app/assets/javascripts/admin/task/task_list_view.js
+++ b/app/assets/javascripts/admin/task/task_list_view.js
@@ -232,22 +232,22 @@ class TaskListView extends React.PureComponent<Props, State> {
               width={80}
               render={(status, task: APITaskType) => (
                 <div className="nowrap">
-                  <span>
+                  <span title="Open Instances">
                     <Icon type="play-circle-o" />
                     {status.open}
                   </span>
                   <br />
-                  <span>
+                  <span title="Active Instances">
                     <Icon type="fork" />
                     {status.active}
                   </span>
                   <br />
-                  <span>
+                  <span title="Finished Instances">
                     <Icon type="check-circle-o" />
                     {status.finished}
                   </span>
                   <br />
-                  <span>
+                  <span title="Tracing Time">
                     <Icon type="clock-circle-o" />
                     {FormatUtils.formatSeconds(task.tracingTime / 1000)}
                   </span>


### PR DESCRIPTION
### Mailable description of changes:
 - Added Mouseover tooltips to task status icons

### Steps to test:
- create tasks, see task list view, spans should have `title`

------
- [x] Ready for review
