### PR TITLE
Add dev instance url to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,9 @@
  - **If the PR is not relevant to the mailing list, remove this whole paragraph.**
  - e.g. *- Deleting large trees will no longer cause webknossos to freeze.*
 
+### URL of deployed dev instance (used for testing):
+- `http://___.webknossos.xyz`
+
 ### Steps to test:
 - abc
 


### PR DESCRIPTION
To simplify the testing process during review, I added a field for the url of a deployed dev instance to the PR template. I think, it's a good best practice to always include such an url so that reviewers can quickly load the version which should be tested. This also encourages testing with the right prod setup.

------
- [X] Ready for review
