### PR TITLE
Fix connected tree test in nml parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 
 - The modals for a new task description and recommended task settings are no longer shown in read-only tracings. [#3724](https://github.com/scalableminds/webknossos/pull/3724)
+- Fixed a bug where some NMLs caused the webKnossos tab to freeze during NML upload. [#3758](https://github.com/scalableminds/webknossos/pull/3758)
 
 
 ## [19.02.0](https://github.com/scalableminds/webknossos/releases/tag/19.02.0) - 2019-02-04

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -368,7 +368,7 @@ function findTreeByNodeId(trees: TreeMap, nodeId: number): ?Tree {
 }
 
 function isTreeConnected(tree: Tree): boolean {
-  const visitedNodes = new Map();
+  const seenNodes = new Map();
 
   if (tree.nodes.size() > 0) {
     // Get the first element from the nodes map
@@ -376,23 +376,25 @@ function isTreeConnected(tree: Tree): boolean {
     // Breadth-First search that marks all reachable nodes as visited
     while (nodeQueue.length !== 0) {
       const nodeId = nodeQueue.shift();
-      visitedNodes.set(nodeId, true);
+      seenNodes.set(nodeId, true);
       const edges = tree.edges.getEdgesForNode(nodeId);
       // If there are no edges for a node, the tree is not connected
       if (edges == null) break;
 
       for (const edge of edges) {
-        if (nodeId === edge.target && !visitedNodes.get(edge.source)) {
+        if (nodeId === edge.target && !seenNodes.get(edge.source)) {
           nodeQueue.push(edge.source);
-        } else if (!visitedNodes.get(edge.target)) {
+          seenNodes.set(edge.source, true);
+        } else if (!seenNodes.get(edge.target)) {
           nodeQueue.push(edge.target);
+          seenNodes.set(edge.target, true);
         }
       }
     }
   }
 
-  // If the size of the visitedNodes map is the same as the number of nodes, the tree is connected
-  return _.size(visitedNodes) === tree.nodes.size();
+  // If the size of the seenNodes map is the same as the number of nodes, the tree is connected
+  return _.size(seenNodes) === tree.nodes.size();
 }
 
 function getEdgeHash(source: number, target: number) {

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -372,10 +372,10 @@ function isTreeConnected(tree: Tree): boolean {
 
   if (tree.nodes.size() > 0) {
     // Get the first element from the nodes map
-    const nodeQueue = [Number(tree.nodes.keys().next().value)];
+    const nodesToBeVisited = new Set([Number(tree.nodes.keys().next().value)]);
     // Breadth-First search that marks all reachable nodes as visited
-    while (nodeQueue.length !== 0) {
-      const nodeId = nodeQueue.shift();
+    while (nodesToBeVisited.size > 0) {
+      const nodeId = nodesToBeVisited.values().next().value;
       visitedNodes.set(nodeId, true);
       const edges = tree.edges.getEdgesForNode(nodeId);
       // If there are no edges for a node, the tree is not connected
@@ -383,11 +383,12 @@ function isTreeConnected(tree: Tree): boolean {
 
       for (const edge of edges) {
         if (nodeId === edge.target && !visitedNodes.get(edge.source)) {
-          nodeQueue.push(edge.source);
+          nodesToBeVisited.add(edge.source);
         } else if (!visitedNodes.get(edge.target)) {
-          nodeQueue.push(edge.target);
+          nodesToBeVisited.add(edge.target);
         }
       }
+      nodesToBeVisited.delete(nodeId);
     }
   }
 

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -372,11 +372,10 @@ function isTreeConnected(tree: Tree): boolean {
 
   if (tree.nodes.size() > 0) {
     // Get the first element from the nodes map
-    const nodesToBeVisited = new Set([Number(tree.nodes.keys().next().value)]);
+    const nodeQueue = [Number(tree.nodes.keys().next().value)];
     // Breadth-First search that marks all reachable nodes as visited
-    while (nodesToBeVisited.size > 0) {
-      // $FlowFixMe nodeId will be a number as we checked the size of the set first
-      const nodeId: number = nodesToBeVisited.values().next().value;
+    while (nodeQueue.length !== 0) {
+      const nodeId = nodeQueue.shift();
       visitedNodes.set(nodeId, true);
       const edges = tree.edges.getEdgesForNode(nodeId);
       // If there are no edges for a node, the tree is not connected
@@ -384,12 +383,11 @@ function isTreeConnected(tree: Tree): boolean {
 
       for (const edge of edges) {
         if (nodeId === edge.target && !visitedNodes.get(edge.source)) {
-          nodesToBeVisited.add(edge.source);
+          nodeQueue.push(edge.source);
         } else if (!visitedNodes.get(edge.target)) {
-          nodesToBeVisited.add(edge.target);
+          nodeQueue.push(edge.target);
         }
       }
-      nodesToBeVisited.delete(nodeId);
     }
   }
 

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -375,7 +375,8 @@ function isTreeConnected(tree: Tree): boolean {
     const nodesToBeVisited = new Set([Number(tree.nodes.keys().next().value)]);
     // Breadth-First search that marks all reachable nodes as visited
     while (nodesToBeVisited.size > 0) {
-      const nodeId = nodesToBeVisited.values().next().value;
+      // $FlowFixMe nodeId will be a number as we checked the size of the set first
+      const nodeId: number = nodesToBeVisited.values().next().value;
       visitedNodes.set(nodeId, true);
       const edges = tree.edges.getEdgesForNode(nodeId);
       // If there are no edges for a node, the tree is not connected


### PR DESCRIPTION
The tree connection test in the frontend nml parser had a bug where "highly" cyclic NMLs could lead to an infinite loop. Using a set instead of a queue fixes this bug.

### URL of deployed dev instance (used for testing):
- https://fixnmlconnectedtest.webknossos.xyz

### Steps to test:
- Upload this NML using the frontend "Import NML" functionality - the tab should not freeze
[highly_cyclic.zip](https://github.com/scalableminds/webknossos/files/2855380/highly_cyclic.zip)


### Issues:
- fixes https://discuss.webknossos.org/t/nml-upload-freezes-webknossos/1357/2

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
