### PR TITLE
Allow Team Managers to create (and own) Scripts

### DIFF
--- a/app/assets/javascripts/admin/admin_rest_api.js
+++ b/app/assets/javascripts/admin/admin_rest_api.js
@@ -127,6 +127,13 @@ export async function getUsers(): Promise<Array<APIUser>> {
   return users;
 }
 
+export async function getTeamManagerOrAdminUsers(): Promise<Array<APIUser>> {
+  const users = await Request.receiveJSON("/api/users?isTeamManagerOrAdmin=true");
+  assertResponseLimit(users);
+
+  return users;
+}
+
 export async function getAdminUsers(): Promise<Array<APIUser>> {
   const users = await Request.receiveJSON("/api/users?isAdmin=true");
   assertResponseLimit(users);

--- a/app/assets/javascripts/admin/scripts/script_create_view.js
+++ b/app/assets/javascripts/admin/scripts/script_create_view.js
@@ -7,7 +7,7 @@ import React from "react";
 import type { APIUser } from "admin/api_flow_types";
 import type { OxalisState } from "oxalis/store";
 import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
-import { getAdminUsers, updateScript, createScript, getScript } from "admin/admin_rest_api";
+import { getTeamManagerOrAdminUsers, updateScript, createScript, getScript } from "admin/admin_rest_api";
 
 const FormItem = Form.Item;
 const Option = Select.Option;
@@ -37,7 +37,7 @@ class ScriptCreateView extends React.PureComponent<Props, State> {
   }
 
   async fetchData() {
-    const users = await getAdminUsers();
+    const users = await getTeamManagerOrAdminUsers();
     this.setState({ users: users.filter(user => user.isActive) });
   }
 

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -184,6 +184,12 @@ class UserController @Inject()(userService: UserService,
       Filter("isEditable",
              (value: Boolean, el: User) =>
                for { isEditable <- userService.isEditableBy(el, request.identity) } yield isEditable == value),
+      Filter(
+        "isTeamManagerOrAdmin",
+        (value: Boolean, el: User) =>
+          for { isTeamManagerOrAdmin <- userService.isTeamManagerOrAdminOfOrg(el, request.identity._organization) } yield
+            isTeamManagerOrAdmin == value
+      ),
       Filter("isAdmin", (value: Boolean, el: User) => Fox.successful(el.isAdmin == value))
     ) { filter =>
       for {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://allowteammanagertocreatescript.webknossos.xyz

### Steps to test:
- create second user, activate, make team manager
- as that user, create a script, should work
- owner drop-down menu should include all team managers of the organization

### Issues:
- fixes #3674 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [ ] Ready for review
