### PR TITLE
sbt start script: set default exit_code

### DIFF
--- a/sbt
+++ b/sbt
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+exit_code=1
 trap 'exit $exit_code' INT TERM
 trap 'exit_code=$?; kill 0' EXIT
 


### PR DESCRIPTION
### Steps to test:
- running the script and exiting with ctrl-c (probably very fast) quits normally (with an exit code of 1) (so #2584 should be fixed)
- running the script with a finite program (e.g. clean/compile/stage) behaves normally

### Issues:
- fixes #2584

------
- [x] Ready for review
