### PR TITLE
make it possible again to kick user out of organization team

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -211,7 +211,7 @@ class UserController @Inject()(val messagesApi: MessagesApi)
           teamsWithUpdate <- Fox.filter(assignedMembershipWTeams)(t => issuingUser.isTeamManagerOrAdminOf(t._1._id))
           _ <- ensureProperTeamAdministration(user, teamsWithUpdate)
           trimmedExperiences = experiences.map { case (key, value) => key.trim -> value }
-          updatedTeams <- ensureOrganizationTeamIsPresent(user, teamsWithUpdate.map(_._1) ++ teamsWithoutUpdate)
+          updatedTeams = teamsWithUpdate.map(_._1) ++ teamsWithoutUpdate
           updatedUser <- UserService.update(user, firstName.trim, lastName.trim, email, isActive, isAdmin, updatedTeams, trimmedExperiences)
         } yield {
           Ok(User.userPublicWrites(request.identity).writes(updatedUser))
@@ -219,18 +219,4 @@ class UserController @Inject()(val messagesApi: MessagesApi)
     }
   }
 
-  def ensureOrganizationTeamIsPresent(user: User, updatedTeams: List[TeamMembership]) = {
-    for {
-      organization <- OrganizationDAO.findOneByName(user.organization)(GlobalAccessContext)
-      orgTeam = organization._organizationTeam
-    } yield {
-      if (updatedTeams.exists(t => t._id == orgTeam))
-        updatedTeams
-      else
-        user.teams.find(t => t._id == orgTeam) match {
-          case Some(teamMembership) => teamMembership :: updatedTeams
-          case None => updatedTeams
-        }
-    }
-  }
 }


### PR DESCRIPTION
### Mailable description of changes:
 - It is now possible again to kick a user out of the organization team

### URL of deployed dev instance (used for testing):
- https://organizationteamremovable.webknossos.xyz

### Steps to test:
- create another team
- create another user, remove Connectomics department in their team list, add them as User to second team
- give the second team access to a dataset
- they should see that dataset, but not the others, even if they have Connectomics department in their allowed teams list

### Issues:
- fixes #2800

------
- [x] Ready for review
