### PR TITLE
fix binarydata docker permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This is only recommended for testing.
 [For production](https://github.com/scalableminds/webknossos/wiki/Production-setup), a more elaborate setup with persistent file mounts and HTTPS reverse proxy is recommended.
 
 ```bash
+docker-compose pull webknossos
 ./start-docker.sh
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,7 @@ For small datasets (max. 1GB), you can use the upload functionality provide in t
 For larger datasets, we recommend the file system upload.
 Read more about the import functionality in the [Datasets guide](./datasets.md).
 
-If you do not have a compatible dataset available, you can use [this small dataset excerpt (300 MB)](https://webknossos.org/data/e2006_wkw.zip) for testing purposes.
+If you do not have a compatible dataset available, you can use [this small dataset excerpt (300 MB)](https://static.webknossos.org/data/e2006_wkw.zip) for testing purposes.
 The data was published by [Helmstaedter et al., 2011](https://www.nature.com/articles/nn.2868).
 
 By default, datasets are visible to all users in your organization.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,7 +21,7 @@ git clone https://github.com/scalableminds/webknossos.git
 cd webknossos
 
 docker-compose pull webknossos
-docker-compose up webknossos
+./start-docker.sh
 ```
 
 This will start an instance of webKnossos on http://localhost:9000/.

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+mkdir -p binaryData
+
 USER_UID=$(id -u) USER_GID=$(id -g) docker-compose up webknossos


### PR DESCRIPTION
### Steps to test:
- clone repository
- run `./start_docker`, visit `localhost:9000` after some waiting
- you should be able to create an orga via “get started” button

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
