### PR TITLE
ensure team administration when pausing/unpausing projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 
 - Fixed a bug where large volume downloads contained invalid data.zip archives [#3086](https://github.com/scalableminds/webknossos/pull/3086)
+- Fixed a bug where non-privileged users were wrongly allowed to pause/unpause projects [#3097](https://github.com/scalableminds/webknossos/pull/3097)
 
 ### Removed
 

--- a/app/controllers/ProjectController.scala
+++ b/app/controllers/ProjectController.scala
@@ -103,6 +103,7 @@ class ProjectController @Inject()(val messagesApi: MessagesApi) extends Controll
   private def updatePauseStatus(projectName: String, isPaused: Boolean)(implicit request: SecuredRequest[_]) = {
     for {
       project <- ProjectDAO.findOneByName(projectName) ?~> Messages("project.notFound", projectName)
+      _ <- ensureTeamAdministration(request.identity, project._team)
       _ <- ProjectDAO.updatePaused(project._id, isPaused) ?~> Messages("project.update.failed", projectName)
       updatedProject <- ProjectDAO.findOne(project._id) ?~> Messages("project.notFound", projectName)
       js <- updatedProject.publicWrites


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://pauseprojectprivileged.webknossos.xyz

### Steps to test:
- login as a normal user, visit /projects (by typing it in the url bar) and try to pause/resume a project.
- should get error toast

### Issues:
- fixes #3093 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
