### PR TITLE
allow specifying groupId in createTree skeleton action

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/SkeletonUpdateActions.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/SkeletonUpdateActions.scala
@@ -11,9 +11,10 @@ import play.api.libs.json._
 
 
 case class CreateTreeSkeletonAction(id: Int, color: Option[com.scalableminds.util.image.Color], name: String,
-                                    branchPoints: List[UpdateActionBranchPoint], timestamp: Long, comments: List[UpdateActionComment], actionTimestamp: Option[Long] = None) extends UpdateAction.SkeletonUpdateAction with SkeletonUpdateActionHelper {
+                                    branchPoints: List[UpdateActionBranchPoint], timestamp: Long, comments: List[UpdateActionComment], actionTimestamp: Option[Long] = None,
+                                    groupId: Option[Int]) extends UpdateAction.SkeletonUpdateAction with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing) = {
-    val newTree = Tree(id, Nil, Nil, convertColorOpt(color), branchPoints.map(convertBranchPoint), comments.map(convertComment), name, timestamp)
+    val newTree = Tree(id, Nil, Nil, convertColorOpt(color), branchPoints.map(convertBranchPoint), comments.map(convertComment), name, timestamp, groupId)
     tracing.withTrees(newTree +: tracing.trees)
   }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://createtreegroupid.webknossos.xyz

### Steps to test:
- start skeleton tracing
- drag’n’drop NMLs into the view, leave the checkbox checked
- save, reload, trees should still be in respective groups

### Issues:
- fixes #2971

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- [x] Ready for review
