### PR TITLE
use new name for cookies to avoid errors when reading old ones

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -149,7 +149,7 @@ google.analytics.trackingID = ""
 
 silhouette {
   cookieAuthenticator {
-    cookieName = "authenticator"
+    cookieName = "id"
     cookiePath = "/"
     secureCookie = false
     httpOnlyCookie = true


### PR DESCRIPTION
When you send a play-2.4-cookie the new silhouette throws an error because of invalid characters.
So we should use a new name for the cookie, just ignoring the old one.
This way, all users will merely be logged out, rather than get an error.
Cool side effect: if we roll back the old cookie should still be valid and used again.

### Steps to test:
- checkout master, login
- checkout this branch, refresh
- should be logged out (or back in if autologin is active) but should not get error message

- [x] Ready for review
