### PR TITLE
added meta key (command) to multi tree selection

### DIFF
--- a/docs/tracing_ui.md
+++ b/docs/tracing_ui.md
@@ -118,7 +118,7 @@ All operations and information regarding trees are organized under a tab called 
 A typical skeleton annotation consists of one or more trees.
 Trees can be nested and organized in so-called `Tree Groups`.
 Tree groups can have a name and are used to structure and label your annotation even further.
-Trees can be dragged and dropped between tree groups. This action can be applied to multiple trees by selecting them with Ctrl + Left Mouse. On Mac OS systems the keys for the multiple selection are Command + Left Mouse.
+Trees can be dragged and dropped between tree groups. This action can be applied to multiple trees by selecting them with Ctrl + Left Mouse (on Mac OS Cmd + Left Mouse).
 Hover over existing tree groups to bring up a little menu for creating new groups and deletion. Renaming of a group can be done by selecting a group and then entering the new name into the input above the tree hierarchy structure view.
 
 ![Organize your skeleton annotation's trees to remember important structures for later reference](images/tracing_ui_trees.jpg)

--- a/docs/tracing_ui.md
+++ b/docs/tracing_ui.md
@@ -118,7 +118,7 @@ All operations and information regarding trees are organized under a tab called 
 A typical skeleton annotation consists of one or more trees.
 Trees can be nested and organized in so-called `Tree Groups`.
 Tree groups can have a name and are used to structure and label your annotation even further.
-Trees can be dragged and dropped between tree groups. This action can be applied to multiple trees by selecting them with Ctrl + Left Mouse. 
+Trees can be dragged and dropped between tree groups. This action can be applied to multiple trees by selecting them with Ctrl + Left Mouse. On Mac OS systems the keys for the multiple selection are Command + Left Mouse.
 Hover over existing tree groups to bring up a little menu for creating new groups and deletion. Renaming of a group can be done by selecting a group and then entering the new name into the input above the tree hierarchy structure view.
 
 ![Organize your skeleton annotation's trees to remember important structures for later reference](images/tracing_ui_trees.jpg)

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -138,7 +138,7 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
   onSelectTree = (evt: SyntheticMouseEvent<*>) => {
     // $FlowFixMe .dataset is unknown to flow
     const treeId = parseInt(evt.target.dataset.id, 10);
-    if (evt.ctrlKey) {
+    if (evt.ctrlKey || evt.metaKey) {
       this.props.onSelectTree(treeId);
     } else {
       this.props.deselectAllTrees();

--- a/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
@@ -87,7 +87,7 @@ const datasetConfigOverrides: { [key: string]: DatasetConfiguration } = {
     fourBit: false,
     interpolation: true,
     layers: {
-      color: { color: [255, 255, 255], contrast: 1, brightness: 0, alpha: 100, isDisabled: true },
+      color: { color: [255, 255, 255], contrast: 1, brightness: 0, alpha: 100, isDisabled: false },
     },
     quality: 0,
     segmentationOpacity: 0,


### PR DESCRIPTION
Add tree multiselection support for mac os. Now the multiselection can be done with left mouse + ctrl /command/windows key.

### URL of deployed dev instance (used for testing):
- [https://enablemutlitreeselectionformac.webknossos.xyz](https://enablemutlitreeselectionformac.webknossos.xyz)

### Steps to test:
- just open a skeleton/hybrid tracing and create some trees and try to multi-select them with one of the listed combinations.

### Issues:
- fixes #3955

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- [x] Updated [documentation](../blob/master/docs) if applicable
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
