### PR TITLE
Fix layout recovery in case of broken localstorage

### DIFF
--- a/app/assets/javascripts/oxalis/view/layouting/golden_layout_adapter.js
+++ b/app/assets/javascripts/oxalis/view/layouting/golden_layout_adapter.js
@@ -5,6 +5,7 @@ import * as React from "react";
 import _ from "lodash";
 
 import { listenToStoreProperty } from "oxalis/model/helpers/listener_helpers";
+import { setStoredLayoutsAction } from "oxalis/model/actions/ui_actions";
 import Constants from "oxalis/constants";
 import Store from "oxalis/store";
 import Toast from "libs/toast";
@@ -140,6 +141,7 @@ export class GoldenLayoutAdapter extends React.PureComponent<Props<*>, *> {
         // This might happen when the serialized layout config is not compatible with the newest version.
         // However, this should be mitigated by currentLayoutVersion in default_layout_configs.js
         Toast.error("Layout couldn't be restored. The default layout is used instead.");
+        Store.dispatch(setStoredLayoutsAction({}));
         layoutEmitter.emit("resetLayout");
         return;
       }

--- a/app/assets/javascripts/oxalis/view/layouting/layout_persistence.js
+++ b/app/assets/javascripts/oxalis/view/layouting/layout_persistence.js
@@ -82,7 +82,7 @@ function readStoredLayoutConfigs() {
 Store.dispatch(setStoredLayoutsAction(readStoredLayoutConfigs()));
 
 function persistLayoutConfigs() {
-  const storedLayouts = Store.getState().uiInformation.storedLayouts;
+  const { storedLayouts } = Store.getState().uiInformation;
   localStorage.setItem(localStorageKeys.goldenWkLayouts, JSON.stringify(storedLayouts));
   localStorage.setItem(localStorageKeys.currentLayoutVersion, JSON.stringify(currentLayoutVersion));
 }
@@ -94,7 +94,7 @@ layoutEmitter.on("resetLayout", (layoutKey: LayoutKeys, activeLayout: string) =>
 const persistLayoutConfigsDebounced = _.debounce(persistLayoutConfigs, 1000);
 
 export function getLayoutConfig(layoutKey: LayoutKeys, activeLayoutName: string) {
-  const storedLayouts = Store.getState().uiInformation.storedLayouts;
+  const { storedLayouts } = Store.getState().uiInformation;
   if (!storedLayouts[layoutKey]) {
     return getDefaultLayouts()[layoutKey];
   }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- To reproduce the actual error following code can be executed in the JS console:
```
	localStorage.setItem("goldenWkLayouts", "{\"OrthoLayoutView\":{\"Custom Layout\":{\"settings\":{\"hasHeaders\":true,\"constrainDragToContainer\":true,\"reorderEnabled\":true,\"selectionEnabled\":false,\"popoutWholeStack\":false,\"blockedPopoutsThrowError\":true,\"closePopoutsOnUnload\":true,\"showPopoutIcon\":false,\"showMaximiseIcon\":false,\"showCloseIcon\":false,\"responsiveMode\":\"onload\",\"tabOverlapAllowance\":0,\"reorderOnTabMenuClick\":true,\"tabControlOffset\":10},\"dimensions\":{\"borderWidth\":1,\"borderGrabWidth\":15,\"minItemHeight\":10,\"minItemWidth\":10,\"headerHeight\":18,\"dragProxyWidth\":300,\"dragProxyHeight\":200},\"labels\":{\"close\":\"close\",\"maximise\":\"maximise\",\"minimise\":\"minimise\",\"popout\":\"open in new window\",\"popin\":\"pop in\",\"tabDropdown\":\"additional tabs\"},\"content\":[{\"type\":\"row\",\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"content\":[{\"type\":\"column\",\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"width\":33.333333333333336,\"content\":[{\"type\":\"stack\",\"height\":50,\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"activeItemIndex\":0,\"content\":[{\"type\":\"component\",\"component\":\"PortalTarget\",\"title\":\"XY\",\"props\":{\"portalId\":\"xy\"},\"componentName\":\"lm-react-component\",\"isClosable\":true,\"reorderEnabled\":true}]},{\"type\":\"stack\",\"height\":50,\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"activeItemIndex\":0,\"content\":[{\"type\":\"component\",\"component\":\"PortalTarget\",\"title\":\"XZ\",\"props\":{\"portalId\":\"xz\"},\"componentName\":\"lm-react-component\",\"isClosable\":true,\"reorderEnabled\":true}]}]},{\"type\":\"column\",\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"width\":33.333333333333336,\"content\":[{\"type\":\"stack\",\"height\":50,\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"activeItemIndex\":0,\"content\":[{\"type\":\"component\",\"component\":\"PortalTarget\",\"title\":\"YZ\",\"props\":{\"portalId\":\"yz\"},\"componentName\":\"lm-react-component\",\"isClosable\":true,\"reorderEnabled\":true}]},{\"type\":\"stack\",\"height\":50,\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"activeItemIndex\":0,\"content\":[{\"type\":\"component\",\"component\":\"PortalTarget\",\"title\":\"3D\",\"props\":{\"portalId\":\"td\"},\"componentName\":\"lm-react-component\",\"isClosable\":true,\"reorderEnabled\":true}]}]},{\"type\":\"stack\",\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"width\":33.333333333333336,\"activeItemIndex\":0,\"content\":[{\"type\":\"component\",\"component\":\"PortalTarget\",\"title\":\"Info\",\"props\":{\"portalId\":\"DatasetInfoTabView\"},\"componentName\":\"lm-react-component\",\"isClosable\":true,\"reorderEnabled\":true},{\"type\":\"component\",\"component\":\"PortalTarget\",\"title\":\"Segmentation\",\"props\":{\"portalId\":\"MappingInfoView\"},\"componentName\":\"lm-react-component\",\"isClosable\":true,\"reorderEnabled\":true}]}]}],\"isClosable\":true,\"reorderEnabled\":true,\"title\":\"\",\"openPopouts\":[],\"maximisedItemId\":null}},\"VolumeTracingView\":{\"Custom Layout\":{\"Custom Layout\":{\"settings\":{\"showPopoutIcon\":false,\"showCloseIcon\":false,\"showMaximiseIcon\":false},\"dimensions\":{\"headerHeight\":20,\"borderWidth\":1},\"content\":[{\"type\":\"row\",\"content\":[{\"type\":\"column\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"XY\",\"props\":{\"portalId\":\"xy\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"XZ\",\"props\":{\"portalId\":\"xz\"}}],\"width\":35.68129330254042},{\"type\":\"column\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"YZ\",\"props\":{\"portalId\":\"yz\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"3D\",\"props\":{\"portalId\":\"td\"}}],\"width\":35.68129330254042},{\"type\":\"stack\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Info\",\"props\":{\"portalId\":\"DatasetInfoTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Segmentation\",\"props\":{\"portalId\":\"MappingInfoView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Meshes\",\"props\":{\"portalId\":\"MeshesView\"}}]}]}]}}},\"ArbitraryLayout\":{\"Custom Layout\":{\"Custom Layout\":{\"settings\":{\"showPopoutIcon\":false,\"showCloseIcon\":false,\"showMaximiseIcon\":false},\"dimensions\":{\"headerHeight\":20,\"borderWidth\":1},\"content\":[{\"type\":\"row\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Arbitrary View\",\"props\":{\"portalId\":\"arbitraryViewport\"}},{\"type\":\"stack\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Info\",\"props\":{\"portalId\":\"DatasetInfoTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Trees\",\"props\":{\"portalId\":\"TreesTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Comments\",\"props\":{\"portalId\":\"CommentTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Tree Viewer\",\"props\":{\"portalId\":\"AbstractTreeTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Segmentation\",\"props\":{\"portalId\":\"MappingInfoView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Meshes\",\"props\":{\"portalId\":\"MeshesView\"}}]}]}]}}},\"OrthoLayout\":{\"Custom Layout\":{\"Custom Layout\":{\"settings\":{\"showPopoutIcon\":false,\"showCloseIcon\":false,\"showMaximiseIcon\":false},\"dimensions\":{\"headerHeight\":20,\"borderWidth\":1},\"content\":[{\"type\":\"row\",\"content\":[{\"type\":\"column\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"XY\",\"props\":{\"portalId\":\"xy\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"XZ\",\"props\":{\"portalId\":\"xz\"}}],\"width\":35.68129330254042},{\"type\":\"column\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"YZ\",\"props\":{\"portalId\":\"yz\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"3D\",\"props\":{\"portalId\":\"td\"}}],\"width\":35.68129330254042},{\"type\":\"stack\",\"content\":[{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Info\",\"props\":{\"portalId\":\"DatasetInfoTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Trees\",\"props\":{\"portalId\":\"TreesTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Comments\",\"props\":{\"portalId\":\"CommentTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Tree Viewer\",\"props\":{\"portalId\":\"AbstractTreeTabView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Segmentation\",\"props\":{\"portalId\":\"MappingInfoView\"}},{\"type\":\"react-component\",\"component\":\"PortalTarget\",\"title\":\"Meshes\",\"props\":{\"portalId\":\"MeshesView\"}}]}]}]}}},\"LastActiveLayouts\":{\"OrthoLayoutView\":\"Custom Layout\",\"VolumeTracingView\":\"Custom Layout\",\"ArbitraryLayout\":\"Custom Layout\",\"OrthoLayout\":\"Custom Layout\"}}")
```
(ideally, pause the main JS so that the localstorage is not overwritten by timers)
- reload --> the page should recover properly

### Issues:
- fixes #3600

------
- [X] Ready for review
