### PR TITLE
Default text to show that no users are assigned to a task in task view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Added functions to the front-end API to activate a tree and to change the color of a tree. [#2997](https://github.com/scalableminds/webknossos/pull/2997)
 - When a new team or project is created, invalid names will be directly marked in red. [#3034](https://github.com/scalableminds/webknossos/pull/3034)
 - Comments can now contain references to nodes (`#<nodeid>`) or positions (`#(<x,y,z>)`). Clicking on such a reference activates the respective node or position and centers it. [#2950](https://github.com/scalableminds/webknossos/pull/2950)
+- Added a default text to the task view to indicate, that no users are assigned to a task. [#3030](https://github.com/scalableminds/webknossos/issues/3030)
 
 ### Changed
 

--- a/app/assets/javascripts/admin/task/task_annotation_view.js
+++ b/app/assets/javascripts/admin/task/task_annotation_view.js
@@ -150,6 +150,9 @@ class TaskAnnotationView extends React.PureComponent<Props & StateProps, State> 
   }
 
   render() {
+    if (!this.state.annotations || this.state.annotations.length <= 0) {
+      return <p> No users are assigned to this task, yet.</p>;
+    }
     return (
       <div>
         <table>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- go to the task view
- expand tasks
- those with users assigned should appear normal
- those without assigned users would display a default text

### Issues:
- fixes [#3030](https://github.com/scalableminds/webknossos/issues/3030)

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [ ] Needs datastore update after deployment
- [x] Ready for review
