### PR TITLE
in ensureTeamAdministration, use nonblocking version of isTeamManager

### DIFF
--- a/app/controllers/Controller.scala
+++ b/app/controllers/Controller.scala
@@ -31,7 +31,7 @@ trait Controller extends PlayController
     r.request
 
   def ensureTeamAdministration(user: User, team: BSONObjectID) =
-    user.isTeamManagerOfBLOCKING(team) ?~> Messages("team.admin.notAllowed")
+    user.assertTeamManagerOrAdminOf(team) ?~> Messages("team.admin.notAllowed")
 
   def allowedToAdministrate(admin: User, dataSet: DataSet) =
     dataSet.isEditableBy(Some(admin)) ?~> Messages("notAllowed")


### PR DESCRIPTION
Since this particular usage of isTeamManager is already only used in asynchronous contexts, here we can easily use the asynchronously implemented version, avoiding potential timeout exceptions.

### Steps to test:
- create tasks in bulk (50 or so)
- should not fail with timeout exception

### Issues:
- contributes to #2467

------
- [x] Ready for review
