### PR TITLE
logout api no longer fails if user is already logged out

### DIFF
--- a/app/controllers/Authentication.scala
+++ b/app/controllers/Authentication.scala
@@ -316,8 +316,11 @@ class Authentication @Inject()(
     } yield result
   }
 
-  def logout = SecuredAction.async { implicit request =>
-    env.authenticatorService.discard(request.authenticator, Ok)
+  def logout = UserAwareAction.async { implicit request =>
+    request.authenticator match {
+      case Some(authenticator) => env.authenticatorService.discard(authenticator, Ok)
+      case _ => Future.successful(Ok)
+    }
   }
 
   def singleSignOn(sso: String, sig: String) = UserAwareAction.async { implicit request =>


### PR DESCRIPTION
### Mailable description of changes:
 - Fix: Logout no longer fails if the user is already logged out

### Steps to test:
- disable autologin
- log in as scmboy
- log out normally, should still work
- log in agian, this time delete your cookie manually
- log out button should work still, no error toast should come up

### Issues:
- fixes #2579

------
- [x] Ready for review
