### PR TITLE
Show sticky toast if progress report request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Reduced the number of scenarios in which segmentation-related warnings are shown (e.g, not for skeleton tracings when there are multiple resolutions for segmentations anyway). [#2715](https://github.com/scalableminds/webknossos/pull/2715)
 - Email addresses for notifications about new users and about task overtime are no longer specified instance-wide but once per organization. [#2939](https://github.com/scalableminds/webknossos/pull/2939)
 - Improved tracing view page load performance by decreasing WebGL shader compilation time. [#2709](https://github.com/scalableminds/webknossos/pull/2709)
+- Improved error reporting for project progress page. [#2955](https://github.com/scalableminds/webknossos/pull/2955)
 - Redesigned the user task list to make it easier to read the whole task description. [#2861](https://github.com/scalableminds/webknossos/pull/2861)
 
 

--- a/app/assets/javascripts/admin/statistic/project_progress_report_view.js
+++ b/app/assets/javascripts/admin/statistic/project_progress_report_view.js
@@ -6,9 +6,9 @@ import Loop from "components/loop";
 import { getProjectProgressReport } from "admin/admin_rest_api";
 import type { APIProjectProgressReportType, APITeamType } from "admin/api_flow_types";
 import FormattedDate from "components/formatted_date";
-import TeamSelectionForm from "./team_selection_form";
 import Toast from "libs/toast";
 import messages from "messages";
+import TeamSelectionForm from "./team_selection_form";
 
 const { Column, ColumnGroup } = Table;
 

--- a/app/assets/javascripts/admin/statistic/project_progress_report_view.js
+++ b/app/assets/javascripts/admin/statistic/project_progress_report_view.js
@@ -7,6 +7,8 @@ import { getProjectProgressReport } from "admin/admin_rest_api";
 import type { APIProjectProgressReportType, APITeamType } from "admin/api_flow_types";
 import FormattedDate from "components/formatted_date";
 import TeamSelectionForm from "./team_selection_form";
+import Toast from "libs/toast";
+import messages from "messages";
 
 const { Column, ColumnGroup } = Table;
 
@@ -36,11 +38,16 @@ class ProjectProgressReportView extends React.PureComponent<{}, State> {
     if (team == null) {
       this.setState({ data: [] });
     } else if (suppressLoadingState) {
+      const errorToastKey = "progress-report-failed-to-refresh";
       try {
         const progessData = await getProjectProgressReport(team.id);
         this.setState({ data: progessData, updatedAt: Date.now() });
+        Toast.close(errorToastKey);
       } catch (err) {
-        // Fail silently
+        Toast.error(messages["project.report.failed_to_refresh"], {
+          sticky: true,
+          key: errorToastKey,
+        });
       }
     } else {
       this.setState({ isLoading: true });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -164,4 +164,6 @@ In order to restore the current window, a reload is necessary.`,
   "mapping.too_few_textures":
     "Not enough textures available to support mappings. Mappings are disabled.",
   "mapping.unsupported_layer": "Mappings can only be enabled for segmentation layers.",
+  "project.report.failed_to_refresh":
+    "The project report page could not be refreshed. Please try to reload the page.",
 };


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://stickytoastreport.webknossos.xyz

### Steps to test:
- lower `RELOAD_INTERVAL` in `project_progress_report_view.js` to 10 seconds or something
- visit the project progress page and delete your auth cookie via dev tools
- after 10 seconds, a sticky toast should show up

### Issues:
- fixes #2954

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
