### PR TITLE
Ensure that only buckets for existing zoom steps are pulled

### DIFF
--- a/app/assets/javascripts/oxalis/model/binary.js
+++ b/app/assets/javascripts/oxalis/model/binary.js
@@ -273,6 +273,7 @@ class Binary {
       const missingBucketPriority = constants.MODES_PLANE.includes(viewMode) ? 100 : -1;
       const missingBuckets = buckets
         .filter(bucket => !bucket.hasData())
+        .filter(bucket => bucket.zoomedAddress[3] <= this.cube.MAX_UNSAMPLED_ZOOM_STEP)
         .map(bucket => ({ bucket: bucket.zoomedAddress, priority: missingBucketPriority }));
       this.pullQueue.addAll(missingBuckets);
       this.pullQueue.pull();


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- `http://___.webknossos.xyz`

### Steps to test:
- load datasets and ensure that no errors are shown (the error originally only appeared for a special  dataset for some reason; for which I explicitly tested this)

### Issues:
- fixes #123

------
- [X] Ready for review
