### PR TITLE
retry bucket loading from file

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -6,12 +6,14 @@ package com.scalableminds.webknossos.datastore.services
 import java.nio.file.Paths
 
 import com.google.inject.Inject
+import com.newrelic.api.agent.NewRelic
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.DataLayer
 import com.scalableminds.webknossos.datastore.models.requests.{DataReadInstruction, DataServiceDataRequest, DataServiceMappingRequest, MappingReadInstruction}
 import com.scalableminds.webknossos.datastore.storage.DataCubeCache
 import com.scalableminds.util.tools.ExtendedTypes.ExtendedArraySeq
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import com.scalableminds.webknossos.datastore.dataformats.BucketProvider
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import play.api.Configuration
@@ -90,14 +92,14 @@ class BinaryDataService @Inject()(config: Configuration) extends FoxImplicits wi
         request.dataLayer,
         bucket)
 
-      loadWithRetry(request, readInstruction, emptyBucket)
+      loadWithRetry(request.dataLayer.bucketProvider, readInstruction, emptyBucket)
     } else {
       Fox.successful(emptyBucket)
     }
   }
 
-  private def loadWithRetry(request: DataServiceDataRequest, readInstruction: DataReadInstruction, emptyBucket: Array[Byte], remainingTries: Int = 5): Fox[Array[Byte]] = {
-    (request.dataLayer.bucketProvider.load(readInstruction, cache, loadTimeout).futureBox.map {
+  private def loadWithRetry(bucketProvider: BucketProvider, readInstruction: DataReadInstruction, emptyBucket: Array[Byte], remainingTries: Int = 5): Fox[Array[Byte]] = {
+    bucketProvider.load(readInstruction, cache, loadTimeout).futureBox.map {
       case Full(data) =>
         Fox.successful(data)
       case Empty =>
@@ -105,13 +107,17 @@ class BinaryDataService @Inject()(config: Configuration) extends FoxImplicits wi
       case f: Failure =>
         if (remainingTries > 0) {
           Thread.sleep(20)
-          logger.debug("BinaryDataService: retrying to load bucket, remaining tries: " + remainingTries + " error: " + f.msg)
-          loadWithRetry(request, readInstruction, emptyBucket, remainingTries - 1)
+          val msg = s"BinaryDataService: retrying bucket loading, remaining tries: $remainingTries, error: ${f.msg}"
+          logger.debug(msg)
+          NewRelic.noticeError(msg)
+          loadWithRetry(bucketProvider, readInstruction, emptyBucket, remainingTries - 1)
         } else {
-          logger.error(s"BinaryDataService failure: ${f.msg}")
+          val msg = s"BinaryDataService failure after all retries: ${f.msg}"
+          logger.error(msg)
+          NewRelic.noticeError(msg)
           f.toFox
         }
-    }).toFox.flatten
+    }.toFox.flatten
   }
 
   /**


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://retrybucketloading.webknossos.xyz

### Steps to test:
- view dataset, data should load
- replace line 24 in `WKWBucketProvider.scala` by
```
    if (math.random < 0.1)
      net.liftweb.common.Failure("random error")
    else
      wkwFile.readBlock(blockOffsetX, blockOffsetY, blockOffsetZ)
```
- buckets should still load, but terminal output should show the errors
- increase the error probability, this time they should come through to the frontend (no endless loop)

### Issues:
- workaround for #2781

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- [x] Ready for review
