### PR TITLE
Volume Tracing Stream: Skip invalid buckets

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -39,12 +39,12 @@ trait VolumeTracingBucketHelper extends WKWMortonHelper with KeyValueStoreImplic
 
   def bucketStream(dataLayer: VolumeTracingLayer, resolution: Int, version: Option[Long]): Iterator[(BucketPosition, Array[Byte])] = {
     val key = buildKeyPrefix(dataLayer.name, resolution)
-    new BucketIterator(key, volumeDataStore, version).flatMap(item => item)
+    new BucketIterator(key, volumeDataStore, version)
   }
 
   def bucketStreamWithVersion(dataLayer: VolumeTracingLayer, resolution: Int, version: Option[Long]): Iterator[(BucketPosition, Array[Byte], Long)] = {
     val key = buildKeyPrefix(dataLayer.name, resolution)
-    new VersionedBucketIterator(key, volumeDataStore, version)
+    new VersionedBucketIterator(key, volumeDataStore, version).flatMap(item => item)
   }
 }
 
@@ -99,7 +99,7 @@ class VersionedBucketIterator(prefix: String, volumeDataStore: FossilDBClient, v
 class BucketIterator(prefix: String, volumeDataStore: FossilDBClient, version: Option[Long] = None) extends Iterator[(BucketPosition, Array[Byte])] {
   val versionedBucketIterator = new VersionedBucketIterator(prefix, volumeDataStore, version).flatMap(item => item)
 
-  override def next: Option[(BucketPosition, Array[Byte])] = {
+  override def next: (BucketPosition, Array[Byte]) = {
     val tuple = versionedBucketIterator.next
     (tuple._1, tuple._2)
   }


### PR DESCRIPTION
The only explanation I can see for the None.get as posted [here](https://github.com/scalableminds/webknossos/issues/3540#issuecomment-444964661) is invalid bucket keys being returned by the getMultipleKeys. This is troubling and we should look into the fossildb contents. However, since wK can show volume data for these tracings, the download (+copy to my account) may be fixed when we just skip all the invalid keys.

### URL of deployed dev instance (used for testing):
- https://volumeskipinvalidbuckets.webknossos.xyz

### Steps to test:
- create volume tracing, trace some
- download should still work, copy to my account should still work
- since I couldn’t reproduce #3540 locally the real test will only be with our production fossil database.

### Issues:
- may hopefully be fixing #3540

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- [x] Needs ~~datastore~~ tracingstore update after deployment
- [x] Ready for review
