### PR TITLE
Color unloaded data gray, even for last zoomstep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 
--
+- Fixed a bug where unloaded data was sometimes shown as black instead of gray. [#2963](https://github.com/scalableminds/webknossos/pull/2963)
 
 
 ### Removed

--- a/app/assets/javascripts/oxalis/shaders/filtering.glsl.js
+++ b/app/assets/javascripts/oxalis/shaders/filtering.glsl.js
@@ -125,11 +125,11 @@ export const getMaybeFilteredColorOrFallback: ShaderModuleType = {
       vec4 color = getMaybeFilteredColor(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords, suppressBilinearFiltering, 0.0);
 
       if (color.a < 0.0 && hasFallback) {
-        color = getMaybeFilteredColor(lookUpTexture, layerIndex, d_texture_width, packingDegree, fallbackCoords, suppressBilinearFiltering, 1.0).rgba;
-        if (color.a < 0.0) {
-          // Render gray for not-yet-existing data
-          color = fallbackColor;
-        }
+        color = getMaybeFilteredColor(lookUpTexture, layerIndex, d_texture_width, packingDegree, fallbackCoords, suppressBilinearFiltering, 1.0);
+      }
+      if (color.a < 0.0) {
+        // Render gray for not-yet-existing data
+        color = fallbackColor;
       }
 
       return color;

--- a/app/assets/javascripts/oxalis/shaders/main_data_fragment.glsl.js
+++ b/app/assets/javascripts/oxalis/shaders/main_data_fragment.glsl.js
@@ -187,7 +187,7 @@ void main() {
 
       // Multiply with color and weight for <%= name %>
       data_color += color_value * <%= name %>_weight * <%= name %>_color;
-    <% }) %> ;
+    <% }) %>
     data_color = clamp(data_color, 0.0, 1.0);
   <% } %>
 


### PR DESCRIPTION
Unloaded data was not shown in gray for the very last zoomstep of a dataset.

### URL of deployed dev instance (used for testing):
- https://fixunloadeddatacolor.webknossos.xyz

### Steps to test:
- Open the dataset 2012-09-28_ex145_07x2_corrected (which has only one zoomstep) and zoom out until at least 1.3.
- Move around - unloaded data should be shown in gray, not black!

### Issues:
- fixes #2893

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
