### PR TITLE
Add DomVisibilityObserver to conditionally render tree search shortcut

### DIFF
--- a/frontend/javascripts/oxalis/view/components/dom_visibility_observer.js
+++ b/frontend/javascripts/oxalis/view/components/dom_visibility_observer.js
@@ -1,0 +1,51 @@
+// @flow
+import * as React from "react";
+
+// This component uses an IntersectionObserver to find out if the element with the id targetId
+// is visible in the current viewport or not. It then calls its children render function with that value.
+// This allows to not render performance-heavy components or to disable shortcuts if their golden layout tab is not visible.
+
+type Props = {
+  targetId: string,
+  children: (isVisibleInDom: boolean) => React.Node,
+};
+
+type State = {
+  isVisibleInDom: boolean,
+};
+
+export default class DomVisibilityObserver extends React.Component<Props, State> {
+  observer: ?IntersectionObserver;
+  target: ?HTMLElement;
+  timeoutId: ?TimeoutID;
+
+  state = {
+    isVisibleInDom: true,
+  };
+
+  componentDidMount() {
+    this.attachObserver();
+  }
+
+  componentWillUnmount() {
+    if (this.observer != null && this.target != null) this.observer.unobserve(this.target);
+    if (this.timeoutId != null) clearTimeout(this.timeoutId);
+  }
+
+  attachObserver = () => {
+    const target = document.getElementById(this.props.targetId);
+    if (target != null) {
+      const callback = interactionEntries =>
+        this.setState({ isVisibleInDom: interactionEntries[0].isIntersecting });
+      this.observer = new IntersectionObserver(callback, {});
+      this.observer.observe(target);
+      this.target = target;
+    } else {
+      this.timeoutId = setTimeout(this.attachObserver, 1000);
+    }
+  };
+
+  render() {
+    return this.props.children(this.state.isVisibleInDom);
+  }
+}

--- a/frontend/javascripts/oxalis/view/components/dom_visibility_observer.js
+++ b/frontend/javascripts/oxalis/view/components/dom_visibility_observer.js
@@ -24,7 +24,14 @@ export default class DomVisibilityObserver extends React.Component<Props, State>
   };
 
   componentDidMount() {
-    this.attachObserver();
+    // Not supported in Safari as of now (see https://caniuse.com/#search=intersectionobserver)
+    if (
+      "IntersectionObserver" in window &&
+      "IntersectionObserverEntry" in window &&
+      "isIntersecting" in window.IntersectionObserverEntry.prototype
+    ) {
+      this.attachObserver();
+    }
   }
 
   componentWillUnmount() {

--- a/frontend/javascripts/oxalis/view/right-menu/advanced_search_popover.js
+++ b/frontend/javascripts/oxalis/view/right-menu/advanced_search_popover.js
@@ -5,6 +5,7 @@ import memoizeOne from "memoize-one";
 import ButtonComponent from "oxalis/view/components/button_component";
 
 import Shortcut from "libs/shortcut_component";
+import DomVisibilityObserver from "oxalis/view/components/dom_visibility_observer";
 
 const InputGroup = Input.Group;
 
@@ -88,11 +89,17 @@ export default class AdvancedSearchPopover<S: Object> extends React.PureComponen
     return (
       <React.Fragment>
         {provideShortcut ? (
-          <Shortcut
-            supportInputElements
-            keys="ctrl + shift + f"
-            onTrigger={this.openSearchPopover}
-          />
+          <DomVisibilityObserver targetId="tree-list">
+            {isVisibleInDom =>
+              isVisibleInDom && (
+                <Shortcut
+                  supportInputElements
+                  keys="ctrl + shift + f"
+                  onTrigger={this.openSearchPopover}
+                />
+              )
+            }
+          </DomVisibilityObserver>
         ) : null}
         <Popover
           title="Search"


### PR DESCRIPTION
See comment in the component, of course if this works well we can use it for other stuff in the future :)

/cc @MichaelBuessemeyer FYI :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- (1) Select Tree Tab and use `Ctrl + Shift + F` - the search should open.
- (2) Select another tab so that the tree tab is no longer visible, use `Ctrl + Shift + F` - the search should open.
- Repeat (1)

------
- [x] Ready for review
