### PR TITLE
Fix merger-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
   - Fixed a bug in for Firefox users where a long tree list created an unnecessary scroll region. [#2787](https://github.com/scalableminds/webknossos/pull/2787)
   - Fixed clicking on a task type within the task list page, so that the task type page will actually only show the linked task type. [#2769](https://github.com/scalableminds/webknossos/pull/2769)
   - Fixed clicking on a project within the task list page, so that the project page will actually only show the linked project. [#2759](https://github.com/scalableminds/webknossos/pull/2759)
+  - Fixed a bug in the front-end API's `setMapping` call which caused ignored calls if the provided object was mutated. [#2921](https://github.com/scalableminds/webknossos/pull/2921)
   - Fixed a bug where cell IDs in the segmentation tab were not shown for all zoomsteps. [#2726](https://github.com/scalableminds/webknossos/pull/2726)
   - Fixed the naming of the initial tree in tasks. [#2689](https://github.com/scalableminds/webknossos/pull/2689)
   - Fixed a regression affecting node selection, shortcuts and 3d viewport navigation. [#2673](https://github.com/scalableminds/webknossos/pull/2673)

--- a/app/assets/javascripts/oxalis/api/api_latest.js
+++ b/app/assets/javascripts/oxalis/api/api_latest.js
@@ -567,7 +567,7 @@ class DataApi {
     if (layerName !== segmentationLayerName) {
       throw new Error(messages["mapping.unsupported_layer"]);
     }
-    Store.dispatch(setMappingAction(mapping));
+    Store.dispatch(setMappingAction(_.clone(mapping)));
   }
 
   /**

--- a/app/assets/javascripts/oxalis/api/api_v2.js
+++ b/app/assets/javascripts/oxalis/api/api_v2.js
@@ -564,7 +564,7 @@ class DataApi {
     if (layerName !== segmentationLayerName) {
       throw new Error(messages["mapping.unsupported_layer"]);
     }
-    Store.dispatch(setMappingAction(mapping));
+    Store.dispatch(setMappingAction(_.clone(mapping)));
   }
 
   /**


### PR DESCRIPTION
Merger mode was broken since it provided its mutably-managed mappings object to the API. In dev-mode this made the mappings object frozen; in prod-mode it led to unnoticed store-changes, since the object identity didn't change. Therefore, the PR makes sure the user-provided mapping is cloned before store dispatch.

### URL of deployed dev instance (used for testing):
- https://fixmergermode.webknossos.xyz

### Steps to test:
- test merger mode

### Issues:
- fixes #2920 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [X] Ready for review
