### PR TITLE
fix task edit bug caused by null values

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,7 +59,7 @@
     "no-restricted-syntax": ["error", "ForInStatement"],
     "no-restricted-globals": "warn",
     "no-underscore-dangle": "off",
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "ignoreRestSiblings": true }],
     "no-use-before-define": ["error", { "functions": false, "classes": false }],
     "one-var": ["error", "never"],
     "operator-assignment": "warn",

--- a/app/assets/javascripts/admin/task/task_create_form_view.js
+++ b/app/assets/javascripts/admin/task/task_create_form_view.js
@@ -119,7 +119,9 @@ class TaskCreateFormView extends React.PureComponent<Props, State> {
         openInstances: task.status.open,
       });
       const validFormValues = _.omitBy(defaultValues, _.isNull);
-      this.props.form.setFieldsValue(validFormValues);
+      // The task type is not needed for the form and leads to antd errors if it contains null values
+      const { type, ...neededFormValues } = validFormValues;
+      this.props.form.setFieldsValue(neededFormValues);
     }
   }
 


### PR DESCRIPTION
A null value in the task type (that was not even used) caused an error in the task edit form.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a task that has a task type without a recommended configuration. Search this task in the task view and click "Edit". All values should be filled in (but be disabled, except for "Remaining Instances").

### Issues:
- fixes #3557

------
- [x] Ready for review
