### PR TITLE
Fix setting of user bounding box in view mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 - Fixed a bug where unloaded data was sometimes shown as black instead of gray. [#2963](https://github.com/scalableminds/webknossos/pull/2963)
 - Fixed that URLs linking to a certain position in a dataset or tracing always led to the position of the active node. [#2960](https://github.com/scalableminds/webknossos/pull/2960)
+- Fixed that setting a bounding box in view mode did not work. [#3015](https://github.com/scalableminds/webknossos/pull/3015)
 
 
 ### Removed

--- a/app/assets/javascripts/oxalis/model/reducers/annotation_reducer.js
+++ b/app/assets/javascripts/oxalis/model/reducers/annotation_reducer.js
@@ -48,10 +48,12 @@ function AnnotationReducer(state: OxalisState, action: ActionType): OxalisState 
       };
       const maybeSkeletonUpdater = state.tracing.skeleton ? { skeleton: updaterObject } : {};
       const maybeVolumeUpdater = state.tracing.volume ? { volume: updaterObject } : {};
+      const maybeReadOnlyUpdater = state.tracing.readOnly ? { readOnly: updaterObject } : {};
       return update(state, {
         tracing: {
           ...maybeSkeletonUpdater,
           ...maybeVolumeUpdater,
+          ...maybeReadOnlyUpdater,
         },
       });
     }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixbbviewmode.webknossos.xyz

### Steps to test:
- view a dataset
- specify a bounding box in the settings --> should be visible as an orange cuboid

### Issues:
- fixes #3016

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
