### PR TITLE
Report error when saga crashes

### DIFF
--- a/app/assets/javascripts/oxalis/model/sagas/root_saga.js
+++ b/app/assets/javascripts/oxalis/model/sagas/root_saga.js
@@ -18,10 +18,11 @@ import {
 } from "oxalis/model/sagas/annotation_saga";
 import { watchDataRelevantChanges } from "oxalis/model/sagas/prefetch_saga";
 import { watchSkeletonTracingAsync } from "oxalis/model/sagas/skeletontracing_saga";
+import ErrorHandling from "libs/error_handling";
 import handleMeshChanges from "oxalis/model/sagas/handle_mesh_changes";
 import isosurfaceSaga from "oxalis/model/sagas/isosurface_saga";
-import watchPushSettingsAsync from "oxalis/model/sagas/settings_saga";
 import watchIsScratchSaga from "oxalis/model/sagas/dataset_saga";
+import watchPushSettingsAsync from "oxalis/model/sagas/settings_saga";
 import watchTasksAsync from "oxalis/model/sagas/task_saga";
 
 export default function* rootSaga(): Saga<void> {
@@ -53,6 +54,7 @@ function* restartableSaga(): Saga<void> {
     ]);
   } catch (err) {
     console.error(err);
+    ErrorHandling.notify(err, {}, true);
     alert(`\
 Internal error.
 Please reload the page to avoid losing data.


### PR DESCRIPTION
The user is notified in case of crashing sagas, but I noticed that we didn't send these errors to airbrake. This PR changes that. Also, I enabled the escalation to slack, to get a picture of the situation before the airbrake quota is renewed.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- see slack channel (I added an explicit throw into the save saga)

### Issues:
- should help with #3632 

------
- [X] Ready for review
