### PR TITLE
Refactor read only tracings to not rely on any "readOnly" tokens in URLs

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -514,10 +514,7 @@ export function getAnnotationInformation(
   annotationId: string,
   tracingType: APITracingType,
 ): Promise<APIAnnotationType> {
-  // Include /readOnly part whenever it is in the pathname
-  const isReadOnly = location.pathname.endsWith("/readOnly");
-  const readOnlyPart = isReadOnly ? "readOnly/" : "";
-  const infoUrl = `/api/annotations/${tracingType}/${annotationId}/${readOnlyPart}info`;
+  const infoUrl = `/api/annotations/${tracingType}/${annotationId}/info`;
   return Request.receiveJSON(infoUrl);
 }
 

--- a/app/assets/javascripts/oxalis/view/action-bar/share_modal_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/share_modal_view.js
@@ -56,9 +56,7 @@ class ShareModalView extends PureComponent<ShareModalPropType, State> {
     const loc = window.location;
     // in readonly mode the pathname already contains "/readonly"
     let { pathname } = loc;
-    pathname = pathname.replace("/readOnly", "");
-
-    const url = `${loc.origin + pathname}/readOnly${loc.hash}`;
+    const url = `${loc.origin + pathname}${loc.hash}`;
     return url;
   }
 

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -229,14 +229,15 @@ class ReactRouter extends React.Component<Props> {
                 path="/annotations/:type/:id"
                 render={this.tracingView}
                 serverAuthenticationCallback={async ({ match }: ContextRouter) => {
-                  const isReadOnly = window.location.pathname.endsWith("readOnly");
-                  if (isReadOnly) {
+                  try {
                     const annotationInformation = await getAnnotationInformation(
                       match.params.id || "",
                       Enum.coalesce(APITracingTypeEnum, match.params.type) ||
                         APITracingTypeEnum.Explorational,
                     );
                     return annotationInformation.isPublic;
+                  } catch (ex) {
+                    // Annotation could not be found
                   }
                   return false;
                 }}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -47,7 +47,7 @@ application {
   enableAutoVerify = false
   insertInitialData = true
   authentication {
-    enableDevAutoLogin = true
+    enableDevAutoLogin = false
     enableDevAutoVerify = false
     enableDevAutoAdmin = false
     defaultUser = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,7 +3157,7 @@ diff@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
-diff@^3.2.0, diff@^3.3.1, diff@^3.5.0:
+diff@^3.3.1, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -4607,12 +4607,6 @@ globby@^8.0.0:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globs@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/globs/-/globs-0.1.4.tgz#1d13639f6174e4ae73a7f936da7d9a079f657c1c"
-  dependencies:
-    glob "^7.1.1"
-
 "glsl-parser@git+https://github.com/anvaka/glslx.git#glsl-parser":
   version "0.1.0"
   resolved "git+https://github.com/anvaka/glslx.git#3991baef1ae335388807764f8bd9207c6323c460"
@@ -5705,12 +5699,6 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
-
-jasmine-diff@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/jasmine-diff/-/jasmine-diff-0.1.3.tgz#93ccc2dcc41028c5ddd4606558074839f2deeaa8"
-  dependencies:
-    diff "^3.2.0"
 
 javascript-natural-sort@^0.7.1:
   version "0.7.1"
@@ -9443,15 +9431,6 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rexreplace@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/rexreplace/-/rexreplace-4.0.1.tgz#e226c4b783bd33eb12eb856dac2f55f7db969d54"
-  dependencies:
-    chalk "^2.4.1"
-    globs "^0.1.4"
-    tsickle "^0.32.0"
-    yargs "^12.0.1"
-
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -10447,16 +10426,6 @@ trim@0.0.1:
 trough@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
-
-tsickle@^0.32.0:
-  version "0.32.1"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.32.1.tgz#f16e94ba80b32fc9ebe320dc94fbc2ca7f3521a5"
-  dependencies:
-    jasmine-diff "^0.1.3"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    source-map "^0.6.0"
-    source-map-support "^0.5.0"
 
 tslib@^1.9.0:
   version "1.9.1"


### PR DESCRIPTION
This PR gets rid of the "readOnly" URLs in favor of letting the back-end decide whether a tracing is readOnly for the user. See the linked issues for more context.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- disable auto login
- login as scmboy and create a tracing
- copy the tracing url (either from the url bar or from the share modal)
- opening that url in incognito should show the login mask
- make the tracing public in the share modal
- opening that url in incognito should show the tracing

### Issues:
- fixes #2152 and #3032 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
