### PR TITLE
sharingToken upgrades User AccessContext

### DIFF
--- a/app/oxalis/security/URLSharing.scala
+++ b/app/oxalis/security/URLSharing.scala
@@ -2,11 +2,13 @@ package oxalis.security
 
 import java.security.SecureRandom
 
-import com.scalableminds.util.accesscontext.{DBAccessContext, DBAccessContextPayload}
+import com.scalableminds.util.accesscontext.{AuthorizedAccessContext, DBAccessContext, DBAccessContextPayload, UnAuthorizedAccessContext}
 import models.user.User
 
 
 case class SharingTokenContainer(sharingToken: String) extends DBAccessContextPayload
+
+case class UserSharingTokenContainer(user: User, sharingToken: Option[String]) extends DBAccessContextPayload
 
 object URLSharing {
 
@@ -14,7 +16,7 @@ object URLSharing {
 
   def fallbackTokenAccessContext(sharingToken: Option[String])(implicit ctx: DBAccessContext) = {
     ctx.data match {
-      case Some(user: User) => ctx
+      case Some(user: User) => DBAccessContext(Some(UserSharingTokenContainer(user, sharingToken)))
       case _ => DBAccessContext(sharingToken.map(SharingTokenContainer(_)))
     }
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -48,7 +48,7 @@ application {
   enableAutoVerify = false
   insertInitialData = true
   authentication {
-    enableDevAutoLogin = true
+    enableDevAutoLogin = false
     enableDevAutoVerify = false
     enableDevAutoAdmin = false
     defaultUser = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -48,7 +48,7 @@ application {
   enableAutoVerify = false
   insertInitialData = true
   authentication {
-    enableDevAutoLogin = false
+    enableDevAutoLogin = true
     enableDevAutoVerify = false
     enableDevAutoAdmin = false
     defaultUser = {


### PR DESCRIPTION
### Steps to test:
- create a new user who is not in any teams (here called 'testUser')
- copy the sharing link from a dataset (using scmboy)
- login with testUser and paste the sharing link
   - the user should now see the dataset even though the user itself has not the needed permission
- paste the link again but remove the `?token=...` from the URL
   - because the user does not have the permission, he should not see the dataset
- logout
- paste the URL again (with the token)
   - you should now see the dataset again

### Issues:
- fixes #3205 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
