### PR TITLE
Add shortcut to maximize golden layout panes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,7 +82,16 @@
     "flow-header/flow-header": "error",
     "react/sort-comp": [
       "error",
-      { "order": ["type-annotations", "static-methods", "lifecycle", "everything-else", "render"] }
+      {
+        "order": [
+          "type-annotations",
+          "instance-variables",
+          "static-methods",
+          "lifecycle",
+          "everything-else",
+          "render"
+        ]
+      }
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - The dataset settings within the tracing view allow to select between different loading strategies now ("best quality first" and "progressive quality"). Additionally, the rendering can use different magnifications as a fallback (instead of only one magnification). [#3801](https://github.com/scalableminds/webknossos/pull/3801)
 - The mapping selection dropbown is now sorted alphabetically. [#3864](https://github.com/scalableminds/webknossos/pull/3864)
 - The HTML template now includes SEO tags for demo instances and hides internal instances from search engines.
-- A maximize-button was added to the viewports in the annotation view. [#3876](https://github.com/scalableminds/webknossos/pull/3876)
+- A maximize-button was added to the viewports in the annotation view. Maximization can also be toggled with the `.` shortcut. [#3876](https://github.com/scalableminds/webknossos/pull/3876)
 
 ### Changed
 - Improved the flight mode performance for tracings with very large trees (>80.000 nodes). [#3880](https://github.com/scalableminds/webknossos/pull/3880)

--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -18,6 +18,8 @@ Find all available keyboard shortcuts for webKnossos listed below.
 | 3                             | Toggle Segmentation Opacity                 |
 | H                             | Increase the Move Value                     |
 | G                             | Decrease the Move Value                     |
+| Q                             | Download Screenshot(s) of Viewport(s)       |
+| .                             | Toggle Viewport Maximization                |
 
 ## Skeleton Tracings
 

--- a/frontend/javascripts/admin/help/keyboardshortcut_view.js
+++ b/frontend/javascripts/admin/help/keyboardshortcut_view.js
@@ -99,7 +99,7 @@ const KeyboardShortcutView = () => {
     },
     {
       keybinding: "M",
-      action: "Toggle Mode (orthogonal, Flight, Oblique)",
+      action: "Toggle Mode (Orthogonal, Flight, Oblique)",
     },
     {
       keybinding: "1",
@@ -124,6 +124,14 @@ const KeyboardShortcutView = () => {
     {
       keybinding: "Ctrl + Shift + F",
       action: "Open Tree Search (if Tree List is visible)",
+    },
+    {
+      keybinding: "Q",
+      action: "Download Screenshot(s) of Viewport(s)",
+    },
+    {
+      keybinding: ".",
+      action: "Toggle Viewport Maximization",
     },
   ];
 

--- a/frontend/javascripts/components/loop.js
+++ b/frontend/javascripts/components/loop.js
@@ -9,6 +9,8 @@ type LoopProps = {
 };
 
 class Loop extends Component<LoopProps, {}> {
+  intervalId: ?number = null;
+
   componentDidMount() {
     this.intervalId = window.setInterval(this.props.onTick, this.props.interval);
   }
@@ -19,8 +21,6 @@ class Loop extends Component<LoopProps, {}> {
       this.intervalId = null;
     }
   }
-
-  intervalId: ?number = null;
 
   render() {
     return null;

--- a/frontend/javascripts/oxalis/view/action-bar/save_button.js
+++ b/frontend/javascripts/oxalis/view/action-bar/save_button.js
@@ -25,6 +25,7 @@ type State = {
 const SAVE_POLLING_INTERVAL = 1000;
 
 class SaveButton extends React.PureComponent<Props, State> {
+  savedPollingInterval: number = 0;
   state = {
     isStateSaved: false,
   };
@@ -38,7 +39,6 @@ class SaveButton extends React.PureComponent<Props, State> {
     window.clearInterval(this.savedPollingInterval);
   }
 
-  savedPollingInterval: number = 0;
   _forceUpdate = () => {
     const isStateSaved = Model.stateSaved();
     this.setState({

--- a/frontend/javascripts/oxalis/view/layouting/golden_layout_adapter.js
+++ b/frontend/javascripts/oxalis/view/layouting/golden_layout_adapter.js
@@ -155,6 +155,16 @@ export class GoldenLayoutAdapter extends React.PureComponent<Props<*>, *> {
     );
 
     gl.on("stateChanged", () => this.onStateChange());
+    gl.on("componentCreated", item => {
+      document.addEventListener("keyup", evt => {
+        const key = evt.keyCode != null ? evt.keyCode : evt.which;
+        // Early return unless Ctrl + M is pressed
+        if (!(key === 77 && evt.ctrlKey)) return;
+        // Only maximize the element the mouse is over
+        const isHovered = item.element[0].matches(":hover");
+        if (isHovered) item.toggleMaximise();
+      });
+    });
 
     this.unbindListeners = [unbindResetListener, unbindChangedScaleListener, unbindResizeListener];
 

--- a/frontend/javascripts/oxalis/view/layouting/golden_layout_adapter.js
+++ b/frontend/javascripts/oxalis/view/layouting/golden_layout_adapter.js
@@ -156,14 +156,16 @@ export class GoldenLayoutAdapter extends React.PureComponent<Props<*>, *> {
 
     gl.on("stateChanged", () => this.onStateChange());
     gl.on("componentCreated", item => {
-      document.addEventListener("keyup", evt => {
+      const maximizeListener = evt => {
         const key = evt.keyCode != null ? evt.keyCode : evt.which;
         // Early return unless Ctrl + M is pressed
         if (!(key === 77 && evt.ctrlKey)) return;
         // Only maximize the element the mouse is over
         const isHovered = item.element[0].matches(":hover");
         if (isHovered) item.toggleMaximise();
-      });
+      };
+      document.addEventListener("keyup", maximizeListener);
+      this.unbindListeners.push(() => document.removeEventListener("keyup", maximizeListener));
     });
 
     this.unbindListeners = [unbindResetListener, unbindChangedScaleListener, unbindResizeListener];

--- a/frontend/javascripts/oxalis/view/right-menu/abstract_tree_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/abstract_tree_tab_view.js
@@ -30,6 +30,7 @@ type State = {
 
 class AbstractTreeView extends Component<Props, State> {
   canvas: ?HTMLCanvasElement;
+  nodeList: Array<NodeListItem> = [];
   state = {
     visible: false,
   };
@@ -47,7 +48,7 @@ class AbstractTreeView extends Component<Props, State> {
     window.removeEventListener("resize", this.drawTree, false);
   }
 
-  nodeList: Array<NodeListItem> = [];
+  // eslint-disable-next-line react/sort-comp
   drawTree = _.throttle(() => {
     if (!this.props.skeletonTracing || !this.state.visible) {
       return;

--- a/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
@@ -94,6 +94,14 @@ type CommentTabState = {
 
 class CommentTabView extends React.PureComponent<PropsWithSkeleton, CommentTabState> {
   listRef: ?List;
+  storePropertyUnsubscribers: Array<() => void> = [];
+  keyboard = new InputKeyboard(
+    {
+      n: () => this.nextComment(),
+      p: () => this.previousComment(),
+    },
+    { delay: Store.getState().userConfiguration.keyboardDelay },
+  );
 
   state = {
     isSortedAscending: true,
@@ -150,16 +158,6 @@ class CommentTabView extends React.PureComponent<PropsWithSkeleton, CommentTabSt
     this.keyboard.destroy();
     this.unsubscribeStoreListeners();
   }
-
-  storePropertyUnsubscribers: Array<() => void> = [];
-
-  keyboard = new InputKeyboard(
-    {
-      n: () => this.nextComment(),
-      p: () => this.previousComment(),
-    },
-    { delay: Store.getState().userConfiguration.keyboardDelay },
-  );
 
   nextComment = (forward: boolean = true) => {
     getActiveNode(this.props.skeletonTracing).map(activeNode => {

--- a/frontend/javascripts/oxalis/view/right-menu/mapping_info_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/mapping_info_view.js
@@ -80,6 +80,8 @@ const convertCellIdToCSS = (id, customColors) =>
 const hasSegmentation = () => Model.getSegmentationLayer() != null;
 
 class MappingInfoView extends React.Component<Props, State> {
+  isMounted: boolean = false;
+
   state = {
     shouldMappingBeEnabled: false,
     isRefreshingMappingList: false,
@@ -106,8 +108,7 @@ class MappingInfoView extends React.Component<Props, State> {
     cube.off("volumeLabeled", this._forceUpdate);
   }
 
-  isMounted: boolean = false;
-
+  // eslint-disable-next-line react/sort-comp
   _forceUpdate = _.throttle(() => {
     if (!this.isMounted) {
       return;

--- a/frontend/javascripts/oxalis/view/version_list.js
+++ b/frontend/javascripts/oxalis/view/version_list.js
@@ -114,6 +114,7 @@ class VersionList extends React.Component<Props, State> {
 
   handlePreviewVersion = (version: number) => previewVersion({ [this.props.tracingType]: version });
 
+  // eslint-disable-next-line react/sort-comp
   getGroupedAndChunkedVersions = _.memoize(
     (versions: Array<APIUpdateActionBatch>): GroupedAndChunkedVersions => {
       // This function first groups the versions by day, where the key is the output of the moment calendar function.


### PR DESCRIPTION
This is the best I could come up with. keyboardjs doesn't easily allow to set a "target element" and keyup event handlers can only be attached at the document level, so I had to get a little more involved. What do you think? :)

~~Of course the shortcut is debatable, I picked M for Maximize, ideally it would be a single key press, but there have been voices in the community to avoid those.~~
The shortcut is `.` now.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open tracing view, move mouse over any pane and press `.` to toggle maximize.

### Issues:
- fixes #3926 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
