### PR TITLE
Render error chain in toast if provided

### DIFF
--- a/app/assets/stylesheets/main.less
+++ b/app/assets/stylesheets/main.less
@@ -228,3 +228,7 @@ img.img-50 {
     }
   }
 }
+
+.errorChainCollapse .ant-collapse-header {
+  padding: 12px 0 0 32px !important;
+}


### PR DESCRIPTION
### Mailable description of changes:
 - WebKnossos will show more debugging related information in case of unexpected errors. You can use the additional information when reporting the error.

### URL of deployed dev instance (used for testing):
- https://errorchainintoast.webknossos.xyz

### Steps to test:
- Apply this patch to produce errors with a chain:

```diff
diff --git a/app/models/annotation/Annotation.scala b/app/models/annotation/Annotation.scala
index a09636778..3b8609f1b 100755
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -58,7 +58,7 @@ case class AnnotationSQL(
     _task.toFox.flatMap(taskId => TaskSQLDAO.findOne(taskId)(GlobalAccessContext))
 
   def dataSet: Fox[DataSet] =
-    DataSetDAO.findOneById(_dataSet)(GlobalAccessContext) ?~> "dataSet.notFound"
+    Fox.failure("very long message. no datasets for annotations right now. very long message. no datasets for annotations right now. very long message. no datasets for annotations right now.")//DataSetDAO.findOneById(_dataSet)(GlobalAccessContext) ?~> "dataSet.notFound"
 
   val tracingType = tracing.typ
 
@@ -92,7 +92,7 @@ case class AnnotationSQL(
   def publicWrites(requestingUser: Option[User] = None, restrictions: Option[AnnotationRestrictions] = None, readOnly: Option[Boolean] = None)(implicit ctx: DBAccessContext): Fox[JsObject] = {
     for {
       taskJson <- task.flatMap(_.publicWrites).getOrElse(JsNull)
-      dataSet <- dataSet
+      dataSet <- dataSet ?~> "could not find dataset."
       userJson <- user.map(u => User.userCompactWrites.writes(u)).getOrElse(JsNull)
       settings <- findSettings
     } yield {
```
- Error chains should be shown like this:
![image](https://user-images.githubusercontent.com/2486553/41548690-f94836a2-7323-11e8-8f15-f01330655fab.png)
- When collapsed:
![image](https://user-images.githubusercontent.com/2486553/41548696-fcc6a23c-7323-11e8-9cbc-3aa2afa4f3c9.png)
- Toasts without error chains (e.g., getting a new task when there aren't any or hitting g/h in the tracing view for a success toast) should behave as usual

### Issues:
- fixes #2748

------
- [X] Ready for review
