### PR TITLE
in timeLogging, ignore expected failures of signalOverTime

### DIFF
--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -188,7 +188,7 @@ object TimeSpanService extends FoxImplicits with LazyLogging {
       case Some(taskId) =>
         for {
           _ <- TaskSQLDAO.logTime(taskId, duration)(GlobalAccessContext) ?~> "FAILED: TaskSQLDAO.logTime"
-          _ <- signalOverTime(duration, annotation)(GlobalAccessContext) ?~> "FAILED: TimeSpanService.signalOverTime"
+          _ <- signalOverTime(duration, annotation)(GlobalAccessContext).futureBox //signalOverTime is expected to fail in some cases, hence the .futureBox
         } yield {}
       case _ =>
         Fox.successful(())


### PR DESCRIPTION
In #2867 we started waiting for the results of time logging. However, one function in the time logging code has expected failures, e.g. when logging time to tasks of projects that don’t have expected times. That broke saving updates to these annotations.
The function should be rewritten to report success with no side-effects in such cases. But as a quick fix, this PR ignores its failures, by not unpacking the Fox in the for-comprehension, but only the Future.

### URL of deployed dev instance (used for testing):
- https://fixtimelogging.webknossos.xyz

### Steps to test:
- create project without expected time (does not seem to be possible via UI, but is possible in the DB and mhlab has several such projects. For testing, try setting it to null in the db directly)
- create task for that project, trace some
- should be able to save

### Issues:
- fixes  #2894

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- [x] Ready for review
