### PR TITLE
Fix CORS header for health check request

### DIFF
--- a/app/assets/javascripts/admin/datastore_health_check.js
+++ b/app/assets/javascripts/admin/datastore_health_check.js
@@ -26,7 +26,7 @@ export const pingDataStoreIfAppropriate = memoizedThrottle(async (requestedUrl: 
   if (usedDataStore != null) {
     const { url } = usedDataStore;
     const healthEndpoint = `${url}/data/health`;
-    Request.triggerRequest(healthEndpoint, { doNotCatch: true, mode: "cors" }).catch(() => {
+    Request.triggerRequest(healthEndpoint, { doNotCatch: true, mode: "cors", timeout: 5000 }).catch(() => {
       Toast.warning(messages["datastore.health"]({ url }));
     });
   }

--- a/app/assets/javascripts/admin/datastore_health_check.js
+++ b/app/assets/javascripts/admin/datastore_health_check.js
@@ -26,9 +26,11 @@ export const pingDataStoreIfAppropriate = memoizedThrottle(async (requestedUrl: 
   if (usedDataStore != null) {
     const { url } = usedDataStore;
     const healthEndpoint = `${url}/data/health`;
-    Request.triggerRequest(healthEndpoint, { doNotCatch: true, mode: "cors", timeout: 5000 }).catch(() => {
-      Toast.warning(messages["datastore.health"]({ url }));
-    });
+    Request.triggerRequest(healthEndpoint, { doNotCatch: true, mode: "cors", timeout: 5000 }).catch(
+      () => {
+        Toast.warning(messages["datastore.health"]({ url }));
+      },
+    );
   }
 }, 5000);
 

--- a/app/assets/javascripts/admin/datastore_health_check.js
+++ b/app/assets/javascripts/admin/datastore_health_check.js
@@ -26,7 +26,7 @@ export const pingDataStoreIfAppropriate = memoizedThrottle(async (requestedUrl: 
   if (usedDataStore != null) {
     const { url } = usedDataStore;
     const healthEndpoint = `${url}/data/health`;
-    Request.triggerRequest(healthEndpoint, { doNotCatch: true, mode: "no-cors" }).catch(() => {
+    Request.triggerRequest(healthEndpoint, { doNotCatch: true, mode: "cors" }).catch(() => {
       Toast.warning(messages["datastore.health"]({ url }));
     });
   }

--- a/app/assets/javascripts/admin/datastore_health_check.js
+++ b/app/assets/javascripts/admin/datastore_health_check.js
@@ -26,7 +26,7 @@ export const pingDataStoreIfAppropriate = memoizedThrottle(async (requestedUrl: 
   if (usedDataStore != null) {
     const { url } = usedDataStore;
     const healthEndpoint = `${url}/data/health`;
-    Request.triggerRequest(healthEndpoint, { doNotCatch: true }).catch(() => {
+    Request.triggerRequest(healthEndpoint, { doNotCatch: true, mode: "no-cors" }).catch(() => {
       Toast.warning(messages["datastore.health"]({ url }));
     });
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
@@ -10,6 +10,8 @@ import play.api.mvc.Action
 
 class Application @Inject()(val messagesApi: MessagesApi) extends Controller {
 
-  def health = Action { implicit request => Ok }
+  def health = Action { implicit request =>
+    AllowRemoteOrigin { Ok }
+  }
 
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- `http://fixcors.webknossos.xyz`

### Steps to test:
- @fm3 and I tested this locally by setting up the local datastore. For review, it should suffice to use the deployed dev instance (which doesn't have a separate datastore) to ensure that requests work as usual (no need to check the datastore-is-down-case).

### Issues:
- fixes #2679

------
- [X] Ready for review
