### PR TITLE
clearer message if task assignment fails due to dataset access rights

### DIFF
--- a/app/models/annotation/AnnotationMutations.scala
+++ b/app/models/annotation/AnnotationMutations.scala
@@ -7,6 +7,7 @@ import com.scalableminds.util.reactivemongo.DBAccessContext
 import com.scalableminds.util.tools.{BoxImplicits, Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.tracings.TracingType
 import models.annotation.AnnotationState._
+import models.binary.DataSetDAO
 import models.user.User
 import play.api.libs.concurrent.Execution.Implicits._
 
@@ -62,7 +63,8 @@ class AnnotationMutations(val annotation: Annotation) extends BoxImplicits with 
       for {
         task <- annotation.task.toFox
         annotationBase <- task.annotationBase
-        newTracingReference <- AnnotationService.tracingFromBase(annotationBase)
+        dataSet <- DataSetDAO.findOneBySourceName(annotationBase.dataSetName) ?~> ("Could not find DataSet " + annotation.dataSetName + ". Does your team have access?")
+        newTracingReference <- AnnotationService.tracingFromBase(annotationBase, dataSet)
         updatedAnnotation <- AnnotationDAO.updateTracingRefernce(annotation._id, newTracingReference)
       } yield {
         updatedAnnotation

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -140,9 +140,8 @@ object AnnotationService
     AnnotationDAO.findFor(user._id, isFinished, AnnotationType.Explorational, limit)
   }
 
-  def tracingFromBase(annotationBase: Annotation)(implicit ctx: DBAccessContext): Fox[TracingReference] = {
+  def tracingFromBase(annotationBase: Annotation, dataSet: DataSet)(implicit ctx: DBAccessContext): Fox[TracingReference] = {
     for {
-      dataSet: DataSet <- DataSetDAO.findOneBySourceName(annotationBase.dataSetName) ?~> ("Could not find DataSet " + annotationBase.dataSetName)
       dataSource <- dataSet.dataSource.toUsable.toFox ?~> "Could not convert to usable DataSource"
       newTracingReference <- dataSet.dataStore.duplicateSkeletonTracing(annotationBase.tracingReference)
     } yield newTracingReference
@@ -151,7 +150,8 @@ object AnnotationService
   def createAnnotationFor(user: User, task: Task, initializingAnnotationId: ObjectId)(implicit messages: Messages, ctx: DBAccessContext): Fox[Annotation] = {
     def useAsTemplateAndInsert(annotation: Annotation) = {
       for {
-        newTracing <- tracingFromBase(annotation) ?~> "Failed to create tracing from base"
+        dataSet <- DataSetDAO.findOneBySourceName(annotation.dataSetName) ?~> ("Could not find DataSet " + annotation.dataSetName + ". Does your team have access?")
+        newTracing <- tracingFromBase(annotation, dataSet) ?~> "Failed to use annotation base as template."
         newAnnotation = annotation.copy(
           _user = user._id,
           tracingReference = newTracing,
@@ -168,7 +168,7 @@ object AnnotationService
 
     for {
       annotationBase <- task.annotationBase ?~> "Failed to retrieve annotation base."
-      result <- useAsTemplateAndInsert(annotationBase).toFox ?~> "Failed to use annotation base as template."
+      result <- useAsTemplateAndInsert(annotationBase).toFox
     } yield {
       result
     }


### PR DESCRIPTION
until we can properly assert in task creation that users have access, maybe this is useful.

### Steps to test:
- create non-admin user + some tasks that he could get (matching experience etc)
- do not allow them to access the dataset
- he should get an understandable message

![image](https://user-images.githubusercontent.com/1390035/41289485-3dae55a8-6e4a-11e8-9f0c-db08ad45afec.png)


### Issues:
- contributes to #2719

------
- [x] Ready for review
