### PR TITLE
Fix the delete initial node warning in tasks

### DIFF
--- a/app/assets/javascripts/oxalis/model/actions/skeletontracing_actions.js
+++ b/app/assets/javascripts/oxalis/model/actions/skeletontracing_actions.js
@@ -277,7 +277,7 @@ export const deleteTreeAction = (
 export const deleteTreeWithConfirmAction = (treeId?: number): NoActionType => {
   const state = Store.getState();
   getTree(state.tracing, treeId).map(tree => {
-    if (state.task != null && tree.nodes.has(1) != null) {
+    if (state.task != null && tree.nodes.has(1)) {
       // Let the user confirm the deletion of the initial node (node with id 1) of a task
       Modal.confirm({
         title: messages["tracing.delete_tree_with_initial_node"],


### PR DESCRIPTION
### Mailable description of changes:
 - Fixed an unnecessary warning when deleting a tree in a task, that warned about deleting the initial node although the initial node was not contained in the deleted tree.

### URL of deployed dev instance (used for testing):
- https://fixdeleteinitialnodewarning.webknossos.xyz

### Steps to test:
- Create a task. Open the task and create a second tree. Deleting the second tree should not trigger the "really delete the initial node" warning, but only the "really delete the tree" warning. Deleting the first tree should trigger the "really delete the initial node" warning.

### Issues:
- fixes https://discuss.webknossos.org/t/initial-node-warning-shows-up-on-tree-deletion-without-initial-node-in-it/967/3

------
- [x] Ready for review
