### PR TITLE
fix extractReleaseNotes script

### DIFF
--- a/tools/extractReleaseNotes.js
+++ b/tools/extractReleaseNotes.js
@@ -7,7 +7,7 @@ const CACHED_RESPONSE_PATH = "";
 
 // Search for Mailable description, then any text until the : and a newline
 // Then match any text: [^]* is used in javascript to match any character including newlines
-const RELEASE_NOTES_REGEX = /Mailable description[^:]*:\r?\n([^]*)/;
+const RELEASE_NOTES_REGEX = /^Mailable description[^:]*:\r?\n([^]*)/;
 
 (async () => {
   let parsedJSON;


### PR DESCRIPTION
This PR fixes the release notes script. The script splits a PR description into paragraphs (`.split("###")`). The following regex didn't enforce that the Mailable Description headline needed to be at the beginning of such a paragraph then.

------
- [x] Ready for review
