### PR TITLE
Allow users to access annotations of other users (if they know the link)

### DIFF
--- a/app/models/annotation/AnnotationRestrictions.scala
+++ b/app/models/annotation/AnnotationRestrictions.scala
@@ -55,9 +55,9 @@ class AnnotationRestrictionDefaults @Inject()(userService: UserService) extends 
         else
           (for {
             user <- option2Fox(userOption)
-            isTeamManagerOrAdminOfTeam <- userService.isTeamManagerOrAdminOf(user, annotation._team)
+            owner <- userService.findOneById(annotation._user, true)
           } yield {
-            annotation._user == user._id || isTeamManagerOrAdminOfTeam
+            owner._organization == user._organization
           }).orElse(Fox.successful(false))
       }
 


### PR DESCRIPTION
### Steps to test:
- create second user (not team manager or admin)
- as the first user, create tracing, save link, logout
- as the non-privileged user you should see the tracing given the link (assuming you have access to the dataset)

### Issues:
- fixes #3347 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [ ] Ready for review
