### PR TITLE
Make abstract tree opt in to avoid performance issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 
--
+- Fixed a performance issue for large tracings with many branch points. [#3519](https://github.com/scalableminds/webknossos/pull/3519)
 
 
 ### Removed

--- a/app/assets/javascripts/oxalis/view/right-menu/abstract_tree_tab_view.js
+++ b/app/assets/javascripts/oxalis/view/right-menu/abstract_tree_tab_view.js
@@ -2,6 +2,7 @@
  * abstract_tree_tab_view.js
  * @flow
  */
+import { Button } from "antd";
 import type { Dispatch } from "redux";
 import { connect } from "react-redux";
 import React, { Component } from "react";
@@ -19,8 +20,15 @@ type Props = {
   skeletonTracing: ?SkeletonTracing,
 };
 
-class AbstractTreeView extends Component<Props> {
+type State = {
+  visible: boolean,
+};
+
+class AbstractTreeView extends Component<Props, State> {
   canvas: ?HTMLCanvasElement;
+  state = {
+    visible: false,
+  };
 
   componentDidMount() {
     window.addEventListener("resize", this.drawTree, false);
@@ -37,7 +45,7 @@ class AbstractTreeView extends Component<Props> {
 
   nodeList: Array<NodeListItem> = [];
   drawTree = _.throttle(() => {
-    if (!this.props.skeletonTracing) {
+    if (!this.props.skeletonTracing || !this.state.visible) {
       return;
     }
     const { activeTreeId, activeNodeId, trees } = this.props.skeletonTracing;
@@ -65,14 +73,30 @@ class AbstractTreeView extends Component<Props> {
 
   render() {
     return (
-      <div>
-        <canvas
-          id="abstract-tree-canvas"
-          ref={canvas => {
-            this.canvas = canvas;
-          }}
-          onClick={this.handleClick}
-        />
+      <div className="flex-center">
+        {this.state.visible ? (
+          <canvas
+            id="abstract-tree-canvas"
+            ref={canvas => {
+              this.canvas = canvas;
+            }}
+            onClick={this.handleClick}
+          />
+        ) : (
+          <React.Fragment>
+            <Button type="primary" onClick={() => this.setState({ visible: true })}>
+              Show Abstract Tree
+            </Button>
+            <span
+              style={{
+                color: "gray",
+                marginTop: 6,
+              }}
+            >
+              This may be slow for very large tracings.
+            </span>
+          </React.Fragment>
+        )}
       </div>
     );
   }

--- a/app/assets/stylesheets/trace_view/_right_menu.less
+++ b/app/assets/stylesheets/trace_view/_right_menu.less
@@ -7,6 +7,14 @@
   width: 100%;
 }
 
+.flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  height: 100%;
+}
+
 #tree-list {
   height: inherit;
   display: flex;


### PR DESCRIPTION
Make the display of the abstract tree opt-in as it causes performance issues for large tracings with many branchpoints. I created a followup issue #3518 to check how many people actually enable the abstract tree, in our analytics (a nice side effect of this solution, thanks @philippotto for the idea).

### URL of deployed dev instance (used for testing):
- https://abstracttreeoptin.webknossos.xyz

### Issues:
- fixes https://discuss.webknossos.org/t/problem-with-further-tracing-after-deleting-nodes-from-big-task/1251

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
