### PR TITLE
Add placeholders for empty tables, lists (#2927)

### DIFF
--- a/app/assets/javascripts/admin/onboarding.js
+++ b/app/assets/javascripts/admin/onboarding.js
@@ -65,6 +65,8 @@ function FeatureCard({ icon, header, children }) {
 
 export class InviteUsersPopover extends React.Component<{
   organizationName: string,
+  visible?: boolean,
+  handleVisibleChange?: Function,
   children: React.Node,
 }> {
   getRegistrationHotLink(): string {
@@ -94,7 +96,13 @@ export class InviteUsersPopover extends React.Component<{
 
   render() {
     return (
-      <Popover trigger="click" title="Invite Users" content={this.getContent()}>
+      <Popover
+        trigger="click"
+        visible={this.props.visible}
+        onVisibleChange={this.props.handleVisibleChange}
+        title="Invite Users"
+        content={this.getContent()}
+      >
         {this.props.children}
       </Popover>
     );

--- a/app/assets/javascripts/admin/project/project_list_view.js
+++ b/app/assets/javascripts/admin/project/project_list_view.js
@@ -138,6 +138,16 @@ class ProjectListView extends React.PureComponent<Props, State> {
     });
   };
 
+  renderPlaceholder() {
+    return (
+      <React.Fragment>
+        {"There are no projects. You can "}
+        <Link to="/projects/create">add a project</Link>
+        {" which can be used to track task progress."}
+      </React.Fragment>
+    );
+  }
+
   render() {
     const marginRight = { marginRight: 20 };
     const typeHint: Array<APIProjectType> = [];
@@ -173,6 +183,7 @@ class ProjectListView extends React.PureComponent<Props, State> {
                 defaultPageSize: 50,
               }}
               style={{ marginTop: 30, marginBotton: 30 }}
+              locale={{ emptyText: this.renderPlaceholder() }}
             >
               <Column
                 title="Name"

--- a/app/assets/javascripts/admin/scripts/script_list_view.js
+++ b/app/assets/javascripts/admin/scripts/script_list_view.js
@@ -88,6 +88,24 @@ class ScriptListView extends React.PureComponent<Props, State> {
     });
   };
 
+  renderPlaceholder() {
+    return (
+      <React.Fragment>
+        {"There are no scripts. You can "}
+        <Link to="/scripts/create">add a script</Link>
+        {
+          " which can be automatically executed in tasks. Scripts can, for example, be used to add custom keyboard shortcuts."
+        }
+        <br />
+        {"See the "}
+        <Link to="/assets/docs/frontend-api/index.html" target="_blank">
+          Frontend API Documentation
+        </Link>
+        {" for more information."}
+      </React.Fragment>
+    );
+  }
+
   render() {
     const marginRight = { marginRight: 20 };
 
@@ -122,6 +140,7 @@ class ScriptListView extends React.PureComponent<Props, State> {
                 defaultPageSize: 50,
               }}
               style={{ marginTop: 30, marginBotton: 30 }}
+              locale={{ emptyText: this.renderPlaceholder() }}
             >
               <Column
                 title="ID"

--- a/app/assets/javascripts/admin/tasktype/task_type_list_view.js
+++ b/app/assets/javascripts/admin/tasktype/task_type_list_view.js
@@ -93,6 +93,18 @@ class TaskTypeListView extends React.PureComponent<Props, State> {
     });
   };
 
+  renderPlaceholder() {
+    return (
+      <React.Fragment>
+        {"There are no task types. You can "}
+        <Link to="/taskTypes/create">add a task type</Link>
+        {
+          " which can be used to configure certain properties for classes of tasks, for example, a description."
+        }
+      </React.Fragment>
+    );
+  }
+
   render() {
     const marginRight = { marginRight: 20 };
     const typeHint: Array<APITaskTypeType> = [];
@@ -103,7 +115,7 @@ class TaskTypeListView extends React.PureComponent<Props, State> {
           <div className="pull-right">
             <Link to="/taskTypes/create">
               <Button icon="plus" style={marginRight} type="primary">
-                Add TaskType
+                Add Task Type
               </Button>
             </Link>
             <Search
@@ -128,6 +140,7 @@ class TaskTypeListView extends React.PureComponent<Props, State> {
                 defaultPageSize: 50,
               }}
               style={{ marginTop: 30, marginBotton: 30 }}
+              locale={{ emptyText: this.renderPlaceholder() }}
             >
               <Column
                 title="ID"

--- a/app/assets/javascripts/admin/team/create_team_modal_view.js
+++ b/app/assets/javascripts/admin/team/create_team_modal_view.js
@@ -43,6 +43,7 @@ class CreateTeamModalView extends React.PureComponent<Props, State> {
       <Modal
         title="Add a New Team"
         visible={this.props.isVisible}
+        onCancel={this.props.onCancel}
         footer={
           <div>
             <Button onClick={this.props.onCancel}>Cancel</Button>

--- a/app/assets/javascripts/admin/team/team_list_view.js
+++ b/app/assets/javascripts/admin/team/team_list_view.js
@@ -6,11 +6,11 @@ import * as React from "react";
 import { Table, Icon, Spin, Button, Input, Modal } from "antd";
 import Utils from "libs/utils";
 import messages from "messages";
-import CreateTeamModal from "admin/team/create_team_modal_view.js";
+import CreateTeamModal from "admin/team/create_team_modal_view";
 import { getEditableTeams, deleteTeam } from "admin/admin_rest_api";
 import Persistence from "libs/persistence";
 import { PropTypes } from "@scalableminds/prop-types";
-import { withRouter } from "react-router-dom";
+import { withRouter, Link } from "react-router-dom";
 import type { APITeamType } from "admin/api_flow_types";
 import type { RouterHistory } from "react-router-dom";
 import { handleGenericError } from "libs/error_handling";
@@ -95,6 +95,16 @@ class TeamListView extends React.PureComponent<Props, State> {
     });
   };
 
+  renderPlaceholder() {
+    return (
+      <React.Fragment>
+        {"There are no teams. You can "}
+        <a onClick={() => this.setState({ isTeamCreationModalVisible: true })}>add a team</a>
+        {" which can be used to allow or disallow access to specific datasets."}
+      </React.Fragment>
+    );
+  }
+
   render() {
     const marginRight = { marginRight: 20 };
 
@@ -132,6 +142,7 @@ class TeamListView extends React.PureComponent<Props, State> {
                 defaultPageSize: 50,
               }}
               style={{ marginTop: 30, marginBotton: 30 }}
+              locale={{ emptyText: this.renderPlaceholder() }}
             >
               <Column
                 title="Name"

--- a/app/assets/javascripts/admin/user/user_list_view.js
+++ b/app/assets/javascripts/admin/user/user_list_view.js
@@ -5,7 +5,7 @@ import _ from "lodash";
 import * as React from "react";
 import { connect } from "react-redux";
 import { Link, withRouter } from "react-router-dom";
-import { Table, Tag, Icon, Spin, Button, Input, Modal } from "antd";
+import { Table, Tag, Icon, Spin, Button, Input, Modal, Alert } from "antd";
 import TeamRoleModalView from "admin/user/team_role_modal_view";
 import ExperienceModalView from "admin/user/experience_modal_view";
 import TemplateHelpers from "libs/template_helpers";
@@ -44,6 +44,7 @@ type State = {
   selectedUserIds: Array<string>,
   isExperienceModalVisible: boolean,
   isTeamRoleModalVisible: boolean,
+  isInvitePopoverVisible: boolean,
   activationFilter: Array<"true" | "false">,
   searchQuery: string,
 };
@@ -63,6 +64,7 @@ class UserListView extends React.PureComponent<Props, State> {
     selectedUserIds: [],
     isExperienceModalVisible: false,
     isTeamRoleModalVisible: false,
+    isInvitePopoverVisible: false,
     activationFilter: ["true"],
     searchQuery: "",
   };
@@ -166,6 +168,29 @@ class UserListView extends React.PureComponent<Props, State> {
     }
   };
 
+  renderPlaceholder() {
+    const noUsersMessage = (
+      <React.Fragment>
+        {"You can "}
+        <a onClick={() => this.setState({ isInvitePopoverVisible: true })}>invite other users</a>
+        {" to join your organization. After users joined, you'll have to activate them manually."}
+      </React.Fragment>
+    );
+    const inactiveUsersMessage =
+      'There are users that have not been activated yet. Make sure the "Show Active Users Only" tag is removed to show those users and activate them.';
+    const inactiveUsersPresent = this.state.users.filter(user => !user.isActive).length > 0;
+
+    return (
+      <Alert
+        message={inactiveUsersPresent ? "Activate users" : "Invite other users"}
+        description={inactiveUsersPresent ? inactiveUsersMessage : noUsersMessage}
+        type="info"
+        showIcon
+        style={{ marginTop: 20 }}
+      />
+    );
+  }
+
   render() {
     const hasRowsSelected = this.state.selectedUserIds.length > 0;
     const rowSelection = {
@@ -179,11 +204,12 @@ class UserListView extends React.PureComponent<Props, State> {
 
     const activationFilterWarning = this.state.activationFilter.includes("true") ? (
       <Tag closable onClose={this.handleDismissActivationFilter} color="blue">
-        Show Active User Only
+        Show Active Users Only
       </Tag>
     ) : null;
 
     const marginRight = { marginRight: 20 };
+    const lessThanOneActiveUser = this.state.users.filter(user => user.isActive).length < 2;
 
     return (
       <div className="container test-UserListView">
@@ -226,7 +252,13 @@ class UserListView extends React.PureComponent<Props, State> {
             Grant Admin Rights
           </Button>
         ) : null}
-        <InviteUsersPopover organizationName={this.props.activeUser.organization}>
+        <InviteUsersPopover
+          organizationName={this.props.activeUser.organization}
+          visible={this.state.isInvitePopoverVisible}
+          handleVisibleChange={visible => {
+            this.setState({ isInvitePopoverVisible: visible });
+          }}
+        >
           <Button icon="user-add" style={marginRight}>
             Invite Users
           </Button>
@@ -238,6 +270,8 @@ class UserListView extends React.PureComponent<Props, State> {
           onChange={this.handleSearch}
           value={this.state.searchQuery}
         />
+
+        {lessThanOneActiveUser ? this.renderPlaceholder() : null}
 
         <Spin size="large" spinning={this.state.isLoading}>
           <Table

--- a/app/assets/javascripts/dashboard/dashboard_task_list_view.js
+++ b/app/assets/javascripts/dashboard/dashboard_task_list_view.js
@@ -314,6 +314,10 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
     return this.state.showFinishedTasks ? this.state.finishedTasks : this.state.unfinishedTasks;
   }
 
+  renderPlaceholder() {
+    return 'You have no assigned tasks. Request a new task by clicking on the "Get a New Task" button.';
+  }
+
   renderTaskList() {
     const tasks = this.getCurrentTasks().sort(Utils.localeCompareBy(typeHint, "created"));
     const descriptionClassName = classNames("task-type-description", {
@@ -360,6 +364,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
         }}
         loading={this.state.isLoading}
         renderItem={TaskCard}
+        locale={{ emptyText: this.renderPlaceholder() }}
       />
     );
   }

--- a/app/assets/javascripts/dashboard/dataset_view.js
+++ b/app/assets/javascripts/dashboard/dataset_view.js
@@ -4,7 +4,7 @@ import _ from "lodash";
 import * as React from "react";
 import { Link, withRouter } from "react-router-dom";
 import Utils from "libs/utils";
-import { Spin, Input, Button } from "antd";
+import { Spin, Input, Button, Icon, Row, Col } from "antd";
 import AdvancedDatasetView from "dashboard/advanced_dataset/advanced_dataset_view";
 import GalleryDatasetView from "dashboard/gallery_dataset_view";
 import Persistence from "libs/persistence";
@@ -127,6 +127,36 @@ class DatasetView extends React.PureComponent<Props, State> {
     });
   };
 
+  renderPlaceholder() {
+    return (
+      <Row type="flex" justify="center" style={{ padding: "20px 50px 70px" }} align="middle">
+        <Col span={18}>
+          <div style={{ paddingBottom: 32, textAlign: "center" }}>
+            <Icon type="cloud-upload" style={{ fontSize: 180, color: "rgb(58, 144, 255)" }} />
+            <p style={{ fontSize: 24, margin: "14px 0 0" }}>
+              Upload the first dataset into your organization.
+            </p>
+            <p
+              style={{
+                fontSize: 14,
+                margin: "14px 0",
+                color: "gray",
+                display: "inline-block",
+                width: 500,
+              }}
+            >
+              <Link to="/datasets/upload">Upload your dataset</Link> or copy it directly onto the
+              hosting server.{" "}
+              <a href="https://github.com/scalableminds/webknossos/wiki/Datasets">
+                Learn more about supported data formats.
+              </a>
+            </p>
+          </div>
+        </Col>
+      </Row>
+    );
+  }
+
   renderGallery() {
     return (
       <GalleryDatasetView datasets={this.state.datasets} searchQuery={this.state.searchQuery} />
@@ -176,7 +206,13 @@ class DatasetView extends React.PureComponent<Props, State> {
       search
     );
 
-    const content = isGallery ? this.renderGallery() : this.renderAdvanced();
+    const isEmpty = this.state.datasets.length === 0;
+    let content;
+    if (isEmpty) {
+      content = this.renderPlaceholder();
+    } else {
+      content = isGallery ? this.renderGallery() : this.renderAdvanced();
+    }
 
     return (
       <div>


### PR DESCRIPTION
This PR adds placeholders for a couple of views that are shown when the lists/tables in those views are empty. This includes both of the dataset views, the user task list, the user view with two different warnings (no other users and no other users but inactive users), the team, project, task type, and scripts view.

@normanrz @hotzenklotz Please check whether the instructions/descriptions shown in these warnings are appropriate and complete.

Some screenshots:

#### Dataset views:
![placeholder-1](https://user-images.githubusercontent.com/1702075/43269937-394a6908-90f4-11e8-8ceb-6ee0a2090b63.png)

#### No other users but inactive users:
![placeholder-2](https://user-images.githubusercontent.com/1702075/43269940-399c3a12-90f4-11e8-8918-0ab9c7a9bdb5.png)

#### No other users:
![placeholder-3](https://user-images.githubusercontent.com/1702075/43269942-39d2300e-90f4-11e8-91b7-12013658691a.png)

#### Script view:
![placeholder-4](https://user-images.githubusercontent.com/1702075/43269943-39f81062-90f4-11e8-83f2-90624dae54e3.png)

### URL of deployed dev instance (used for testing):
- https://placeholderforemptyviews.webknossos.xyz

### Steps to test:
- Open all of the views that show tabular data or lists and check that the placeholders are only shown if they are empty (or when otherwise appropriate).
- Check that the links in those placeholders are working.

### Issues:
- fixes #2927

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [x] Ready for review
