### PR TITLE
Check whether golden layout is initialized before calling toConfig

### DIFF
--- a/frontend/javascripts/oxalis/view/layouting/golden_layout_adapter.js
+++ b/frontend/javascripts/oxalis/view/layouting/golden_layout_adapter.js
@@ -100,7 +100,7 @@ export class GoldenLayoutAdapter extends React.PureComponent<Props<*>, *> {
 
   onStateChange() {
     const { onLayoutChange } = this.props;
-    if (onLayoutChange != null) {
+    if (onLayoutChange != null && this.gl.isInitialised) {
       onLayoutChange(this.gl.toConfig(), this.props.activeLayoutName);
     }
   }


### PR DESCRIPTION
Someone reported this error (see image below) and I found this related issue https://github.com/golden-layout/golden-layout/issues/253
I couldn't reproduce the issue, seems like a race condition, but this should fix it.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I could not reproduce it :/ The reporting user had it happen, when viewing a read-only annotation from the task search view.

### Issues:
- fixes

![pasted_image_at_2019-02-12__8_33_pm](https://user-images.githubusercontent.com/1702075/52717184-ce10ef80-2fa0-11e9-89c7-b1f303a4fbb0.png)



------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
