### PR TITLE
Make headless gl an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "file-loader": "^1.1.5",
     "flow-bin": "^0.71.0",
     "flow-coverage-report": "^0.5.0",
-    "gl": "scalableminds/headless-gl#4.0.5",
     "himalaya": "^0.2.12",
     "isomorphic-fetch": "^2.2.0",
     "jsdom": "^11.5.1",
@@ -62,6 +61,9 @@
     "url-loader": "^1.0.1",
     "webpack": "^4.7.0",
     "webpack-cli": "^2.1.3"
+  },
+  "optionalDependencies": {
+    "gl": "scalableminds/headless-gl#4.0.5"
   },
   "scripts": {
     "start": "./sbt run -jvm-debug 5005",


### PR DESCRIPTION
Since headless gl cannot be compiled under os x at the moment, I changed the dependency to be optional. As a result, `yarn install --ignore-optional` should allow installing the dependencies under os x.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- run `yarn install --ignore-optional` under os x

------
- [X] Ready for review
