### PR TITLE
Directly enable keyboard in volume tracing

### DIFF
--- a/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -30,7 +30,11 @@ class VolumeActionsView extends PureComponent<Props> {
 
   render() {
     return (
-      <div onClick={() => document.activeElement.blur()}>
+      <div
+        onClick={() => {
+          if (document.activeElement) document.activeElement.blur();
+        }}
+      >
         <RadioGroup
           onChange={this.handleSetTool}
           value={this.props.volumeTracing.activeTool}

--- a/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -22,6 +22,7 @@ type Props = {
 class VolumeActionsView extends PureComponent<Props> {
   handleSetTool = (event: { target: { value: VolumeToolType } }) => {
     Store.dispatch(setToolAction(event.target.value));
+    document.activeElement.blur();
   };
 
   handleCreateCell = () => {

--- a/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -22,7 +22,6 @@ type Props = {
 class VolumeActionsView extends PureComponent<Props> {
   handleSetTool = (event: { target: { value: VolumeToolType } }) => {
     Store.dispatch(setToolAction(event.target.value));
-    document.activeElement.blur();
   };
 
   handleCreateCell = () => {
@@ -31,7 +30,7 @@ class VolumeActionsView extends PureComponent<Props> {
 
   render() {
     return (
-      <div>
+      <div onClick={() => document.activeElement.blur()}>
         <RadioGroup
           onChange={this.handleSetTool}
           value={this.props.volumeTracing.activeTool}


### PR DESCRIPTION
This PR enables keyboard shortcuts directly after switching modes in volume tracing.

### URL of deployed dev instance (used for testing):
- [https://directlyenablekeyboardinvolumetracing.webknossos.xyz](https://directlyenablekeyboardinvolumetracing.webknossos.xyz)

### Steps to test:
- open volume tracing
- change modes as you like by using the mouse
- the keyboard shortcuts should work no matter on which of the buttons you clicked !without" the requirement of clicking somewhere else in the document to regain focus on the whole page. 

### Issues:
- fixes #3123

------
- ~~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~~
- ~~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~~
- ~~~[ ] Updated [documentation](../blob/master/docs) if applicable~~~
- ~~~[ ] Needs datastore update after deployment~~~
- [x] Ready for review
