### PR TITLE
Show appropriate error message when webgl crashes

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -50,6 +50,8 @@ In order to restore the current window, a reload is necessary.`,
   "tracing.changed_move_value": "The move value was changed to: ",
   "datastore.unknown_type": "Unknown datastore type:",
   "webgl.disabled": "Couldn't initialise WebGL, please make sure WebGL is enabled.",
+  "webgl.context_loss":
+    "Unfortunately, WebGL crashed. Please ensure that your graphics card driver is up to date to avoid such crashes. If this message keeps appearing, restarting your browser might also help.",
   "task.user_script_retrieval_error": "Unable to retrieve script",
   "task.new_description": "You are now tracing a new task with the following description",
   "task.no_description": "You are now tracing a new task with no description.",

--- a/app/assets/javascripts/oxalis/view/tracing_view.js
+++ b/app/assets/javascripts/oxalis/view/tracing_view.js
@@ -14,6 +14,8 @@ import { isVolumeTracingDisallowed } from "oxalis/model/accessors/volumetracing_
 import type { OxalisState } from "oxalis/store";
 import type { ModeType } from "oxalis/constants";
 import type { Dispatch } from "redux";
+import Toast from "libs/toast";
+import messages from "messages";
 
 type Props = {
   flightmodeRecording: boolean,
@@ -21,6 +23,20 @@ type Props = {
   viewMode: ModeType,
   scale: number,
   isVolumeTracingDisallowed: boolean,
+};
+
+const registerWebGlCrashHandler = canvas => {
+  if (!canvas) {
+    return;
+  }
+  canvas.addEventListener(
+    "webglcontextlost",
+    e => {
+      Toast.error(messages["webgl.context_loss"], { sticky: true });
+      console.error("Webgl context lost", e);
+    },
+    false,
+  );
 };
 
 class TracingView extends React.PureComponent<Props> {
@@ -57,7 +73,7 @@ class TracingView extends React.PureComponent<Props> {
       <div id="tracing" className={divClassName} onContextMenu={this.handleContextMenu}>
         {inputCatchers}
         {flightModeRecordingSwitch}
-        <canvas id="render-canvas" style={canvasStyle} />
+        <canvas ref={registerWebGlCrashHandler} id="render-canvas" style={canvasStyle} />
       </div>
     );
   }


### PR DESCRIPTION
At the moment, a webgl crash can be quite silent. The browser does not always show an appropriate error message. I added an event handler which alerts the user and also tells him/her ensure up-to-date graphic cards drivers. This should propagate the news that driver versions are important across the user base.

### URL of deployed dev instance (used for testing):
- https://warnonwebglcontextloss.webknossos.xyz

### Steps to test:
- You can provoke the a webgl crash by executing the following line in the console:
- `document.getElementById("render-canvas").getContext("webgl").getExtension('WEBGL_lose_context').loseContext();`

------
- [X] Ready for review
