### PR TITLE
Render Markdown in View mode

### DIFF
--- a/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -16,6 +16,7 @@ import {
 } from "oxalis/model/actions/annotation_actions";
 import EditableTextLabel from "oxalis/view/components/editable_text_label";
 import { Table } from "antd";
+import Markdown from "react-remarkable";
 import type { APIDatasetType } from "admin/api_flow_types";
 import type { OxalisState, TracingType, TaskType, FlycamType } from "oxalis/store";
 
@@ -155,7 +156,9 @@ class DatasetInfoTabView extends React.PureComponent<DatasetInfoTabProps> {
       return (
         <div>
           <p>Dataset: {displayName || datasetName}</p>
-          {description ? <p>{description}</p> : null}
+          {description ? (
+            <Markdown source={description} options={{ html: false, breaks: true, linkify: true }} />
+          ) : null}
         </div>
       );
     }


### PR DESCRIPTION
### Steps to test:
- Add a Markdown description to your dataset, e.g.

```
This dataset contains slices 2-30 of the [CREMI](https://cremi.org/) challenge A+ dataset.
The segmentation is done by Georg Wiese and Valentin Pinkau at [scalable minds](https://scalableminds.com/) using the popular U-Net as described in this [blogpost](https://scm.io/blog/MachineLearning/2018/04/image-segmentation/).
```
- View the dataset and marvel at the well-formatted description in the right panel.


### Issues:
- fixes #2854 

------
- [x] Ready for review
