### PR TITLE
use GlobalAccessContext in user publicWrites. fix id selection in create explorational

### DIFF
--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -144,7 +144,6 @@ class UserController @Inject()(val messagesApi: MessagesApi)
     }
   }
 
-  // REST API
   def list = SecuredAction.async { implicit request =>
     UsingFilters(
       Filter("isEditable", (value: Boolean, el: UserSQL) => for {isEditable <- el.isEditableBy(request.identity)} yield isEditable == value),

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -42,8 +42,9 @@ object AnnotationService
   private def selectSuitableTeam(user: UserSQL, dataSet: DataSet)(implicit ctx: DBAccessContext): Fox[ObjectId] = {
     (for {
       userTeamIds <- user.teamIds
+      userTeamIdsBson <- Fox.serialCombined(userTeamIds)(_.toBSONObjectId.toFox)
     } yield {
-      val selectedTeamOpt = dataSet.allowedTeams.intersect(userTeamIds).headOption
+      val selectedTeamOpt = dataSet.allowedTeams.intersect(userTeamIdsBson).headOption
       selectedTeamOpt match {
         case Some(selectedTeam) => Fox.successful(ObjectId.fromBsonId(selectedTeam))
         case None =>

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -99,7 +99,8 @@ case class UserSQL(
   def isAdminOf(otherUser: UserSQL): Boolean =
     isAdminOf(otherUser._organization)
 
-  def publicWrites(requestingUser: UserSQL)(implicit ctx: DBAccessContext): Fox[JsObject] =
+  def publicWrites(requestingUser: UserSQL): Fox[JsObject] = {
+    implicit val ctx = GlobalAccessContext
     for {
       isEditable <- isEditableBy(requestingUser)
       organization <- organization
@@ -122,8 +123,10 @@ case class UserSQL(
         "organization" -> organization.name
       )
     }
+  }
 
-  def compactWrites(implicit ctx: DBAccessContext): Fox[JsObject] =
+  def compactWrites: Fox[JsObject] = {
+    implicit val ctx = GlobalAccessContext
     for {
       teamMemberships <- teamMemberships
       teamMembershipsJs <- Fox.serialCombined(teamMemberships)(_.publicWrites)
@@ -137,6 +140,7 @@ case class UserSQL(
         "teams" -> teamMembershipsJs
       )
     }
+  }
 
 }
 


### PR DESCRIPTION
non-admin/non-teammanager users were unable to (1) list a couple of things because user writes were too restrictive and to (2) create explorationals because the team id selection compared BsonIds to ObjectIds. this fixes both

### URL of deployed dev instance (used for testing):
- https://fixuserrights.webknossos.xyz

### Steps to test:
- as non-privileged user (I created a@b.de / asdfasdf), create explorational, call /api/scripts and /api/users

------
- [x] Ready for review
