### PR TITLE
Hide login/register and redirect to onboarding when there are no organizations

### DIFF
--- a/frontend/javascripts/admin/auth/registration_form.js
+++ b/frontend/javascripts/admin/auth/registration_form.js
@@ -9,6 +9,7 @@ import Request from "libs/request";
 import Store from "oxalis/throttled_store";
 import messages from "messages";
 import features from "features";
+import { setHasOrganizationsAction } from "oxalis/model/actions/ui_actions";
 
 const FormItem = Form.Item;
 const { Option } = Select;
@@ -74,6 +75,8 @@ class RegistrationForm extends React.PureComponent<Props, State> {
           : "/api/auth/register",
         { data: formValues },
       );
+
+      Store.dispatch(setHasOrganizationsAction(true));
 
       const organization = this.state.organizations.find(
         org => org.name === formValues.organization,

--- a/frontend/javascripts/main.js
+++ b/frontend/javascripts/main.js
@@ -13,10 +13,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { document } from "libs/window";
-import { getActiveUser } from "admin/admin_rest_api";
+import { getActiveUser, getOrganizations } from "admin/admin_rest_api";
 import { googleAnalyticsLogClicks } from "oxalis/model/helpers/analytics";
 import { load as loadFeatureToggles } from "features";
 import { setActiveUserAction } from "oxalis/model/actions/user_actions";
+import { setHasOrganizationsAction } from "oxalis/model/actions/ui_actions";
 import ErrorHandling from "libs/error_handling";
 import Router from "router";
 import Store from "oxalis/throttled_store";
@@ -32,11 +33,21 @@ async function loadActiveUser() {
   }
 }
 
+async function loadHasOrganizations() {
+  // Check whether any organizations exist
+  try {
+    const organizations = await getOrganizations();
+    Store.dispatch(setHasOrganizationsAction(organizations.length > 0));
+  } catch (e) {
+    // pass
+  }
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   ErrorHandling.initialize({ throwAssertions: false, sendLocalErrors: false });
 
   document.addEventListener("click", googleAnalyticsLogClicks);
-  await Promise.all([loadFeatureToggles(), loadActiveUser()]);
+  await Promise.all([loadFeatureToggles(), loadActiveUser(), loadHasOrganizations()]);
 
   const containerElement = document.getElementById("main-container");
   if (containerElement) {

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -25,6 +25,7 @@ type OwnProps = {|
 type StateProps = {|
   activeUser: ?APIUser,
   isInAnnotationView: boolean,
+  hasOrganizations: boolean,
 |};
 type Props = {| ...OwnProps, ...StateProps |};
 
@@ -264,7 +265,7 @@ async function getAndTrackVersion() {
   return version;
 }
 
-function Navbar({ activeUser, isAuthenticated, history, isInAnnotationView }) {
+function Navbar({ activeUser, isAuthenticated, history, isInAnnotationView, hasOrganizations }) {
   const handleLogout = async () => {
     await Request.receiveJSON("/api/auth/logout");
     Store.dispatch(logoutUserAction());
@@ -288,7 +289,7 @@ function Navbar({ activeUser, isAuthenticated, history, isInAnnotationView }) {
   const isAdmin = activeUser != null ? Utils.isUserAdmin(activeUser) : false;
 
   const collapseAllNavItems = isInAnnotationView;
-  const { hideNavbarLogin } = features();
+  const hideNavbarLogin = features().hideNavbarLogin || !hasOrganizations;
 
   const menuItems = [];
   const trailingNavItems = [];
@@ -366,6 +367,7 @@ function Navbar({ activeUser, isAuthenticated, history, isInAnnotationView }) {
 const mapStateToProps = (state: OxalisState): StateProps => ({
   activeUser: state.activeUser,
   isInAnnotationView: state.uiInformation.isInAnnotationView,
+  hasOrganizations: state.uiInformation.hasOrganizations,
 });
 
 export default withRouter(connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(Navbar));

--- a/frontend/javascripts/oxalis/model/actions/ui_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/ui_actions.js
@@ -25,12 +25,18 @@ type SetIsInAnnotationViewAction = {
   value: boolean,
 };
 
+type SetHasOrganizationsAction = {
+  type: "SET_HAS_ORGANIZATIONS",
+  value: boolean,
+};
+
 export type UiAction =
   | SetDropzoneModalVisibilityAction
   | SetVersionRestoreVisibilityAction
   | SetImportingMeshStateAction
   | SetStoredLayoutsAction
-  | SetIsInAnnotationViewAction;
+  | SetIsInAnnotationViewAction
+  | SetHasOrganizationsAction;
 
 export const setDropzoneModalVisibilityAction = (
   visible: boolean,
@@ -58,5 +64,10 @@ export const setImportingMeshStateAction = (isImporting: boolean): SetImportingM
 
 export const setIsInAnnotationViewAction = (value: boolean): SetIsInAnnotationViewAction => ({
   type: "SET_IS_IN_ANNOTATION_VIEW",
+  value,
+});
+
+export const setHasOrganizationsAction = (value: boolean): SetHasOrganizationsAction => ({
+  type: "SET_HAS_ORGANIZATIONS",
   value,
 });

--- a/frontend/javascripts/oxalis/model/reducers/ui_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/ui_reducer.js
@@ -27,6 +27,10 @@ function UiReducer(state: OxalisState, action: Action): OxalisState {
       return updateKey(state, "uiInformation", { isInAnnotationView: action.value });
     }
 
+    case "SET_HAS_ORGANIZATIONS": {
+      return updateKey(state, "uiInformation", { hasOrganizations: action.value });
+    }
+
     default:
       return state;
   }

--- a/frontend/javascripts/oxalis/store.js
+++ b/frontend/javascripts/oxalis/store.js
@@ -371,6 +371,7 @@ type UiInformation = {
   +storedLayouts: Object,
   +isImportingMesh: boolean,
   +isInAnnotationView: boolean,
+  +hasOrganizations: boolean,
 };
 
 export type OxalisState = {|
@@ -570,6 +571,7 @@ export const defaultState: OxalisState = {
     storedLayouts: {},
     isImportingMesh: false,
     isInAnnotationView: false,
+    hasOrganizations: false,
   },
 };
 

--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -51,6 +51,7 @@ const { Content } = Layout;
 
 type StateProps = {|
   activeUser: ?APIUser,
+  hasOrganizations: boolean,
 |};
 
 type Props = StateProps;
@@ -131,6 +132,7 @@ class ReactRouter extends React.Component<Props> {
                 exact
                 path="/"
                 render={() => {
+                  if (!this.props.hasOrganizations) return <Redirect to="/onboarding" />;
                   if (enableFrontpage) return <SpotlightView />;
 
                   return isAuthenticated ? (
@@ -432,6 +434,7 @@ class ReactRouter extends React.Component<Props> {
 
 const mapStateToProps = (state: OxalisState): StateProps => ({
   activeUser: state.activeUser,
+  hasOrganizations: state.uiInformation.hasOrganizations,
 });
 
 export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(ReactRouter);


### PR DESCRIPTION
With this PR, wk will always check whether there are any organizations or the instance is "fresh". If there are no organizations `/` is redirected to the onboarding and the UserAvatar/Login/Register is hidden.

### URL of deployed dev instance (used for testing):
- https://disableregister.webknossos.xyz

### Steps to test:
- Comment out the `setHasOrganizationsAction` dispatch in the `main.js`.
- Logout and open `/`. You should be redirected to the onboarding and no user avatar/login should be shown.

### Issues:
- fixes #3738
- fixes #3871 

------
- [x] Ready for review
