### PR TITLE
fix compoundtracing permission lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,12 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed a bug where unloaded data was sometimes shown as black instead of gray. [#2963](https://github.com/scalableminds/webknossos/pull/2963)
 - Fixed that URLs linking to a certain position in a dataset or tracing always led to the position of the active node. [#2960](https://github.com/scalableminds/webknossos/pull/2960)
 - Fixed that setting a bounding box in view mode did not work. [#3015](https://github.com/scalableminds/webknossos/pull/3015)
+- Fixed a bug where viewing Compound Annotations (such as viewing all instances of a task at once) failed with a permission issue. [#3023](https://github.com/scalableminds/webknossos/pull/3023)
 
 
 ### Removed
 
-- 
+-
 
 ## [18.08.0](https://github.com/scalableminds/webknossos/releases/tag/18.08.0) - 2018-07-23
 [Commits](https://github.com/scalableminds/webknossos/compare/18.07.0...18.08.0)

--- a/app/models/annotation/AnnotationStore.scala
+++ b/app/models/annotation/AnnotationStore.scala
@@ -58,7 +58,7 @@ object AnnotationStore extends LazyLogging {
   }
 
   def findCachedByTracingId(tracingId: String): Box[Annotation] = {
-    val annotationOpt = TemporaryAnnotationStore.findAll.find(a => a.skeletonTracingId == tracingId || a.volumeTracingId == tracingId)
+    val annotationOpt = TemporaryAnnotationStore.findAll.find(a => a.skeletonTracingId == Some(tracingId) || a.volumeTracingId == Some(tracingId))
     annotationOpt match {
       case Some(annotation) => Full(annotation)
       case None => Empty


### PR DESCRIPTION
Compared String with Option[String] – Sadly, the compiler allows this…

### URL of deployed dev instance (used for testing):
- https://fixcompoundtracingpermissions.webknossos.xyz

### Steps to test:
- create task, trace some, finish (one is enough)
- view task from admin→tasks menu
- url should feature “CompoundTask”, tracing should load

### Issues:
- fixes #3022

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- [x] Ready for review
