### PR TITLE
Make AnnotationStore singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed a regression bug which caused the initial data loading to fail sometimes. [#3149](https://github.com/scalableminds/webknossos/pull/3149)
 - Fixed a bug which caused a blank screen sometimes when the user is not logged in. [#3167](https://github.com/scalableminds/webknossos/pull/3167)
 - Fixed a bug where NML downloads of Task Annotations failed. [#3166](https://github.com/scalableminds/webknossos/pull/3166)
+- Fixed a bug where vieweing Compound Annotations (such as all tasks for a project in one view) failed. [#3174](https://github.com/scalableminds/webknossos/pull/3174)
 
 ### Removed
 

--- a/app/WebKnossosModule.scala
+++ b/app/WebKnossosModule.scala
@@ -1,5 +1,6 @@
 import com.google.inject.AbstractModule
 import controllers.InitialDataService
+import models.annotation.AnnotationStore
 import models.task.TaskService
 import models.user._
 import oxalis.user.UserCache

--- a/app/WebKnossosModule.scala
+++ b/app/WebKnossosModule.scala
@@ -17,5 +17,6 @@ class WebKnossosModule extends AbstractModule {
     bind(classOf[UserExperiencesDAO]).asEagerSingleton()
     bind(classOf[UserDataSetConfigurationDAO]).asEagerSingleton()
     bind(classOf[UserCache]).asEagerSingleton()
+    bind(classOf[AnnotationStore]).asEagerSingleton()
   }
 }


### PR DESCRIPTION
The CompoundAnnotation is temporary and stored in the AnnotationStore (not in the DB).
The datastore then asks wk if the user can see the corresponding temporary tracing. WK looks that up in this AnnotationStore.
It is important that the storing and the lookup happen in *the same* annotation store.
Before this change, the two usages used different instances (as created by dependency injection)

### URL of deployed dev instance (used for testing):
- https://annotationstoresingleton.webknossos.xyz

### Steps to test:
- create task, trace some, finish at least one
- in admin project list view, select view project
- you should see the tracing(s), not an error message

### Issues:
- fixes #3022 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
