### PR TITLE
De-duplicate Knossos Layer Resolutions

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataLayers.scala
@@ -24,10 +24,10 @@ trait KnossosLayer extends DataLayer {
 
   lazy val boundingBox = BoundingBox.combine(sections.map(_.boundingBox))
 
-  lazy val resolutions: List[Point3D] = sections.map(_.resolutions).reduce(_ union _).toSet.toList.map {
+  lazy val resolutions: List[Point3D] = sections.map(_.resolutions).reduce(_ union _).map {
     case Left(r) => Point3D(r, r, r)
     case Right(r) => r
-  }
+  }.toSet.toList
 
   def lengthOfUnderlyingCubes(resolution: Point3D) = KnossosDataFormat.cubeLength
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/knossos/KnossosDataLayers.scala
@@ -24,7 +24,7 @@ trait KnossosLayer extends DataLayer {
 
   lazy val boundingBox = BoundingBox.combine(sections.map(_.boundingBox))
 
-  lazy val resolutions: List[Point3D] = sections.map(_.resolutions).reduce(_ union _).map {
+  lazy val resolutions: List[Point3D] = sections.map(_.resolutions).reduce(_ union _).toSet.toList.map {
     case Left(r) => Point3D(r, r, r)
     case Right(r) => r
   }


### PR DESCRIPTION
When a knossos layer has multiple sections, their resolutions where unioned. Should be unique, though, (to satisfy our database constraints, for one).

### Steps to test:
- have a knossos dataset with multiple sections in a layer (with the same resolution)
- click “refresh” in dataset list view, no sql errors should show in terminal
- you should be able to view the dataset (resolutions should not be empty)

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- [x] Needs datastore update after deployment
- [x] Ready for review
