### PR TITLE
API route for listing experience domains

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -8,6 +8,7 @@ User-facing changes are documented in the [changelog](CHANGELOG.md).
 ### Postgres Evolutions:
 - [018-hybrid-annotations.sql](conf/evolutions/018-hybrid-annotations.sql)
 - [019-dataset-lastusedtime.sql](conf/evolutions/019-dataset-lastusedtime.sql)
+- [021-list-experiences.sql](conf/evolutions/021-list-experiences.sql)
 
 ## [18.08.0](https://github.com/scalableminds/webknossos/releases/tag/18.08.0) - 2018-07-23
 ### Postgres Evolutions:

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -254,7 +254,6 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
     } yield {
       Ok(Json.toJson(jsResult))
     }
-
   }
 
   def request = SecuredAction.async { implicit request =>
@@ -303,4 +302,10 @@ class TaskController @Inject() (val messagesApi: MessagesApi)
     } yield Ok(taskJson)
   }
 
+
+  def listExperienceDomains = SecuredAction.async { implicit request =>
+    for {
+      experienceDomains <- TaskDAO.listExperienceDomains
+    } yield Ok(Json.toJson(experienceDomains))
+  }
 }

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -310,6 +310,12 @@ object TaskDAO extends SQLDAO[Task, TasksRow, Tasks] {
     }
   }
 
+  def listExperienceDomains(implicit ctx: DBAccessContext): Fox[List[String]] = {
+    for {
+      rowsRaw <- run(sql"select domain from webknossos.experienceDomains".as[String])
+    } yield rowsRaw.toList
+  }
+
   def insertOne(t: Task): Fox[Unit] = {
     for {
       _ <- run(

--- a/conf/evolutions/021-list-experiences.sql
+++ b/conf/evolutions/021-list-experiences.sql
@@ -1,4 +1,4 @@
--- https://github.com/scalableminds/webknossos/pull/TODO
+-- https://github.com/scalableminds/webknossos/pull/3060
 
 START TRANSACTION;
 

--- a/conf/evolutions/021-list-experiences.sql
+++ b/conf/evolutions/021-list-experiences.sql
@@ -1,0 +1,38 @@
+-- https://github.com/scalableminds/webknossos/pull/TODO
+
+START TRANSACTION;
+
+CREATE TABLE webknossos.experienceDomains(
+  domain VARCHAR(256) PRIMARY KEY
+);
+
+INSERT INTO webknossos.experienceDomains(domain) SELECT neededExperience_domain FROM webknossos.tasks_ ON CONFLICT DO NOTHING;
+INSERT INTO webknossos.experienceDomains(domain) SELECT domain FROM webknossos.user_experiences ON CONFLICT DO NOTHING;
+
+
+CREATE FUNCTION webknossos.onInsertTask() RETURNS trigger AS $$
+  BEGIN
+    INSERT INTO webknossos.experienceDomains(domain) values(NEW.neededExperience_domain) ON CONFLICT DO NOTHING;
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION webknossos.onInsertUserExperience() RETURNS trigger AS $$
+  BEGIN
+    INSERT INTO webknossos.experienceDomains(domain) values(NEW.domain) ON CONFLICT DO NOTHING;
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER onDeleteAnnotationTrigger
+AFTER INSERT ON webknossos.tasks
+FOR EACH ROW EXECUTE PROCEDURE webknossos.onInsertTask();
+
+CREATE TRIGGER onInsertUserExperienceTrigger
+AFTER INSERT ON webknossos.user_experiences
+FOR EACH ROW EXECUTE PROCEDURE webknossos.onInsertUserExperience();
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 21;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/21-list-experiences.sql
+++ b/conf/evolutions/reversions/21-list-experiences.sql
@@ -1,0 +1,10 @@
+
+START TRANSACTION;
+
+DROP FUNCTION webknossos.onInsertTask CASCADE;
+DROP FUNCTION webknossos.onInsertUserExperience CASCADE;
+DROP TABLE webknossos.experienceDomains;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 20;
+
+COMMIT TRANSACTION;

--- a/conf/webknossos.routes
+++ b/conf/webknossos.routes
@@ -103,6 +103,7 @@ GET           /api/annotations/:typ/:id/loggedTime                              
 POST          /api/tasks                                                        controllers.TaskController.create
 POST          /api/tasks/createFromFile                                         controllers.TaskController.createFromFile
 POST          /api/tasks/list                                                   controllers.TaskController.listTasks
+GET           /api/tasks/experienceDomains                                      controllers.TaskController.listExperienceDomains
 GET           /api/tasks/:id                                                    controllers.TaskController.read(id: String)
 DELETE        /api/tasks/:id                                                    controllers.TaskController.delete(id: String)
 PUT           /api/tasks/:id                                                    controllers.TaskController.update(id: String)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://structureexperiences.webknossos.xyz

### Steps to test:
- create some tasks with some needed experiences, give some experiences to users
- both should be listed in `api/tasks/experienceDomains`

### Issues:
- to support #3031 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- [x] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
- [ ] should be merged after #3057 (or evolution numbers should be swapped)
