### PR TITLE
Also flow-ignore binaryData when using symlinks

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,7 @@
 <PROJECT_ROOT>/test/db/.*
 <PROJECT_ROOT>/userBinaryData/.*
 <PROJECT_ROOT>/binaryData/.*
+.*/binaryData/.*
 <PROJECT_ROOT>/conf/.*
 <PROJECT_ROOT>/lib/.*
 <PROJECT_ROOT>/public/.*


### PR DESCRIPTION
After I symlinked the binaryData folder to another partition, flow went crazy due to the mapping json files. This PR fixes this.