### PR TITLE
Fix NmlWriter TaskId meta tag

### DIFF
--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -283,8 +283,10 @@ class NmlWriter @Inject() extends FoxImplicits {
       }
     }
     taskOpt.foreach { task =>
-      writer.writeAttribute("name", "taskId")
-      writer.writeAttribute("content", task._id.toString)
+      Xml.withinElementSync("meta") {
+        writer.writeAttribute("name", "taskId")
+        writer.writeAttribute("content", task._id.toString)
+      }
     }
   }
 }


### PR DESCRIPTION
### Steps to test:
- create a task, trace some, download as nml
- in resulting nml, there should be a `meta name="taskId"` content="…" tag

### Issues:
- fixes #3165 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
