### PR TITLE
Fix some issues with batch saving

### DIFF
--- a/frontend/javascripts/oxalis/model/reducers/save_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/save_reducer.js
@@ -57,7 +57,7 @@ function SaveReducer(state: OxalisState, action: Action): OxalisState {
         );
         const remainingQueue = state.save.queue[action.tracingType].slice(count);
         const otherQueue =
-          state.save.queue[action.tracingType === "skeleton" ? "skeleton" : "volume"];
+          state.save.queue[action.tracingType === "skeleton" ? "volume" : "skeleton"];
         const resetCounter = remainingQueue.length === 0 && otherQueue.length === 0;
         return update(state, {
           save: {

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.js
@@ -118,9 +118,14 @@ export function* pushTracingTypeAsync(tracingType: "skeleton" | "volume"): Saga<
       forcePush: _take("SAVE_NOW"),
     });
     yield* put(setSaveBusyAction(true, tracingType));
-    saveQueue = yield* select(state => state.save.queue[tracingType]);
-    if (saveQueue.length > 0) {
-      yield* call(sendRequestToServer, tracingType);
+    while (true) {
+      // Send batches to the server until the save queue is empty
+      saveQueue = yield* select(state => state.save.queue[tracingType]);
+      if (saveQueue.length > 0) {
+        yield* call(sendRequestToServer, tracingType);
+      } else {
+        break;
+      }
     }
     yield* put(setSaveBusyAction(false, tracingType));
   }

--- a/frontend/javascripts/test/sagas/save_saga.spec.js
+++ b/frontend/javascripts/test/sagas/save_saga.spec.js
@@ -100,9 +100,10 @@ test("SaveSaga should send update actions", t => {
   expectValueDeepEqual(t, saga.next([]), take("PUSH_SAVE_QUEUE"));
   saga.next(); // race
   saga.next(SaveActions.pushSaveQueueAction(updateActions));
-  saga.next();
+  saga.next(); // select state
   expectValueDeepEqual(t, saga.next(saveQueue), call(sendRequestToServer, TRACING_TYPE));
-  expectValueDeepEqual(t, saga.next(), put(setSaveBusyAction(false, TRACING_TYPE)));
+  saga.next(); // select state
+  expectValueDeepEqual(t, saga.next([]), put(setSaveBusyAction(false, TRACING_TYPE)));
 
   // Test that loop repeats
   saga.next(); // select state
@@ -202,7 +203,8 @@ test("SaveSaga should send update actions right away", t => {
   saga.next(SaveActions.saveNowAction()); // put setSaveBusyAction
   saga.next(); // select state
   saga.next(saveQueue); // call sendRequestToServer
-  expectValueDeepEqual(t, saga.next(), put(setSaveBusyAction(false, TRACING_TYPE)));
+  saga.next(); // select state
+  expectValueDeepEqual(t, saga.next([]), put(setSaveBusyAction(false, TRACING_TYPE)));
 });
 
 test("SaveSaga should remove the correct update actions", t => {


### PR DESCRIPTION
I noticed that after my recent PR #3729 when the save queue consists of multiple batches, those are no longer ALL saved immediately, but always only ONE (each time pressing the save button, or each time the save interval kicks in).
At least if the user doesn't press the save button, but instead the auto-saving does its job, this seems to have been the case for quite some time.

I adapted the code, so that a single save request will always save the whole save queue even if it consists of multiple batches (one after the other).

I also found a bug with the save progressInfo, which was essentially never reset because one of the conditions was wrong. This explains the issue we were seeing yesterday, where the percentage counter was displayed although the tracing did not contain big update action batches.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Upload an NML with more than 5000 nodes in the frontend. Press save - the percentage counter should show, but all batches should be saved (the checkmark should be visible after saving).
- Go offline afterwards. Set a few nodes and press save - the percentage counter should not show again (it did before the fix). Going online again and pressing save, should save the tracing.

### Issues:
- fixes an issue with batch saving

------
- [x] Ready for review
