### PR TITLE
Fix comment/branchpoint removal for last node of a tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 
   - Fixed a bug which caused segmentation data to be requested as four-bit when four-bit-mode was enabled. [#2828](https://github.com/scalableminds/webknossos/pull/2828)
+  - Fixed a bug where possible comments or branchpoints sometimes were not properly deleted when deleting a node. [2897](https://github.com/scalableminds/webknossos/pull/2897)
   - Fixed a bug which caused projects to be unpaused when the project priority was changed. [#2795](https://github.com/scalableminds/webknossos/pull/2795)
   - Fixed an unnecessary warning when deleting a tree in a task, that warned about deleting the initial node although the initial node was not contained in the deleted tree. [#2812](https://github.com/scalableminds/webknossos/pull/2812)
   - Fixed a bug where the comment tab was scrolled into view horizontally if a node with a comment was activated. [#2805](https://github.com/scalableminds/webknossos/pull/2805)

--- a/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
+++ b/app/assets/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
@@ -145,9 +145,14 @@ export function deleteNode(
     const { allowUpdate } = skeletonTracing.restrictions;
 
     if (allowUpdate) {
-      // Delete Node
+      // Delete node and possible branchpoints/comments
       const activeTree = update(tree, {
         nodes: { $apply: nodes => nodes.delete(node.id) },
+        comments: { $apply: comments => comments.filter(comment => comment.nodeId !== node.id) },
+        branchPoints: {
+          $apply: branchPoints =>
+            branchPoints.filter(branchPoint => branchPoint.nodeId !== node.id),
+        },
       });
 
       // Do we need to split trees? Are there edges leading to/from it?

--- a/app/assets/javascripts/test/reducers/skeletontracing_reducer.spec.js
+++ b/app/assets/javascripts/test/reducers/skeletontracing_reducer.spec.js
@@ -205,6 +205,31 @@ test("SkeletonTracing should delete a node from a tree", t => {
   t.deepEqual(newStateB, newState);
 });
 
+test("SkeletonTracing should delete respective comments and branchpoints when deleting a node from a tree", t => {
+  const createNodeAction = SkeletonTracingActions.createNodeAction(
+    position,
+    rotation,
+    viewport,
+    resolution,
+  );
+  const deleteNodeAction = SkeletonTracingActions.deleteNodeAction();
+  const createCommentAction = SkeletonTracingActions.createCommentAction("foo");
+  const createBranchPointAction = SkeletonTracingActions.createBranchPointAction();
+
+  // Add a node, comment, and branchpoint, then delete the node again
+  const newState = SkeletonTracingReducer(initialState, createNodeAction);
+  const newStateA = SkeletonTracingReducer(newState, createCommentAction);
+  const newStateB = SkeletonTracingReducer(newStateA, createBranchPointAction);
+  const newStateC = SkeletonTracingReducer(newStateB, deleteNodeAction);
+
+  // Workaround, because the diffable map creates a new chunk but doesn't delete it again
+  const nodes = newStateC.tracing.trees[1].nodes;
+  t.is(nodes.chunks.length, 1);
+  t.is(nodes.chunks[0].size, 0);
+  nodes.chunks = [];
+  t.deepEqual(newStateC, initialState);
+});
+
 test("SkeletonTracing should not delete tree when last node is deleted from the tree", t => {
   const createNodeAction = SkeletonTracingActions.createNodeAction(
     position,


### PR DESCRIPTION
There was a bug when deleting the last node of a tree. If that node had a comment or branchpoint, that comment/bp was not properly deleted. This led to dangling comments/bps. This PR also fixed the `Get empty` error that has shown up in airbrake.

The code that deleted comments of deleted nodes in the other (working) cases is rather implicit. It moves the comments of all existing nodes to their respective new trees (in case of a split) and the comment of the deleted tree is never moved (and therefore implicitly deleted). This code was not executed for trees of size 1. I made this step more explicit in this PR.

I'm not sure whether we'll have to search for dangling comments/bps in the tasks created in the last weeks, I'll check in discuss.

### URL of deployed dev instance (used for testing):
- https://fixcommentdeletion.webknossos.xyz

### Steps to test:
- Create a tree with one node and add a comment and branchpoint to that node. Now delete the node, the comment and branchpoint should be properly deleted (no comment in the comment tab and hitting "J" should show the warning that there are no more branchpoints).
- Creating/Deleting comments and deleting nodes should continue to work in other cases.

### Issues:
- fixes https://discuss.webknossos.org/t/comments-error/1005

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
~- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [x] Ready for review
