### PR TITLE
only log time for 'Task' or 'Explorational'

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -43,7 +43,7 @@ class AnnotationController @Inject()(val messagesApi: MessagesApi)
         js <- annotation.toJson(request.identity, Some(restrictions), Some(readOnly))
       } yield {
         request.identity.foreach { user =>
-          TimeSpanService.logUserInteraction(user, annotation)            // log time when a user starts working
+          if (typ == "Task" || typ == "Explorational") TimeSpanService.logUserInteraction(user, annotation)            // log time when a user starts working
         }
         Ok(js)
       }


### PR DESCRIPTION
When going to Administration >> Project >> 'View' it tried to start logging the time (This only happens at the start). The Problem is that the AnnotationType is 'CompoundProject'. This means that the ID of the annotation is the ID of the project. This causes the SQL Query to fail.

### Steps to test:
1. get a Task and trace something
2. go to  Administration >> Project >> 'View' and look at the console. There should no (SQL) error appear.

### Issues:
- fixes #2702 
- contributes to #2488

------
- [x] Ready for review
