### PR TITLE
Link to docs instead of wiki in onboarding

### DIFF
--- a/frontend/javascripts/admin/onboarding.js
+++ b/frontend/javascripts/admin/onboarding.js
@@ -251,7 +251,7 @@ class OnboardingView extends React.PureComponent<Props, State> {
           <React.Fragment>
             Upload your dataset via drag and drop or by directly copying the dataset on the hosting
             server.{" "}
-            <a href="https://github.com/scalableminds/webknossos/wiki/Datasets">
+            <a href="https://docs.webknossos.org/reference/data_formats">
               Learn more about supported data formats.
             </a>
           </React.Fragment>
@@ -316,7 +316,7 @@ class OnboardingView extends React.PureComponent<Props, State> {
           </FeatureCard>
           <FeatureCard header="More Datasets" icon={<Icon type="cloud-upload-o" />}>
             <a href="/datasets/upload">Upload more of your datasets.</a>{" "}
-            <a href="https://github.com/scalableminds/webknossos/wiki/Datasets">Learn more</a> about
+            <a href="https://docs.webknossos.org/reference/data_formats">Learn more</a> about
             the formats and upload processes webKnossos supports.
           </FeatureCard>
           <FeatureCard header="User & Team Management" icon={<Icon type="team" />}>

--- a/frontend/javascripts/admin/onboarding.js
+++ b/frontend/javascripts/admin/onboarding.js
@@ -316,8 +316,8 @@ class OnboardingView extends React.PureComponent<Props, State> {
           </FeatureCard>
           <FeatureCard header="More Datasets" icon={<Icon type="cloud-upload-o" />}>
             <a href="/datasets/upload">Upload more of your datasets.</a>{" "}
-            <a href="https://docs.webknossos.org/reference/data_formats">Learn more</a> about
-            the formats and upload processes webKnossos supports.
+            <a href="https://docs.webknossos.org/reference/data_formats">Learn more</a> about the
+            formats and upload processes webKnossos supports.
           </FeatureCard>
           <FeatureCard header="User & Team Management" icon={<Icon type="team" />}>
             <InviteUsersPopover


### PR DESCRIPTION
Link to docs instead of wiki in onboarding

------
~- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~
~- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
~- [ ] Updated [documentation](../blob/master/docs) if applicable~
~- [ ] Needs datastore update after deployment~
- [x] Ready for review
