### PR TITLE
catch requests for non-existent resolution, reply with empty

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
@@ -30,6 +30,7 @@ trait WKWLayer extends DataLayer {
   def lengthOfUnderlyingCubes(resolution: Point3D): Int = {
     wkwResolutions.find(_.resolutionAsPoint3D == resolution).map(_.cubeLength).getOrElse(0)
   }
+
 }
 
 case class WKWDataLayer(

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -104,6 +104,8 @@ trait DataLayer extends DataLayerLike {
   def lengthOfUnderlyingCubes(resolution: Point3D): Int
 
   def bucketProvider: BucketProvider
+  
+  def containsResolution(resolution: Point3D) = resolutions.contains(resolution)
 
   def doesContainBucket(bucket: BucketPosition) =
     boundingBox.intersects(bucket.toHighestResBoundingBox)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -81,7 +81,7 @@ class BinaryDataService @Inject()(config: DataStoreConfig) extends FoxImplicits 
   }
 
   private def handleBucketRequest(request: DataServiceDataRequest, bucket: BucketPosition): Fox[Array[Byte]] = {
-    if (request.dataLayer.doesContainBucket(bucket)) {
+    if (request.dataLayer.doesContainBucket(bucket) && request.dataLayer.containsResolution(bucket.resolution)) {
       val readInstruction = DataReadInstruction(
         dataBaseDir,
         request.dataSource,


### PR DESCRIPTION
We had many requests fail with division by zero errors, where non-existent data resolutions were queried. Such queries are now answered with a 404.
@philippotto I’m a bit confused where these requests came from in the first place. I could also reproduce this locally but I don’t understand enough about the requesting code.
The dataset has a layer that has only one resolution (4, 4, 2)
data requests are asking for zoomStep (=resolutionExponent) 0, which can’t be found by 
`val resPower = Math.pow(2, resolutionExponent).toInt`
`layer.resolutions.find(resolution => resolution.maxDim == resPower)`
We did set the zoomStep to be the exponent, right? I remember we also talked about defining it as an index lookup, but I’m not sure what we ended up with. But the above code is active in the datastores.


### Issues:
- contributes to #3297 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- [x] Needs datastore update after deployment
- [x] Ready for review
