### PR TITLE
Ensure shared Data Cube Cache by holding Binary Data Service in injected Singleton

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
@@ -18,5 +18,6 @@ class DataStoreModule(environment: Environment, configuration: Configuration) ex
     bind(classOf[DataSourceRepository]).asEagerSingleton()
     bind(classOf[DataSourceService]).asEagerSingleton()
     bind(classOf[DataStoreWkRpcClient]).asEagerSingleton()
+    bind(classOf[BinaryDataServiceHolder]).asEagerSingleton()
   }
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -28,12 +28,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class BinaryDataController @Inject()(
                                       dataSourceRepository: DataSourceRepository,
                                       config: DataStoreConfig,
-                                      accessTokenService: DataStoreAccessTokenService)
+                                      accessTokenService: DataStoreAccessTokenService,
+                                      binaryDataServiceHolder: BinaryDataServiceHolder)
                                     (implicit ec: ExecutionContext,
                                      bodyParsers: PlayBodyParsers)
   extends Controller {
 
-  val binaryDataService = new BinaryDataService(Paths.get(config.Braingames.Binary.baseFolder), config.Braingames.Binary.loadTimeout, config.Braingames.Binary.cacheMaxSize)
+  val binaryDataService = binaryDataServiceHolder.binaryDataService
 
   /**
     * Handles requests for raw binary data via HTTP POST from webKnossos.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
@@ -1,0 +1,21 @@
+package com.scalableminds.webknossos.datastore.services
+
+import java.nio.file.Paths
+
+import com.scalableminds.webknossos.datastore.DataStoreConfig
+import javax.inject.Inject
+
+/*
+ * The BinaryDataService needs to be instantiated as singleton to provide a shared DataCubeCache.
+ * The TracingStore one (for VolumeTracings) already is, since the surrounding VolumeTracingService is a singleton.
+ * The DataStore one is singleton-ized via this holder.
+ */
+
+class BinaryDataServiceHolder @Inject()(config: DataStoreConfig) {
+
+  val binaryDataService = new BinaryDataService(
+    Paths.get(config.Braingames.Binary.baseFolder),
+    config.Braingames.Binary.loadTimeout,
+    config.Braingames.Binary.cacheMaxSize)
+
+}


### PR DESCRIPTION
Since #3281 the binary data service is created once in the datastore module and once in the tracingstore module. Because controllers aren’t inherently singletons, this meant that the binary data service was not ensured to be singleton, and thus, neither was the data cube cache. That cache thus became useless, resulting in tons of redundantly opened file handles for cube files, which were also not closed properly (since that happens on removal from the LRU cache).
This PR encloses the entire binary data service in an injected singleton holder class, thus re-sharing this cache while still not creating conflicts between the binary data service instances of the datastore and tracingstore modules respectively.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- load some data, you should still get it
- check that there are no duplicates (and not more than 40 *.wkw or *.raw entries) in the output of `ll /proc/{datastore-pid}/fd` even after browsing data for a few minutes

### Issues:
- fixes #3380

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- [x] Needs datastore update after deployment
- [x] Ready for review
