### PR TITLE
Fix test-prepare-watch

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -13,10 +13,11 @@ shift;
 additionalParams=$@
 
 function prepare {
-  rm -rf "$testBundlePath" && BABEL_ENV=test babel "$jsPath" --out-dir "$testBundlePath" $additionalParams
+  rm -rf "$testBundlePath" && mkdir "$testBundlePath"
   # Webpack with the proto loader isn't used when running the tests, so the proto files need to be prepared manually
   pbjs -t json "webknossos-datastore/proto/SkeletonTracing.proto" > "$testBundlePath/SkeletonTracing.proto.json"
   pbjs -t json "webknossos-datastore/proto/VolumeTracing.proto" > "$testBundlePath/VolumeTracing.proto.json"
+  BABEL_ENV=test babel "$jsPath" --out-dir "$testBundlePath" $additionalParams
 }
 
 function ensureUpToDateTests {


### PR DESCRIPTION
The proto files were not created when the babel watcher was used. I switched up the order and it should work fine now.

### Steps to test:
- Check out locally, run `yarn test-prepare-watch` and then execute the e2e-tests. There should be no error messages regarding the proto files.

### Issues:
- fixes missing proto files when using the test-prepare watcher

------
- [x] Ready for review
