### PR TITLE
Avoid loading of unnecessary buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 - Fixed a rendering bug which caused data to be clipped in certain scenarios for datasets with anisotropic resolutions. [#3609](https://github.com/scalableminds/webknossos/pull/3609)
 - Fixed a bug where saving tracings failed after they were open for >24h. [#3633](https://github.com/scalableminds/webknossos/pull/3633)
+- Fixed a bug that resulted in slow data loading when moving quickly through a dataset. [#3656](https://github.com/scalableminds/webknossos/pull/3656)
 - Fixed a bug which caused the wrong magnification to be rendered when zooming out very far. [#3609](https://github.com/scalableminds/webknossos/pull/3641/files)
 
 ### Removed

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/bucket.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/bucket.js
@@ -47,7 +47,6 @@ export class DataBucket {
   BYTE_OFFSET: number;
   visualizedMesh: ?Object;
   visualizationColor: number;
-  neededAtPickerTick: ?number;
 
   state: BucketStateEnumType;
   dirty: boolean;
@@ -346,10 +345,6 @@ export class DataBucket {
         }
       }
     }
-  }
-
-  setNeededAtPickerTick(tick: number) {
-    this.neededAtPickerTick = tick;
   }
 
   // The following three methods can be used for debugging purposes.

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/layer_rendering_manager.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/layer_rendering_manager.js
@@ -196,6 +196,7 @@ export default class LayerRenderingManager {
       this.lastIsInvisible = isInvisible;
       this.needsRefresh = false;
       this.currentBucketPickerTick++;
+      this.pullQueue.clear();
 
       const bucketQueue = new PriorityQueue({
         // small priorities take precedence

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
@@ -38,7 +38,7 @@ const createPriorityQueue = () =>
 
 const BATCH_SIZE = 3;
 // If ${maximumPickerTickCount} bucket picker ticks didn't select a bucket, that bucket is discarded from the pullqueue
-const maximumPickerTickCount = 5;
+const maximumPickerTickCount = 0;
 
 class PullQueue {
   cube: DataCube;
@@ -211,6 +211,10 @@ class PullQueue {
     for (const item of items) {
       this.add(item, currentBucketPickerTick);
     }
+  }
+
+  clear() {
+    this.priorityQueue.clear();
   }
 
   maybeWhitenEmptyBucket(bucketData: Uint8Array) {

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
@@ -15,7 +15,6 @@ import { requestWithFallback } from "oxalis/model/bucket_data_handling/wkstore_a
 import ConnectionInfo from "oxalis/model/data_connection_info";
 import Constants, { type Vector3, type Vector4 } from "oxalis/constants";
 import type DataCube from "oxalis/model/bucket_data_handling/data_cube";
-import Model from "oxalis/model";
 import Store, { type DataStoreInfo, type DataLayerType } from "oxalis/store";
 
 export type PullQueueItem = {
@@ -37,8 +36,6 @@ const createPriorityQueue = () =>
   });
 
 const BATCH_SIZE = 3;
-// If ${maximumPickerTickCount} bucket picker ticks didn't select a bucket, that bucket is discarded from the pullqueue
-const maximumPickerTickCount = 0;
 
 class PullQueue {
   cube: DataCube;
@@ -70,9 +67,6 @@ class PullQueue {
 
   pull(): Array<Promise<void>> {
     // Starting to download some buckets
-    const layerRenderingManager = Model.getLayerRenderingManagerByName(this.layerName);
-    const { currentBucketPickerTick } = layerRenderingManager;
-
     const promises = [];
     while (this.batchCount < PullQueueConstants.BATCH_LIMIT && this.priorityQueue.length > 0) {
       const batch = [];
@@ -81,15 +75,8 @@ class PullQueue {
         const bucket = this.cube.getOrCreateBucket(address);
 
         if (bucket.type === "data" && bucket.needsRequest()) {
-          const isOutdated =
-            bucket.neededAtPickerTick != null &&
-            currentBucketPickerTick - bucket.neededAtPickerTick > maximumPickerTickCount;
-          if (!isOutdated) {
-            batch.push(address);
-            bucket.pull();
-          } else {
-            bucket.unvisualize();
-          }
+          batch.push(address);
+          bucket.pull();
         }
       }
 
@@ -192,24 +179,13 @@ class PullQueue {
     }
   }
 
-  add(item: PullQueueItem, currentBucketPickerTick?: number): void {
-    const bucket = this.cube.getOrCreateBucket(item.bucket);
-    if (bucket.type === "data") {
-      if (currentBucketPickerTick == null) {
-        const layerRenderingManager = Model.getLayerRenderingManagerByName(this.layerName);
-        currentBucketPickerTick = layerRenderingManager.currentBucketPickerTick;
-      }
-      bucket.setNeededAtPickerTick(currentBucketPickerTick);
-    }
-
+  add(item: PullQueueItem): void {
     this.priorityQueue.queue(item);
   }
 
   addAll(items: Array<PullQueueItem>): void {
-    const layerRenderingManager = Model.getLayerRenderingManagerByName(this.layerName);
-    const { currentBucketPickerTick } = layerRenderingManager;
     for (const item of items) {
-      this.add(item, currentBucketPickerTick);
+      this.add(item);
     }
   }
 


### PR DESCRIPTION
When moving quickly through a dataset, bucket loading got slower and slower, eventually grinding to a halt. The cause of this was, that a lot of bucket that were no longer needed were loaded. Because we never decrease the priority of buckets once they are inserted in the pullqueue, buckets as far as 5*32 voxels away from the current position were loaded with high priority (because `maximumPickerTickCount = 5`). Also the priority queue holding the requested buckets got bigger and bigger (>50000 buckets), causing a slowdown of the priority queue functions (queue, dequeue), but I did not measure this slowdown.
This effect was amplified, because the prefetch strategy was not synchronized to the bucket picker ticks, but instead pushed buckets into the queue up to every 50ms.

I've mitigated these problems by clearing the pullqueue priority queue EVERY bucket picker tick and synchronizing the prefetch strat to the bucket picker ticks as well (only prefetch once for every bucket picker tick).
In my opinion, only fetching the most "up-to-date" buckets will result in the fastest and smoothest user experience, we should not load buckets requested during an older tick. This behavior is as if `maximumPickerTickCount` is 0. Do you know the reasoning behind setting the value to 5 originally? If you agree with the method in this PR, I'll remove the `maximumPickerTickCount` and related code in a new commit :)

### URL of deployed dev instance (used for testing):
- https://priorityqueuedetox.webknossos.xyz

### Steps to test:
- Open different datasets and trace using a high move value in a zoomstep where many buckets need to be requested.
- Moving for 10s and then stopping should result in a fast loading of the data in the current viewports.
- Prefetching should still work as expected, visualize using `window.bucketDebuggingFlags.visualizePrefetchedBuckets = true` in the dev console.

### Issues:
- fixes #3646 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
