### PR TITLE
Don't error in postcheckout hook if there are no flow-check files

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "enable-autologin": "sed -i -e 's/enableDevAutoLogin = false/enableDevAutoLogin = true/g' ./conf/application.conf",
     "disable-autologin": "sed -i -e 's/enableDevAutoLogin = true/enableDevAutoLogin = false/g' ./conf/application.conf",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "postcheckout": "echo 'Deleting auto-generated flow files...' && rm app/assets/javascripts/test/snapshots/flow-check/*.js"
+    "postcheckout": "echo 'Deleting auto-generated flow files...' && rm -f app/assets/javascripts/test/snapshots/flow-check/*.js"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Until now, the post checkout hook showed an error in the console when there were no flow-check files. `-f` ignores non-existent files.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- run git checkout twice --> no error should be printed

------
- [X] Ready for review
