### PR TITLE
Allow decimal scale in simple import view (fixes #2911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
   - Fixed a regression affecting node selection, shortcuts and 3d viewport navigation. [#2673](https://github.com/scalableminds/webknossos/pull/2673)
   - Fixed the dataset zip upload for datasets, which only have one data layer and no config file. [#2840](https://github.com/scalableminds/webknossos/pull/2840)
   - Fixed a bug where task deletion broke the task listing for users who had active annotations for the task [#2884](https://github.com/scalableminds/webknossos/pull/2884)
+  - Fixed that decimal scales (e.g., 11.24, 11.24, 30) couldn't be defined for datasets in "simple" mode. [#2912](https://github.com/scalableminds/webknossos/pull/2912)
 
 
 ### Removed

--- a/app/assets/javascripts/dashboard/dataset/simple_advanced_data_form.js
+++ b/app/assets/javascripts/dashboard/dataset/simple_advanced_data_form.js
@@ -109,7 +109,7 @@ function SimpleDatasetForm({ form, dataSource }) {
                   ),
                 },
               ],
-            })(<Vector3Input style={{ width: 400 }} />)}
+            })(<Vector3Input style={{ width: 400 }} allowDecimals />)}
           </FormItemWithInfo>
         </List.Item>
       </List>

--- a/app/assets/javascripts/libs/vector_input.js
+++ b/app/assets/javascripts/libs/vector_input.js
@@ -11,6 +11,7 @@ type BaseProps<T> = {
   value: T | string,
   onChange: (value: T) => void,
   changeOnlyOnBlur?: boolean,
+  allowDecimals?: boolean,
 };
 
 type State = {
@@ -78,7 +79,7 @@ class BaseVector<T: Vector3 | Vector6> extends React.PureComponent<BaseProps<T>,
 
   makeInvalidValueValid(text: string): T {
     const validSubVector = text
-      .replace(/[^,0-9]/gm, "")
+      .replace(this.props.allowDecimals ? /[^0-9,.]/gm : /[^0-9,]/gm, "")
       .split(",")
       .map(el => parseFloat(el) || 0)
       .slice(0, this.defaultValue.length);
@@ -99,7 +100,10 @@ class BaseVector<T: Vector3 | Vector6> extends React.PureComponent<BaseProps<T>,
     const text = evt.target.value;
 
     // only numbers, commas and whitespace is allowed
-    const isValidInput = /^[\d\s,]*$/g.test(text);
+    const isValidInput = this.props.allowDecimals
+      ? /^[\d\s,.]*$/g.test(text)
+      : /^[\d\s,]*$/g.test(text);
+
     const value = Utils.stringToNumberArray(text);
     const isValidFormat = value.length === this.defaultValue.length;
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://decimalscale.webknossos.xyz

### Steps to test:
- Input decimal scale in edit-view of dataset
- Make sure decimals don't work in position-field

### Issues:
- fixes #2911 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [X] Ready for review
