### PR TITLE
Cancelled Annotations should not be viewable

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -50,6 +50,7 @@ class AnnotationController @Inject()(
         if (request.identity.isEmpty) "annotation.notFound.considerLoggingIn" else "annotation.notFound"
       for {
         annotation <- provider.provideAnnotation(typ, id, request.identity) ?~> notFoundMessage
+        _ <- bool2Fox(annotation.state != Cancelled) ?~> "annotation.cancelled"
         restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound"
         _ <- restrictions.allowAccess(request.identity) ?~> "notAllowed" ~> BAD_REQUEST
         typedTyp <- AnnotationType.fromString(typ).toFox ?~> "annotationType.notFound"

--- a/conf/messages
+++ b/conf/messages
@@ -160,6 +160,7 @@ annotation.notFound=Annotation couldn’t be found
 annotation.notFound.considerLoggingIn=Annotation couldn’t be found. If the annotation is not public, you need to log in to see it.
 annotation.invalid=Invalid annotation
 annotation.finished=Annotation is archived
+annotation.cancelled=This annotation is marked as cancelled and can’t be viewed
 annotation.allFinished=All annotations are archived
 annotation.reopened=Annotation was reopened
 annotation.saved=Annotation was saved


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://dontshowcancelledannotations.webknossos.xyz

### Steps to test:
- create task, request it, trace some, copy its url
- in dashboard, hit »reset and cancel« on this task
- go to its url again, you should get an error message
- viewing non-cancelled annotations should not have changed

### Issues:
- fixes #3737 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
