### PR TITLE
Rename cancel to reset-and-cancel

### DIFF
--- a/app/assets/javascripts/admin/task/task_annotation_view.js
+++ b/app/assets/javascripts/admin/task/task_annotation_view.js
@@ -129,7 +129,7 @@ class TaskAnnotationView extends React.PureComponent<Props & StateProps, State> 
         </Item>
         <Item key={`${annotation.id}-delete`}>
           <span onClick={() => this.deleteAnnotation(annotation)}>
-            <Icon type="delete" />Cancel
+            <Icon type="delete" />Reset and Cancel
           </span>
         </Item>
         {annotation.state === "Finished" ? (

--- a/app/assets/javascripts/dashboard/dashboard_task_list_view.js
+++ b/app/assets/javascripts/dashboard/dashboard_task_list_view.js
@@ -212,7 +212,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
             </a>
             <br />
             <a href="#" onClick={() => this.cancelAnnotation(annotation)}>
-              <Icon type="delete" />Cancel
+              <Icon type="delete" />Reset and Cancel
             </a>
             <br />
           </div>

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -88,7 +88,7 @@ In order to restore the current window, a reload is necessary.`,
   "annotation.finish": "Are you sure you want to permanently finish this tracing?",
   "annotation.was_finished": "Annotation was archived",
   "annotation.was_re_opened": "Annotation was reopened",
-  "annotation.delete": "Do you really want to cancel this annotation?",
+  "annotation.delete": "Do you really want to reset and cancel this annotation?",
   "annotation.dataset_no_public":
     "Public tracings require the respective dataset to be public too. Please, make sure to add public access rights to the dataset as well.",
   "annotation.was_edited": "Successfully updated annotation",


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://renameresetandcancel.webknossos.xyz

### Steps to test:
- open the corresponding views

### Issues:
-  fixes #2909

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [ ] Ready for review
