### PR TITLE
make bucket debugging flags available via window

### DIFF
--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/bucket.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/bucket.js
@@ -30,6 +30,15 @@ const warnAboutDownsamplingRGB = _.once(() =>
   Toast.warning("Zooming out for RGB data is limited. Zoom further in if data is not shown."),
 );
 
+export const bucketDebuggingFlags = {
+  // DEBUG flag for visualizing buckets which are passed to the GPU
+  visualizeBucketsOnGPU: false,
+  // DEBUG flag for visualizing buckets which are prefetched
+  visualizePrefetchedBuckets: false,
+};
+// Exposing this variable allows debugging on deployed systems
+window.bucketDebuggingFlags = bucketDebuggingFlags;
+
 export class DataBucket {
   type: "data" = "data";
   BIT_DEPTH: number;

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
@@ -2,7 +2,7 @@
 import * as THREE from "three";
 import _ from "lodash";
 
-import { DataBucket } from "oxalis/model/bucket_data_handling/bucket";
+import { DataBucket, bucketDebuggingFlags } from "oxalis/model/bucket_data_handling/bucket";
 import { createUpdatableTexture } from "oxalis/geometries/materials/abstract_plane_material_factory";
 import { getRenderer } from "oxalis/controller/renderer";
 import { waitForCondition } from "libs/utils";
@@ -23,9 +23,6 @@ import window from "libs/window";
 // writing buckets to the data texture (i.e., "committing the buckets").
 
 const lookUpBufferWidth = constants.LOOK_UP_TEXTURE_WIDTH;
-
-// DEBUG flag for visualizing buckets which are passed to the GPU
-const visualizeBucketsOnGPU = false;
 
 // At the moment, we only store one float f per bucket.
 // If f >= 0, f denotes the index in the data texture where the bucket is stored.
@@ -98,7 +95,7 @@ export default class TextureBucketManager {
     if (unusedIndex == null) {
       return;
     }
-    if (visualizeBucketsOnGPU) {
+    if (bucketDebuggingFlags.visualizeBucketsOnGPU) {
       bucket.unvisualize();
     }
     this.activeBucketToIndexMap.delete(bucket);
@@ -181,7 +178,7 @@ export default class TextureBucketManager {
       const dataTextureIndex = Math.floor(_index / bucketsPerTexture);
       const indexInDataTexture = _index % bucketsPerTexture;
 
-      if (visualizeBucketsOnGPU) {
+      if (bucketDebuggingFlags.visualizeBucketsOnGPU) {
         bucket.visualize();
       }
 


### PR DESCRIPTION
This should help when debugging #3593.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open dataset
- mutate `window.bucketDebuggingFlags` appropriately
- move within dataset and look at 3d viewport

### Issues:
- contributes to #3593

------
- [X] Ready for review
