### PR TITLE
Fix isosurface for anisotropic segmentations

### DIFF
--- a/app/assets/javascripts/oxalis/controller/scene_controller.js
+++ b/app/assets/javascripts/oxalis/controller/scene_controller.js
@@ -149,7 +149,9 @@ class SceneController {
 
     // convert to normal (unbuffered) geometry to merge vertices
     geometry = new THREE.Geometry().fromBufferGeometry(geometry);
-    geometry.mergeVertices();
+    if (window.__isosurfaceMergeVertices) {
+      geometry.mergeVertices();
+    }
     geometry.computeVertexNormals();
     geometry.computeFaceNormals();
 

--- a/app/assets/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -168,7 +168,7 @@ function* maybeLoadIsosurface(
   if (threeDMap.get(clippedPosition)) {
     return;
   }
-  if (batchCounterPerSegment[segmentId] > MAXIMUM_BATCH_SIZE) {
+  if (batchCounterPerSegment[segmentId] > (window.__isosurfaceMaxBatchSize || MAXIMUM_BATCH_SIZE)) {
     return;
   }
   batchCounterPerSegment[segmentId]++;

--- a/app/assets/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -139,7 +139,7 @@ function* ensureSuitableIsosurface(): Saga<void> {
   const position = yield* select(state => getFlooredPosition(state.flycam));
   const { resolutions } = layer;
   const preferredZoomStep = window.__isosurfaceZoomStep != null ? window.__isosurfaceZoomStep : 1;
-  const zoomStep = Math.min(preferredZoomStep, resolutions.length);
+  const zoomStep = Math.min(preferredZoomStep, resolutions.length - 1);
 
   const clippedPosition = clipPositionToCubeBoundary(position, zoomStep, resolutions);
 

--- a/app/assets/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -11,6 +11,7 @@ import DataLayer from "oxalis/model/data_layer";
 import Model from "oxalis/model";
 import * as Utils from "libs/utils";
 import getSceneController from "oxalis/controller/scene_controller_provider";
+import window from "libs/window";
 
 class ThreeDMap<T> {
   map: Map<number, ?Map<number, ?Map<number, T>>>;
@@ -137,7 +138,7 @@ function* ensureSuitableIsosurface(): Saga<void> {
   }
   const position = yield* select(state => getFlooredPosition(state.flycam));
   const { resolutions } = layer;
-  const preferredZoomStep = 1;
+  const preferredZoomStep = window.__isosurfaceZoomStep != null ? window.__isosurfaceZoomStep : 1;
   const zoomStep = Math.min(preferredZoomStep, resolutions.length);
 
   const clippedPosition = clipPositionToCubeBoundary(position, zoomStep, resolutions);
@@ -174,7 +175,7 @@ function* maybeLoadIsosurface(
 
   threeDMap.set(clippedPosition, true);
 
-  const voxelDimensions = [4, 4, 4];
+  const voxelDimensions = window.__isosurfaceVoxelDimensions || [4, 4, 4];
   const dataStoreHost = yield* select(state => state.dataset.dataStore.url);
 
   const { buffer: responseBuffer, neighbors } = yield* call(


### PR DESCRIPTION
This PR fixes some conversions in the anisotropic case. Also, it makes some isosurface settings available via the browser console (`__isosurfaceZoomStep`, `__isosurfaceVoxelDimensions`, `__isosurfaceMergeVertices` and `__isosurfaceMaxBatchSize`).

### Steps to test:
- I downloaded georg's segmentation and tested the isosurfaces for anisotropic rendering

------
- [X] Ready for review
