### PR TITLE
Hotfix for editing TaskTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed a bug where the initial onboarding setup failed if automatic initial data was disabled. [#3421](https://github.com/scalableminds/webknossos/pull/3421)
 - Fixed a bug where the guessed bounding box for datasets that do not start at (0,0,0) was too large [#3437](https://github.com/scalableminds/webknossos/pull/3437)
 - Fixed a bug where dataset list refresh failed when datasets for non-existing organizations were reported. [#3438](https://github.com/scalableminds/webknossos/pull/3438)
+- Fixed a bug where the form values when editing TaskTypes were missing [#3451](https://github.com/scalableminds/webknossos/pull/3451)
 
 ### Removed
 

--- a/app/assets/javascripts/admin/tasktype/task_type_create_view.js
+++ b/app/assets/javascripts/admin/tasktype/task_type_create_view.js
@@ -46,7 +46,8 @@ class TaskTypeCreateView extends React.PureComponent<Props, State> {
     };
     const taskType = this.props.taskTypeId ? await getTaskType(this.props.taskTypeId) : null;
     // Use merge which is deep _.extend
-    const formValues = _.merge({}, defaultValues, taskType);
+    // eslint-disable-next-line no-unused-vars
+    const { recommendedConfiguration, ...formValues } = _.merge({}, defaultValues, taskType);
     this.props.form.setFieldsValue(formValues);
   }
 


### PR DESCRIPTION
The new field `recommendedConfiguration` which is set to null for now broke the tasktype editing page.

This should become obsolete with the upcoming front-end changes that allow setting the recommended configuration in task types

### Steps to test:
- go to tasktype editing page, values should be filled in, changing them and saving should work

### Issues:
- fixes #3452

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
