### PR TITLE
remove color from logging change root level to INFO for datastore

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,12 +1,10 @@
 <configuration>
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>DEBUG</level>
     </filter>
     <encoder>
-      <pattern>%date %coloredLevel %logger - %message%n%xException{10}</pattern>
+      <pattern>%date [%level] %logger - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
 

--- a/webknossos-datastore/conf/logback.xml
+++ b/webknossos-datastore/conf/logback.xml
@@ -1,12 +1,10 @@
 <configuration>
-    <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>DEBUG</level>
         </filter>
         <encoder>
-            <pattern>%date - %coloredLevel - %message%n%xException{15}</pattern>
+            <pattern>%date [%level] - %message%n%xException{15}</pattern>
         </encoder>
     </appender>
 
@@ -17,7 +15,7 @@
     <logger name="actor" level="DEBUG"/>
     <logger name="akka" level="INFO"/>
 
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Color unfortunately leads to problems when piping stdout to files. Almost expected…

### Steps to test:
- standalone-datastore should log stuff again, not only warning/error

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- [x] Needs datastore update after deployment
- [x] Ready for review
