### PR TITLE
Enable /api/switch Cross-Organization

### DIFF
--- a/app/controllers/Authentication.scala
+++ b/app/controllers/Authentication.scala
@@ -262,6 +262,7 @@ class Authentication @Inject()(actorSystem: ActorSystem,
   }
 
   def switchTo(email: String) = sil.SecuredAction.async { implicit request =>
+    implicit val ctx = GlobalAccessContext
     if (request.identity.isSuperUser) {
       val loginInfo = LoginInfo(CredentialsProvider.ID, email)
       for {


### PR DESCRIPTION
### Steps to test:
- set up a second organization
- as scmboy (or other super user), call /api/switch
- should be logged in as other user from different organization

### Issues:
- fixes #3460 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
