### PR TITLE
remove alt text for abstract brain loading image

### DIFF
--- a/frontend/javascripts/components/brain_spinner.js
+++ b/frontend/javascripts/components/brain_spinner.js
@@ -19,7 +19,7 @@ export default function BrainSpinner() {
           <div style={{ width: 375 }}>
             <img
               src="/images/brain.png"
-              alt="Abstract brain"
+              alt=""
               style={{
                 width: 375,
                 height: 299,


### PR DESCRIPTION
This alt text kept flashing before the image was loaded. I’d argue that the image is only eye-candy and does not have to be replaced by an alt-text if it cannot be displayed.

- [x] Ready for review
