### PR TITLE
Secure docker login in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       - run:
           name: Push docker images
           command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
             docker tag \
               scalableminds/webknossos:${CIRCLE_BRANCH}__${CIRCLE_BUILD_NUM} \
               scalableminds/webknossos:${CIRCLE_BRANCH}


### PR DESCRIPTION
`docker login` with password as param is considered insecure.

### Steps to test:
- see CI 

------
- [x] Ready for review
