### PR TITLE
Make unfinished work warning more drastic

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -17,7 +17,7 @@ In order to restore the current window, a reload is necessary.`,
   "react.rendering_error":
     "Unfortunately, we encountered an error during rendering. We cannot guarantee that your work is persisted. Please reload the page and try again.",
   "save.leave_page_unfinished":
-    "You haven't saved your progress, please give us 2 seconds to do so and and then leave this site.",
+    "WARNING: You have unsaved progress that may be lost when hitting OK. Please click cancel, wait until the progress is saved and the save button displays a checkmark before leaving the page..",
   "save.failed": "Failed to save tracing. Retrying.",
   "undo.no_undo": "There is no action that could be undone.",
   "undo.no_redo": "There is no action that could be redone.",


### PR DESCRIPTION
The onbeforeleave message will be deprecated very soon (I think, most current browsers don't support it anymore), but the current message is quite permisse, which is why I'd suggest to change it anyway.

### Issues:
- contributes #2669

------
- [X] Ready for review
