### PR TITLE
Disable PID file creation

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -210,6 +210,9 @@ play.filters.headers.frameOptions = null
 play.server.http.idleTimeout = 1000s
 play.server.akka.requestTimeout = 1000s
 
+# Avoid the creation of a pid file
+pidfile.path = "/dev/null"
+
 operatorData = """
   **scalable minds GmbH**
 


### PR DESCRIPTION
this line got lost some time in the past. Datastore and Tracingstore still have it, and according to https://www.playframework.com/documentation/2.6.x/ProductionConfiguration#Changing-the-path-of-RUNNING_PID it is still the way to go :)

### Issues
 - fixes #3957 

- [x] Ready for review
