### PR TITLE
Revert "Avoid endless render loop when segmentation is not rendered"

### DIFF
--- a/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
@@ -114,7 +114,6 @@ export default class TextureBucketManager {
       this.freeBucket(freeBucket);
     }
 
-    let needsNewBucket = false;
     const freeIndexArray = Array.from(this.freeIndexSet);
     for (const nextBucket of buckets) {
       if (!this.activeBucketToIndexMap.has(nextBucket)) {
@@ -123,15 +122,10 @@ export default class TextureBucketManager {
         }
         const freeBucketIdx = freeIndexArray.shift();
         this.reserveIndexForBucket(nextBucket, freeBucketIdx);
-        needsNewBucket = true;
       }
     }
 
-    // The lookup buffer only needs to be refreshed if some previously active buckets are no longer needed
-    // or if new buckets are needed. Otherwise we may end up in an endless loop.
-    if (freeBuckets.length > 0 || needsNewBucket) {
-      this._refreshLookUpBuffer();
-    }
+    this._refreshLookUpBuffer();
   }
 
   getPackedBucketSize() {


### PR DESCRIPTION
Reverts scalableminds/webknossos#3892

Fixes #3909.

Apparently, it can happen that the bucket set which should be committed to the GPU doesn't change, but the anchor point changes. Therefore, the refresh of the buffer was not executed.