### PR TITLE
in task search, when filtered by user, show all un-cancelled instead of just active

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -244,7 +244,7 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
       projectNameOpt = (request.body \ "project").asOpt[String]
       taskIdsOpt <- Fox.runOptional((request.body \ "ids").asOpt[List[String]])(ids => Fox.serialCombined(ids)(ObjectId.parse))
       taskTypeIdOpt <- Fox.runOptional((request.body \ "taskType").asOpt[String])(ObjectId.parse(_))
-      tasks <- TaskSQLDAO.findAllByPojectAndTaskTypeAndIds(projectNameOpt, taskTypeIdOpt, taskIdsOpt, userIdOpt)
+      tasks <- TaskSQLDAO.findAllByPojectAndTaskTypeAndUserAndIds(projectNameOpt, taskTypeIdOpt, taskIdsOpt, userIdOpt)
       jsResult <- Fox.serialCombined(tasks)(_.publicWrites)
     } yield {
       Ok(Json.toJson(jsResult))

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -239,35 +239,15 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
 
   def listTasks = SecuredAction.async(parse.json) { implicit request =>
 
-    val userOpt = (request.body \ "user").asOpt[String]
-    val projectOpt = (request.body \ "project").asOpt[String]
-    val idsOpt = (request.body \ "ids").asOpt[List[String]]
-    val taskTypeOpt = (request.body \ "taskType").asOpt[String]
-
-    userOpt match {
-      case Some(userId) => {
-        for {
-          user <- UserDAO.findOneById(userId) ?~> Messages("user.notFound")
-          userAnnotations <- AnnotationSQLDAO.findAllActiveForUser(ObjectId.fromBsonId(user._id), AnnotationTypeSQL.Task)
-          taskIdsFromAnnotations = userAnnotations.flatMap(_._task).map(_.toString).toSet
-          taskIds = idsOpt match {
-            case Some(ids) => taskIdsFromAnnotations.intersect(ids.toSet)
-            case None => taskIdsFromAnnotations
-          }
-          tasks <- TaskSQLDAO.findAllByPojectAndTaskTypeAndIds(projectOpt, taskTypeOpt, Some(taskIds.toList))
-          jsResult <- Fox.serialCombined(tasks)(_.publicWrites)
-        } yield {
-          Ok(Json.toJson(jsResult))
-        }
-      }
-      case None => {
-        for {
-          tasks <- TaskSQLDAO.findAllByPojectAndTaskTypeAndIds(projectOpt, taskTypeOpt, idsOpt)
-          jsResult <- Fox.serialCombined(tasks)(_.publicWrites)
-        } yield {
-          Ok(Json.toJson(jsResult))
-        }
-      }
+    for {
+      userIdOpt <- Fox.runOptional((request.body \ "user").asOpt[String])(ObjectId.parse(_))
+      projectNameOpt = (request.body \ "project").asOpt[String]
+      taskIdsOpt <- Fox.runOptional((request.body \ "ids").asOpt[List[String]])(ids => Fox.serialCombined(ids)(ObjectId.parse))
+      taskTypeIdOpt <- Fox.runOptional((request.body \ "taskType").asOpt[String])(ObjectId.parse(_))
+      tasks <- TaskSQLDAO.findAllByPojectAndTaskTypeAndIds(projectNameOpt, taskTypeIdOpt, taskIdsOpt, userIdOpt)
+      jsResult <- Fox.serialCombined(tasks)(_.publicWrites)
+    } yield {
+      Ok(Json.toJson(jsResult))
     }
 
   }

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -244,7 +244,7 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
       projectNameOpt = (request.body \ "project").asOpt[String]
       taskIdsOpt <- Fox.runOptional((request.body \ "ids").asOpt[List[String]])(ids => Fox.serialCombined(ids)(ObjectId.parse))
       taskTypeIdOpt <- Fox.runOptional((request.body \ "taskType").asOpt[String])(ObjectId.parse(_))
-      tasks <- TaskSQLDAO.findAllByPojectAndTaskTypeAndUserAndIds(projectNameOpt, taskTypeIdOpt, taskIdsOpt, userIdOpt)
+      tasks <- TaskSQLDAO.findAllByProjectAndTaskTypeAndIdsAndUser(projectNameOpt, taskTypeIdOpt, taskIdsOpt, userIdOpt)
       jsResult <- Fox.serialCombined(tasks)(_.publicWrites)
     } yield {
       Ok(Json.toJson(jsResult))

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -193,14 +193,6 @@ object AnnotationSQLDAO extends SQLDAO[AnnotationSQL, AnnotationsRow, Annotation
     } yield parsed
   }
 
-  def findAllActiveForUser(userId: ObjectId, typ: AnnotationTypeSQL)(implicit ctx: DBAccessContext): Fox[List[AnnotationSQL]] =
-    for {
-      accessQuery <- readAccessQuery
-      r <- run(sql"""select #${columns} from #${existingCollectionName}
-                     where _user = ${userId.id} and typ = '#${typ.toString}' and state = '#${AnnotationState.Active.toString}' and #${accessQuery}""".as[AnnotationsRow])
-      parsed <- Fox.combined(r.toList.map(parse))
-    } yield parsed
-
   // hint: does not use access query (because they dont support prefixes yet). use only after separate access check
   def findAllFinishedForProject(projectId: ObjectId)(implicit ctx: DBAccessContext): Fox[List[AnnotationSQL]] =
     for {

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -125,7 +125,7 @@ object ProjectSQLDAO extends SQLDAO[ProjectSQL, ProjectsRow, Projects] {
   def findOneByName(name: String)(implicit ctx: DBAccessContext): Fox[ProjectSQL] =
     for {
       accessQuery <- readAccessQuery
-      rList <- run(sql"select #${columns} from #${existingCollectionName} where name = ${name} and #${accessQuery}".as[ProjectsRow])
+      rList <- run(sql"select #${columns} from #${existingCollectionName} where name = '#${sanitize(name)}' and #${accessQuery}".as[ProjectsRow])
       r <- rList.headOption.toFox
       parsed <- parse(r)
     } yield parsed

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -239,7 +239,7 @@ object TaskSQLDAO extends SQLDAO[TaskSQL, TasksRow, Tasks] {
     } yield parsed
   }
 
-  def findAllByPojectAndTaskTypeAndUserAndIds(
+  def findAllByProjectAndTaskTypeAndIdsAndUser(
                                         projectNameOpt: Option[String],
                                         taskTypeIdOpt: Option[ObjectId],
                                         taskIdsOpt: Option[List[ObjectId]],

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -239,7 +239,7 @@ object TaskSQLDAO extends SQLDAO[TaskSQL, TasksRow, Tasks] {
     } yield parsed
   }
 
-  def findAllByPojectAndTaskTypeAndIds(
+  def findAllByPojectAndTaskTypeAndUserAndIds(
                                         projectNameOpt: Option[String],
                                         taskTypeIdOpt: Option[ObjectId],
                                         taskIdsOpt: Option[List[ObjectId]],

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -239,19 +239,36 @@ object TaskSQLDAO extends SQLDAO[TaskSQL, TasksRow, Tasks] {
     } yield parsed
   }
 
-  def findAllByPojectAndTaskTypeAndIds(projectOpt: Option[String], taskTypeOpt: Option[String], idsOpt: Option[List[String]])(implicit ctx: DBAccessContext): Fox[List[TaskSQL]] = {
+  def findAllByPojectAndTaskTypeAndIds(
+                                        projectNameOpt: Option[String],
+                                        taskTypeIdOpt: Option[ObjectId],
+                                        taskIdsOpt: Option[List[ObjectId]],
+                                        userIdOpt: Option[ObjectId]
+                                      )(implicit ctx: DBAccessContext): Fox[List[TaskSQL]] = {
+
     /* WARNING: This code composes an sql query with #${} without sanitize(). Change with care. */
-    val projectFilterFox = projectOpt match {
-      case Some(pName) => for {project <- ProjectSQLDAO.findOneByName(pName)} yield s"(_project = '${sanitize(project._id.toString)}')"
+
+    val projectFilterFox = projectNameOpt match {
+      case Some(pName) => for {project <- ProjectSQLDAO.findOneByName(pName)} yield s"(t._project = '${project._id}')"
       case _ => Fox.successful("true")
     }
-    val taskTypeFilter = taskTypeOpt.map(tId => s"(_taskType = '${sanitize(tId)}')").getOrElse("true")
-    val idsFilter = idsOpt.map(ids => if (ids.isEmpty) "false" else s"(_id in ${writeStructTupleWithQuotes(ids.map(sanitize(_)))})").getOrElse("true")
+    val taskTypeFilter = taskTypeIdOpt.map(ttId => s"(t._taskType = '${ttId}')").getOrElse("true")
+    val taskIdsFilter = taskIdsOpt.map(tIds => if (tIds.isEmpty) "false" else s"(t._id in ${writeStructTupleWithQuotes(tIds.map(_.toString))})").getOrElse("true")
+    val userJoin = userIdOpt.map(_ => "join webknossos.annotations_ a on a._task = t._id join webknossos.users_ u on a._user = u._id").getOrElse("")
+    val userFilter = userIdOpt.map(uId => s"(u._id = '${uId}' and a.typ = '${AnnotationTypeSQL.Task}' and a.state != '${AnnotationState.Cancelled}')").getOrElse("true")
 
     for {
       projectFilter <- projectFilterFox
       accessQuery <- readAccessQuery
-      q = sql"select #${columns} from webknossos.tasks where webknossos.tasks.isDeleted = false and #${projectFilter} and #${taskTypeFilter} and #${idsFilter} and #${accessQuery} limit 1000"
+      q = sql"""select #${columnsWithPrefix("t.")}
+                from webknossos.tasks_ t
+                #${userJoin}
+                where #${projectFilter}
+                and #${taskTypeFilter}
+                and #${taskIdsFilter}
+                and #${userFilter}
+                and #${accessQuery}
+                limit 1000"""
       r <- run(q.as[TasksRow])
       parsed <- Fox.combined(r.toList.map(parse))
     } yield parsed

--- a/app/utils/SQLHelpers.scala
+++ b/app/utils/SQLHelpers.scala
@@ -39,7 +39,7 @@ object ObjectId extends FoxImplicits {
   implicit val jsonFormat = Json.format[ObjectId]
   def fromBsonId(bson: BSONObjectID) = ObjectId(bson.stringify)
   def generate = fromBsonId(BSONObjectID.generate)
-  def parse(input: String) = BSONObjectID.parse(input).map(fromBsonId).toOption.toFox ?~> Messages("bsonid.invalid_", input)
+  def parse(input: String) = BSONObjectID.parse(input).map(fromBsonId).toOption.toFox ?~> Messages("bsonid.invalid", input)
 }
 
 trait SQLTypeImplicits {

--- a/app/utils/SQLHelpers.scala
+++ b/app/utils/SQLHelpers.scala
@@ -4,8 +4,6 @@
 package utils
 
 
-import java.util.UUID
-
 import com.newrelic.api.agent.NewRelic
 import com.scalableminds.util.reactivemongo.DBAccessContext
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
@@ -13,15 +11,16 @@ import com.typesafe.scalalogging.LazyLogging
 import models.user.User
 import net.liftweb.common.Full
 import oxalis.security.SharingTokenContainer
-import play.api.Play.current
+import play.api.i18n.Messages
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import reactivemongo.bson.BSONObjectID
 import slick.dbio.DBIOAction
-import slick.driver
 import slick.jdbc.{PositionedParameters, PostgresProfile, SetParameter}
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{AbstractTable, Rep, TableQuery}
+import play.api.Play.current
+import play.api.i18n.Messages.Implicits._
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -40,7 +39,7 @@ object ObjectId extends FoxImplicits {
   implicit val jsonFormat = Json.format[ObjectId]
   def fromBsonId(bson: BSONObjectID) = ObjectId(bson.stringify)
   def generate = fromBsonId(BSONObjectID.generate)
-  def parse(input: String) = BSONObjectID.parse(input).map(fromBsonId).toOption.toFox ?~> "bsonid.invalid"
+  def parse(input: String) = BSONObjectID.parse(input).map(fromBsonId).toOption.toFox ?~> Messages("bsonid.invalid_", input)
 }
 
 trait SQLTypeImplicits {

--- a/conf/messages
+++ b/conf/messages
@@ -28,8 +28,7 @@ gain=Gain
 lose=Loss
 task=Task
 
-bsonid.invalid=The passed resource id is invalid.
-bsonid.invalid_=The passed resource id ''{0}'' is invalid
+bsonid.invalid=The passed resource id ''{0}'' is invalid
 query.type.invalid=Invalid query type argument
 
 format.json.invalid=Invalid Json format

--- a/conf/messages
+++ b/conf/messages
@@ -29,6 +29,7 @@ lose=Loss
 task=Task
 
 bsonid.invalid=The passed resource id is invalid.
+bsonid.invalid_=The passed resource id ''{0}'' is invalid
 query.type.invalid=Invalid query type argument
 
 format.json.invalid=Invalid Json format

--- a/util/src/main/scala/com/scalableminds/util/tools/Fox.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Fox.scala
@@ -3,7 +3,6 @@
  */
 package com.scalableminds.util.tools
 
-import com.scalableminds.util.tools.Fox.sequenceOfFulls
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import play.api.libs.json.{JsError, JsResult, JsSuccess}
 
@@ -135,6 +134,16 @@ object Fox{
       results <- serialCombined(seq)(f)
       zipped = results.zip(seq)
     } yield (zipped.filter(_._1 != inverted).map(_._2))
+  }
+
+  def runOptional[A, B](input: Option[A])(f: A => Fox[B])(implicit ec: ExecutionContext) = {
+    input match {
+      case Some(i) =>
+        for {
+          result <- f(i)
+        } yield Some(result)
+      case None =>
+        Fox.successful(None)}
   }
 
 }


### PR DESCRIPTION
Also introduced a bit of refactoring here:
 - when ID fields are filled in, parse them to `ObjectId`s and report errors if they are invalid
 - run the entire search via sql, instead of first fetching annotations

### Mailable description of changes:
 - Task search, when filtered by user, now shows all (except cancelled) instead of just active tasks

### URL of deployed dev instance (used for testing):
- https://searchalltasksofuser.webknossos.xyz

### Steps to test:
- create a bunch of tasks, preferably with different projects + task types
- trace in some of them, cancel some, finish some
- the task search should be able to filter by the different criteria without failing, and when filtered by user, should list the tasks that user has ever had (and not cancelled)
- entering invalid task IDs in the upper left field should be rejected (watch out for https://github.com/scalableminds/webknossos/issues/2773 though)

### Issues:
- fixes #2753

------
- [x] Ready for review
