### PR TITLE
Split shader into two compilation units & better clean up

### DIFF
--- a/app/assets/javascripts/oxalis/controller/viewmodes/arbitrary_controller.js
+++ b/app/assets/javascripts/oxalis/controller/viewmodes/arbitrary_controller.js
@@ -349,6 +349,7 @@ class ArbitraryController extends React.PureComponent<Props> {
     }
 
     this.arbitraryView.stop();
+    this.plane.destroy();
 
     this.isStarted = false;
   }

--- a/app/assets/javascripts/oxalis/geometries/arbitrary_plane.js
+++ b/app/assets/javascripts/oxalis/geometries/arbitrary_plane.js
@@ -30,15 +30,21 @@ import PlaneMaterialFactory from "oxalis/geometries/materials/plane_material_fac
 class ArbitraryPlane {
   mesh: THREE.Mesh;
   isDirty: boolean;
-  textureMaterial: THREE.RawShaderMaterial;
+  stopStoreListening: () => void;
+  materialFactory: PlaneMaterialFactory;
 
   constructor() {
     this.isDirty = true;
     this.mesh = this.createMesh();
 
-    Store.subscribe(() => {
+    this.stopStoreListening = Store.subscribe(() => {
       this.isDirty = true;
     });
+  }
+
+  destroy() {
+    this.stopStoreListening();
+    this.materialFactory.stopListening();
   }
 
   updateAnchorPoints(anchorPoint: ?Vector4, fallbackAnchorPoint: ?Vector4): void {
@@ -92,11 +98,12 @@ class ArbitraryPlane {
   }
 
   createMesh() {
-    this.textureMaterial = new PlaneMaterialFactory(OrthoViews.PLANE_XY, 4).setup().getMaterial();
+    this.materialFactory = new PlaneMaterialFactory(OrthoViews.PLANE_XY, false, 4);
+    const textureMaterial = this.materialFactory.setup().getMaterial();
 
     const plane = new THREE.Mesh(
       new THREE.PlaneGeometry(constants.VIEWPORT_WIDTH, constants.VIEWPORT_WIDTH, 1, 1),
-      this.textureMaterial,
+      textureMaterial,
     );
     plane.rotation.x = Math.PI;
 

--- a/app/assets/javascripts/oxalis/geometries/materials/abstract_plane_material_factory.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/abstract_plane_material_factory.js
@@ -13,10 +13,6 @@ import { listenToStoreProperty } from "oxalis/model/helpers/listener_helpers";
 import shaderEditor from "oxalis/model/helpers/shader_editor";
 import { getColorLayers } from "oxalis/model/accessors/dataset_accessor";
 
-export type TextureMapType = {
-  [key: string]: THREE.DataTexture,
-};
-
 export type UniformsType = {
   [key: string]: {
     type: "f" | "i" | "t" | "v2" | "v3" | "tv",
@@ -105,10 +101,10 @@ class AbstractPlaneMaterialFactory {
   material: THREE.ShaderMaterial;
   uniforms: UniformsType;
   attributes: Object;
-  textures: TextureMapType;
   minFilter: THREE.NearestFilter;
   maxFilter: THREE.NearestFilter;
   shaderId: number;
+  storePropertyUnsubscribers: Array<() => void> = [];
 
   constructor(shaderId: number) {
     this.minFilter = THREE.NearestFilter;
@@ -119,13 +115,12 @@ class AbstractPlaneMaterialFactory {
   setup() {
     this.setupUniforms();
     this.makeMaterial();
-    this.attachTextures(this.textures);
+    this.attachTextures();
     this.setupChangeListeners();
     return this;
   }
 
-  /* eslint-disable no-unused-vars */
-  attachTextures(textures: TextureMapType): void {}
+  attachTextures(): void {}
 
   setupUniforms(): void {
     this.uniforms = {};
@@ -153,15 +148,6 @@ class AbstractPlaneMaterialFactory {
     );
 
     shaderEditor.addMaterial(this.shaderId, this.material);
-
-    this.material.setData = (name, data) => {
-      const textureName = sanitizeName(name);
-      const texture = this.textures[textureName];
-      if (texture) {
-        texture.image.data = data;
-        texture.needsUpdate = true;
-      }
-    };
   }
 
   setupChangeListeners(): void {

--- a/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
+++ b/app/assets/javascripts/oxalis/geometries/materials/plane_material_factory.js
@@ -234,7 +234,6 @@ class PlaneMaterialFactory extends AbstractPlaneMaterialFactory {
       listenToStoreProperty(
         storeState => getRequestLogZoomStep(storeState),
         zoomStep => {
-          console.log("zoomStep");
           this.uniforms.zoomStep.value = zoomStep;
         },
         true,

--- a/app/assets/javascripts/oxalis/geometries/plane.js
+++ b/app/assets/javascripts/oxalis/geometries/plane.js
@@ -53,6 +53,7 @@ class Plane {
 
     const textureMaterial = new PlaneMaterialFactory(
       this.planeID,
+      true,
       OrthoViewValues.indexOf(this.planeID),
     )
       .setup()

--- a/app/assets/javascripts/oxalis/shaders/coords.glsl.js
+++ b/app/assets/javascripts/oxalis/shaders/coords.glsl.js
@@ -72,9 +72,11 @@ export const getWorldCoordUVW: ShaderModuleType = {
         // In orthogonal mode, the planes are offset in 3D space to allow skeletons to be rendered before
         // each plane. Since w (e.g., z for xy plane) is
         // the same for all texels computed in this shader, we simply use globalPosition[w] instead
-        isArbitrary() ?
+        <% if (isOrthogonal) { %>
+          getW(globalPosition)
+        <% } else { %>
           worldCoordUVW.z / datasetScaleUVW.z
-          : getW(globalPosition)
+        <% } %>
       );
 
       return worldCoordUVW;

--- a/app/assets/javascripts/oxalis/shaders/filtering.glsl.js
+++ b/app/assets/javascripts/oxalis/shaders/filtering.glsl.js
@@ -95,12 +95,11 @@ const getMaybeFilteredColor: ShaderModuleType = {
     ) {
       vec4 color;
       if (!suppressBilinearFiltering && useBilinearFiltering) {
-        // Todo: Re-compile shader based on this condition
-        if (isArbitrary()) {
-          color = getTrilinearColorFor(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords, isFallback);
-        } else {
+        <% if (isOrthogonal) { %>
           color = getBilinearColorFor(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords, isFallback);
-        }
+        <% } else { %>
+          color = getTrilinearColorFor(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords, isFallback);
+        <% } %>
       } else {
         color = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords, isFallback);
       }

--- a/app/assets/javascripts/oxalis/shaders/utils.glsl.js
+++ b/app/assets/javascripts/oxalis/shaders/utils.glsl.js
@@ -162,14 +162,6 @@ export const getW: ShaderModuleType = {
   `,
 };
 
-export const isArbitrary: ShaderModuleType = {
-  code: `
-    bool isArbitrary() {
-      return viewMode == <%= ModeValuesIndices.Flight %> || viewMode == <%= ModeValuesIndices.Oblique %>;
-    }
-  `,
-};
-
 export const isFlightMode: ShaderModuleType = {
   code: `
     bool isFlightMode() {

--- a/app/assets/javascripts/test/shaders/shader_syntax.spec.js
+++ b/app/assets/javascripts/test/shaders/shader_syntax.spec.js
@@ -3,7 +3,6 @@ import test from "ava";
 import glslParser from "glsl-parser";
 import getMainFragmentShader from "oxalis/shaders/main_data_fragment.glsl";
 import resolutions from "test/fixtures/resolutions";
-import { OrthoViews } from "oxalis/constants";
 
 test("Shader syntax: Ortho Mode", t => {
   const code = getMainFragmentShader({
@@ -12,11 +11,11 @@ test("Shader syntax: Ortho Mode", t => {
     segmentationName: "",
     segmentationPackingDegree: 1,
     isRgb: false,
-    planeID: OrthoViews.PLANE_XY,
     isMappingSupported: true,
     dataTextureCountPerLayer: 3,
     resolutions,
     datasetScale: [1, 1, 1],
+    isOrthogonal: true,
   });
 
   const parseResult = glslParser.check(code);
@@ -32,11 +31,51 @@ test("Shader syntax: Ortho Mode + Segmentation", t => {
     segmentationName: "segmentationLayer",
     segmentationPackingDegree: 1,
     isRgb: false,
-    planeID: OrthoViews.PLANE_XY,
     isMappingSupported: true,
     dataTextureCountPerLayer: 3,
     resolutions,
     datasetScale: [1, 1, 1],
+    isOrthogonal: true,
+  });
+
+  const parseResult = glslParser.check(code);
+
+  t.is(parseResult.log.warningCount, 0);
+  t.is(parseResult.log.errorCount, 0);
+});
+
+test("Shader syntax: Arbitrary Mode (no segmentation available)", t => {
+  const code = getMainFragmentShader({
+    colorLayerNames: ["color_layer_1", "color_layer_2"],
+    hasSegmentation: false,
+    segmentationName: "",
+    segmentationPackingDegree: 1,
+    isRgb: false,
+    isMappingSupported: true,
+    dataTextureCountPerLayer: 3,
+    resolutions,
+    datasetScale: [1, 1, 1],
+    isOrthogonal: false,
+  });
+
+  const parseResult = glslParser.check(code);
+
+  t.is(parseResult.log.warningCount, 0);
+  t.is(parseResult.log.errorCount, 0);
+});
+
+test("Shader syntax: Arbitrary Mode (segmentation available)", t => {
+  const code = getMainFragmentShader({
+    colorLayerNames: ["color_layer_1", "color_layer_2"],
+    hasSegmentation: true,
+    segmentationName: "segmentationLayer",
+    segmentationPackingDegree: 1,
+    isRgb: false,
+    isMappingSupported: true,
+    dataTextureCountPerLayer: 3,
+    resolutions,
+    datasetScale: [1, 1, 1],
+    isOrthogonal: false,
   });
 
   const parseResult = glslParser.check(code);


### PR DESCRIPTION
This PR splits the shader into ortho and non-ortho units. For a multi layer dataset, the orthogonal mode loads way faster for me :tada: (1 seconds vs. 5,6 seconds). The arbitrary mode will be a bit slow upon first loading (2.8 seconds vs. 0 seconds previously), but the total compilation time is faster, anyway.

I also took care of destroying some listeners when switching the view mode. We should clean this up a bit more in the future..

### Mailable description of changes:
 - Performance improvements for orthogonal mode.

### URL of deployed dev instance (used for testing):
- https://shadersplit.webknossos.xyz

### Steps to test:
- load different datasets in different modes


------
- [X] Ready for review
