### PR TITLE
Adds the last git tag to buildinfo

### DIFF
--- a/project/BuildInfoSettings.scala
+++ b/project/BuildInfoSettings.scala
@@ -26,6 +26,17 @@ object BuildInfoSettings {
     }
   }.toString()
 
+  def gitTag = new java.lang.Object() {
+    override def toString(): String = {
+      try {
+        val extracted = new java.io.InputStreamReader(java.lang.Runtime.getRuntime().exec("git describe --abbrev=0 --tags").getInputStream())
+        (new java.io.BufferedReader(extracted)).readLine()
+      } catch {
+        case t: Throwable => "get git tag failed"
+      }
+    }
+  }.toString()
+
   val ciBuild = if (System.getenv().containsKey("CIRCLE_BUILD_NUM")) System.getenv().get("CIRCLE_BUILD_NUM") else "";
   val ciTag = if (System.getenv().containsKey("CIRCLE_TAG")) System.getenv().get("CIRCLE_TAG") else "";
 
@@ -35,7 +46,8 @@ object BuildInfoSettings {
       "commitHash" -> commitHash,
       "commitDate" -> commitDate,
       "ciBuild" -> ciBuild,
-      "ciTag" -> ciTag
+      "ciTag" -> ciTag,
+      "gitTag" -> gitTag
     ),
     buildInfoPackage := "webknossos",
     buildInfoOptions := Seq(BuildInfoOption.ToJson)
@@ -46,7 +58,8 @@ object BuildInfoSettings {
       "commitHash" -> commitHash,
       "commitDate" -> commitDate,
       "ciBuild" -> ciBuild,
-      "ciTag" -> ciTag
+      "ciTag" -> ciTag,
+      "gitTag" -> gitTag
     ),
     buildInfoPackage := "webknossosDatastore",
     buildInfoOptions := Seq(BuildInfoOption.ToJson)


### PR DESCRIPTION
Adds the last git tag (of the branch) to the buildinfo. Can be used to compose new version numbers:
```
version = ciTag !== "" ? ciTag : `${gitTag}-${ciBuild}`

e.g.
version = "18.08.0"
version = "18.08.0-1234"
```

Should we use these new versions also in the frontend?

### URL of deployed dev instance (used for testing):
- https://buildinfotag.webknossos.xyz

### Steps to test:
- https://buildinfotag.webknossos.xyz/api/buildinfo

------
- [x] Needs datastore update after deployment
- [x] Ready for review
