### PR TITLE
Fix renaming of trees with no name

### DIFF
--- a/app/assets/javascripts/oxalis/model/sagas/skeletontracing_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/skeletontracing_saga.js
@@ -97,8 +97,8 @@ export function* watchTreeNames(): Generator<*, *, *> {
 }
 
 export function* watchSkeletonTracingAsync(): Generator<*, *, *> {
-  yield takeEvery(["INITIALIZE_SKELETONTRACING"], watchTreeNames);
-  yield take("WK_READY");
+  yield take("INITIALIZE_SKELETONTRACING");
+  yield takeEvery("WK_READY", watchTreeNames);
   yield takeEvery(
     [
       "SET_ACTIVE_TREE",


### PR DESCRIPTION
Although trees with an empty name were renamed, they were not persisted. This PR fixes that by starting the respective tree-renaming saga later, so the save-saga is properly initialized beforehand.

### Mailable description of changes:
 - [Fix] Trees in a task will be correctly named again.

### URL of deployed dev instance (used for testing):
- http://fixemptrytreerename.webknossos.xyz

### Steps to test:
- Create some tasks. Open a task - the save button should show an hourglass.
  Press save and leave the page.
  Download the task on the dashboard, the nml should contain the correct tree name.

- Same should be the case if the task is started using the "Finish and get next task" button.

### Issues:
- fixes #2686

------
- [x] Ready for review
