### PR TITLE
Hotfix unnecessary scrolling area for firefox

### DIFF
--- a/app/assets/javascripts/oxalis/view/tracing_layout_view.js
+++ b/app/assets/javascripts/oxalis/view/tracing_layout_view.js
@@ -67,7 +67,7 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
             </ButtonComponent>
             <ActionBarView />
           </Header>
-          <Layout style={{ marginTop: 64 }}>
+          <Layout style={{ marginTop: 64, height: "calc(100% - 64px)" }}>
             <Sider
               collapsible
               trigger={null}


### PR DESCRIPTION
https://discuss.webknossos.org/t/tree-list-goes-beyond-viewports/954/3

### Mailable description of changes:
 - Bug fix for Firefox: A long tree list created an unnecessary scroll region which is resolved now.

### URL of deployed dev instance (used for testing):
- https://fixscrollinginfx.webknossos.xyz

### Steps to test:
- open tracing --> normal layout expected
- create lots of trees --> it shouldn't be necessary to scroll in two scroll areas to see all trees (in firefox there is still small, unnecessary scroll region; but I didn't find a nice solution. also, custom viewports will revamp the layouting anyway)
- repeat for second browser (firefox originally showed this problem)

------
- [X] Ready for review
