### PR TITLE
Don't throw permanent error on save failure

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -955,7 +955,7 @@ export function getExistingExperienceDomains(): Promise<ExperienceDomainList> {
 }
 
 export async function isInMaintenance(): Promise<boolean> {
-  const info = await Request.receiveJSON("/api/maintenance");
+  const info = await Request.receiveJSON("/api/maintenance", { doNotInvestigate: true });
   return info.isMaintenance;
 }
 

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -48,9 +48,6 @@ export default {
 Editing should be done in a single window only.
 
 In order to restore the current window, a reload is necessary.`,
-  "save.failed_client_error": `We've encountered a permanent error while trying to save.
-
-In order to restore the current window, a reload is necessary.`,
   "react.rendering_error":
     "Unfortunately, we encountered an error during rendering. We cannot guarantee that your work is persisted. Please reload the page and try again.",
   "save.leave_page_unfinished":

--- a/app/assets/javascripts/oxalis/model/sagas/save_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/save_saga.js
@@ -182,14 +182,10 @@ export function* sendRequestToServer(
     yield* call(toggleErrorHighlighting, false);
   } catch (error) {
     yield* call(toggleErrorHighlighting, true);
-    if (error.status >= 400 && error.status < 500) {
+    if (error.status === 409) {
       // HTTP Code 409 'conflict' for dirty state
       window.onbeforeunload = null;
-      if (error.status === 409) {
-        yield* call(alert, messages["save.failed_simultaneous_tracing"]);
-      } else {
-        yield* call(alert, messages["save.failed_client_error"]);
-      }
+      yield* call(alert, messages["save.failed_simultaneous_tracing"]);
       location.reload();
       return;
     }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -107,7 +107,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
                 if (version + 1 == updateGroup.version || freezeVersions) {
                   tracingService.handleUpdateGroup(tracingId, updateGroup, version).map(_ => if (freezeVersions) version else updateGroup.version)
                 } else {
-                  Failure(s"incorrect version. expected: ${version + 1}; got: ${updateGroup.version}")
+                  Failure(s"Incorrect version. Expected: ${version + 1}; Got: ${updateGroup.version}")
                 }
               }
             }


### PR DESCRIPTION
, except when encountering a version mismatch.
I've also made sure that checking whether the server is in maintenance mode, does not potentially trigger another isInMaintenance request, which triggers another ... you get the idea :D

@fm3 I noticed that the version mismatch error (when tracing in multiple windows simultaneously) response no longer has the agreed upon status code 409, and therefore does not work as expected. Could you fix that? :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I'm open for ideas how to test this. The problem is that when going offline or killing the server, we obviously don't get a response with a status code. But I removed the status code check from the code and only check for 409 now, so testing the simultaneous tracing (once it is repaired), should be sufficient.

### Issues:
- fixes #3527 

------
- ~~[ ] Needs datastore update after deployment~~ (Simple change of the response text, can be deployed at a later time)
- [ ] Ready for review
