### PR TITLE
only use xyz components of segmentation id to check for zero

### DIFF
--- a/app/assets/javascripts/oxalis/shaders/main_data_fragment.glsl.js
+++ b/app/assets/javascripts/oxalis/shaders/main_data_fragment.glsl.js
@@ -194,7 +194,7 @@ void main() {
   <% } %>
 
   // Color map (<= to fight rounding mistakes)
-  if ( length(id) > 0.1 ) {
+  if ( length(id.xyz) > 0.1 ) {
     // Increase cell opacity when cell is hovered
     float hoverAlphaIncrement =
       // Hover cell only if it's the active one, if the feature is enabled


### PR DESCRIPTION
### Mailable description of changes:
 - Bug fix: Sometimes empty segmentation data was displayed red instead of transparent.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open segmentation, annotate / delete data. ensure that cell id === 0 is displayed transparent

------
- [X] Ready for review
