### PR TITLE
in project create form, add default for isBlacklistedFromReport

### DIFF
--- a/app/assets/javascripts/admin/project/project_create_view.js
+++ b/app/assets/javascripts/admin/project/project_create_view.js
@@ -60,6 +60,7 @@ class ProjectCreateView extends React.PureComponent<Props, State> {
     const defaultValues = {
       priority: 100,
       expectedTime: 90,
+      isBlacklistedFromReport: false,
     };
 
     const defaultFormValues = Object.assign({}, defaultValues, project, {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixprojectcreation.webknossos.xyz

### Steps to test:
- in admin→projects→Add Project, create new project, but do not touch the hide-from-report checkbox
- project creation should succeed

### Issues:
- fixes #3335 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
