### PR TITLE
Even if initialData is disabled, insert local stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,19 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Added
 
-- 
+-
 
 ### Changed
 
-- 
+-
 
 ### Fixed
 
-- 
+- Fixed a bug where the initial onboarding setup failed if automatic initial data was disabled. [#3421](https://github.com/scalableminds/webknossos/pull/3421)
 
 ### Removed
 
-- 
+-
 
 
 ## [18.11.0](https://github.com/scalableminds/webknossos/releases/tag/18.11.0) - 2018-10-29

--- a/app/Startup.scala
+++ b/app/Startup.scala
@@ -45,12 +45,10 @@ class Startup @Inject() (actorSystem: ActorSystem,
   }
 
   ensurePostgresDatabase.onComplete { _ =>
-    if (conf.Application.insertInitialData) {
-      initialDataService.insert.futureBox.map {
-        case Full(_) => ()
-        case Failure(msg, _, _) => logger.info("No initial data inserted: " + msg)
-        case _ => logger.warn("Error while inserting initial data")
-      }
+    initialDataService.insert.futureBox.map {
+      case Full(_) => ()
+      case Failure(msg, _, _) => logger.info("No initial data inserted: " + msg)
+      case _ => logger.warn("Error while inserting initial data")
     }
   }
 

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -79,6 +79,8 @@ Samplecountry
 
   def insert: Fox[Unit] =
     for {
+      _ <- insertLocalDataStoreIfEnabled
+      _ <- insertLocalTracingStoreIfEnabled
       _ <- assertInitialDataEnabled
       _ <- assertNoOrganizationsPresent
       _ <- insertOrganization
@@ -87,8 +89,6 @@ Samplecountry
       _ <- insertToken
       _ <- insertTaskType
       _ <- insertProject
-      _ <- insertLocalDataStoreIfEnabled
-      _ <- insertLocalTracingStoreIfEnabled
     } yield ()
 
   def assertInitialDataEnabled =
@@ -183,6 +183,7 @@ Samplecountry
     if (conf.Datastore.enabled) {
       dataStoreDAO.findOneByName("localhost").futureBox.map { maybeStore =>
         if (maybeStore.isEmpty) {
+          logger.info("inserting local datastore");
           dataStoreDAO.insertOne(DataStore("localhost", conf.Http.uri, conf.Datastore.key))
         }
       }
@@ -193,6 +194,7 @@ Samplecountry
     if (conf.Tracingstore.enabled) {
       tracingStoreDAO.findOneByName("localhost").futureBox.map { maybeStore =>
         if (maybeStore.isEmpty) {
+          logger.info("inserting local tracingstore");
           tracingStoreDAO.insertOne(TracingStore("localhost", conf.Http.uri, conf.Tracingstore.key))
         }
       }


### PR DESCRIPTION
### Steps to test:
- in application.conf, set `application.insertInitialData = false`
- drop db / refresh schema
- start wk. onboarding flow should work
- console output should show `inserting local datastore`, and `inserting local tracingstore`


### Issues:
- fixes #3420 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
