### PR TITLE
Remove badge shown when no user is logged in

### DIFF
--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -1,5 +1,5 @@
 // @flow
-import { Avatar, Badge, Icon, Layout, Menu, Popover } from "antd";
+import { Avatar, Icon, Layout, Menu, Popover } from "antd";
 import { Link, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import React from "react";
@@ -250,9 +250,7 @@ function AnonymousAvatar() {
       content={<LoginForm layout="horizontal" style={{ maxWidth: 500 }} />}
       trigger="click"
     >
-      <Badge dot>
         <Avatar className="hover-effect-via-opacity" icon="user" style={{ marginLeft: 8 }} />
-      </Badge>
     </Popover>
   );
 }

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -250,7 +250,7 @@ function AnonymousAvatar() {
       content={<LoginForm layout="horizontal" style={{ maxWidth: 500 }} />}
       trigger="click"
     >
-        <Avatar className="hover-effect-via-opacity" icon="user" style={{ marginLeft: 8 }} />
+      <Avatar className="hover-effect-via-opacity" icon="user" style={{ marginLeft: 8 }} />
     </Popover>
   );
 }


### PR DESCRIPTION
This PR just removes the badge around the login button in the navbar when no user is logged in

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- log out
- the red bobble (badge) should not be there anymore

### Issues:
- fixes #3966

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
