### PR TITLE
Fix redirect url after dataset upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 - Fixed a performance issue for large tracings with many branch points. [#3519](https://github.com/scalableminds/webknossos/pull/3519)
 - Fixed bug which caused buckets to disappear randomly. [#3531](https://github.com/scalableminds/webknossos/pull/3531)
+- Fixed a bug which broke the redirect after dataset upload via GUI. [#3571](https://github.com/scalableminds/webknossos/pull/3571)
 
 ### Removed
 

--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -774,8 +774,7 @@ export async function isDatasetNameValid(datasetId: APIDatasetId): Promise<?stri
     );
     return null;
   } catch (ex) {
-    const json = JSON.parse(await ex.text());
-    return json.messages.map(msg => Object.values(msg)[0]).join(". ");
+    return ex.messages.map(msg => Object.values(msg)[0]).join(". ");
   }
 }
 

--- a/app/assets/javascripts/admin/dataset/dataset_add_view.js
+++ b/app/assets/javascripts/admin/dataset/dataset_add_view.js
@@ -24,8 +24,8 @@ const DatasetAddView = ({ history }: Props) => (
       key="1"
     >
       <DatasetUploadView
-        onUploaded={datasetName => {
-          const url = `/datasets/${datasetName}/import`;
+        onUploaded={(organization: string, datasetName: string) => {
+          const url = `/datasets/${organization}/${datasetName}/import`;
           history.push(url);
         }}
       />

--- a/app/assets/javascripts/admin/dataset/dataset_upload_view.js
+++ b/app/assets/javascripts/admin/dataset/dataset_upload_view.js
@@ -21,7 +21,7 @@ type StateProps = {
 type Props = StateProps & {
   form: Object,
   withoutCard?: boolean,
-  onUploaded: string => void,
+  onUploaded: (string, string) => void,
 };
 
 type State = {
@@ -84,7 +84,7 @@ class DatasetUploadView extends React.PureComponent<Props, State> {
           async () => {
             Toast.success(messages["dataset.upload_success"]);
             await Utils.sleep(3000); // wait for 3 seconds so the server can catch up / do its thing
-            this.props.onUploaded(formValues.name);
+            this.props.onUploaded(activeUser.organization, formValues.name);
           },
           () => {
             this.setState({ isUploading: false });


### PR DESCRIPTION
### Steps to test:
- upload a dataset via the GUI
- you should then be redirected to the proper import page

### Issues:
- fixes #3485 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
