### PR TITLE
Fix crosshair display

### DIFF
--- a/frontend/javascripts/oxalis/geometries/plane.js
+++ b/frontend/javascripts/oxalis/geometries/plane.js
@@ -80,6 +80,10 @@ class Plane {
         crosshairGeometries[i],
         this.getLineBasicMaterial(OrthoViewCrosshairColors[this.planeID][i], 1),
       );
+      // Objects are rendered according to their renderOrder (lowest to highest).
+      // The default renderOrder is 0. In order for the crosshairs to be shown
+      // render them AFTER the plane has been rendered.
+      this.crosshair[i].renderOrder = 1;
     }
 
     // create borders


### PR DESCRIPTION
By explicitly setting the renderOrder, so the crosshairs are rendered last. Much cleaner than the plane offset solution from before :)

See https://threejs.org/docs/#api/en/core/Object3D.renderOrder

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open tracing view. Crosshairs should be displayed if the setting is enabled.

### Issues:
- fixes missing crosshairs

------
- [x] Ready for review
