### PR TITLE
fix element class conversion to/from protobuf 

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/ProtoGeometryImplicits.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/ProtoGeometryImplicits.scala
@@ -23,7 +23,7 @@ trait ProtoGeometryImplicits {
 
   implicit def boundingBoxOptFromProto(bbOpt: Option[ProtoBoundingBox]): Option[BoundingBox] = bbOpt.map(bb => BoundingBox(bb.topLeft, bb.width, bb.height, bb.depth))
 
-  implicit def elementClassToProto(ec: ElementClass.Value): ProtoElementClass = ProtoElementClass.fromValue(ec.id)
+  implicit def elementClassToProto(ec: ElementClass.Value): ProtoElementClass = ProtoElementClass.fromValue(ElementClass.bytesPerElement(ec))
 
-  implicit def elementClassFromProto(ec: ProtoElementClass): ElementClass.Value = ElementClass(ec.value)
+  implicit def elementClassFromProto(ec: ProtoElementClass): ElementClass.Value = ElementClass.guessFromBytesPerElement(ec.value).getOrElse(ElementClass.uint32)
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create volume tracing on dataset with 32 bit segmentation
- should have elementclass 32 (show no red squares)

------
- ~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- [x] Needs tracingstore update after deployment
- [x] Ready for review
