### PR TITLE
fix check for monotonically increasing resolutions

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -100,9 +100,9 @@ class DataSourceService @Inject()(
     def Check(expression: Boolean, msg: String): Option[String] = if (!expression) Some(msg) else None
 
     // Check, that each dimension increases monotonically between different resolutions.
-    val resolutionsByX = dataSource.dataLayers.flatMap(_.resolutions).sortBy(_.x)
-    val resolutionsByY = dataSource.dataLayers.flatMap(_.resolutions).sortBy(_.y)
-    val resolutionsByZ = dataSource.dataLayers.flatMap(_.resolutions).sortBy(_.z)
+    val resolutionsByX = dataSource.dataLayers.map(_.resolutions.sortBy(_.x))
+    val resolutionsByY = dataSource.dataLayers.map(_.resolutions.sortBy(_.y))
+    val resolutionsByZ = dataSource.dataLayers.map(_.resolutions.sortBy(_.z))
 
     val errors = List(
       Check(dataSource.scale.isValid, "DataSource scale is invalid"),


### PR DESCRIPTION
- with previous flatMap-version
`val layer1 = List(Point(1,1,1), Point(2,2,1))
val layer2 = List(Point(1,1,1), Point(2,2,1))`
would be sortedByZ to
`List(Point(1,1,1), Point(2,2,1), Point(1,1,1), Point(2,2,1))`
- the new version sorts the same lists byZ to
`List(List(Point(1,1,1), Point(2,2,1)), List(Point(1,1,1), Point(2,2,1)))`

### Steps to test:
- try uploading a dataset with multiple layers and anisotrophic resolutions

------
- [x] Ready for review
