### PR TITLE
Store screenshots and diffs on CircleCI after running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,11 +236,14 @@ jobs:
             done
             (exit $s)
 
+      - store_artifacts:
+          path: app/assets/javascripts/test/screenshots
+
 workflows:
   version: 2
   default:
     jobs:
-      - build_test_deploy:
+      - nightly:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ workflows:
   version: 2
   default:
     jobs:
-      - nightly:
+      - build_test_deploy:
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This will allow us to get a quick overview over what went wrong when the screenshot tests fail :)

/cc @philippotto 

### Steps to test:
- Have a look at the artifacts section of [this](https://circleci.com/gh/scalableminds/webknossos/6311#artifacts/containers/0) build. You should see the original screenshots as well as the diff and new shots of the one dataset where the test failed during the first run.

------
- [x] Ready for review
