### PR TITLE
added priority to project progess view

### DIFF
--- a/app/assets/javascripts/admin/api_flow_types.js
+++ b/app/assets/javascripts/admin/api_flow_types.js
@@ -348,6 +348,7 @@ export type APIProjectProgressReport = {
   +openInstances: number,
   +activeInstances: number,
   +finishedInstances: number,
+  +priority: number,
 };
 
 export type APIOpenTasksReport = {

--- a/app/assets/javascripts/admin/statistic/project_progress_report_view.js
+++ b/app/assets/javascripts/admin/statistic/project_progress_report_view.js
@@ -120,6 +120,12 @@ class ProjectProgressReportView extends React.PureComponent<{}, State> {
               sorter={Utils.compareBy(typeHint, project => project.totalTasks)}
               render={number => number.toLocaleString()}
             />
+            <Column
+              title="Priority"
+              dataIndex="priority"
+              sorter={Utils.compareBy(typeHint, project => project.priority)}
+              render={number => number.toLocaleString()}
+            />
             <ColumnGroup title="Instances">
               <Column
                 title="Total"


### PR DESCRIPTION
This PR adds the project priority to the project progress view.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a project with a long name like "FD_2017-01-12_FD0156-2_LongRangeConnectivityS1BF_27_09_2018"
- open the project progress report
- everything in the table should be aligned nicely. The priority should not take too much space and should adjust its width, as other columns get wider.

### Issues:
- fixes #3474

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [ ] Ready for review
