### PR TITLE
In asset path resolution, remove only first “assets” occurrence

### DIFF
--- a/app/RequestHandler.scala
+++ b/app/RequestHandler.scala
@@ -27,7 +27,7 @@ class RequestHandler @Inject()(router: Router,
     if (request.uri.matches("^(/api/|/data/|/tracings/).*$")) {
       super.routeRequest(request)
     } else if (request.uri.matches("^(/assets/).*$")) {
-      val path = request.path.split('/').filter(_ != "assets").mkString("/")
+      val path = request.path.replaceFirst("^(/assets/)", "")
       Some(assets.at(path = "/public", file = path))
     } else {
       Some(Action { Ok(views.html.main(conf)) })


### PR DESCRIPTION
The old version removed all occurrences of `assets` from the URL, this broke URLs where a second `assets` was actually intended.

### URL of deployed dev instance (used for testing):
- https://assetsurls.webknossos.xyz

### Steps to test:
- assets should still load
- frontend api docs should load their own assets

------
- [x] Ready for review
