### PR TITLE
Add create-tracing button when viewing dataset

### DIFF
--- a/app/assets/javascripts/oxalis/view/action_bar_view.js
+++ b/app/assets/javascripts/oxalis/view/action_bar_view.js
@@ -1,14 +1,17 @@
 // @flow
-import { Icon, Alert, Dropdown, Menu } from "antd";
+import { Alert, Dropdown, Icon, Menu, Tooltip } from "antd";
 import { connect } from "react-redux";
 import * as React from "react";
 
+import type { APIDataset, APIUser } from "admin/api_flow_types";
+import { createExplorational } from "admin/admin_rest_api";
 import {
   layoutEmitter,
   deleteLayout,
   getLayoutConfig,
   addNewLayout,
 } from "oxalis/view/layouting/layout_persistence";
+import { trackAction } from "oxalis/model/helpers/analytics";
 import { updateUserSettingAction } from "oxalis/model/actions/settings_actions";
 import AddNewLayoutModal from "oxalis/view/action-bar/add_new_layout_modal";
 import ButtonComponent from "oxalis/view/components/button_component";
@@ -31,6 +34,8 @@ const VersionRestoreWarning = (
 );
 
 type StateProps = {
+  dataset: APIDataset,
+  activeUser: ?APIUser,
   viewMode: Mode,
   controlMode: ControlMode,
   hasVolume: boolean,
@@ -76,6 +81,34 @@ class ActionBarView extends React.PureComponent<Props, State> {
     }
   };
 
+  renderStartTracingButton(): React.Node {
+    const createTracing = async () => {
+      const type = "hybrid";
+      const annotation = await createExplorational(this.props.dataset, type, true);
+      trackAction(`Create ${type} tracing (from view mode)`);
+      location.href = `${location.origin}/annotations/${annotation.typ}/${annotation.id}`;
+    };
+
+    const needsAuthentication = this.props.activeUser == null;
+    const MaybeTooltip = needsAuthentication
+      ? ({ children }) => (
+          <Tooltip title="Please log in or register to create a tracing.">{children}</Tooltip>
+        )
+      : ({ children }) => children;
+    return (
+      <MaybeTooltip>
+        <ButtonComponent
+          onClick={createTracing}
+          style={{ marginLeft: 12 }}
+          type="primary"
+          disabled={needsAuthentication}
+        >
+          Create Tracing
+        </ButtonComponent>
+      </MaybeTooltip>
+    );
+  }
+
   render() {
     const isTraceMode = this.props.controlMode === ControlModeEnum.TRACE;
     const isVolumeSupported = !Constants.MODES_ARBITRARY.includes(this.props.viewMode);
@@ -111,6 +144,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
           <DatasetPositionView />
           {this.props.hasVolume && isVolumeSupported ? <VolumeActionsView /> : null}
           {this.props.hasSkeleton && isTraceMode ? <ViewModesView /> : null}
+          {isTraceMode ? null : this.renderStartTracingButton()}
         </div>
         <AddNewLayoutModal
           addLayout={this.addNewLayout}
@@ -122,6 +156,8 @@ class ActionBarView extends React.PureComponent<Props, State> {
   }
 }
 const mapStateToProps = (state: OxalisState): StateProps => ({
+  dataset: state.dataset,
+  activeUser: state.activeUser,
   viewMode: state.temporaryConfiguration.viewMode,
   controlMode: state.temporaryConfiguration.controlMode,
   showVersionRestore: state.uiInformation.showVersionRestore,


### PR DESCRIPTION
I added a simple button to create a hybrid tracing when viewing a dataset. When not being logged in, the button is disabled. The log in mask is quite prominent in the top-right corner anyway (see screenshots). We should still improve the UX for registering etc. (see #3683).

### URL of deployed dev instance (used for testing):
- https://createtracinginviewmode.webknossos.xyz

### Steps to test:
- view a dataset while being logged in --> create tracing button should be there --> clicking on it should create a hybrid tracing
- view a dataset while not being logged in --> button should be disabled and tooltip should explain what to do

![image](https://user-images.githubusercontent.com/2486553/51921181-2cf23880-23e7-11e9-8c3d-2fd05a8a425c.png)
![image](https://user-images.githubusercontent.com/2486553/51921189-2fed2900-23e7-11e9-8cbc-30315c05546f.png)



### Issues:
- fixes #3490

------
- [X] Ready for review
