### PR TITLE
Fix task list in Firefox for low x resolutions (#2708)

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard_task_list_view.js
+++ b/app/assets/javascripts/dashboard/dashboard_task_list_view.js
@@ -318,6 +318,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
         pagination={{
           defaultPageSize: 50,
         }}
+        style={{ overflowX: "auto" }}
       >
         <Column
           title="ID"
@@ -329,13 +330,13 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
         <Column
           title="Type"
           dataIndex="type.summary"
-          width={200}
+          width={150}
           sorter={Utils.localeCompareBy(t => t.type.summary)}
         />
         <Column
           title="Project"
           dataIndex="projectName"
-          width={110}
+          width={150}
           sorter={Utils.localeCompareBy("projectName")}
         />
         <Column
@@ -355,6 +356,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
         <Column
           title="Modes"
           dataIndex="type.settings.allowedModes"
+          width={150}
           sorter={Utils.localeCompareBy(t => t.type.settings.allowedModes.join("-"))}
           render={modes => modes.map(mode => <Tag key={mode}>{mode}</Tag>)}
         />


### PR DESCRIPTION
This PR fixes that the actions were not visible in the dashboard task list for users with a low horizontal resolution in Firefox. Most of the other views where Antd Tables are used don't have that many columns, so I would say those are fine.

### URL of deployed dev instance (used for testing):
- https://fixtasklistwidth.webknossos.xyz/

### Steps to test:
- Open Firefox, create a task and click Get New Task on the Dashboard.
- The task actions for your task should be visible even when shrinking the window horizontally.

### Issues:
- fixes #2708

------
- [x] Ready for review
