### PR TITLE
In User update, check Organization Team Membership of correct User

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -205,7 +205,7 @@ class UserController @Inject()(val messagesApi: MessagesApi)
           teamsWithUpdate = assignedMembershipWTeams.filter(t => issuingUser.isTeamManagerOfBLOCKING(t._1._id))
           _ <- ensureProperTeamAdministration(user, teamsWithUpdate)
           trimmedExperiences = experiences.map { case (key, value) => key.trim -> value }
-          updatedTeams <- ensureOrganizationTeamIsPresent(issuingUser, teamsWithUpdate.map(_._1) ++ teamsWithoutUpdate)
+          updatedTeams <- ensureOrganizationTeamIsPresent(user, teamsWithUpdate.map(_._1) ++ teamsWithoutUpdate)
           updatedUser <- UserService.update(user, firstName.trim, lastName.trim, email, isActive, isAdmin, updatedTeams, trimmedExperiences)
         } yield {
           Ok(User.userPublicWrites(request.identity).writes(updatedUser))


### PR DESCRIPTION
### Steps to test:
- create user, make them User (but not teammanager) of the orga team
- in the edit-teams dialogue, attempt to remove the orga team from their memberships
- should still be there (in particular, should still be User but not teammanager)

### Issues:
- fixes #2667

------
- [x] Ready for review
