### PR TITLE
Fix nocache attribute in main html template

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,22 +1,22 @@
 @( conf: utils.WkConf )
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta name="commit-hash" content="@(webknossos.BuildInfo.commitHash)">
     <title>webKnossos</title>
     <link rel="shortcut icon" type="image/png" href="/images/favicon.png">
-    <link rel="stylesheet" type="text/css" media="screen" href="/bundle/vendors~main.css"?nocache=@(webknossos.BuildInfo.commitHash)>
-    <link rel="stylesheet" type="text/css" media="screen" href="/bundle/main.css"?nocache=@(webknossos.BuildInfo.commitHash)>
+    <link rel="stylesheet" type="text/css" media="screen" href="/bundle/vendors~main.css?nocache=@(webknossos.BuildInfo.commitHash)">
+    <link rel="stylesheet" type="text/css" media="screen" href="/bundle/main.css?nocache=@(webknossos.BuildInfo.commitHash)">
     @Html(com.newrelic.api.agent.NewRelic.getBrowserTimingHeader)
     @if(conf.Application.Authentication.enableDevAutoLogin){
       <script src="/api/auth/autoLogin"></script>
     }
-    <script type="text/javascript"
+    <script
       data-airbrake-project-id="@(conf.Airbrake.projectID)"
       data-airbrake-project-key="@(conf.Airbrake.projectKey)"
       data-airbrake-environment-name="@(conf.Airbrake.environment)"></script>
-    <script type="text/javascript" src="/bundle/vendors~main.js"?nocache=@(webknossos.BuildInfo.commitHash)></script>
-    <script type="text/javascript" src="/bundle/main.js"?nocache=@(webknossos.BuildInfo.commitHash)></script>
+    <script src="/bundle/vendors~main.js?nocache=@(webknossos.BuildInfo.commitHash)"></script>
+    <script src="/bundle/main.js?nocache=@(webknossos.BuildInfo.commitHash)"></script>
   </head>
   <body>
     <main id="main-container"></main>


### PR DESCRIPTION
This might have contributed to the tabs executing old code, in turn causing the save requests with expired tokens

### URL of deployed dev instance (used for testing):
- https://mainhtmlnocache.webknossos.xyz

### Steps to test:
- view source in a browser, shouldn’t complain of invalid syntax
- reload with new commit hash should load new js

### Issues:
- fixes #3754 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
