### PR TITLE
Improve nml parsing error messages for missing strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Renamed "Soma Clicking" to "Single-Node-Tree Mode". [#3141](https://github.com/scalableminds/webknossos/pull/3141/files)
 - The fallback segmentation layer attribute of volume tracings is now persisted to NML/ZIP files. Upon re-upload, only volume tracings with this attribute will show a fallback layer. Use `tools/volumeAddFallbackLayer.py` to add this attribute to existing volume tracings. [#3088](https://github.com/scalableminds/webknossos/pull/3088)
 - When splitting a tree, the split part that contains the initial node will now keep the original tree name and id. [#3145](https://github.com/scalableminds/webknossos/pull/3145)
+- Improve error messages for parsing faulty NMLs. [#3227](https://github.com/scalableminds/webknossos/pull/3227)
 - Finished tasks will be displayed with less details and sorted by their finishing date in the dashboard. [#3202](https://github.com/scalableminds/webknossos/pull/3202)
 - The welcome header will now also show on the default page if there are no existing organisations. [#3133](https://github.com/scalableminds/webknossos/pull/3133)
 - Simplified the sharing of tracings. Users can simply copy the active URL from the browser's URL bar to share a tracing (assuming the tracing is public). [#3176](https://github.com/scalableminds/webknossos/pull/3176)

--- a/app/assets/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/app/assets/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -351,6 +351,13 @@ function _parseBool(obj: Object, key: string, defaultValue?: boolean): boolean {
   return obj[key] === "true";
 }
 
+function _parseEntities(obj: Object, key: string): string {
+  if (obj[key] == null) {
+    throw new NmlParseError(`${messages["nml.expected_attribute_missing"]} ${key}`);
+  }
+  return Saxophone.parseEntities(obj[key]);
+}
+
 function findTreeByNodeId(trees: TreeMapType, nodeId: number): ?TreeType {
   return _.values(trees).find(tree => tree.nodes.has(nodeId));
 }
@@ -447,7 +454,7 @@ export function parseNml(
                 _parseFloat(attr, "color.g", DEFAULT_COLOR[1]),
                 _parseFloat(attr, "color.b", DEFAULT_COLOR[2]),
               ],
-              name: Saxophone.parseEntities(attr.name),
+              name: _parseEntities(attr, "name"),
               comments: [],
               nodes: new DiffableMap(),
               branchPoints: [],
@@ -519,7 +526,7 @@ export function parseNml(
           case "comment": {
             const currentComment = {
               nodeId: _parseInt(attr, "node"),
-              content: Saxophone.parseEntities(attr.content),
+              content: _parseEntities(attr, "content"),
             };
             const tree = findTreeByNodeId(trees, currentComment.nodeId);
             if (tree == null)
@@ -545,7 +552,7 @@ export function parseNml(
           case "group": {
             const newGroup = {
               groupId: _parseInt(attr, "id"),
-              name: Saxophone.parseEntities(attr.name),
+              name: _parseEntities(attr, "name"),
               children: [],
             };
             if (existingGroupIds.has(newGroup.groupId))


### PR DESCRIPTION
We had a faulty NML for a better error message would have been helpful.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- upload an NML where the name attribute is missing for a tree
- there should be an error message pointing that out

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
