### PR TITLE
Change missing-node-id-assertion to user warning

### DIFF
--- a/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
@@ -43,7 +43,7 @@ import DiffableMap from "libs/diffable_map";
 import type { ActionType } from "oxalis/model/actions/actions";
 import type { ServerNodeType, ServerBranchPointType } from "admin/api_flow_types";
 import Maybe from "data.maybe";
-import ErrorHandling from "libs/error_handling";
+import Toast from "libs/toast";
 
 function serverNodeToNode(n: ServerNodeType): NodeType {
   return {
@@ -105,15 +105,13 @@ function SkeletonTracingReducer(state: OxalisState, action: ActionType): OxalisS
           const treeIdMaybe = findTreeByNodeId(trees, nodeId).map(tree => tree.treeId);
           if (treeIdMaybe.isNothing) {
             // There is an activeNodeId without a corresponding tree.
-            // Log this, since this shouldn't happen, but clear the activeNodeId
+            // Warn the user, since this shouldn't happen, but clear the activeNodeId
             // so that wk is usable.
-            ErrorHandling.assert(
-              false,
+            Toast.warning(
               `This tracing was initialized with an active node ID, which does not
               belong to any tracing (nodeId: ${nodeId}). WebKnossos will fall back to
               the last tree instead.`,
-              undefined,
-              true,
+              { timeout: 10000 },
             );
             activeNodeId = null;
           }


### PR DESCRIPTION
Since I couldn't reproduce the assertion by merging tracings, I decided to convert the assertion to a warning. At the moment, we don't act on this particular airbrake notification, anyway. If users become annoyed by the warning they will either tell us to turn it off, as it's not important, or they will tell us how they are running into this consistently.

### URL of deployed dev instance (used for testing):
- https://nodeidassertiontowarning.webknossos.xyz

### Steps to test:
- provoke the missing-node-id warning (e.g., upload an appropriate nml)

### Issues:
- fixes #2741

------
- [X] Ready for review
