### PR TITLE
Parallelize some awaits and avoid fetching user twice in dashboard

### DIFF
--- a/app/assets/javascripts/admin/project/project_create_view.js
+++ b/app/assets/javascripts/admin/project/project_create_view.js
@@ -10,7 +10,7 @@ import {
   getProject,
   updateProject,
 } from "admin/admin_rest_api";
-import { getActiveUser } from "oxalis/model/accessors/user_accessor";
+import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
 
 import type { APIUserType, APITeamType } from "admin/api_flow_types";
 import type { OxalisState } from "oxalis/store";
@@ -46,8 +46,7 @@ class ProjectCreateView extends React.PureComponent<Props, State> {
   }
 
   async fetchData() {
-    const users = await getUsers();
-    const teams = await getEditableTeams();
+    const [users, teams] = await Promise.all([getUsers(), getEditableTeams()]);
 
     this.setState({
       users: users.filter(user => user.isActive),
@@ -171,7 +170,7 @@ class ProjectCreateView extends React.PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state: OxalisState): StateProps => ({
-  activeUser: getActiveUser(state.activeUser),
+  activeUser: enforceActiveUser(state.activeUser),
 });
 
 export default connect(mapStateToProps)(withRouter(Form.create()(ProjectCreateView)));

--- a/app/assets/javascripts/admin/project/project_list_view.js
+++ b/app/assets/javascripts/admin/project/project_list_view.js
@@ -7,7 +7,7 @@ import { Link, withRouter } from "react-router-dom";
 import { Table, Icon, Spin, Button, Input, Modal } from "antd";
 import Utils from "libs/utils";
 import messages from "messages";
-import { getActiveUser } from "oxalis/model/accessors/user_accessor";
+import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
 import {
   getProjectsWithOpenAssignments,
   increaseProjectTaskInstances,
@@ -290,7 +290,7 @@ class ProjectListView extends React.PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state: OxalisState): StateProps => ({
-  activeUser: getActiveUser(state.activeUser),
+  activeUser: enforceActiveUser(state.activeUser),
 });
 
 export default connect(mapStateToProps)(withRouter(ProjectListView));

--- a/app/assets/javascripts/admin/scripts/script_create_view.js
+++ b/app/assets/javascripts/admin/scripts/script_create_view.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import { Form, Input, Select, Button, Card } from "antd";
 import { getAdminUsers, updateScript, createScript, getScript } from "admin/admin_rest_api";
-import { getActiveUser } from "oxalis/model/accessors/user_accessor";
+import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
 
 import type { APIUserType } from "admin/api_flow_types";
 import type { OxalisState } from "oxalis/store";
@@ -132,7 +132,7 @@ class ScriptCreateView extends React.PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state: OxalisState): StateProps => ({
-  activeUser: getActiveUser(state.activeUser),
+  activeUser: enforceActiveUser(state.activeUser),
 });
 
 export default connect(mapStateToProps)(withRouter(Form.create()(ScriptCreateView)));

--- a/app/assets/javascripts/admin/task/task_search_form.js
+++ b/app/assets/javascripts/admin/task/task_search_form.js
@@ -85,11 +85,12 @@ class TaskSearchForm extends React.Component<Props, State> {
   }
 
   async fetchData() {
-    this.setState({
-      users: await getEditableUsers(),
-      projects: await getProjects(),
-      taskTypes: await getTaskTypes(),
-    });
+    const [users, projects, taskTypes] = await Promise.all([
+      getEditableUsers(),
+      getProjects(),
+      getTaskTypes(),
+    ]);
+    this.setState({ users, projects, taskTypes });
   }
 
   handleFormSubmit = (event: ?SyntheticInputEvent<*>) => {

--- a/app/assets/javascripts/admin/user/user_list_view.js
+++ b/app/assets/javascripts/admin/user/user_list_view.js
@@ -13,7 +13,7 @@ import Utils from "libs/utils";
 import { getEditableUsers, updateUser } from "admin/admin_rest_api";
 import Persistence from "libs/persistence";
 import { PropTypes } from "@scalableminds/prop-types";
-import { getActiveUser } from "oxalis/model/accessors/user_accessor";
+import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
 import messages from "messages";
 
 import type { APIUserType, APITeamMembershipType, ExperienceMapType } from "admin/api_flow_types";
@@ -400,7 +400,7 @@ class UserListView extends React.PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state: OxalisState): StateProps => ({
-  activeUser: getActiveUser(state.activeUser),
+  activeUser: enforceActiveUser(state.activeUser),
 });
 
 export default connect(mapStateToProps)(withRouter(UserListView));

--- a/app/assets/javascripts/dashboard/dashboard_task_list_view.js
+++ b/app/assets/javascripts/dashboard/dashboard_task_list_view.js
@@ -20,7 +20,7 @@ import {
   requestTask,
   peekNextTasks,
 } from "admin/admin_rest_api";
-import { getActiveUser } from "oxalis/model/accessors/user_accessor";
+import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
 import Persistence from "libs/persistence";
 import { PropTypes } from "@scalableminds/prop-types";
 import type {
@@ -421,7 +421,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state: OxalisState): StateProps => ({
-  activeUser: getActiveUser(state.activeUser),
+  activeUser: enforceActiveUser(state.activeUser),
 });
 
 export default connect(mapStateToProps)(withRouter(DashboardTaskListView));

--- a/app/assets/javascripts/dashboard/dashboard_view.js
+++ b/app/assets/javascripts/dashboard/dashboard_view.js
@@ -3,14 +3,13 @@
 
 import * as React from "react";
 import { connect } from "react-redux";
-import Request from "libs/request";
 import { Spin, Tabs } from "antd";
 import Utils from "libs/utils";
 import DatasetView from "dashboard/dataset_view";
 import DashboardTaskListView from "dashboard/dashboard_task_list_view";
 import ExplorativeAnnotationsView from "dashboard/explorative_annotations_view";
-import { getActiveUser } from "oxalis/model/accessors/user_accessor";
-
+import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
+import { getUser } from "admin/admin_rest_api";
 import type { APIUserType } from "admin/api_flow_types";
 import type { OxalisState } from "oxalis/store";
 
@@ -52,12 +51,10 @@ class DashboardView extends React.PureComponent<Props, State> {
   }
 
   async fetchData(): Promise<void> {
-    const url = this.props.userId ? `/api/users/${this.props.userId}` : "/api/user";
-    const user = await Request.receiveJSON(url);
+    const user =
+      this.props.userId != null ? await getUser(this.props.userId) : this.props.activeUser;
 
-    this.setState({
-      user,
-    });
+    this.setState({ user });
   }
 
   getTabs(user: APIUserType) {
@@ -126,7 +123,7 @@ class DashboardView extends React.PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state: OxalisState): StateProps => ({
-  activeUser: getActiveUser(state.activeUser),
+  activeUser: enforceActiveUser(state.activeUser),
 });
 
 export default connect(mapStateToProps)(DashboardView);

--- a/app/assets/javascripts/dashboard/dataset/dataset_import_view.js
+++ b/app/assets/javascripts/dashboard/dataset/dataset_import_view.js
@@ -112,8 +112,10 @@ class DatasetImportView extends React.PureComponent<Props, State> {
   async fetchData(): Promise<void> {
     try {
       this.setState({ isLoading: true });
-      const sharingToken = await getDatasetSharingToken(this.props.datasetName);
-      const dataset = await getDataset(this.props.datasetName);
+      const [sharingToken, dataset] = await Promise.all([
+        getDatasetSharingToken(this.props.datasetName),
+        getDataset(this.props.datasetName),
+      ]);
       const { dataSource, messages: dataSourceMessages } = await getDatasetDatasource(dataset);
 
       this.props.form.setFieldsValue({

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -26,8 +26,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // try retreive the currently active user if logged in
   try {
-    await loadFeatureToggles();
-    const user = await getActiveUser({ doNotCatch: true });
+    // eslint-disable-next-line no-unused-vars
+    const [_, user] = await Promise.all([
+      loadFeatureToggles(),
+      getActiveUser({ doNotCatch: true }),
+    ]);
     Store.dispatch(setActiveUserAction(user));
     ErrorHandling.setCurrentUser(user);
   } catch (e) {

--- a/app/assets/javascripts/oxalis/model/accessors/user_accessor.js
+++ b/app/assets/javascripts/oxalis/model/accessors/user_accessor.js
@@ -3,7 +3,7 @@
 import messages from "messages";
 import type { APIUserType } from "admin/api_flow_types";
 
-export function getActiveUser(activeUser: ?APIUserType): APIUserType {
+export function enforceActiveUser(activeUser: ?APIUserType): APIUserType {
   if (activeUser) {
     return activeUser;
   } else {

--- a/app/assets/javascripts/oxalis/view/action-bar/merge_modal_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/merge_modal_view.js
@@ -70,8 +70,10 @@ class MergeModalView extends PureComponent<Props, MergeModalViewState> {
 
   componentWillMount() {
     (async () => {
-      const taskTypes = await Request.receiveJSON("/api/taskTypes", { doNotCatch: true });
-      const projects = await Request.receiveJSON("/api/projects", { doNotCatch: true });
+      const [taskTypes, projects] = await Promise.all([
+        Request.receiveJSON("/api/taskTypes", { doNotCatch: true }),
+        Request.receiveJSON("/api/projects", { doNotCatch: true }),
+      ]);
       this.setState({
         taskTypes: taskTypes.map(taskType => ({ id: taskType.id, label: taskType.summary })),
         projects: projects.map(project => ({ id: project.id, label: project.name })),

--- a/app/assets/javascripts/test/backend-snapshot-tests/datasets.e2e.js
+++ b/app/assets/javascripts/test/backend-snapshot-tests/datasets.e2e.js
@@ -48,8 +48,7 @@ test("getDatasetAccessList", async t => {
 });
 
 test("updateDatasetTeams", async t => {
-  const dataset = await getFirstDataset();
-  const newTeams = await api.getEditableTeams();
+  const [dataset, newTeams] = await Promise.all([getFirstDataset(), api.getEditableTeams()]);
 
   const updatedDataset = await api.updateDatasetTeams(dataset.name, newTeams.map(team => team.id));
   t.snapshot(updatedDataset, { id: "dataset-updateDatasetTeams" });


### PR DESCRIPTION
I noticed that the user is fetched twice when opening the dashboard, which I fixed then. Also I took the opportunity to parallelize some sequential awaits.

### URL of deployed dev instance (used for testing):
- https://parallelizeawaits.webknossos.xyz

### Steps to test:
- spot check some views

------
- [X] Ready for review
