### PR TITLE
Fix timeline chart by explicitly setting start and end time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 
 - Fixed an error that occured when changing the URL hash. [#3746](https://github.com/scalableminds/webknossos/pull/3746)
+- Fixed a bug in the timeline chart rendering. The start and end time of the timeline chart now match the selected time range. [#3772](https://github.com/scalableminds/webknossos/pull/3772)
 - The modals for a new task description and recommended task settings are no longer shown in read-only tracings. [#3724](https://github.com/scalableminds/webknossos/pull/3724)
 - Fixed a bug where some NMLs caused the webKnossos tab to freeze during NML upload. [#3758](https://github.com/scalableminds/webknossos/pull/3758)
 

--- a/frontend/javascripts/admin/time/time_line_view.js
+++ b/frontend/javascripts/admin/time/time_line_view.js
@@ -116,6 +116,7 @@ class TimeLineView extends React.PureComponent<*, State> {
       { id: "End", type: "date" },
     ];
 
+    const { dateRange } = this.state;
     const timeTrackingRowGrouped = []; // shows each time span grouped by annotation id
     const timeTrackingRowTotal = []; // show all times spans in a single row
 
@@ -167,7 +168,7 @@ class TimeLineView extends React.PureComponent<*, State> {
                 <RangePicker
                   allowClear={false}
                   style={{ width: "100%" }}
-                  value={this.state.dateRange}
+                  value={dateRange}
                   onChange={this.handleDateChange}
                 />
               </FormItem>
@@ -201,7 +202,13 @@ class TimeLineView extends React.PureComponent<*, State> {
               chartType="Timeline"
               columns={columns}
               rows={rows}
-              options={{ timeline: { singleColor: "#108ee9" } }}
+              options={{
+                timeline: { singleColor: "#108ee9" },
+                hAxis: {
+                  minValue: dateRange[0].toDate(),
+                  maxValue: dateRange[1].toDate(),
+                },
+              }}
               graph_id="TimeLineGraph"
               chartPackages={["timeline"]}
               width="100%"

--- a/frontend/javascripts/admin/time/time_line_view.js
+++ b/frontend/javascripts/admin/time/time_line_view.js
@@ -204,6 +204,7 @@ class TimeLineView extends React.PureComponent<*, State> {
               rows={rows}
               options={{
                 timeline: { singleColor: "#108ee9" },
+                // Workaround for google-charts bug, see https://github.com/scalableminds/webknossos/pull/3772
                 hAxis: {
                   minValue: dateRange[0].toDate(),
                   maxValue: dateRange[1].toDate(),

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "react-debounce-render": "^4.0.1",
     "react-dom": "^16.8.0",
     "react-dropzone": "^4.2.13",
-    "react-google-charts": "^1.5.5",
+    "react-google-charts": "^2.0.0",
     "react-redux": "^5.0.6",
     "react-remarkable": "^1.1.3",
     "react-router-dom": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6624,10 +6624,6 @@ loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-loadjs@^3.3.1:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/loadjs/-/loadjs-3.5.4.tgz#ef0f4eb5a6ac2b86c7597a3d4de97b83816e36b8"
-
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -9354,15 +9350,6 @@ react-dom@15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-"react-dom@^15.3.2 || ^16":
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-dom@^16.8.0:
   version "16.8.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.0.tgz#18f28d4be3571ed206672a267c66dd083145a9c4"
@@ -9380,15 +9367,12 @@ react-dropzone@^4.2.13:
     attr-accept "^1.0.3"
     prop-types "^15.5.7"
 
-react-google-charts@^1.5.5:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/react-google-charts/-/react-google-charts-1.5.7.tgz#70d5daf1e362a9ef199576f15e37769185888067"
+react-google-charts@^2.0.0:
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/react-google-charts/-/react-google-charts-2.0.29.tgz#1f07b6cccf6c6b0965a00ae9e50f1d75d48f723d"
+  integrity sha512-VwP4AhNJp24oI7yUq6ItJ+jOPlxjsXTk/QMWWaGLkNInaRoQno4PHSNOebNmvZv97E4rqnJpxPwddhqXcK3R8g==
   dependencies:
-    debug "^2.2.0"
-    loadjs "^3.3.1"
-    prop-types "^15.5.8"
-    react "^15.3.2 || ^16"
-    react-dom "^15.3.2 || ^16"
+    react-load-script "^0.0.6"
 
 react-is@^16.3.2:
   version "16.3.2"
@@ -9411,6 +9395,11 @@ react-lazy-load@^3.0.12:
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
+react-load-script@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/react-load-script/-/react-load-script-0.0.6.tgz#db6851236aaa25bb622677a2eb51dad4f8d2c258"
+  integrity sha512-aRGxDGP9VoLxcsaYvKWIW+LRrMOzz2eEcubTS4NvQPPugjk2VvMhow0wWTkSl7RxookomD1MwcP4l5UStg5ShQ==
 
 react-redux@^5.0.6:
   version "5.0.7"
@@ -9521,15 +9510,6 @@ react@15.5.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.7"
-
-"react@^15.3.2 || ^16":
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 react@^16.8.0:
   version "16.8.0"


### PR DESCRIPTION
Users with only a single sub-second timerange triggered this bug: https://github.com/google/google-visualization-issues/issues/2269

I fixed it by explicitly setting a start and end time for the timeline start (the range the user selected), which is better than the adaptive start/end from before anyways imo. This way it is easier to see which days the selected tracer actually worked and which not.

I also upgraded the charts lib to v2 (v3 didn't work) to get rid of an old version of react that was included specifically for this lib.

Single Day (which triggered the bug before):
![single-day](https://user-images.githubusercontent.com/1702075/52710607-05c36b80-2f90-11e9-9d90-861f6fa1500f.png)

Range:
![timeranges](https://user-images.githubusercontent.com/1702075/52710422-8b92e700-2f8f-11e9-8e1b-f34b023921f0.png)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a task and set a single node, then close it again.
- Open the timeline view and select today's date - the chart should render and not crash.

### Issues:
- fixes #3771 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
