### PR TITLE
remove copyright comment blocks in backend

### DIFF
--- a/app/controllers/ProjectController.scala
+++ b/app/controllers/ProjectController.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package controllers
 import javax.inject.Inject
 import com.scalableminds.util.accesscontext.GlobalAccessContext

--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package controllers
 
 import javax.inject.Inject

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2018 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package models.annotation
 
 import com.scalableminds.util.mvc.Formatter

--- a/app/models/annotation/AnnotationMutations.scala
+++ b/app/models/annotation/AnnotationMutations.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package models.annotation
 
 import com.scalableminds.util.accesscontext.DBAccessContext

--- a/app/models/annotation/TemporaryAnnotationStore.scala
+++ b/app/models/annotation/TemporaryAnnotationStore.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package models.annotation
 
 import com.scalableminds.webknossos.datastore.storage.TemporaryStore

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package models.annotation.nml
 
 import java.io.InputStream

--- a/app/models/basics/TemporaryStore.scala
+++ b/app/models/basics/TemporaryStore.scala
@@ -4,12 +4,7 @@ import akka.agent.Agent
 import play.api.Play
 import play.api.libs.concurrent.Akka
 import play.api.libs.concurrent.Execution.Implicits._
-/**
- * Company: scalableminds
- * User: tmbo
- * Date: 29.10.13
- * Time: 14:36
- */
+
 trait TemporaryStore[T] {
   implicit val sys = Akka.system(Play.current)
   lazy val ts = Agent[Map[String, T]](Map())

--- a/app/models/task/CompletionStatus.scala
+++ b/app/models/task/CompletionStatus.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package models.task
 
 import play.api.libs.json.Json

--- a/app/models/user/time/Interval.scala
+++ b/app/models/user/time/Interval.scala
@@ -4,12 +4,6 @@ import play.api.libs.json.Json
 import java.util.Calendar
 import org.joda.time.{DateTimeConstants, DateTime}
 
-/**
- * Company: scalableminds
- * User: tmbo
- * Date: 28.10.13
- * Time: 00:58
- */
 trait Interval {
   def start: DateTime
 

--- a/app/oxalis/cleanup/CleanupService.scala
+++ b/app/oxalis/cleanup/CleanupService.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package oxalis.cleanup
 
 import com.scalableminds.util.tools.Fox

--- a/app/oxalis/security/URLSharing.scala
+++ b/app/oxalis/security/URLSharing.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2018 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package oxalis.security
 
 import java.security.SecureRandom

--- a/app/utils/CustomPostgresProfile.scala
+++ b/app/utils/CustomPostgresProfile.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package utils
 /*
 import com.github.tminglei.slickpg._

--- a/app/utils/SQLHelpers.scala
+++ b/app/utils/SQLHelpers.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2018 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package utils
 
 

--- a/test/e2e/End2EndSpec.scala
+++ b/test/e2e/End2EndSpec.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package e2e
 
 import scala.concurrent.{Await, Future}

--- a/util/src/main/scala/com/scalableminds/util/auth/AccessToken.scala
+++ b/util/src/main/scala/com/scalableminds/util/auth/AccessToken.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.auth
 
 import play.api.libs.json._

--- a/util/src/main/scala/com/scalableminds/util/auth/GithubOAuth.scala
+++ b/util/src/main/scala/com/scalableminds/util/auth/GithubOAuth.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.auth
 
 import com.scalableminds.util.tools.{Fox, FoxImplicits}

--- a/util/src/main/scala/com/scalableminds/util/auth/OAuth2Info.scala
+++ b/util/src/main/scala/com/scalableminds/util/auth/OAuth2Info.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.auth
 
 import play.api.libs.json.{Format, Json}

--- a/util/src/main/scala/com/scalableminds/util/auth/Session.scala
+++ b/util/src/main/scala/com/scalableminds/util/auth/Session.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.auth
 
 import play.api.libs.json.Json

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import net.liftweb.common.{Box, Empty, Full}

--- a/util/src/main/scala/com/scalableminds/util/geometry/Figure.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Figure.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import com.scalableminds.util.tools.ExtendedTypes._

--- a/util/src/main/scala/com/scalableminds/util/geometry/NGonalFrustum.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/NGonalFrustum.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 /**

--- a/util/src/main/scala/com/scalableminds/util/geometry/OrientedPosition.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/OrientedPosition.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 case class OrientedPosition(translation: Vector3D, direction: Vector3D)

--- a/util/src/main/scala/com/scalableminds/util/geometry/Point3D.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Point3D.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import play.api.data.validation.ValidationError

--- a/util/src/main/scala/com/scalableminds/util/geometry/Polygon.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Polygon.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import play.api.libs.json.Json._

--- a/util/src/main/scala/com/scalableminds/util/geometry/Scale.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Scale.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import play.api.libs.json._

--- a/util/src/main/scala/com/scalableminds/util/geometry/TransformationMatrix.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/TransformationMatrix.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 case class MatrixBase3D(x: Vector3D, y: Vector3D, z: Vector3D)
@@ -19,9 +16,9 @@ object TransformationMatrix {
       0, 1, 0, 0,
       0, 0, 1, 0,
       0, 0, 0, 1))
-  
+
   def apply(pos: Vector3D, rotationBase: MatrixBase3D): TransformationMatrix = {
-    
+
     val MatrixBase3D(ny, nx, nz) = rotationBase
 
     TransformationMatrix(Array(

--- a/util/src/main/scala/com/scalableminds/util/geometry/Vector2D.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Vector2D.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import scala.math._

--- a/util/src/main/scala/com/scalableminds/util/geometry/Vector3D.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Vector3D.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import com.scalableminds.util.tools.Math._

--- a/util/src/main/scala/com/scalableminds/util/geometry/Vector3I.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Vector3I.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.geometry
 
 import play.api.data.validation.ValidationError

--- a/util/src/main/scala/com/scalableminds/util/image/Color.scala
+++ b/util/src/main/scala/com/scalableminds/util/image/Color.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.image
 
 import com.scalableminds.util.tools.ExtendedTypes._

--- a/util/src/main/scala/com/scalableminds/util/image/ImageCreator.scala
+++ b/util/src/main/scala/com/scalableminds/util/image/ImageCreator.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.image
 
 import java.awt.image.BufferedImage

--- a/util/src/main/scala/com/scalableminds/util/image/ImageWriter.scala
+++ b/util/src/main/scala/com/scalableminds/util/image/ImageWriter.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.image
 
 import java.awt.image.{BufferedImage, DataBufferByte}

--- a/util/src/main/scala/com/scalableminds/util/io/FileIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/FileIO.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.util.io
 
 import java.io._

--- a/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.io
 
 import java.io.File

--- a/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.io
 
 import java.io._

--- a/util/src/main/scala/com/scalableminds/util/mail/Mail.scala
+++ b/util/src/main/scala/com/scalableminds/util/mail/Mail.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.util.mail;
 
 case class Mail(

--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.util.mvc
 
 import com.scalableminds.util.tools.{BoxImplicits, Fox, FoxImplicits}

--- a/util/src/main/scala/com/scalableminds/util/mvc/Formatter.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/Formatter.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.mvc
 
 import java.text.SimpleDateFormat

--- a/util/src/main/scala/com/scalableminds/util/mvc/WithHighlightableResult.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/WithHighlightableResult.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.util.mvc
 
 import play.api.http.HeaderNames._

--- a/util/src/main/scala/com/scalableminds/util/security/InsecureSSLSocketFactory.scala
+++ b/util/src/main/scala/com/scalableminds/util/security/InsecureSSLSocketFactory.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.util.security
 
 import java.security.cert.X509Certificate

--- a/util/src/main/scala/com/scalableminds/util/security/SCrypt.scala
+++ b/util/src/main/scala/com/scalableminds/util/security/SCrypt.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.util.security
 
 /**

--- a/util/src/main/scala/com/scalableminds/util/tools/BoxImplicits.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/BoxImplicits.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import net.liftweb.common.{Box, Failure, Full}

--- a/util/src/main/scala/com/scalableminds/util/tools/Converter.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Converter.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 object DefaultConverters{
@@ -50,7 +47,7 @@ object DefaultConverters{
         value =>
           (0 until bytesPerElement).map{
             pos =>
-              (value >> (8 * pos)).byteValue 
+              (value >> (8 * pos)).byteValue
           }
       }
     }

--- a/util/src/main/scala/com/scalableminds/util/tools/ExtendedTypes.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/ExtendedTypes.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.util.tools
 
 import java.io.RandomAccessFile

--- a/util/src/main/scala/com/scalableminds/util/tools/FileExtensionFilter.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/FileExtensionFilter.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import java.io.{File, FilenameFilter}

--- a/util/src/main/scala/com/scalableminds/util/tools/Interpolator.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Interpolator.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import com.scalableminds.util.geometry.Vector3D

--- a/util/src/main/scala/com/scalableminds/util/tools/JsonHelper.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/JsonHelper.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import java.io.FileNotFoundException

--- a/util/src/main/scala/com/scalableminds/util/tools/Math.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Math.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 object Math {

--- a/util/src/main/scala/com/scalableminds/util/tools/ProgressTracker.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/ProgressTracker.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import akka.agent.Agent

--- a/util/src/main/scala/com/scalableminds/util/tools/Reflect.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Reflect.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import scala.util.control.NonFatal

--- a/util/src/main/scala/com/scalableminds/util/tools/StartableActor.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/StartableActor.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import akka.actor.{Actor, Props}

--- a/util/src/main/scala/com/scalableminds/util/tools/TextUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/TextUtils.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import org.apache.commons.lang3.StringUtils

--- a/util/src/main/scala/com/scalableminds/util/tools/TimeLogger.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/TimeLogger.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.tools
 
 import scala.concurrent.ExecutionContext

--- a/util/src/main/scala/com/scalableminds/util/xml/XMLUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/xml/XMLUtils.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 20011-2014 Scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.util.xml
 
 object XMLUtils {

--- a/webknossos-datastore/app/Global.scala
+++ b/webknossos-datastore/app/Global.scala
@@ -1,7 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
-
 import play.api._
 import play.api.mvc.Results._
 import play.api.mvc.{Action, Handler, RequestHeader}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore
 
 import akka.actor.ActorSystem

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.controllers
 
 import com.scalableminds.webknossos.datastore.DataStoreConfig

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.controllers
 
 import java.io.{ByteArrayOutputStream, OutputStream}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.datastore.controllers
 
 import java.io.FileInputStream

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.datastore.controllers
 
 import java.io.File

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/SkeletonTracingController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/SkeletonTracingController.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.datastore.controllers
 
 import com.google.inject.Inject

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.datastore.controllers
 
 import com.google.inject.Inject

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/TracingController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/TracingController.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.controllers
 
 import com.scalableminds.webknossos.datastore.services.{DataSourceRepository, UserAccessRequest, WebKnossosServer}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/VolumeTracingController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/VolumeTracingController.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.datastore.controllers
 
 import com.google.inject.Inject

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats
 
 import java.util.concurrent.TimeoutException

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/Cube.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/Cube.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats
 
 import com.newrelic.api.agent.NewRelic

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/MappingProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/MappingProvider.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats
 
 import java.nio.file.Path

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosBucketProvider.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats.knossos
 
 import java.io.{FileInputStream, FileNotFoundException, RandomAccessFile}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataFormat.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataFormat.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats.knossos
 
 import java.io.File

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataLayers.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats.knossos
 
 import com.scalableminds.webknossos.datastore.models.CubePosition

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats.wkw
 
 import com.scalableminds.webknossos.datastore.dataformats.{BucketProvider, Cube}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataFormat.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataFormat.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats.wkw
 
 import java.nio.file.Path

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.dataformats.wkw
 
 import com.scalableminds.util.geometry.{BoundingBox, Point3D}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/DataRequests.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/DataRequests.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.models
 
 import com.scalableminds.util.geometry.Point3D

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/ImageThumbnail.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/ImageThumbnail.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.datastore.models
 
 import com.scalableminds.util.geometry.Point3D

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/Positions.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/Positions.scala
@@ -1,6 +1,3 @@
-/*
-* Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
-*/
 package com.scalableminds.webknossos.datastore.models
 
 import com.scalableminds.webknossos.datastore.models.datasource.DataLayer

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.models.datasource
 
 import com.scalableminds.util.geometry.BoundingBox

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.models
 
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.GenericInboxDataSource

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/InboxDataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/InboxDataSource.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.models.datasource
 
 import com.scalableminds.util.geometry.Scale

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/Cuboid.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/Cuboid.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.models.requests
 
 import com.scalableminds.webknossos.datastore.models.{BucketPosition, VoxelPosition}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/DataServiceRequests.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/DataServiceRequests.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.models.requests
 
 import java.nio.file.Path

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2014 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.services
 
 import com.google.inject.Inject

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.services
 
 import java.nio.file.Paths

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceImporter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceImporter.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.services
 
 import java.nio.file.Path

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceRepository.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceRepository.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.services
 
 import akka.actor.ActorSystem

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/WebKnossosServer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/WebKnossosServer.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.services
 
 import akka.actor.ActorSystem

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataCubeCache.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataCubeCache.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.storage
 
 import com.newrelic.api.agent.NewRelic

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/TemporaryStore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/TemporaryStore.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.storage
 
 import akka.actor.ActorSystem

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/FossilDBClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/FossilDBClient.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import com.google.protobuf.ByteString

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/ProtoGeometryImplicits.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/ProtoGeometryImplicits.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import com.scalableminds.webknossos.datastore.models.datasource.ElementClass

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TemporaryTracingStore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TemporaryTracingStore.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import akka.actor.ActorSystem

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingDataStore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingDataStore.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import com.google.inject.Inject

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingSelector.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingSelector.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import play.api.libs.json.Json

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingService.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import java.util.UUID

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingType.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/TracingType.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import play.api.libs.json.{Format, Json, Reads, Writes}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/UpdateActions.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/UpdateActions.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings
 
 import com.scalableminds.webknossos.datastore.SkeletonTracing.SkeletonTracing

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/SkeletonElementDefaults.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/SkeletonElementDefaults.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.skeleton
 
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{Node, SkeletonTracing}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/SkeletonTracingService.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.skeleton
 
 import com.google.inject.Inject

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.skeleton.updating
 
 import com.scalableminds.webknossos.datastore.SkeletonTracing._

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/UpdateActionBranchPoint.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/UpdateActionBranchPoint.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.skeleton.updating
 
 import play.api.libs.json.Json

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/UpdateActionComment.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/UpdateActionComment.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.skeleton.updating
 
 import play.api.libs.json.Json

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/UpdateActionTreeGroup.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/updating/UpdateActionTreeGroup.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2018 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.skeleton.updating
 
 import play.api.libs.json.Json

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/FallbackLayerAdapter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/FallbackLayerAdapter.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
 import com.scalableminds.webknossos.datastore.dataformats.{BucketProvider, MappingProvider}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/Volume.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/Volume.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
 case class Volume(location: String)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
 import com.scalableminds.util.geometry.Point3D

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingDefaults.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingDefaults.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
 import com.scalableminds.webknossos.datastore.models.datasource.ElementClass

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingLayer.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
 import com.scalableminds.util.geometry.{BoundingBox, Point3D}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeTracingService.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
 import java.io.File

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeUpdateActions.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/volume/VolumeUpdateActions.scala
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2011-2017 scalable minds UG (haftungsbeschränkt) & Co. KG. <http://scm.io>
- */
 package com.scalableminds.webknossos.datastore.tracings.volume
 
 import java.util.Base64


### PR DESCRIPTION
Those were very inconsistent (some showed 20011-2016) and not really useful. Also, the frontend doesn’t have them so I think we’re safe removing them

------
- [x] Ready for review
