### PR TITLE
Do not clear buckets from pullqueue that have the highest priority

### DIFF
--- a/app/assets/javascripts/oxalis/api/api_latest.js
+++ b/app/assets/javascripts/oxalis/api/api_latest.js
@@ -70,6 +70,7 @@ import { discardSaveQueuesAction } from "oxalis/model/actions/save_actions";
 import messages from "messages";
 import type { ToastStyle } from "libs/toast";
 import type { Versions } from "oxalis/view/version_view";
+import { PullQueueConstants } from "oxalis/model/bucket_data_handling/pullqueue";
 
 function assertExists(value: any, message: string) {
   if (value == null) {
@@ -704,7 +705,7 @@ class DataApi {
     if (bucket.isRequested()) {
       needsToAwaitBucket = true;
     } else if (bucket.needsRequest()) {
-      pullQueue.add({ bucket: bucketAddress, priority: -1 });
+      pullQueue.add({ bucket: bucketAddress, priority: PullQueueConstants.PRIORITY_HIGHEST });
       pullQueue.pull();
       needsToAwaitBucket = true;
     }

--- a/app/assets/javascripts/oxalis/api/api_v2.js
+++ b/app/assets/javascripts/oxalis/api/api_v2.js
@@ -60,6 +60,7 @@ import { discardSaveQueuesAction } from "oxalis/model/actions/save_actions";
 import messages from "messages";
 import type { ToastStyle } from "libs/toast";
 import update from "immutability-helper";
+import { PullQueueConstants } from "oxalis/model/bucket_data_handling/pullqueue";
 
 function assertExists(value: any, message: string) {
   if (value == null) {
@@ -592,7 +593,7 @@ class DataApi {
     if (bucket.isRequested()) {
       needsToAwaitBucket = true;
     } else if (bucket.needsRequest()) {
-      pullQueue.add({ bucket: bucketAddress, priority: -1 });
+      pullQueue.add({ bucket: bucketAddress, priority: PullQueueConstants.PRIORITY_HIGHEST });
       pullQueue.pull();
       needsToAwaitBucket = true;
     }

--- a/app/assets/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
+++ b/app/assets/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
@@ -190,7 +190,18 @@ class PullQueue {
   }
 
   clear() {
+    // Clear all but the highest priority
+    const highestPriorityElements = [];
+    while (
+      this.priorityQueue.length > 0 &&
+      this.priorityQueue.peek().priority === PullQueueConstants.PRIORITY_HIGHEST
+    ) {
+      highestPriorityElements.push(this.priorityQueue.dequeue());
+    }
     this.priorityQueue.clear();
+    for (const el of highestPriorityElements) {
+      this.priorityQueue.queue(el);
+    }
   }
 
   maybeWhitenEmptyBucket(bucketData: Uint8Array) {


### PR DESCRIPTION
This is important for the temporal bucket logic, meaning, if a user volume traced across a bucket that was not loaded yet. Thanks @philippotto for "envisioning" this bug :D

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a volume tracing with an existing segmentation. Throttle your internet connection in the dev console, and move to a place where buckets are not loaded yet.
- Use the brush tool to annotate a bit, then move far away ^^
- Un-throttle your internet connection and press the save button. The tracing should be saved successfully. (Before, saving was not possible, because the temporal bucket was never fetched!)

### Issues:
- fixes regression introduced by #3656 

------
- [x] Ready for review
