### PR TITLE
Fix hard-source breaking master

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,6 +17,7 @@
 <PROJECT_ROOT>/node_modules/documentation/
 <PROJECT_ROOT>/node_modules/flow-coverage-report/
 <PROJECT_ROOT>/node_modules/jsonlint/
+<PROJECT_ROOT>/node_modules/hard-source-webpack-plugin/
 <PROJECT_ROOT>/.nyc_output
 
 [untyped]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "flow-bin": "^0.80.0",
     "flow-coverage-report": "^0.5.0",
     "glob": "^7.1.3",
-    "hard-source-webpack-plugin": "^0.12.0",
+    "hard-source-webpack-plugin": "git+https://github.com/talkable/hard-source-webpack-plugin.git#e774ef34ac7de7badf83f8560cca13861e76f23c",
     "husky": "^0.14.3",
     "isomorphic-fetch": "^2.2.0",
     "jsdom": "^11.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4788,9 +4788,9 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
-hard-source-webpack-plugin@^0.12.0:
+"hard-source-webpack-plugin@git+https://github.com/talkable/hard-source-webpack-plugin.git#e774ef34ac7de7badf83f8560cca13861e76f23c":
   version "0.12.0"
-  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.12.0.tgz#ea21f0407538fcb62f6995371541baab0a5f679e"
+  resolved "git+https://github.com/talkable/hard-source-webpack-plugin.git#e774ef34ac7de7badf83f8560cca13861e76f23c"
   dependencies:
     chalk "^2.4.1"
     find-cache-dir "^2.0.0"


### PR DESCRIPTION
This PR switches the hard-source version to a fork which fixes https://github.com/mzgoddard/hard-source-webpack-plugin/issues/416

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- CI

------
- [X] Ready for review
