### PR TITLE
Respect resolutions when copying segmentation slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed the sorting of the dashboard task list and explorative annotation list. [#3153](https://github.com/scalableminds/webknossos/pull/3153)
 - Fixed a missing notification when a task annotation was reset. [#3207](https://github.com/scalableminds/webknossos/pull/3207)
 - Fixed a bug where non-privileged users were wrongly allowed to pause/unpause projects. [#3097](https://github.com/scalableminds/webknossos/pull/3097)
+- Fixed a bug in copy-segmentation-slice feature. [#3245](https://github.com/scalableminds/webknossos/pull/3245)
 - Fixed a regression bug which caused the initial data loading to fail sometimes. [#3149](https://github.com/scalableminds/webknossos/pull/3149)
 - Fixed a bug which caused a blank screen sometimes when the user is not logged in. [#3167](https://github.com/scalableminds/webknossos/pull/3167)
 - Fixed a bug where NML downloads of Task Annotations failed. [#3166](https://github.com/scalableminds/webknossos/pull/3166)


### PR DESCRIPTION
For anisotropic datasets, copying a segmentation slice (via "v") in viewports other than xy didn't work properly. Some voxels outside the visible viewport were copied even though this should not be the case.

### URL of deployed dev instance (used for testing):
- https://fixcopysegmentation.webknossos.xyz

### Steps to test:
- brush over the edges in yz and xz viewport
- move to next slice
- hit "v"
- move the viewports to see that the brushed segmentation has a hard cut (--> only visible voxels were written)

### Issues:
- fixes #3243 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
