### PR TITLE
Fix link from tasks list to task type

### DIFF
--- a/app/assets/javascripts/admin/tasktype/task_type_list_view.js
+++ b/app/assets/javascripts/admin/tasktype/task_type_list_view.js
@@ -19,6 +19,7 @@ const { Search } = Input;
 
 type Props = {
   history: RouterHistory,
+  initialSearchValue?: string,
 };
 
 type State = {
@@ -41,6 +42,11 @@ class TaskTypeListView extends React.PureComponent<Props, State> {
 
   componentWillMount() {
     this.setState(persistence.load(this.props.history));
+    if (this.props.initialSearchValue && this.props.initialSearchValue !== "") {
+      this.setState({
+        searchQuery: this.props.initialSearchValue,
+      });
+    }
   }
 
   componentDidMount() {

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -262,7 +262,10 @@ class ReactRouter extends React.Component<Props> {
               <SecuredRoute
                 isAuthenticated={isAuthenticated}
                 path="/taskTypes"
-                component={TaskTypeListView}
+                render={({ location }: ContextRouter) => (
+                  // Strip the leading # away. If there is no hash, "".slice(1) will evaluate to "", too.
+                  <TaskTypeListView initialSearchValue={location.hash.slice(1)} />
+                )}
                 exact
               />
               <SecuredRoute


### PR DESCRIPTION
Similar to #2759, but for links to task types.

### Mailable description of changes:
 - Fix: Clicking on a task type within the task list page was fixed so that the task type page will actually only show the linked task type.

### URL of deployed dev instance (used for testing):
- https://fixtasktypelink.webknossos.xyz

### Steps to test:
- click on the task type link within the task list view --> task type page should be loaded and search value should be filled with the task type name
- visit task types page via the navbar (everything should work)
- search for something in the task type page and reload the page --> search query should be persisted

------
- [X] Ready for review
