### PR TITLE
Allow downloading computed isosurfaces as stl plus re-upload

### DIFF
--- a/frontend/javascripts/libs/error_handling.js
+++ b/frontend/javascripts/libs/error_handling.js
@@ -132,7 +132,7 @@ class ErrorHandling {
   notify(error: Error, optParams: Object = {}, escalateToSlack: boolean = false) {
     const actionLog = getActionLog();
     this.airbrake.notify({ error, params: { ...optParams, actionLog } });
-    if (escalateToSlack) {
+    if (false && escalateToSlack) {
       const webhookUrl =
         "https://hooks.slack.com/services/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";
       fetch(webhookUrl, {

--- a/frontend/javascripts/libs/error_handling.js
+++ b/frontend/javascripts/libs/error_handling.js
@@ -129,24 +129,9 @@ class ErrorHandling {
     };
   }
 
-  notify(error: Error, optParams: Object = {}, escalateToSlack: boolean = false) {
+  notify(error: Error, optParams: Object = {}) {
     const actionLog = getActionLog();
     this.airbrake.notify({ error, params: { ...optParams, actionLog } });
-    if (false && escalateToSlack) {
-      const webhookUrl =
-        "https://hooks.slack.com/services/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";
-      fetch(webhookUrl, {
-        method: "POST",
-        headers: {},
-        body: JSON.stringify({
-          text: `*Inconsistent tracing* :k:
-*Error*: \`${error.toString()}\`
-*Url*: \`${location.href}\`
-*Action Log*: \`${JSON.stringify(actionLog)}\`
-*Params*: \`${JSON.stringify(optParams)}\``,
-        }),
-      });
-    }
   }
 
   assertExtendContext(additionalContext: Object) {

--- a/frontend/javascripts/libs/stl_exporter.js
+++ b/frontend/javascripts/libs/stl_exporter.js
@@ -3,6 +3,9 @@
 
 import * as THREE from "three";
 
+// Original Source: https://github.com/mrdoob/three.js/blob/master/examples/js/exporters/STLExporter.js
+// Only the `exportToStl` function was added as a wrapper.
+
 /**
  * @author kovacsv / http://kovacsv.hu/
  * @author mrdoob / http://mrdoob.com/

--- a/frontend/javascripts/libs/stl_exporter.js
+++ b/frontend/javascripts/libs/stl_exporter.js
@@ -1,0 +1,159 @@
+// @noflow
+/* eslint-disable */
+
+import * as THREE from "three";
+
+/**
+ * @author kovacsv / http://kovacsv.hu/
+ * @author mrdoob / http://mrdoob.com/
+ * @author mudcube / http://mudcu.be/
+ * @author Mugen87 / https://github.com/Mugen87
+ *
+ * Usage:
+ *  var exporter = new THREE.STLExporter();
+ *
+ *  // second argument is a list of options
+ *  var data = exporter.parse( mesh, { binary: true } );
+ *
+ */
+
+THREE.STLExporter = function() {};
+
+THREE.STLExporter.prototype = {
+  constructor: THREE.STLExporter,
+
+  parse: (function() {
+    var vector = new THREE.Vector3();
+    var normalMatrixWorld = new THREE.Matrix3();
+
+    return function parse(scene, options) {
+      if (options === undefined) options = {};
+
+      var binary = options.binary !== undefined ? options.binary : false;
+
+      var objects = [];
+      var triangles = 0;
+
+      scene.traverse(function(object) {
+        if (object.isMesh) {
+          var geometry = object.geometry;
+
+          if (geometry.isBufferGeometry) {
+            geometry = new THREE.Geometry().fromBufferGeometry(geometry);
+          }
+
+          if (geometry.isGeometry) {
+            triangles += geometry.faces.length;
+
+            objects.push({
+              geometry: geometry,
+              matrixWorld: object.matrixWorld,
+            });
+          }
+        }
+      });
+
+      if (binary) {
+        var offset = 80; // skip header
+        var bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
+        var arrayBuffer = new ArrayBuffer(bufferLength);
+        var output = new DataView(arrayBuffer);
+        output.setUint32(offset, triangles, true);
+        offset += 4;
+
+        for (var i = 0, il = objects.length; i < il; i++) {
+          var object = objects[i];
+
+          var vertices = object.geometry.vertices;
+          var faces = object.geometry.faces;
+          var matrixWorld = object.matrixWorld;
+
+          normalMatrixWorld.getNormalMatrix(matrixWorld);
+
+          for (var j = 0, jl = faces.length; j < jl; j++) {
+            var face = faces[j];
+
+            vector
+              .copy(face.normal)
+              .applyMatrix3(normalMatrixWorld)
+              .normalize();
+
+            output.setFloat32(offset, vector.x, true);
+            offset += 4; // normal
+            output.setFloat32(offset, vector.y, true);
+            offset += 4;
+            output.setFloat32(offset, vector.z, true);
+            offset += 4;
+
+            var indices = [face.a, face.b, face.c];
+
+            for (var k = 0; k < 3; k++) {
+              vector.copy(vertices[indices[k]]).applyMatrix4(matrixWorld);
+
+              output.setFloat32(offset, vector.x, true);
+              offset += 4; // vertices
+              output.setFloat32(offset, vector.y, true);
+              offset += 4;
+              output.setFloat32(offset, vector.z, true);
+              offset += 4;
+            }
+
+            output.setUint16(offset, 0, true);
+            offset += 2; // attribute byte count
+          }
+        }
+
+        return output;
+      } else {
+        var output = "";
+
+        output += "solid exported\n";
+
+        for (var i = 0, il = objects.length; i < il; i++) {
+          var object = objects[i];
+
+          var vertices = object.geometry.vertices;
+          var faces = object.geometry.faces;
+          var matrixWorld = object.matrixWorld;
+
+          normalMatrixWorld.getNormalMatrix(matrixWorld);
+
+          for (var j = 0, jl = faces.length; j < jl; j++) {
+            var face = faces[j];
+
+            vector
+              .copy(face.normal)
+              .applyMatrix3(normalMatrixWorld)
+              .normalize();
+
+            output += "\tfacet normal " + vector.x + " " + vector.y + " " + vector.z + "\n";
+            output += "\t\touter loop\n";
+
+            var indices = [face.a, face.b, face.c];
+
+            for (var k = 0; k < 3; k++) {
+              vector.copy(vertices[indices[k]]).applyMatrix4(matrixWorld);
+
+              output += "\t\t\tvertex " + vector.x + " " + vector.y + " " + vector.z + "\n";
+            }
+
+            output += "\t\tendloop\n";
+            output += "\tendfacet\n";
+          }
+        }
+
+        output += "endsolid exported\n";
+
+        return output;
+      }
+    };
+  })(),
+};
+
+export default function exportToStl(mesh) {
+  var exporter = new THREE.STLExporter();
+
+  // second argument is a list of options
+  var data = exporter.parse(mesh, { binary: true });
+  return data;
+}

--- a/frontend/javascripts/oxalis/constants.js
+++ b/frontend/javascripts/oxalis/constants.js
@@ -70,9 +70,9 @@ export const OrthoViewValuesWithoutTDView = [
 ];
 
 export const OrthoViewColors: OrthoViewMap<number> = {
-  [OrthoViews.PLANE_XY]: 0xff0000,
-  [OrthoViews.PLANE_YZ]: 0x0000ff,
-  [OrthoViews.PLANE_XZ]: 0x00ff00,
+  [OrthoViews.PLANE_XY]: 0xc81414, // red
+  [OrthoViews.PLANE_YZ]: 0x1414c8, // blue
+  [OrthoViews.PLANE_XZ]: 0x14c814, // green
   [OrthoViews.TDView]: 0xffffff,
 };
 

--- a/frontend/javascripts/oxalis/controller/scene_controller.js
+++ b/frontend/javascripts/oxalis/controller/scene_controller.js
@@ -3,7 +3,6 @@
  * @flow
  */
 
-import { saveAs } from "file-saver";
 import BackboneEvents from "backbone-events-standalone";
 import * as THREE from "three";
 import TWEEN from "tween.js";
@@ -41,7 +40,6 @@ import constants, {
   OrthoViews,
   type Vector3,
 } from "oxalis/constants";
-import exportToStl from "libs/stl_exporter";
 import window from "libs/window";
 
 import { convertCellIdToHSLA } from "../view/right-menu/mapping_info_view";
@@ -130,26 +128,17 @@ class SceneController {
 
     window.removeBucketMesh = (mesh: THREE.LineSegments) => this.rootNode.remove(mesh);
 
-    window.exportStl = () => {
-      const stl = exportToStl(this.isosurfacesGroup);
-      const cellId = 5;
-
-      binaryIsosurfaceMarker.forEach((marker, index) => {
-        stl.setUint8(index, marker);
-      });
-
-      stl.setUint32(3, cellId, true);
-
-      const blob = new Blob([stl]);
-      saveAs(blob, `isosurface-${cellId}.stl`);
-      return stl;
-    };
-
     window.clearIsosurfaces = () => {
       this.scene.remove(this.isosurfacesGroup);
       this.isosurfacesGroup = new THREE.Group();
       this.scene.add(this.isosurfacesGroup);
     };
+  }
+
+  getIsosurfaceGeometry(cellId: number): THREE.Geometry {
+    // todo: return proper subgroup wth
+
+    return this.isosurfacesGroup;
   }
 
   addSTL(meshMetaData: MeshMetaData, geometry: THREE.Geometry): void {

--- a/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -77,12 +77,13 @@ const isosurfaceLeftClick = (pos: Point2, plane: OrthoView, event: MouseEvent) =
   if (!segmentation) {
     return;
   }
+  const position = calculateGlobalPos(pos);
   const cellId = segmentation.cube.getMappedDataValue(
-    calculateGlobalPos(pos),
+    position,
     getRequestLogZoomStep(Store.getState()),
   );
   if (cellId > 0) {
-    Store.dispatch(changeActiveIsosurfaceCellAction(cellId));
+    Store.dispatch(changeActiveIsosurfaceCellAction(cellId, position));
   }
 };
 

--- a/frontend/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/annotation_actions.js
@@ -65,6 +65,15 @@ export type CreateMeshFromBufferAction = {
   name: string,
 };
 
+export type TriggerIsosurfaceDownloadAction = {
+  type: "TRIGGER_ISOSURFACE_DOWNLOAD",
+};
+
+export type ImportIsosurfaceFromStlAction = {
+  type: "IMPORT_ISOSURFACE_FROM_STL",
+  buffer: ArrayBuffer,
+};
+
 export type AnnotationActionTypes =
   | InitializeAnnotation
   | SetAnnotationNameAction
@@ -76,7 +85,9 @@ export type AnnotationActionTypes =
   | AddMeshMetadataAction
   | DeleteMeshAction
   | CreateMeshFromBufferAction
-  | UpdateLocalMeshMetaDataAction;
+  | UpdateLocalMeshMetaDataAction
+  | TriggerIsosurfaceDownloadAction
+  | ImportIsosurfaceFromStlAction;
 
 export const initializeAnnotationAction = (annotation: APIAnnotation): InitializeAnnotation => ({
   type: "INITIALIZE_ANNOTATION",
@@ -151,4 +162,15 @@ export const createMeshFromBufferAction = (
   type: "CREATE_MESH_FROM_BUFFER",
   buffer,
   name,
+});
+
+export const triggerIsosurfaceDownloadAction = (): TriggerIsosurfaceDownloadAction => ({
+  type: "TRIGGER_ISOSURFACE_DOWNLOAD",
+});
+
+export const importIsosurfaceFromStlAction = (
+  buffer: ArrayBuffer,
+): ImportIsosurfaceFromStlAction => ({
+  type: "IMPORT_ISOSURFACE_FROM_STL",
+  buffer,
 });

--- a/frontend/javascripts/oxalis/model/actions/segmentation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/segmentation_actions.js
@@ -1,16 +1,21 @@
 // @flow
 /* eslint-disable import/prefer-default-export */
 
+import type { Vector3 } from "oxalis/constants";
+
 export type ChangeActiveIsosurfaceCellAction = {
   type: "CHANGE_ACTIVE_ISOSURFACE_CELL",
   cellId: number,
+  seedPosition: Vector3,
 };
 
 export type IsosurfaceAction = ChangeActiveIsosurfaceCellAction;
 
 export const changeActiveIsosurfaceCellAction = (
   cellId: number,
+  seedPosition: Vector3,
 ): ChangeActiveIsosurfaceCellAction => ({
   type: "CHANGE_ACTIVE_ISOSURFACE_CELL",
   cellId,
+  seedPosition,
 });

--- a/frontend/javascripts/oxalis/model/sagas/handle_mesh_changes.js
+++ b/frontend/javascripts/oxalis/model/sagas/handle_mesh_changes.js
@@ -91,6 +91,7 @@ function* createMeshFromBuffer(action: CreateMeshFromBufferAction): Saga<void> {
   // Parse and persist STL in parallel
   const [geometry, meshMetaData] = yield _all([
     _call(parseStlBuffer, action.buffer),
+    _call(() => ({ position: [0, 0, 0], id: 3 })),
     _call(
       createMesh,
       {

--- a/frontend/javascripts/oxalis/model/sagas/handle_mesh_changes.js
+++ b/frontend/javascripts/oxalis/model/sagas/handle_mesh_changes.js
@@ -91,7 +91,6 @@ function* createMeshFromBuffer(action: CreateMeshFromBufferAction): Saga<void> {
   // Parse and persist STL in parallel
   const [geometry, meshMetaData] = yield _all([
     _call(parseStlBuffer, action.buffer),
-    _call(() => ({ position: [0, 0, 0], id: 3 })),
     _call(
       createMesh,
       {

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -155,7 +155,7 @@ function* maybeLoadIsosurface(
   );
 
   const vertices = new Float32Array(responseBuffer);
-  getSceneController().addIsosurface(vertices, segmentId);
+  getSceneController().addIsosurfaceFromVertices(vertices, segmentId);
 
   for (const neighbor of neighbors) {
     const neighborPosition = getNeighborPosition(clippedPosition, neighbor, zoomStep, resolutions);

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -5,6 +5,7 @@ import type { APIDataset } from "admin/api_flow_types";
 import type { ChangeActiveIsosurfaceCellAction } from "oxalis/model/actions/segmentation_actions";
 import { ControlModeEnum, type Vector3 } from "oxalis/constants";
 import { FlycamActions } from "oxalis/model/actions/flycam_actions";
+import type { ImportIsosurfaceFromStlAction } from "oxalis/model/actions/annotation_actions";
 import {
   type Saga,
   _takeEvery,

--- a/frontend/javascripts/oxalis/model/sagas/root_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/root_saga.js
@@ -54,7 +54,7 @@ function* restartableSaga(): Saga<void> {
     ]);
   } catch (err) {
     console.error(err);
-    ErrorHandling.notify(err, {}, true);
+    ErrorHandling.notify(err, {});
     alert(`\
 Internal error.
 Please reload the page to avoid losing data.

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
@@ -147,7 +147,7 @@ function* watchTracingConsistency(): Saga<void> {
   if (invalidTreeDetails.length > 0) {
     const error = new Error("Corrupted tracing. See the action log for details.");
     Toast.error(messages["tracing.invalid_state"]);
-    ErrorHandling.notify(error, { invalidTreeDetails }, true);
+    ErrorHandling.notify(error, { invalidTreeDetails });
   }
 }
 

--- a/frontend/javascripts/oxalis/view/right-menu/meshes_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/meshes_view.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Button, Upload, Checkbox, Icon, Input, Modal, Spin } from "antd";
+import { Button, Checkbox, Icon, Input, Modal, Spin, Tooltip, Upload } from "antd";
 import type { Dispatch } from "redux";
 import { connect } from "react-redux";
 import React from "react";
@@ -25,7 +25,10 @@ import ButtonComponent from "oxalis/view/components/button_component";
 
 const ButtonGroup = Button.Group;
 
-export const binaryIsosurfaceMarker = [105, 115, 111];
+export const stlIsosurfaceConstants = {
+  isosurfaceMarker: [105, 115, 111], // ASCII codes for ISO
+  cellIdIndex: 3, // Write cell index after the isosurfaceMarker
+};
 
 // This file defines the components EditMeshModal and MeshesView.
 
@@ -143,9 +146,11 @@ class MeshesView extends React.Component<Props, { currentlyEditedMesh: ?MeshMeta
               Import
             </ButtonComponent>
           </Upload>
-          <ButtonComponent icon="download" onClick={this.props.downloadIsosurface}>
-            Download
-          </ButtonComponent>
+          <Tooltip title="Download the isosurface of the currently active cell as STL.">
+            <ButtonComponent icon="download" onClick={this.props.downloadIsosurface}>
+              Download
+            </ButtonComponent>
+          </Tooltip>
         </ButtonGroup>
         {this.state.currentlyEditedMesh != null ? (
           <EditMeshModal

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "deep-freeze": "0.0.1",
     "dice-coefficient": "^1.0.2",
     "es6-promise": "^3.0.2",
-    "file-saver": "^1.3.3",
+    "file-saver": "^2.0.1",
     "font-awesome": "^4.5.0",
     "glsl-parser": "git+https://github.com/anvaka/glslx.git#glsl-parser",
     "golden-layout": "^1.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4485,9 +4485,10 @@ file-loader@^1.1.5:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
 
-file-saver@^1.3.3:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
+file-saver@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.1.tgz#7fe2242af1cbc559a29d8176078a8b56d781fa79"
+  integrity sha512-dCB3K7/BvAcUmtmh1DzFdv0eXSVJ9IAFt1mw3XZfAexodNRoE29l3xB2EX4wH2q8m/UTzwzEPq/ArYk98kUkBQ==
 
 file-type@^3.1.0:
   version "3.9.0"


### PR DESCRIPTION
This PR adds a download button to the mesh tab which will start an stl download for the currently active cell id (shift+click to change; only works in view mode).
Within the stl file, the header is used to decode that the file represents an computed isosurface plus the cell id. This information is used to deal with the STL import differently. The differences are:

- for a normal mesh import, we persist the STL on the server, show the element in a list which allows further modification (position, visibility, name etc.). also, a normal mesh doesn't have a designated color
- for an isosurface mesh, we simply add the mesh to the scene as if it were computed from the server. the only difference is where the mesh is coming from and that we don't update the cache which avoids redundant re-computations. the cache is indexed by the position for which isosurfaces were requested. however, I didn't want to encode these within the stl (the header size is limited). I think, that's fine for now. the only downside is that it **can** happen that the isosurface is redundantly recomputed (however, they will perfectly overlap so it's not a rendering issue).

All in all, I'm not really satisfied with the current state of meshes and isosurfaces. UI- and code-wise it feels quite messy. A proper clean up would be good. But probably out of scope for this sprint (requires a bit of brainstorming, too, I think).

### URL of deployed dev instance (used for testing):
- https://stldownload.webknossos.xyz

### Steps to test:
- open a dataset in view mode with a segmentation
- enable isosurfaces rendering
- shift click on a cell (right now, the center position is used as result of another bug)
- click the download button in the mesh view
- refresh the page
- use the import button in the mesh view to import the stl you just downloaded
- the mesh should be rendered as it was before the page refresh (same position, color & appearance)

### Issues:
- fixes #3714 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
