### PR TITLE
Fix team search

### DIFF
--- a/app/assets/javascripts/admin/team/team_list_view.js
+++ b/app/assets/javascripts/admin/team/team_list_view.js
@@ -127,7 +127,7 @@ class TeamListView extends React.PureComponent<Props, State> {
             <Table
               dataSource={Utils.filterWithSearchQueryOR(
                 this.state.teams,
-                ["name", "owner", "parent"],
+                ["name"],
                 this.state.searchQuery,
               )}
               rowKey="id"


### PR DESCRIPTION
Due to the restructuring of owners/organizations, the search broke (see #2571).

### Mailable description of changes:
 - Fix search in team list.

### Steps to test:
- use the search on the team page

### Issues:
- fixes #2571

------
- [ ] Ready for review
