### PR TITLE
Show reset layout option in view mode

### DIFF
--- a/app/assets/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/app/assets/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -35,6 +35,20 @@ type State = {
   isUserScriptsModalOpen: boolean,
 };
 
+export const resetLayoutItem = (
+  <Menu.Item key="reset-layout">
+    <div
+      onClick={() => {
+        Store.dispatch(updateUserSettingAction("layoutScaleValue", 1));
+        layoutEmitter.emit("resetLayout");
+      }}
+    >
+      <Icon type="laptop" />
+      Reset Layout
+    </div>
+  </Menu.Item>
+);
+
 class TracingActionsView extends PureComponent<StateProps, State> {
   state = {
     isShareModalOpen: false,
@@ -249,19 +263,7 @@ class TracingActionsView extends PureComponent<StateProps, State> {
       );
     }
 
-    elements.push(
-      <Menu.Item key="reset-layout">
-        <div
-          onClick={() => {
-            Store.dispatch(updateUserSettingAction("layoutScaleValue", 1));
-            layoutEmitter.emit("resetLayout");
-          }}
-        >
-          <Icon type="laptop" />
-          Reset Layout
-        </div>
-      </Menu.Item>,
-    );
+    elements.push(resetLayoutItem);
 
     const menu = <Menu>{elements}</Menu>;
 

--- a/app/assets/javascripts/oxalis/view/action_bar_view.js
+++ b/app/assets/javascripts/oxalis/view/action_bar_view.js
@@ -1,14 +1,15 @@
 // @flow
 import * as React from "react";
-import { Alert } from "antd";
+import { Icon, Alert, Dropdown, Menu } from "antd";
 import { connect } from "react-redux";
-import TracingActionsView from "oxalis/view/action-bar/tracing_actions_view";
+import TracingActionsView, { resetLayoutItem } from "oxalis/view/action-bar/tracing_actions_view";
 import DatasetPositionView from "oxalis/view/action-bar/dataset_position_view";
 import ViewModesView from "oxalis/view/action-bar/view_modes_view";
 import VolumeActionsView from "oxalis/view/action-bar/volume_actions_view";
 import Constants, { ControlModeEnum } from "oxalis/constants";
 import type { ModeType, ControlModeType } from "oxalis/constants";
 import type { OxalisState, TracingType } from "oxalis/store";
+import ButtonComponent from "oxalis/view/components/button_component";
 
 const VersionRestoreWarning = (
   <Alert
@@ -31,10 +32,17 @@ class ActionBarView extends React.PureComponent<Props> {
     const isTraceMode = this.props.controlMode === ControlModeEnum.TRACE;
     const hasVolume = this.props.tracing.volume != null;
     const isVolumeSupported = !Constants.MODES_ARBITRARY.includes(this.props.viewMode);
+    const readonlyDropdown = (
+      <Dropdown overlay={<Menu>{resetLayoutItem}</Menu>}>
+        <ButtonComponent>
+          <Icon type="down" />
+        </ButtonComponent>
+      </Dropdown>
+    );
 
     return (
       <div className="action-bar">
-        {isTraceMode && !this.props.showVersionRestore ? <TracingActionsView /> : null}
+        {isTraceMode && !this.props.showVersionRestore ? <TracingActionsView /> : readonlyDropdown}
         {this.props.showVersionRestore ? VersionRestoreWarning : null}
         <DatasetPositionView />
         {hasVolume && isVolumeSupported ? <VolumeActionsView /> : null}


### PR DESCRIPTION
I added a dropdown for the readonly view to accommodate the reset-layout option. A dropdown menu with only one item seems a bit unnecessary, but maybe we'll need it in the future and just showing the reset button seemed weird, too.

### URL of deployed dev instance (used for testing):
- https://layoutresetinview.webknossos.xyz

### Steps to test:
- open a tracing --> everything should be normal
- view a dataset --> a dropdown for resetting the layout should be there

### Issues:
- fixes #3241 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
