### PR TITLE
thumbnails default to black again, if no data is found at requested position

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "gl": "scalableminds/headless-gl#4.0.5"
   },
   "scripts": {
-    "start": "./sbt run -jvm-debug 5005",
+    "start": "./sbt run -jvm-debug 5005 -J-XX:MaxMetaspaceSize=2048m",
     "build": "node_modules/.bin/webpack --env.production",
     "build-watch": "node_modules/.bin/webpack -w",
     "test": "tools/test.sh test --timeout=30s",

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -337,7 +337,8 @@ class BinaryDataController @Inject()(
       blackAndWhite = blackAndWhite)
     for {
       (data, indices) <- requestData(dataSource, dataLayer, request)
-      spriteSheet <- ImageCreator.spriteSheetFor(data, params) ?~> Messages("image.create.failed")
+      dataWithFallback = if (data.length == 0) new Array[Byte](params.slideHeight * params.slideWidth * params.bytesPerElement) else data
+      spriteSheet <- ImageCreator.spriteSheetFor(dataWithFallback, params) ?~> Messages("image.create.failed")
       firstSheet <- spriteSheet.pages.headOption ?~> Messages("image.page.failed")
     } yield {
       new JPEGWriter().writeToOutputStream(firstSheet.image)(_)


### PR DESCRIPTION
this was lost in #3148 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- change a datasource-properties.json to a bounding box where there isn’t actually any data
- thumbnail request should not fail but fall back to black

### Issues:
- fixes #3342 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- [x] Needs datastore update after deployment
- [x] Ready for review
