### PR TITLE
[WIP] restrain organization api

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -679,7 +679,7 @@ export async function getOpenTasksReport(teamId: string): Promise<Array<APIOpenT
 }
 
 // ### Organizations
-export async function getOrganizations(): Promise<Array<APIOrganizationType>> {
+export async function getOrganizationNames(): Promise<Array<string>> {
   return Request.receiveJSON("/api/organizations");
 }
 

--- a/app/assets/javascripts/admin/auth/registration_view.js
+++ b/app/assets/javascripts/admin/auth/registration_view.js
@@ -5,12 +5,11 @@ import { Form, Input, Button, Row, Col, Icon, Card, Select } from "antd";
 import messages from "messages";
 import Request from "libs/request";
 import Toast from "libs/toast";
-import { getOrganizations } from "admin/admin_rest_api";
-import type { APIOrganizationType } from "admin/api_flow_types";
+import { getOrganizationNames } from "admin/admin_rest_api";
 import type { RouterHistory } from "react-router-dom";
 
 const FormItem = Form.Item;
-const Option = Select.Option;
+const { Option } = Select;
 
 type Props = {
   form: Object,
@@ -19,7 +18,7 @@ type Props = {
 
 type State = {
   confirmDirty: boolean,
-  organizations: Array<APIOrganizationType>,
+  organizations: Array<string>,
 };
 
 class RegistrationView extends React.PureComponent<Props, State> {
@@ -33,7 +32,7 @@ class RegistrationView extends React.PureComponent<Props, State> {
   }
 
   async fetchData() {
-    const organizations = await getOrganizations();
+    const organizations = await getOrganizationNames();
 
     this.setState({ organizations });
   }
@@ -52,12 +51,12 @@ class RegistrationView extends React.PureComponent<Props, State> {
   };
 
   handleConfirmBlur = (e: SyntheticInputEvent<>) => {
-    const value = e.target.value;
+    const { value } = e.target;
     this.setState({ confirmDirty: this.state.confirmDirty || !!value });
   };
 
   checkPassword = (rule, value, callback) => {
-    const form = this.props.form;
+    const { form } = this.props;
     if (value && value !== form.getFieldValue("password.password1")) {
       callback(messages["auth.registration_password_missmatch"]);
     } else {
@@ -66,7 +65,7 @@ class RegistrationView extends React.PureComponent<Props, State> {
   };
 
   checkConfirm = (rule, value, callback) => {
-    const form = this.props.form;
+    const { form } = this.props;
     if (value && this.state.confirmDirty) {
       form.validateFields(["confirm"], { force: true });
     }
@@ -88,8 +87,8 @@ class RegistrationView extends React.PureComponent<Props, State> {
         })(
           <Select placeholder="Organization">
             {this.state.organizations.map(organization => (
-              <Option value={organization.name} key={organization.name}>
-                {organization.name}
+              <Option value={organization} key={organization}>
+                {organization}
               </Option>
             ))}
           </Select>,

--- a/app/controllers/OrganizationController.scala
+++ b/app/controllers/OrganizationController.scala
@@ -19,9 +19,8 @@ class OrganizationController @Inject()(val messagesApi: MessagesApi) extends Con
   def listAllOrganizations = Action.async { implicit request =>
     for {
       allOrgs <- OrganizationDAO.findAll(GlobalAccessContext)
-      js <- Future.traverse(allOrgs)(Organization.organizationPublicWritesBasic(_)(GlobalAccessContext))
     } yield {
-      Ok(Json.toJson(js))
+      Ok(Json.toJson(allOrgs.map(_.name)))
     }
   }
 }

--- a/app/models/team/Organization.scala
+++ b/app/models/team/Organization.scala
@@ -92,34 +92,6 @@ object Organization extends FoxImplicits {
 
   val organizationFormat = Json.format[Organization]
 
-  def organizationPublicWrites(organization: Organization, requestingUser: User)(implicit ctx: DBAccessContext): Future[JsObject] =
-    for {
-      teams <- Fox.combined(organization.teams.map(TeamDAO.findOneById(_).map(_.name))).futureBox
-    } yield {
-      Json.obj(
-        "id" -> organization.id,
-        "name" -> organization.name,
-        "teams" -> teams.toOption,
-        "organizationTeam" -> organization.organizationTeam)
-    }
-
-  def organizationPublicWritesBasic(organization: Organization)(implicit ctx: DBAccessContext): Future[JsObject] =
-    for {
-      teams <- Fox.combined(organization.teams.map(TeamDAO.findOneById(_).map(_.name))).futureBox
-    } yield {
-      Json.obj(
-        "id" -> organization.id,
-        "name" -> organization.name,
-        "teams" -> teams.toOption,
-        "organizationTeam" -> organization.organizationTeam)
-    }
-
-  def organizationsPublicReads(requestingUser: User): Reads[Organization] =
-    ((__ \ "name").read[String](Reads.minLength[String](3)) and
-      (__ \ "teams").read[List[BSONObjectID]] and
-      (__ \ "organizationTeam").read[String](JsonFormatHelper.StringObjectIdReads("organizationTeam"))
-      ) ((name, teams, organizationTeam) => Organization(name, teams, BSONObjectID(organizationTeam)))
-
   def fromOrganizationSQL(o: OrganizationSQL)(implicit ctx: DBAccessContext) = {
     for {
       idBson <- o._id.toBSONObjectId.toFox ?~> Messages("sql.invalidBSONObjectId")


### PR DESCRIPTION
- the organization api showed to much information to any user who requested it
- now the api only return the names as they are the only thing which are needed

### Steps to test:
- call /api/organizations and return a JSON with all organization names
- registering a new user should still work as before

### Issues:
- fixes #2576 

------
- [ ] Ready for review
