### PR TITLE
Fix bi- and trilinear filtering along z axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 - Fixed the setting which enables to hide the planes within the 3D viewport. [#3857](https://github.com/scalableminds/webknossos/pull/3857)
 - Fixed a bug which allowed the brush size to become negative when using shortcuts. [#3861](https://github.com/scalableminds/webknossos/pull/3861)
+- Fixed interpolation along z-axis. [#3888](https://github.com/scalableminds/webknossos/pull/3888)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/shaders/filtering.glsl.js
+++ b/frontend/javascripts/oxalis/shaders/filtering.glsl.js
@@ -10,16 +10,16 @@ export const getBilinearColorFor: ShaderModule = {
       float layerIndex,
       float d_texture_width,
       float packingDegree,
-      vec3 coords
+      vec3 coordsUVW
     ) {
-      coords = coords + transDim(vec3(-0.5, -0.5, 0.0));
-      vec2 bifilteringParams = transDim((coords - floor(coords))).xy;
-      coords = floor(coords);
+      coordsUVW = coordsUVW + vec3(-0.5, -0.5, 0.0);
+      vec2 bifilteringParams = (coordsUVW - floor(coordsUVW)).xy;
+      coordsUVW = floor(coordsUVW);
 
-      vec4 a = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords);
-      vec4 b = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(1, 0, 0)));
-      vec4 c = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(0, 1, 0)));
-      vec4 d = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(1, 1, 0)));
+      vec4 a = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW);
+      vec4 b = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 0, 0));
+      vec4 c = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 1, 0));
+      vec4 d = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 1, 0));
       if (a.a < 0.0 || b.a < 0.0 || c.a < 0.0 || d.a < 0.0) {
         // We need to check all four colors for a negative parts, because there will be black
         // lines at the borders otherwise (black gets mixed with data)
@@ -42,21 +42,21 @@ export const getTrilinearColorFor: ShaderModule = {
       float layerIndex,
       float d_texture_width,
       float packingDegree,
-      vec3 coords
+      vec3 coordsUVW
     ) {
-      coords = coords + transDim(vec3(-0.5, -0.5, 0.0));
-      vec3 bifilteringParams = transDim((coords - floor(coords))).xyz;
-      coords = floor(coords);
+      coordsUVW = coordsUVW + vec3(-0.5, -0.5, 0.0);
+      vec3 bifilteringParams = (coordsUVW - floor(coordsUVW)).xyz;
+      coordsUVW = floor(coordsUVW);
 
-      vec4 a = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords);
-      vec4 b = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(1, 0, 0)));
-      vec4 c = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(0, 1, 0)));
-      vec4 d = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(1, 1, 0)));
+      vec4 a = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW);
+      vec4 b = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 0, 0));
+      vec4 c = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 1, 0));
+      vec4 d = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 1, 0));
 
-      vec4 a2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(0, 0, 1)));
-      vec4 b2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(1, 0, 1)));
-      vec4 c2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(0, 1, 1)));
-      vec4 d2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coords + transDim(vec3(1, 1, 1)));
+      vec4 a2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 0, 1));
+      vec4 b2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 0, 1));
+      vec4 c2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 1, 1));
+      vec4 d2 = getColorForCoords(lookUpTexture, layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 1, 1));
 
       if (a.a < 0.0 || b.a < 0.0 || c.a < 0.0 || d.a < 0.0 ||
         a2.a < 0.0 || b2.a < 0.0 || c2.a < 0.0 || d2.a < 0.0) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://zfiltering.webknossos.xyz

### Steps to test:
- toggle bilinear filtering and ensure that filtering is done in all three data panes in ortho mode
- also check filtering in flight mode (cant be toggled via settings)

### Issues:
- fixes #3865 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
