### PR TITLE
Update flow to 0.78

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -35,3 +35,4 @@ all=error
 sketchy-null=warn
 untyped-import=off
 unclear-type=warn
+deprecated-type=warn

--- a/app/assets/javascripts/dashboard/explorative_annotations_view.js
+++ b/app/assets/javascripts/dashboard/explorative_annotations_view.js
@@ -366,7 +366,11 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
         <Column
           title="Stats"
           render={(__, annotation: APIAnnotationType) =>
-            annotation.stats.treeCount && annotation.tracing.skeleton != null ? (
+            // Flow doesn't recognize that stats must contain the nodeCount if the treeCount is != null
+            annotation.stats.treeCount != null &&
+            annotation.stats.nodeCount != null &&
+            annotation.stats.edgeCount != null &&
+            annotation.tracing.skeleton != null ? (
               <div>
                 <span title="Trees">
                   <i className="fa fa-sitemap" />

--- a/app/assets/javascripts/oxalis/model/accessors/dataset_accessor.js
+++ b/app/assets/javascripts/oxalis/model/accessors/dataset_accessor.js
@@ -98,7 +98,7 @@ export function getDatasetCenter(dataset: APIDatasetType): Vector3 {
   ];
 }
 
-export function determineAllowedModes(dataset: APIDatasetType, settings: SettingsType): * {
+export function determineAllowedModes(dataset: APIDatasetType, settings: SettingsType) {
   // The order of allowedModes should be independent from the server and instead be similar to ModeValues
   let allowedModes = _.intersection(ModeValues, settings.allowedModes);
 

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/layer_rendering_manager.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/layer_rendering_manager.js
@@ -11,6 +11,8 @@ import determineBucketsForOrthogonal from "oxalis/model/bucket_data_handling/buc
 import determineBucketsForOblique from "oxalis/model/bucket_data_handling/bucket_picker_strategies/oblique_bucket_picker";
 import determineBucketsForFlight from "oxalis/model/bucket_data_handling/bucket_picker_strategies/flight_bucket_picker";
 import { getAreas, getZoomedMatrix } from "oxalis/model/accessors/flycam_accessor";
+import * as THREE from "three";
+import UpdatableTexture from "libs/UpdatableTexture";
 import type { Vector3, Vector4, OrthoViewMapType, ModeType } from "oxalis/constants";
 import type { AreaType } from "oxalis/model/accessors/flycam_accessor";
 import { getResolutions, getByteCount } from "oxalis/model/accessors/dataset_accessor";
@@ -104,7 +106,7 @@ export default class LayerRenderingManager {
     shaderEditor.addBucketManagers(this.textureBucketManager);
   }
 
-  getDataTextures(): Array<*> {
+  getDataTextures(): Array<THREE.DataTexture | UpdatableTexture> {
     if (!this.textureBucketManager) {
       // Initialize lazily since SceneController.renderer is not available earlier
       this.setupDataTextures();

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/mappings.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/mappings.js
@@ -74,7 +74,7 @@ class Mappings {
     }
   }
 
-  async fetchMappings(mappingName: string, fetchedMappings: APIMappingsType): Promise<*> {
+  async fetchMappings(mappingName: string, fetchedMappings: APIMappingsType): Promise<void> {
     const mapping = await this.fetchMapping(mappingName);
     if (mapping == null) return Promise.reject();
     fetchedMappings[mappingName] = mapping;

--- a/app/assets/javascripts/oxalis/view/right-menu/mapping_info_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/mapping_info_view.js
@@ -108,7 +108,7 @@ class MappingInfoView extends Component<Props> {
     ]
       .map(idInfo => ({
         ...idInfo,
-        mapped: idInfo.unmapped && cube.mapId(idInfo.unmapped),
+        mapped: idInfo.unmapped != null ? cube.mapId(idInfo.unmapped) : undefined,
       }))
       .map(idInfo => ({
         ...idInfo,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.5.1",
     "file-loader": "^1.1.5",
-    "flow-bin": "^0.71.0",
+    "flow-bin": "^0.78.0",
     "flow-coverage-report": "^0.5.0",
     "himalaya": "^0.2.12",
     "isomorphic-fetch": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4143,9 +4143,9 @@ flow-annotation-check@1.8.0:
     glob "7.1.1"
     load-pkg "^3.0.1"
 
-flow-bin@^0.71.0:
-  version "0.71.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.71.0.tgz#fd1b27a6458c3ebaa5cb811853182ed631918b70"
+flow-bin@^0.78.0:
+  version "0.78.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.78.0.tgz#df9fe7f9c9a2dfaff39083949fe2d831b41627b7"
 
 flow-coverage-report@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
As discussed, we'll take care of the deprecated existential type (`*`) in a later PR.
Small change, could be merged into `fe-hybrid` directly imo.

### Steps to test:
- CI should be enough

------
- [x] Ready for review
