### PR TITLE
Hotfix bucket loading order for ortho mode

### DIFF
--- a/app/assets/javascripts/oxalis/model/binary.js
+++ b/app/assets/javascripts/oxalis/model/binary.js
@@ -269,9 +269,11 @@ class Binary {
       );
 
       // In general, pull buckets which are not available but should be sent to the GPU
+      // Don't use -1 for ortho mode since this will make at the corner of the viewport more important than the ones in the middle
+      const missingBucketPriority = viewMode === constants.MODE_PLANE_TRACING ? 100 : -1;
       const missingBuckets = buckets
         .filter(bucket => !bucket.hasData())
-        .map(bucket => ({ bucket: bucket.zoomedAddress, priority: -1 }));
+        .map(bucket => ({ bucket: bucket.zoomedAddress, priority: missingBucketPriority }));
       this.pullQueue.addAll(missingBuckets);
       this.pullQueue.pull();
     }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- `http://___.webknossos.xyz`

### Steps to test:
- jump in ortho and arbitrary modes and ensure that the bucket loading order is sane (throttle the internet speed via dev tools)

### Issues:
- fixes #2678 

------
- [X] Ready for review
