### PR TITLE
Correctly check tracingstore health

### DIFF
--- a/app/assets/javascripts/admin/datastore_health_check.js
+++ b/app/assets/javascripts/admin/datastore_health_check.js
@@ -25,14 +25,16 @@ export const pingDataStoreIfAppropriate = memoizedThrottle(async (requestedUrl: 
     RestAPI.getTracingStoreCached(),
     RestAPI.isInMaintenance(),
   ]);
-  const stores = datastores.concat(tracingstore);
+  const stores = datastores
+    .map(datastore => ({ ...datastore, path: "data" }))
+    .concat({ ...tracingstore, path: "tracings" });
   if (isInMaintenance) {
     Toast.warning(messages.planned_maintenance);
   } else {
-    const usedDataStore = stores.find(ds => requestedUrl.indexOf(ds.url) > -1);
-    if (usedDataStore != null) {
-      const { url } = usedDataStore;
-      const healthEndpoint = `${url}/data/health`;
+    const usedStore = stores.find(ds => requestedUrl.indexOf(ds.url) > -1);
+    if (usedStore != null) {
+      const { url, path } = usedStore;
+      const healthEndpoint = `${url}/${path}/health`;
       Request.triggerRequest(healthEndpoint, {
         doNotInvestigate: true,
         mode: "cors",


### PR DESCRIPTION
The correct health URL for the tracingstore is `/tracings/health` and not `/data/health`.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I didn't find an easy way to test this, except checking it out locally and modifying some code, but the change is fairly straightforward I'd say :/

### Issues:
- fixes #3539 

------
- [x] Ready for review
