### PR TITLE
fix test.sh when not calling prepare before first run

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -12,6 +12,9 @@ cmd=$1
 shift;
 additionalParams=$@
 
+# Create test-bundle dir if it does not exist
+mkdir -p "$testBundlePath"
+
 function prepare {
   rm -rf "$testBundlePath" && mkdir "$testBundlePath"
   # Webpack with the proto loader isn't used when running the tests, so the proto files need to be prepared manually
@@ -24,7 +27,7 @@ function ensureUpToDateTests {
   lastChangedSource=$($FIND "$jsPath" -regex ".*\.js$" -type f -printf '%T@ %p \n' | sort -n | tail -1 | awk -F'.' '{print $1}')
   lastChangedTests=$($FIND "$testBundlePath" -type f -printf '%T@ %p \n' | sort -n | tail -1 | awk -F'.' '{print $1}')
 
-  if [ $lastChangedSource -gt $lastChangedTests ]
+  if [ ! $lastChangedTests ] || [ $lastChangedSource -gt $lastChangedTests ]
   then
     YELLOW='\e[33m'
     NC='\033[0m' # No Color


### PR DESCRIPTION
Executing any frontend tests without calling `prepare` first, failed if it was the very first execution of the tests. This was because the test-bundle folder was not existing in that case. It also failed if the folder was empty. Both fixed now, should fix the nightly screenshot tests.

### Steps to test:
- Remove your local public/test-bundle folder (same state as when checking out the repo).
- Execute `yarn test-e2e` - should no longer fail. (You can abort if it doesn't fail in the first half minute)

### Issues:
- fixes nightly screenshot tests

------
- [x] Ready for review
