### PR TITLE
Revert "Clean up: Remove Volume Version-Freezing code"

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -29,6 +29,7 @@ tracingstore {
   enabled = true
   key = "something-secure"
   name = "localhost"
+  freezeVolumeVersions = false
   webKnossos {
     uri = "localhost:9000"
     secured = false

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
@@ -16,6 +16,7 @@ class TracingStoreConfig @Inject()(configuration: Configuration) extends ConfigR
   object Tracingstore {
     val key = get[String]("tracingstore.key")
     val name = get[String]("tracingstore.name")
+    val freezeVolumeVersions = get[Boolean]("tracingstore.freezeVolumeVersions")
     object WebKnossos {
       val uri = get[String]("tracingstore.webKnossos.uri")
       val secured = get[Boolean]("tracingstore.webKnossos.secured")

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -24,6 +24,8 @@ trait TracingController[T <: GeneratedMessage with Message[T],
 
   def accessTokenService: TracingStoreAccessTokenService
 
+  def freezeVersions = false
+
   implicit val tracingCompanion: GeneratedMessageCompanion[T] = tracingService.tracingCompanion
 
   implicit val tracingsCompanion: GeneratedMessageCompanion[Ts]
@@ -109,8 +111,8 @@ trait TracingController[T <: GeneratedMessage with Message[T],
           webKnossosServer.reportTracingUpdates(tracingId, timestamps, latestStatistics, userToken).flatMap { _ =>
             updateGroups.foldLeft(currentVersion) { (previousVersion, updateGroup) =>
               previousVersion.flatMap { version =>
-                if (version + 1 == updateGroup.version) {
-                  tracingService.handleUpdateGroup(tracingId, updateGroup, version).map(_ => updateGroup.version)
+                if (version + 1 == updateGroup.version || freezeVersions) {
+                  tracingService.handleUpdateGroup(tracingId, updateGroup, version).map(_ => if (freezeVersions) version else updateGroup.version)
                 } else {
                   Failure(s"Incorrect version. Expected: ${version + 1}; Got: ${updateGroup.version}") ~> CONFLICT
                 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -37,6 +37,8 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
 
   implicit def unpackMultiple(tracings: VolumeTracings): List[Option[VolumeTracing]] = tracings.tracings.toList.map(_.tracing)
 
+  override def freezeVersions = config.Tracingstore.freezeVolumeVersions
+
   def initialData(tracingId: String) = Action.async { implicit request =>
     log {
       accessTokenService.validateAccess(UserAccessRequest.webknossos) {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -55,8 +55,9 @@ class VolumeTracingService @Inject()(
 
   override def currentVersion(tracingId: String): Fox[Long] = tracingDataStore.volumes.getVersion(tracingId).getOrElse(0L)
 
-  def handleUpdateGroup(tracingId: String, updateGroup: UpdateActionGroup[VolumeTracing], previousVersion: Long): Fox[Unit] = {
+  def handleUpdateGroup(tracingId: String, updateGroupVersioned: UpdateActionGroup[VolumeTracing], previousVersion: Long): Fox[Unit] = {
     for {
+      updateGroup: UpdateActionGroup[VolumeTracing] <- freezeVersionIfEnabled(updateGroupVersioned, previousVersion)
       updatedTracing: VolumeTracing <- updateGroup.actions.foldLeft(find(tracingId)) { (tracingFox, action) =>
           tracingFox.futureBox.flatMap {
             case Full(t) =>
@@ -79,6 +80,13 @@ class VolumeTracingService @Inject()(
       _ <- save(updatedTracing.copy(version = updateGroup.version), Some(tracingId), updateGroup.version)
       _ <- tracingDataStore.volumeUpdates.put(tracingId, updateGroup.version, updateGroup.actions.map(_.addTimestamp(updateGroup.timestamp)).map(_.transformToCompact))
     } yield Fox.successful(())
+  }
+
+  def freezeVersionIfEnabled(updateGroupVersioned: UpdateActionGroup[VolumeTracing], previousVersion: Long) = {
+    if (config.Tracingstore.freezeVolumeVersions)
+      Fox.successful(updateGroupVersioned.copy(version = previousVersion))
+    else
+      Fox.successful(updateGroupVersioned)
   }
 
   private def revertToVolumeVersion(tracingId: String, sourceVersion: Long, newVersion: Long, tracing: VolumeTracing): Fox[VolumeTracing] = {

--- a/webknossos-tracingstore/conf/standalone-tracingstore.conf
+++ b/webknossos-tracingstore/conf/standalone-tracingstore.conf
@@ -15,6 +15,7 @@ http {
 tracingstore {
   key = "something-secur3"
   name = "standalone-9090"
+  freezeVolumeVersions = false
   webKnossos {
     uri = "localhost:9000"
     secured = false


### PR DESCRIPTION
Reverts scalableminds/webknossos#3788

because the frontend relies on those config options being present. frontend and bakend for this should be cleaned up at the same time.