### PR TITLE
Fix node selection & 3d viewport rotation/zooming & shortcuts

### DIFF
--- a/app/assets/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
@@ -80,14 +80,13 @@ class SkeletonTracingPlaneController extends PlaneControllerClass {
   }
 
   getKeyboardControls(): Object {
-    return {
+    return _.extend(super.getKeyboardControls(), {
       "1": () => Store.dispatch(toggleAllTreesAction()),
       "2": () => Store.dispatch(toggleInactiveTreesAction()),
 
       // Delete active node
       delete: () => Store.dispatch(deleteNodeWithConfirmAction()),
       c: () => Store.dispatch(createTreeAction()),
-
       // Branches
       b: () => Store.dispatch(createBranchPointAction()),
       j: () => Store.dispatch(requestDeleteBranchPointAction()),
@@ -96,7 +95,7 @@ class SkeletonTracingPlaneController extends PlaneControllerClass {
         api.tracing.centerNode();
         api.tracing.centerTDView();
       },
-    };
+    });
   }
 
   scrollPlanes(delta: number, type: ?ModifierKeys): void {
@@ -127,7 +126,10 @@ class SkeletonTracingPlaneController extends PlaneControllerClass {
     const pickingScene = new THREE.Scene();
     pickingScene.add(pickingNode);
 
-    const { width, height } = getInputCatcherRect(plane);
+    let { width, height } = getInputCatcherRect(plane);
+    width = Math.round(width);
+    height = Math.round(height);
+
     const buffer = this.planeView.renderOrthoViewToTexture(plane, pickingScene);
     // Beware of the fact that new browsers yield float numbers for the mouse position
     const [x, y] = [Math.round(position.x), Math.round(position.y)];

--- a/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/combinations/volumetracing_plane_controller.js
@@ -207,7 +207,7 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
   }
 
   getKeyboardControls(): Object {
-    return {
+    return _.extend(super.getKeyboardControls(), {
       c: () => Store.dispatch(createCellAction()),
       "ctrl + i": async event => {
         const mousePosition = Store.getState().temporaryConfiguration.mousePosition;
@@ -223,7 +223,7 @@ class VolumeTracingPlaneController extends PlaneControllerClass {
           Toast.warning("No cell under cursor.");
         }
       },
-    };
+    });
   }
 
   handleCellSelection(cellId: number) {

--- a/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -11,7 +11,7 @@ import _ from "lodash";
 import Utils from "libs/utils";
 import Toast from "libs/toast";
 import { document } from "libs/window";
-import { InputMouse, InputKeyboard } from "libs/input";
+import { InputMouse, InputKeyboard, InputKeyboardNoLoop } from "libs/input";
 import * as THREE from "three";
 import TrackballControls from "libs/trackball_controls";
 import Model from "oxalis/model";
@@ -70,6 +70,7 @@ class PlaneController extends React.PureComponent<Props> {
     mouseControllers: OrthoViewMapType<InputMouse>,
     keyboard?: InputKeyboard,
     keyboardLoopDelayed?: InputKeyboard,
+    keyboardNoLoop?: InputKeyboardNoLoop,
   };
   storePropertyUnsubscribers: Array<Function>;
   isStarted: boolean;
@@ -262,6 +263,8 @@ class PlaneController extends React.PureComponent<Props> {
       { delay: Store.getState().userConfiguration.keyboardDelay },
     );
 
+    this.input.keyboardNoLoop = new InputKeyboardNoLoop(this.getKeyboardControls());
+
     this.storePropertyUnsubscribers.push(
       listenToStoreProperty(
         state => state.userConfiguration.keyboardDelay,
@@ -273,6 +276,10 @@ class PlaneController extends React.PureComponent<Props> {
         },
       ),
     );
+  }
+
+  getKeyboardControls(): Object {
+    return {};
   }
 
   init(): void {
@@ -472,6 +479,7 @@ class PlaneController extends React.PureComponent<Props> {
     }
     this.input.mouseControllers = {};
     Utils.__guard__(this.input.keyboard, x => x.destroy());
+    Utils.__guard__(this.input.keyboardNoLoop, x1 => x1.destroy());
     Utils.__guard__(this.input.keyboardLoopDelayed, x2 => x2.destroy());
     this.unsubscribeStoreListeners();
   }

--- a/app/assets/javascripts/oxalis/view/input_catcher.js
+++ b/app/assets/javascripts/oxalis/view/input_catcher.js
@@ -29,7 +29,7 @@ function makeInputCatcherQuadratic(inputCatcherDOM: HTMLElement): Rect {
     height: wrapperHeight,
   } = noneOverflowWrapper.getBoundingClientRect();
 
-  const squareExtent = Math.min(wrapperWidth - 10, wrapperHeight - 10);
+  const squareExtent = Math.round(Math.min(wrapperWidth - 10, wrapperHeight - 10));
   inputCatcherDOM.style.width = `${squareExtent}px`;
   inputCatcherDOM.style.height = `${squareExtent}px`;
 

--- a/app/assets/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/app/assets/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -78,6 +78,12 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
     Toast.error(messages["react.rendering_error"]);
   }
 
+  onLayoutChange = (layoutConfig, layoutKey) => {
+    recalculateInputCatcherSizes();
+    window.needsRerender = true;
+    storeLayoutConfig(layoutConfig, layoutKey);
+  };
+
   render() {
     const layoutType = determineLayout(this.props.initialControlmode, this.props.viewMode);
 
@@ -124,11 +130,7 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
                 style={{ display: "block", height: "100%", width: "100%", flex: "1 1 auto" }}
                 layoutKey={layoutType}
                 layoutConfigGetter={getLayoutConfig}
-                onLayoutChange={(layoutConfig, layoutKey) => {
-                  recalculateInputCatcherSizes();
-                  window.needsRerender = true;
-                  storeLayoutConfig(layoutConfig, layoutKey);
-                }}
+                onLayoutChange={this.onLayoutChange}
               >
                 {/*
                    * All possible layout panes are passed here. Depending on the actual layout,

--- a/app/assets/javascripts/oxalis/view/plane_view.js
+++ b/app/assets/javascripts/oxalis/view/plane_view.js
@@ -107,7 +107,10 @@ class PlaneView {
     const { renderer } = SceneController;
 
     renderer.autoClear = true;
-    const { width, height } = getInputCatcherRect(plane);
+    let { width, height } = getInputCatcherRect(plane);
+    width = Math.round(width);
+    height = Math.round(height);
+
     renderer.setViewport(0, 0, width, height);
     renderer.setScissorTest(false);
     renderer.setClearColor(0x000000, 1);


### PR DESCRIPTION
### Mailable description of changes:
 - Fix regression affecting node selection, shortcuts and 3d viewport navigation

### Steps to test:
- select nodes with shift + click
- rotate viewport (toggle settings in between)
- use shortcuts like c for creating a cell for a skeleton

### Issues:
- fixes https://discuss.webknossos.org/t/selecting-nodes-in-3d-viewport/918/3

------
- [X] Ready for review
