### PR TITLE
Better analytics

### DIFF
--- a/app/assets/javascripts/admin/dataset/dataset_upload_view.js
+++ b/app/assets/javascripts/admin/dataset/dataset_upload_view.js
@@ -10,6 +10,7 @@ import { getDatastores, addDataset, isDatasetNameValid } from "admin/admin_rest_
 import Toast from "libs/toast";
 import * as Utils from "libs/utils";
 import messages from "messages";
+import { trackAction } from "oxalis/model/helpers/analytics";
 
 const FormItem = Form.Item;
 const { Option } = Select;
@@ -83,6 +84,7 @@ class DatasetUploadView extends React.PureComponent<Props, State> {
         addDataset(datasetConfig).then(
           async () => {
             Toast.success(messages["dataset.upload_success"]);
+            trackAction("Upload dataset");
             await Utils.sleep(3000); // wait for 3 seconds so the server can catch up / do its thing
             this.props.onUploaded(activeUser.organization, formValues.name);
           },

--- a/app/assets/javascripts/dashboard/advanced_dataset/dataset_action_view.js
+++ b/app/assets/javascripts/dashboard/advanced_dataset/dataset_action_view.js
@@ -9,6 +9,7 @@ import type { APIMaybeUnimportedDataset } from "admin/api_flow_types";
 import { createExplorational, triggerDatasetClearCache } from "admin/admin_rest_api";
 import Toast from "libs/toast";
 import messages from "messages";
+import { trackAction } from "oxalis/model/helpers/analytics";
 
 type Props = {
   dataset: APIMaybeUnimportedDataset,
@@ -25,6 +26,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
     withFallback: boolean,
   ) => {
     const annotation = await createExplorational(dataset, typ, withFallback);
+    trackAction(`Create ${typ} tracing`);
     this.props.history.push(`/annotations/${annotation.typ}/${annotation.id}`);
   };
 

--- a/app/assets/javascripts/dashboard/dataset/dataset_import_view.js
+++ b/app/assets/javascripts/dashboard/dataset/dataset_import_view.js
@@ -27,6 +27,7 @@ import { handleGenericError } from "libs/error_handling";
 import { jsonStringify } from "libs/utils";
 import Toast from "libs/toast";
 import messages from "messages";
+import { trackAction } from "oxalis/model/helpers/analytics";
 
 import { Hideable, confirmAsync, hasFormError } from "./helper_components";
 import DefaultConfigComponent from "./default_config_component";
@@ -241,6 +242,7 @@ class DatasetImportView extends React.PureComponent<Props, State> {
       const verb = this.props.isEditingMode ? "updated" : "imported";
       Toast.success(`Successfully ${verb} ${this.props.datasetId.name}`);
       datasetCache.clear();
+      trackAction(`Dataset ${verb}`);
       this.props.onComplete();
     });
   };

--- a/app/assets/javascripts/dashboard/explorative_annotations_view.js
+++ b/app/assets/javascripts/dashboard/explorative_annotations_view.js
@@ -31,6 +31,7 @@ import Store from "oxalis/store";
 import Toast from "libs/toast";
 import * as Utils from "libs/utils";
 import messages from "messages";
+import { trackAction } from "oxalis/model/helpers/analytics";
 
 const { Column } = Table;
 const { Search } = Input;
@@ -317,6 +318,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
           editAnnotation(newAnnotation.id, newAnnotation.typ, {
             tags: newAnnotation.tags,
           });
+          trackAction("Edit annotation tag");
         }
         return newAnnotation;
       });

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -14,7 +14,7 @@ import ReactDOM from "react-dom";
 
 import { document } from "libs/window";
 import { getActiveUser } from "admin/admin_rest_api";
-import { googleAnalyticsLogClicks } from "oxalis/model/helpers/google_analytics_middleware";
+import { googleAnalyticsLogClicks } from "oxalis/model/helpers/analytics";
 import { load as loadFeatureToggles } from "features";
 import { setActiveUserAction } from "oxalis/model/actions/user_actions";
 import ErrorHandling from "libs/error_handling";

--- a/app/assets/javascripts/oxalis/model/actions/settings_actions.js
+++ b/app/assets/javascripts/oxalis/model/actions/settings_actions.js
@@ -14,7 +14,7 @@ import type {
   Mapping,
 } from "oxalis/store";
 
-type UpdateUserSettingAction = {
+export type UpdateUserSettingAction = {
   type: "UPDATE_USER_SETTING",
   propertyName: $Keys<UserConfiguration>,
   value: any,

--- a/app/assets/javascripts/oxalis/model/helpers/analytics.js
+++ b/app/assets/javascripts/oxalis/model/helpers/analytics.js
@@ -3,11 +3,15 @@
 import window from "libs/window";
 import Store from "oxalis/store";
 
-export function trackAction(action: string) {
+function getOrganization() {
+  const { activeUser } = Store.getState();
+  return activeUser != null ? activeUser.organization : null;
+}
+
+// The void return type is needed for flow to check successfully
+export function trackAction(action: string): void {
   if (typeof window.ga !== "undefined" && window.ga !== null) {
-    const { activeUser } = Store.getState();
-    const organization = activeUser != null ? activeUser.organization : null;
-    window.ga("send", "event", "Action", action, organization);
+    window.ga("send", "event", "Action", action, getOrganization());
   }
 }
 
@@ -20,7 +24,7 @@ export function googleAnalyticsLogClicks(evt: MouseEvent) {
       // Restrict the textContent to a maximum length
       const textContent = target.textContent.trim().slice(0, 50);
       if (textContent.length > 0) {
-        window.ga("send", "event", "Click", textContent);
+        window.ga("send", "event", "Click", textContent, getOrganization());
       }
     }
   }

--- a/app/assets/javascripts/oxalis/model/helpers/analytics.js
+++ b/app/assets/javascripts/oxalis/model/helpers/analytics.js
@@ -1,23 +1,14 @@
 // @flow
-import type { Dispatch } from "redux";
 
 import window from "libs/window";
+import Store from "oxalis/store";
 
-const blacklistedActionTypes = ["SET_MOUSE_POSITION", "SET_VIEWPORT"];
-
-export default function GoogleAnalyticsMiddleWare<A: $Subtype<{ type: $Subtype<string> }>>(): (
-  next: Dispatch<A>,
-) => Dispatch<A> {
-  return (next: Dispatch<A>) => (action: A): A => {
-    // Google Analytics
-    if (typeof window.ga !== "undefined" && window.ga !== null) {
-      if (!blacklistedActionTypes.includes(action.type)) {
-        window.ga("send", "event", "ReduxAction", action.type);
-      }
-    }
-
-    return next(action);
-  };
+export function trackAction(action: string) {
+  if (typeof window.ga !== "undefined" && window.ga !== null) {
+    const { activeUser } = Store.getState();
+    const organization = activeUser != null ? activeUser.organization : null;
+    window.ga("send", "event", "Action", action, organization);
+  }
 }
 
 export function googleAnalyticsLogClicks(evt: MouseEvent) {
@@ -34,3 +25,5 @@ export function googleAnalyticsLogClicks(evt: MouseEvent) {
     }
   }
 }
+
+export default {};

--- a/app/assets/javascripts/oxalis/model/sagas/settings_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/settings_saga.js
@@ -29,9 +29,9 @@ function* pushDatasetSettingsAsync(): Saga<void> {
   yield* call(updateDatasetConfiguration, dataset, datasetConfiguration);
 }
 
-function trackUserSettingsAsync(action: UpdateUserSettingAction) {
+function* trackUserSettingsAsync(action: UpdateUserSettingAction): Saga<void> {
   if (action.propertyName === "newNodeNewTree") {
-    trackAction(`${action.value ? "Enabled" : "Disabled"} soma clicking`);
+    yield* call(trackAction, `${action.value ? "Enabled" : "Disabled"} soma clicking`);
   }
 }
 
@@ -41,6 +41,6 @@ export default function* watchPushSettingsAsync(): Saga<void> {
     _throttle(500, "UPDATE_USER_SETTING", pushUserSettingsAsync),
     _throttle(500, "UPDATE_DATASET_SETTING", pushDatasetSettingsAsync),
     _throttle(500, "UPDATE_LAYER_SETTING", pushDatasetSettingsAsync),
-    yield _takeEvery("UPDATE_USER_SETTING", trackUserSettingsAsync),
+    _takeEvery("UPDATE_USER_SETTING", trackUserSettingsAsync),
   ]);
 }

--- a/app/assets/javascripts/oxalis/store.js
+++ b/app/assets/javascripts/oxalis/store.js
@@ -49,7 +49,6 @@ import UiReducer from "oxalis/model/reducers/ui_reducer";
 import UserReducer from "oxalis/model/reducers/user_reducer";
 import ViewModeReducer from "oxalis/model/reducers/view_mode_reducer";
 import VolumeTracingReducer from "oxalis/model/reducers/volumetracing_reducer";
-import googleAnalyticsMiddleware from "oxalis/model/helpers/google_analytics_middleware";
 import overwriteActionMiddleware from "oxalis/model/helpers/overwrite_action_middleware";
 import reduceReducers from "oxalis/model/helpers/reduce_reducers";
 import rootSaga from "oxalis/model/sagas/root_saga";
@@ -566,7 +565,7 @@ const combinedReducers = reduceReducers(
 const store = createStore(
   combinedReducers,
   defaultState,
-  applyMiddleware(googleAnalyticsMiddleware, overwriteActionMiddleware, sagaMiddleware),
+  applyMiddleware(overwriteActionMiddleware, sagaMiddleware),
 );
 sagaMiddleware.run(rootSaga);
 

--- a/app/assets/javascripts/oxalis/view/nml_upload_zone_container.js
+++ b/app/assets/javascripts/oxalis/view/nml_upload_zone_container.js
@@ -8,6 +8,7 @@ import prettyBytes from "pretty-bytes";
 import type { OxalisState } from "oxalis/store";
 import { setDropzoneModalVisibilityAction } from "oxalis/model/actions/ui_actions";
 import FormattedDate from "components/formatted_date";
+import { trackAction } from "oxalis/model/helpers/analytics";
 
 type State = {
   files: Array<File>,
@@ -104,6 +105,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
     } else {
       this.setState({ dropzoneActive: false });
     }
+    trackAction("NML drag and drop");
     this.props.hideDropzoneModal();
   };
 

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -58,9 +58,15 @@ type Props = StateProps;
 const browserHistory = createBrowserHistory();
 browserHistory.listen(location => {
   if (typeof window.ga !== "undefined" && window.ga !== null) {
-    // Update the tracker state first, so that subsequent pageviews AND events use the correct page
-    window.ga("set", "page", location.pathname);
-    window.ga("send", "pageview");
+    // t0 is the default tracker name
+    const lastPage = window.ga.getByName("t0").get("page");
+    const newPage = location.pathname;
+    // The listener is called repeatedly for a single page change, don't send repeated pageviews
+    if (lastPage !== newPage) {
+      // Update the tracker state first, so that subsequent pageviews AND events use the correct page
+      window.ga("set", "page", newPage);
+      window.ga("send", "pageview");
+    }
   }
 });
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -26,7 +26,7 @@
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
           m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
         ga('create', '@(conf.Google.Analytics.trackingID)', 'auto');
         ga('set', 'anonymizeIp', true);


### PR DESCRIPTION
Remove the ReduxAction analytics tracking, see #3537 for the explanation. Use targeted action tracking instead. I wrote a little wrapper that includes the user's organization in the tracking request and also added the organization to the click tracking.
I've added the tracking to the spots suggested in #3459, if you have more suggestions, please let me know.

### URL of deployed dev instance (used for testing):
- https://betteranalytics.webknossos.xyz

### Steps to test:
- Add a TrackingID in your application.conf, any string will suffice, the key is `google.analytics.trackingID`
- Open the dev console network tab and filter for `analytics`
- Test some of the actions, e.g. drag and drop NML, enable/disable soma clicking, etc
- You should see respective analytics requests with the correct `ec, ea, el` values set

### Issues:
- fixes #3459 

------
- [x] Ready for review
