### PR TITLE
Ask for confirmation when resetting task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - The fallback segmentation layer attribute of volume tracings is now persisted to NML/ZIP files. Upon re-upload, only volume tracings with this attribute will show a fallback layer. Use `tools/volumeAddFallbackLayer.py` to add this attribute to existing volume tracings. [#3088](https://github.com/scalableminds/webknossos/pull/3088)
 - When splitting a tree, the split part that contains the initial node will now keep the original tree name and id. [#3145](https://github.com/scalableminds/webknossos/pull/3145)
 - The welcome header will now also show on the default page if there are no existing organisations. [#3133](https://github.com/scalableminds/webknossos/pull/3133)
+- Resetting a user's task requires a confirmation now. [#3181](https://github.com/scalableminds/webknossos/pull/3181)
 
 ### Fixed
 

--- a/app/assets/javascripts/dashboard/dashboard_task_list_view.js
+++ b/app/assets/javascripts/dashboard/dashboard_task_list_view.js
@@ -231,9 +231,16 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
     );
   };
 
-  async resetTask(annotation: APIAnnotationType) {
-    await resetAnnotation(annotation.id, annotation.typ);
-    Toast.success(messages["task.reset_success"]);
+  resetTask(annotation: APIAnnotationType) {
+    Modal.confirm({
+      content: messages["task.confirm_reset"],
+      cancelText: messages.no,
+      okText: messages.yes,
+      onOk: async () => {
+        await resetAnnotation(annotation.id, annotation.typ);
+        Toast.success(messages["task.reset_success"]);
+      },
+    });
   }
 
   cancelAnnotation(annotation: APIAnnotationType) {

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -67,6 +67,7 @@ In order to restore the current window, a reload is necessary.`,
   "task.peek_next": _.template(
     "The next task will most likely be part of project <%- projectName %>",
   ),
+  "task.confirm_reset": "Do you really want to reset this task?",
   "task.reset_success": "Annotation was successfully reset.",
   "task.bulk_create_invalid":
     "Can not parse task specification. It includes at least one invalid task.",


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://confirmtaskreset.webknossos.xyz

### Steps to test:
- create and get a new task
- trace a bit in the task
- click reset but cancel the dialog --> when clicking trace, the old state should still be there
- click reset and confirm --> tracing should be reset

### Issues:
- fixes #3180 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
