### PR TITLE
Save dataset Configuration even if dataset belongs to different orga

### DIFF
--- a/app/controllers/ConfigurationController.scala
+++ b/app/controllers/ConfigurationController.scala
@@ -61,7 +61,10 @@ class ConfigurationController @Inject()(userService: UserService,
       for {
         jsConfiguration <- request.body.asOpt[JsObject] ?~> "user.configuration.dataset.invalid"
         conf = jsConfiguration.fields.toMap
-        _ <- userService.updateDataSetConfiguration(request.identity, dataSetName, DataSetConfiguration(conf))
+        _ <- userService.updateDataSetConfiguration(request.identity,
+                                                    dataSetName,
+                                                    organizationName,
+                                                    DataSetConfiguration(conf))
       } yield {
         JsonOk(Messages("user.configuration.dataset.updated"))
       }

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -17,6 +17,7 @@ import models.team._
 import oxalis.mail.DefaultMails
 import oxalis.security.TokenDAO
 import oxalis.user.UserCache
+import play.api.i18n.{Messages, MessagesProvider}
 import play.api.libs.json._
 import utils.{ObjectId, WkConf}
 
@@ -138,10 +139,15 @@ class UserService @Inject()(conf: WkConf,
       result
     }
 
-  def updateDataSetConfiguration(user: User, dataSetName: String, configuration: DataSetConfiguration)(
-      implicit ctx: DBAccessContext) =
+  def updateDataSetConfiguration(
+      user: User,
+      dataSetName: String,
+      organizationName: String,
+      configuration: DataSetConfiguration)(implicit ctx: DBAccessContext, m: MessagesProvider) =
     for {
-      dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, user._organization)
+      dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName) ?~> Messages(
+        "dataSet.notFound",
+        dataSetName)
       _ <- userDataSetConfigurationDAO.updateDatasetConfigurationForUserAndDataset(user._id,
                                                                                    dataSet._id,
                                                                                    configuration.configuration)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://datasetconfigcrossorga.webknossos.xyz

### Steps to test:
- set a dataset to public
- create a second organization
- as a user of the second organization, view the dataset, change dataset config (e.g. segmentation opacity)
- should not throw errors
- reload, should still be your changed value

### Issues:
- fixes #3639 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
