### PR TITLE
in updateActionLog, annotate batches with version number

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/tracings/skeleton/SkeletonTracingService.scala
@@ -9,7 +9,7 @@ import com.scalableminds.webknossos.datastore.tracings._
 import com.scalableminds.webknossos.datastore.tracings.skeleton.updating._
 import net.liftweb.common.{Empty, Full}
 import play.api.libs.concurrent.Execution.Implicits._
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{JsObject, Json, Writes}
 
 class SkeletonTracingService @Inject()(
                                         tracingDataStore: TracingDataStore,
@@ -124,9 +124,16 @@ class SkeletonTracingService @Inject()(
   def merge(tracings: Seq[SkeletonTracing]): SkeletonTracing = tracings.reduceLeft(mergeTwo)
 
   def updateActionLog(tracingId: String) = {
+    def versionedTupleToJson(tuple: (Long, List[SkeletonUpdateAction])): JsObject = {
+      Json.obj(
+        "version" -> tuple._1,
+        "value" -> Json.toJson(tuple._2)
+      )
+    }
     for {
-      updateActionGroups <- tracingDataStore.skeletonUpdates.getMultipleVersions(tracingId)(fromJson[List[SkeletonUpdateAction]])
-    } yield (Json.toJson(updateActionGroups))
+      updateActionGroups <- tracingDataStore.skeletonUpdates.getMultipleVersionsAsVersionValueTuple(tracingId)(fromJson[List[SkeletonUpdateAction]])
+      updateActionGroupsJs = updateActionGroups.map(versionedTupleToJson)
+    } yield (Json.toJson(updateActionGroupsJs))
   }
 
   def updateActionStatistics(tracingId: String) = {


### PR DESCRIPTION
```json
[
  {
    "version": 7,
    "value" : [
      {<anUpdateAction>},
      {<anUpdateAction>}
    ]
  },
  {
    "version": 6,
    "value" : [
      {<anUpdateAction>},
      {<anUpdateAction>},
      {<anUpdateAction>}
    ]
  }
]
```
down to version 1
(version 0 of the tracing is the originally created one)

### Steps to test:
- http://localhost:9000/data/tracings/skeleton/…/updateActionLog?token=…

------
- [x] Ready for review
