### PR TITLE
properly wait for individual steps of datasource upload

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -514,7 +514,7 @@ export async function updateDatasetDatasource(
   dataStoreUrl: string,
   datasource: APIDataSourceType,
 ): Promise<void> {
-  return doWithToken(token =>
+  await doWithToken(token =>
     Request.sendJSONReceiveJSON(`${dataStoreUrl}/data/datasets/${datasetName}?token=${token}`, {
       data: datasource,
     }),
@@ -580,7 +580,7 @@ export async function addNDStoreDataset(
 }
 
 export async function addDataset(datatsetConfig: DatasetConfigType): Promise<void> {
-  return doWithToken(token =>
+  await doWithToken(token =>
     Request.sendMultipartFormReceiveJSON(`/data/datasets?token=${token}`, {
       data: datatsetConfig,
       host: datatsetConfig.datastore,
@@ -598,7 +598,7 @@ export async function updateDatasetTeams(
 }
 
 export async function triggerDatasetCheck(datatstoreHost: string): Promise<void> {
-  return doWithToken(token =>
+  await doWithToken(token =>
     Request.triggerRequest(`/data/triggers/checkInboxBlocking?token=${token}`, {
       host: datatstoreHost,
     }),

--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -580,7 +580,7 @@ export async function addNDStoreDataset(
 }
 
 export async function addDataset(datatsetConfig: DatasetConfigType): Promise<void> {
-  doWithToken(token =>
+  return doWithToken(token =>
     Request.sendMultipartFormReceiveJSON(`/data/datasets?token=${token}`, {
       data: datatsetConfig,
       host: datatsetConfig.datastore,
@@ -598,7 +598,7 @@ export async function updateDatasetTeams(
 }
 
 export async function triggerDatasetCheck(datatstoreHost: string): Promise<void> {
-  doWithToken(token =>
+  return doWithToken(token =>
     Request.triggerRequest(`/data/triggers/checkInboxBlocking?token=${token}`, {
       host: datatstoreHost,
     }),

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceRepository.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceRepository.scala
@@ -25,10 +25,12 @@ class DataSourceRepository @Inject()(
   def findUsableByName(name: String): Option[DataSource] =
     find(name).flatMap(_.toUsable)
 
-  def updateDataSource(dataSource: InboxDataSource): Unit = {
-    insert(dataSource.id.name, dataSource)
-    webKnossosServer.reportDataSource(dataSource)
-  }
+  def updateDataSource(dataSource: InboxDataSource): Fox[Unit] =
+    for {
+      _ <- Fox.successful(())
+      _ = insert(dataSource.id.name, dataSource)
+      _ <- webKnossosServer.reportDataSource(dataSource)
+    } yield ()
 
   def updateDataSources(dataSources: List[InboxDataSource]): Fox[Unit] =
     for {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -67,21 +67,24 @@ class DataSourceService @Inject()(
     }
   }
 
-  def handleUpload(id: DataSourceId, dataSetZip: File): Box[Unit] = {
+  def handleUpload(id: DataSourceId, dataSetZip: File): Fox[Unit] = {
     val dataSourceDir = dataBaseDir.resolve(id.team).resolve(id.name)
     PathUtils.ensureDirectory(dataSourceDir)
 
     logger.info(s"Uploading and unzipping dataset into $dataSourceDir")
 
-    ZipIO.unzipToFolder(dataSetZip, dataSourceDir, includeHiddenFiles = false, truncateCommonPrefix = true) match {
-      case Full(_) =>
-        dataSourceRepository.updateDataSource(dataSourceFromFolder(dataSourceDir, id.team))
-        Full(())
-      case e =>
-        val errorMsg = s"Error unzipping uploaded dataset to $dataSourceDir: $e"
-        logger.warn(errorMsg)
-        Failure(errorMsg)
-    }
+    for {
+      _ <- Fox.successful(())
+      unzipResult = ZipIO.unzipToFolder(dataSetZip, dataSourceDir, includeHiddenFiles = false, truncateCommonPrefix = true)
+      _ <- unzipResult match {
+        case Full(_) => dataSourceRepository.updateDataSource(dataSourceFromFolder(dataSourceDir, id.team))
+        case e => {
+          val errorMsg = s"Error unzipping uploaded dataset to $dataSourceDir: $e"
+          logger.warn(errorMsg)
+          Fox.failure(errorMsg)
+        }
+      }
+    } yield ()
   }
 
   def exploreDataSource(id: DataSourceId, previous: Option[DataSource]): Box[(DataSource, List[(String, String)])] = {
@@ -123,13 +126,13 @@ class DataSourceService @Inject()(
     }
   }
 
-  def updateDataSource(dataSource: DataSource): Box[Unit] = {
-    validateDataSource(dataSource).flatMap { _ =>
-      val propertiesFile = dataBaseDir.resolve(dataSource.id.team).resolve(dataSource.id.name).resolve(propertiesFileName)
-      JsonHelper.jsonToFile(propertiesFile, dataSource).map { _ =>
-        dataSourceRepository.updateDataSource(dataSource)
-      }
-    }
+  def updateDataSource(dataSource: DataSource): Fox[Unit] = {
+    for {
+      _ <- validateDataSource(dataSource).toFox
+      propertiesFile = dataBaseDir.resolve(dataSource.id.team).resolve(dataSource.id.name).resolve(propertiesFileName)
+      _ = JsonHelper.jsonToFile(propertiesFile, dataSource)
+      _ <- dataSourceRepository.updateDataSource(dataSource)
+    } yield ()
   }
 
   private def teamAwareInboxSources(path: Path): List[InboxDataSource] = {


### PR DESCRIPTION
Changes the datastore to reply to the upload and update requests only when its steps are complete.
Also changes the frontend api calls to wait for the request. This should also fix that the refresh button sometimes needed to be clicked twice

### Mailable description of changes:
 - Fix: dataset upload no longer prematurely reports success

### Steps to test:
- upload a (potentially large) dataset
- import view should come up only after everything is properly unpacked and reported to wK – meaning that its initial requests should not fail and json data should be displayed

### Issues:
- fixes #2564
- fixes #2582

------
- [x] Ready for review
