### PR TITLE
maybe-fix: loading already closed bucket file

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/Cube.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/Cube.scala
@@ -22,10 +22,11 @@ trait Cube {
     this.synchronized {
       if (isRemoved) {
         NewRelic.noticeError("Tried to access cube which is already removed.")
-        return false
+        false
+      } else {
+        accessCounter += 1
+        true
       }
-      accessCounter += 1
-      return true
     }
   }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/Cube.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/Cube.scala
@@ -43,7 +43,7 @@ trait Cube {
     this.synchronized {
       scheduledForRemoval = true
       // Check if we can directly remove this cube (only possible if it is currently unused)
-      if(accessCounter.get() == 0) {
+      if (accessCounter == 0) {
         isRemoved = true
         onFinalize()
       }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataCubeCache.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataCubeCache.scala
@@ -51,36 +51,41 @@ class DataCubeCache(val maxEntries: Int) extends FakeDataCubeCache with LRUConcu
   override def withCache[T](readInstruction: DataReadInstruction)(loadF: DataReadInstruction => Fox[Cube])(f: Cube => Box[T]): Fox[T] = {
     val cachedCubeInfo = CachedCube.from(readInstruction)
 
+    def getUncachedCube(): Fox[T] = {
+      val cubeFox = loadF(readInstruction).futureBox.map {
+        case Full(cube) =>
+          if (! cube.tryAccess())
+            return getUncachedCube()
+          Full(cube)
+        case f: Failure =>
+          remove(cachedCubeInfo)
+          f
+        case _ =>
+          Empty
+      }.toFox
+
+      put(cachedCubeInfo, cubeFox)
+      NewRelic.incrementCounter("Custom/FileDataStore/Cache/miss")
+      NewRelic.recordMetric("Custom/FileDataStore/Cache/size", size())
+
+      cubeFox.flatMap { cube =>
+        val result = f(cube)
+        cube.finishAccess()
+        result
+      }
+    }
+
     get(cachedCubeInfo) match {
       case Some(cubeFox) =>
         cubeFox.flatMap { cube =>
-          cube.startAccess()
+          if (! cube.tryAccess())
+            return getUncachedCube()
           NewRelic.incrementCounter("Custom/FileDataStore/Cache/hit")
           val result = f(cube)
           cube.finishAccess()
           result.toFox
         }
-      case _ =>
-        val cubeFox = loadF(readInstruction).futureBox.map {
-          case Full(cube) =>
-            cube.startAccess()
-            Full(cube)
-          case f: Failure =>
-            remove(cachedCubeInfo)
-            f
-          case _ =>
-            Empty
-        }.toFox
-
-        put(cachedCubeInfo, cubeFox)
-        NewRelic.incrementCounter("Custom/FileDataStore/Cache/miss")
-        NewRelic.recordMetric("Custom/FileDataStore/Cache/size", size())
-
-        cubeFox.flatMap { cube =>
-          val result = f(cube)
-          cube.finishAccess()
-          result
-        }
+      case _ => getUncachedCube()
     }
   }
 


### PR DESCRIPTION
This PR
* makes Cube aware that it's removed
* and makes the cache open a new file, if that is the case.

### URL of deployed dev instance (used for testing):
- https://cubecacherespectclosed.webknossos.xyz

### Steps to test:
- only testable under high load --> in production

### Issues:
- maybefixes #2781 / [discuss-entry](https://discuss.webknossos.org/t/error-processing-wkw-file/950)
- fixes #2976

------
- [ ] ~~Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- [ ] ~~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- [x] Needs datastore update after deployment
- [x] Ready for review
