### PR TITLE
clean up NMLParseResult logic

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -38,6 +38,9 @@ class AnnotationIOController @Inject()(val messagesApi: MessagesApi)
     else
       None
 
+  private def descriptionForNMLs(descriptions: Seq[Option[String]]) =
+    if (descriptions.size == 1) descriptions.headOption.flatten.getOrElse("") else ""
+
 
   def upload = SecuredAction.async(parse.multipartFormData) { implicit request =>
 
@@ -68,28 +71,29 @@ class AnnotationIOController @Inject()(val messagesApi: MessagesApi)
 
     val parseResultsPrefixed = NmlService.addPrefixesToTreeNames(parsedFiles.parseResults)
 
+    val parseSuccess = parseResultsPrefixed.filter(_.succeeded)
+
     if (!parsedFiles.isEmpty) {
-      val parseSuccess = parseResultsPrefixed.filter(_.succeeded)
-      val fileNames = parseSuccess.map(_.fileName)
       val tracings = parseSuccess.flatMap(_.tracing)
       val (skeletonTracings, volumeTracings) = NmlService.splitVolumeAndSkeletonTracings(tracings)
-      val name = nameForNmls(fileNames)
+      val name = nameForNmls(parseSuccess.map(_.fileName))
+      val description = descriptionForNMLs(parseSuccess.map(_.description))
       if (volumeTracings.nonEmpty) {
         for {
           dataSet: DataSet <- DataSetDAO.findOneBySourceName(volumeTracings.head._1.dataSetName).toFox ?~> Messages("dataSet.notFound", volumeTracings.head._1.dataSetName)
           tracingReference <- dataSet.dataStore.saveVolumeTracing(volumeTracings.head._1, parsedFiles.otherFiles.get(volumeTracings.head._2).map(_.file))
           annotation <- AnnotationService.createFrom(
-            request.identity, dataSet, tracingReference, AnnotationType.Explorational, AnnotationSettings.defaultFor(tracingReference.typ), name, volumeTracings.head._3)
+            request.identity, dataSet, tracingReference, AnnotationType.Explorational, AnnotationSettings.defaultFor(tracingReference.typ), name, description)
         } yield JsonOk(
           Json.obj("annotation" -> Json.obj("typ" -> annotation.typ, "id" -> annotation.id)),
           Messages("nml.file.uploadSuccess")
         )
       } else if (skeletonTracings.nonEmpty) {
         for {
-          dataSet: DataSet <- DataSetDAO.findOneBySourceName(skeletonTracings.head._1.dataSetName).toFox ?~> Messages("dataSet.notFound", skeletonTracings.head._1.dataSetName)
-          mergedTracingReference <- storeMergedSkeletonTracing(skeletonTracings.map(_._1), dataSet)
+          dataSet: DataSet <- DataSetDAO.findOneBySourceName(skeletonTracings.head.dataSetName).toFox ?~> Messages("dataSet.notFound", skeletonTracings.head.dataSetName)
+          mergedTracingReference <- storeMergedSkeletonTracing(skeletonTracings, dataSet)
           annotation <- AnnotationService.createFrom(
-            request.identity, dataSet, mergedTracingReference, AnnotationType.Explorational, AnnotationSettings.defaultFor(mergedTracingReference.typ), name, skeletonTracings.head._2)
+            request.identity, dataSet, mergedTracingReference, AnnotationType.Explorational, AnnotationSettings.defaultFor(mergedTracingReference.typ), name, description)
         } yield JsonOk(
           Json.obj("annotation" -> Json.obj("typ" -> annotation.typ, "id" -> annotation.id)),
           Messages("nml.file.uploadSuccess")

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -38,7 +38,10 @@ case class TaskParameters(
                            boundingBox: Option[BoundingBox],
                            dataSet: String,
                            editPosition: Point3D,
-                           editRotation: Vector3D)
+                           editRotation: Vector3D,
+                           creationInfo: Option[String],
+                           description: Option[String]
+                         )
 
 object TaskParameters {
   implicit val taskParametersFormat: Format[TaskParameters] = Json.format[TaskParameters]
@@ -78,12 +81,11 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
   def create = SecuredAction.async(validateJson[List[TaskParameters]]) { implicit request =>
     createTasks(request.body.map { params =>
       val tracing = AnnotationService.createTracingBase(params.dataSet, params.boundingBox, params.editPosition, params.editRotation)
-      (params, tracing, None, None)
+      (params, tracing)
     })
   }
 
   def createFromFile = SecuredAction.async { implicit request =>
-
     for {
       body <- request.body.asMultipartFormData ?~> Messages("invalid")
       inputFile <- body.file("nmlFile[]") ?~> Messages("nml.file.notFound")
@@ -94,24 +96,14 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
       team <- TeamDAO.findOneByName(params.teamName) ?~> Messages("team.notFound")
       _ <- ensureTeamAdministration(request.identity, team._id)
       parseResults: List[NmlService.NmlParseResult] = NmlService.extractFromFile(inputFile.ref.file, inputFile.filename).parseResults
-      namedTracingFoxes = parseResults.map(parseResultToSkeletonTracingFox)
-      namedTracings <- Fox.combined(namedTracingFoxes) ?~> Messages("task.create.failed")
-      result <- createTasks(namedTracings.map(t => (buildFullParams(params, t._1), t._1, Some(t._2), Some(t._3))))
+      skeletonSuccesses <- Fox.serialCombined(parseResults)(_.toSkeletonSuccessFox) ?~> Messages("task.create.failed")
+      result <- createTasks(skeletonSuccesses.map(s => (buildFullParams(params, s.tracing.get.left.get, s.fileName, s.description), s.tracing.get.left.get)))
     } yield {
       result
     }
   }
 
-  private def parseResultToSkeletonTracingFox(parseResult: NmlService.NmlParseResult): Fox[(SkeletonTracing, String, String)] = parseResult match {
-    case NmlService.NmlParseFailure(fileName, error) =>
-      Fox.failure(Messages("nml.file.invalid", fileName, error))
-    case NmlService.NmlParseSuccess(fileName, (Left(skeletonTracing), description)) =>
-      Fox.successful((skeletonTracing, fileName, description))
-    case _ =>
-      Fox.failure(Messages("nml.file.invalid"))
-  }
-
-  private def buildFullParams(nmlParams: NmlTaskParameters, tracing: SkeletonTracing) = {
+  private def buildFullParams(nmlParams: NmlTaskParameters, tracing: SkeletonTracing, fileName: String, description: Option[String]) = {
     TaskParameters(
       nmlParams.taskTypeId,
       nmlParams.neededExperience,
@@ -122,12 +114,15 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
       nmlParams.boundingBox,
       tracing.dataSetName,
       tracing.editPosition,
-      tracing.editRotation)
+      tracing.editRotation,
+      Some(fileName),
+      description
+    )
   }
 
-  def createTasks(requestedTasks: List[(TaskParameters, SkeletonTracing, Option[String], Option[String])])(implicit request: SecuredRequest[_]): Fox[Result] = {
+  def createTasks(requestedTasks: List[(TaskParameters, SkeletonTracing)])(implicit request: SecuredRequest[_]): Fox[Result] = {
     def assertAllOnSameDataset(): Fox[String] = {
-      def allOnSameDatasetIter(requestedTasksRest: List[(TaskParameters, SkeletonTracing, Option[String], Option[String])], dataSetName: String): Boolean = {
+      def allOnSameDatasetIter(requestedTasksRest: List[(TaskParameters, SkeletonTracing)], dataSetName: String): Boolean = {
         requestedTasksRest match {
           case List() => true
           case head :: tail => head._1.dataSet == dataSetName && allOnSameDatasetIter(tail, dataSetName)
@@ -145,14 +140,14 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
       dataSetName <- assertAllOnSameDataset()
       dataSet <- DataSetDAO.findOneBySourceName(requestedTasks.head._1.dataSet) ?~> Messages("dataSet.notFound", dataSetName)
       tracingReferences: List[Box[TracingReference]] <- dataSet.dataStore.saveSkeletonTracings(SkeletonTracings(requestedTasks.map(_._2)))
-      taskObjects: List[Fox[Task]] = requestedTasks.map(r => createTaskWithoutAnnotationBase(r._1, r._3))
+      taskObjects: List[Fox[Task]] = requestedTasks.map(r => createTaskWithoutAnnotationBase(r._1))
       zipped = (requestedTasks, tracingReferences, taskObjects).zipped.toList
       annotationBases = zipped.map(tuple => AnnotationService.createAnnotationBase(
         taskFox = tuple._3,
         request.identity._id,
         tracingReferenceBox = tuple._2,
         dataSetName,
-        description = tuple._1._4
+        description = tuple._1._1.description
       ))
       zippedTasksAndAnnotations = taskObjects zip annotationBases
       taskJsons = zippedTasksAndAnnotations.map(tuple => Task.transformToJsonFoxed(tuple._1, tuple._2))
@@ -175,7 +170,7 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
     }
   }
 
-  private def createTaskWithoutAnnotationBase(params: TaskParameters, creationInfo: Option[String])(implicit request: SecuredRequest[_]): Fox[Task] = {
+  private def createTaskWithoutAnnotationBase(params: TaskParameters)(implicit request: SecuredRequest[_]): Fox[Task] = {
     for {
       taskType <- TaskTypeDAO.findOneById(params.taskTypeId) ?~> Messages("taskType.notFound")
       project <- ProjectDAO.findOneByName(params.projectName) ?~> Messages("project.notFound", params.projectName)
@@ -194,7 +189,7 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
         editRotation = params.editRotation,
         boundingBox = params.boundingBox.flatMap { box => if (box.isEmpty) None else Some(box) },
         priority = if (project.paused) -1 else project.priority,
-        creationInfo = creationInfo)
+        creationInfo = params.creationInfo)
       _ <- TaskService.insert(task, project)
     } yield task
   }


### PR DESCRIPTION
Attempting to get rid of some of the nested tuples in NML-based task creation

(based on #2617, pls change base to master if that one is merged first)

### Steps to test:
- upload explorative annotation (volume, skeleton, zip with multiple skeletons)
- create tasks (form-only, with single NML, with multi-NML-zip, in bulk)
- should work (and have expected description)

### Issues:
- fixes #2618

------
- [x] Ready for review
