### PR TITLE
guess bounding box from correct resolution dir. remove duplicate methods

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceImporter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceImporter.scala
@@ -67,11 +67,9 @@ trait DataSourceImporter {
       case Some(resolutionInt) => Some(Left(resolutionInt))
       case None => {
         val pattern = """(\d+)-(\d+)-(\d+)""".r
-        try {
-          val pattern(x, y, z) = path.getFileName.toString
-          Some(Right(Point3D(x.toInt, y.toInt, z.toInt)))
-        } catch {
-          case e: Exception => None
+        path.getFileName.toString match {
+          case pattern(x, y, z) => Some(Right(Point3D(x.toInt, y.toInt, z.toInt)))
+          case _ => None
         }
       }
     }


### PR DESCRIPTION
### Mailable description of changes:
 - Fix: in wkw dataset import, ensure that the bounding box is always guessed from the right resolution directory

### Steps to test:
- import a wkw dataset that has no datasource-properties.json
- guessed bounding box should be large enough (usually 1024 × number of cubes per dimension)

### Issues:
- fixes #2459

------
- [x] Ready for review
