### PR TITLE
allow teammanagers to create explorationals on datasets without allowed teams

### DIFF
--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -49,7 +49,7 @@ object AnnotationService
       case Some(selectedTeam) => Fox.successful(ObjectId.fromBsonId(selectedTeam))
       case None =>
         for {
-          _ <- user.isAdmin
+          _ <- (user.isTeamManagerInOrg(user.organization) || user.isAdmin)
           organization <- OrganizationSQLDAO.findOneByName(user.organization)
           organizationTeamId <- OrganizationSQLDAO.findOrganizationTeamId(organization._id)
         } yield organizationTeamId


### PR DESCRIPTION

### Mailable description of changes:
 - Team Managers are now allowed to create explorational tracings on datasets without allowed teams

### URL of deployed dev instance (used for testing):
- https://teammanagerexplorational.webknossos.xyz

### Steps to test:
- create user who is not admin but teammanager
- log in as that user, try to create explorational on dataset without allowed teams
- should work

### Issues:
- fixes #2757

------
- [x] Ready for review
