### PR TITLE
Rename organization for screenshot tests

### DIFF
--- a/app/assets/javascripts/test/puppeteer/dataset_rendering.screenshot.js
+++ b/app/assets/javascripts/test/puppeteer/dataset_rendering.screenshot.js
@@ -76,7 +76,7 @@ datasetNames.map(async datasetName => {
     const { screenshot, width, height } = await screenshotDataset(
       await getNewPage(t.context.browser),
       URL,
-      { name: datasetName, owningOrganization: "Connectomics department" },
+      { name: datasetName, owningOrganization: "Connectomics_Department" },
     );
     const changedPixels = await compareScreenshot(
       screenshot,


### PR DESCRIPTION
The default organization was (finally) renamed on our dev servers as well, which broke the screenshot tests as the organization is hardcoded there.

### Steps to test:
- `docker-compose up screenshot-tests`

### Issues:
- fixes screenshot tests

------
- [x] Ready for review
