### PR TITLE
Enable NML downloads even if Datasource is unusable (write Scale -1)

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -122,21 +122,19 @@ class AnnotationIOController @Inject()(val messagesApi: MessagesApi)
     def skeletonToDownloadStream(dataSet: DataSet, annotation: Annotation, name: String) = {
       for {
         tracing <- dataSet.dataStore.getSkeletonTracing(annotation.tracingReference)
-        scale <- dataSet.dataSource.scaleOpt ?~> Messages("nml.scaleNotFound")
       } yield {
-        (NmlWriter.toNmlStream(Left(tracing), annotation, scale), name + ".nml")
+        (NmlWriter.toNmlStream(Left(tracing), annotation, dataSet.dataSource.scaleOpt), name + ".nml")
       }
     }
 
     def volumeToDownloadStream(dataSet: DataSet, annotation: Annotation, name: String) = {
       for {
         (tracing, data) <- dataSet.dataStore.getVolumeTracing(annotation.tracingReference)
-        scale <- dataSet.dataSource.scaleOpt
       } yield {
         (Enumerator.outputStream { outputStream =>
           ZipIO.zip(
             List(
-              new NamedEnumeratorStream(name + ".nml", NmlWriter.toNmlStream(Right(tracing), annotation, scale)),
+              new NamedEnumeratorStream(name + ".nml", NmlWriter.toNmlStream(Right(tracing), annotation, dataSet.dataSource.scaleOpt)),
               new NamedEnumeratorStream("data.zip", data)
             ), outputStream)
         }, name + ".zip")

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -240,7 +240,7 @@ object AnnotationService
     ((l1, l2, l3).zipped.toList, l4).zipped.toList.map( tuple => (tuple._1._1, tuple._1._2, tuple._1._3, tuple._2))
   }
 
-  private def getTracingsScalesAndNamesFor(annotations: List[Annotation])(implicit ctx: DBAccessContext): Fox[List[(List[SkeletonTracing], List[String], List[Scale], List[Annotation])]] = {
+  private def getTracingsScalesAndNamesFor(annotations: List[Annotation])(implicit ctx: DBAccessContext): Fox[List[(List[SkeletonTracing], List[String], List[Option[Scale]], List[Annotation])]] = {
 
     def getTracings(dataSetName: String, tracingReferences: List[TracingReference]) = {
       for {
@@ -252,8 +252,7 @@ object AnnotationService
     def getDatasetScale(dataSetName: String) = {
       for {
         dataSet <- DataSetDAO.findOneBySourceName(dataSetName)
-        scale <- dataSet.dataSource.scaleOpt ?~> Messages("nml.scaleNotFound")
-      } yield scale
+      } yield dataSet.dataSource.scaleOpt
     }
 
     def getNames(annotations: List[Annotation]) = Fox.combined(annotations.map(a => SavedTracingInformationHandler.nameForAnnotation(a).toFox))

--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
 object NmlWriter extends FoxImplicits {
   private lazy val outputService = XMLOutputFactory.newInstance()
 
-  def toNmlStream(tracing: Either[SkeletonTracing, VolumeTracing], annotation: Annotation, scale: Scale) = Enumerator.outputStream { os =>
+  def toNmlStream(tracing: Either[SkeletonTracing, VolumeTracing], annotation: Annotation, scale: Option[Scale]) = Enumerator.outputStream { os =>
     implicit val writer = new IndentingXMLStreamWriter(outputService.createXMLStreamWriter(os))
 
     for {
@@ -33,7 +33,7 @@ object NmlWriter extends FoxImplicits {
     }
   }
 
-  def toNml(tracing: Either[SkeletonTracing, VolumeTracing], annotation: Annotation, scale: Scale)(implicit writer: XMLStreamWriter): Fox[Unit] = {
+  def toNml(tracing: Either[SkeletonTracing, VolumeTracing], annotation: Annotation, scale: Option[Scale])(implicit writer: XMLStreamWriter): Fox[Unit] = {
     tracing match {
       case Right(volumeTracing) => {
         for {
@@ -52,7 +52,7 @@ object NmlWriter extends FoxImplicits {
     }
   }
 
-  def writeVolumeThings(annotation: Annotation, volumeTracing: VolumeTracing, scale: Scale)(implicit writer: XMLStreamWriter): Fox[Unit] = {
+  def writeVolumeThings(annotation: Annotation, volumeTracing: VolumeTracing, scale: Option[Scale])(implicit writer: XMLStreamWriter): Fox[Unit] = {
     for {
       _ <- writeMetaData(annotation)
       _ = Xml.withinElementSync("parameters")(writeParametersAsXml(volumeTracing, annotation.description, scale))
@@ -62,7 +62,7 @@ object NmlWriter extends FoxImplicits {
     } yield ()
   }
 
-  def writeSkeletonThings(annotation: Annotation, skeletonTracing: SkeletonTracing, scale: Scale)(implicit writer: XMLStreamWriter): Fox[Unit] = {
+  def writeSkeletonThings(annotation: Annotation, skeletonTracing: SkeletonTracing, scale: Option[Scale])(implicit writer: XMLStreamWriter): Fox[Unit] = {
     for {
       _ <- writeMetaData(annotation)
       _ = Xml.withinElementSync("parameters")(writeParametersAsXml(skeletonTracing, annotation.description, scale))
@@ -73,15 +73,15 @@ object NmlWriter extends FoxImplicits {
     } yield ()
   }
 
-  def writeParametersAsXml(tracing: SkeletonTracing, description: String, scale: Scale)(implicit writer: XMLStreamWriter) = {
+  def writeParametersAsXml(tracing: SkeletonTracing, description: String, scale: Option[Scale])(implicit writer: XMLStreamWriter) = {
     Xml.withinElementSync("experiment") {
       writer.writeAttribute("name", tracing.dataSetName)
       writer.writeAttribute("description", description)
     }
     Xml.withinElementSync("scale") {
-      writer.writeAttribute("x", scale.x.toString)
-      writer.writeAttribute("y", scale.y.toString)
-      writer.writeAttribute("z", scale.z.toString)
+      writer.writeAttribute("x", scale.map(_.x).getOrElse(-1).toString)
+      writer.writeAttribute("y", scale.map(_.y).getOrElse(-1).toString)
+      writer.writeAttribute("z", scale.map(_.z).getOrElse(-1).toString)
     }
     Xml.withinElementSync("offset") {
       writer.writeAttribute("x", "0")
@@ -121,15 +121,15 @@ object NmlWriter extends FoxImplicits {
     }
   }
 
-  def writeParametersAsXml(tracing: VolumeTracing, description: String, scale: Scale)(implicit writer: XMLStreamWriter) = {
+  def writeParametersAsXml(tracing: VolumeTracing, description: String, scale: Option[Scale])(implicit writer: XMLStreamWriter) = {
     Xml.withinElementSync("experiment") {
       writer.writeAttribute("name", tracing.dataSetName)
       writer.writeAttribute("description", description)
     }
     Xml.withinElementSync("scale") {
-      writer.writeAttribute("x", scale.x.toString)
-      writer.writeAttribute("y", scale.y.toString)
-      writer.writeAttribute("z", scale.z.toString)
+      writer.writeAttribute("x", scale.map(_.x).getOrElse(-1).toString)
+      writer.writeAttribute("y", scale.map(_.y).getOrElse(-1).toString)
+      writer.writeAttribute("z", scale.map(_.z).getOrElse(-1).toString)
     }
     Xml.withinElementSync("offset") {
       writer.writeAttribute("x", "0")


### PR DESCRIPTION
### Mailable description of changes:
 - Enabled NML downloads even if dataset is no longer available. Will result in `<scale x="-1" y="-1" z="-1" />`

### Steps to test:
- create tasks + explorational annotation
- download them, scale should be in NML
- rename dataset they were created on, press refresh in dataset gallery
- download them again, you should get NMLs, scale should be -1 as described above

### Issues:
- fixes #2622

------
- [x] Ready for review
