### PR TITLE
Fix redirection when registering for existing organization which has autoVerify=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - 
 
 ### Fixed
-- 
+- Fixed a missing redirect after registering for an existing organization (with autoVerify=true) via the onboarding flow. [#3984](https://github.com/scalableminds/webknossos/pull/3984)
 
 ### Removed
 - 

--- a/frontend/javascripts/admin/onboarding.js
+++ b/frontend/javascripts/admin/onboarding.js
@@ -13,21 +13,21 @@ import {
   Card,
   AutoComplete,
 } from "antd";
+import { type RouterHistory, Link, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import Clipboard from "clipboard-js";
 import React, { type Node, useState, useEffect } from "react";
-import { Link } from "react-router-dom";
 
 import type { APIUser, APIDataStore } from "admin/api_flow_types";
 import type { OxalisState } from "oxalis/store";
+import { getOrganizations, getDatastores } from "admin/admin_rest_api";
 import { location } from "libs/window";
 import DatasetImportView from "dashboard/dataset/dataset_import_view";
 import DatasetUploadView from "admin/dataset/dataset_upload_view";
 import RegistrationForm from "admin/auth/registration_form";
+import SampleDatasetsModal from "dashboard/dataset/sample_datasets_modal";
 import Toast from "libs/toast";
 import renderIndependently from "libs/render_independently";
-import SampleDatasetsModal from "dashboard/dataset/sample_datasets_modal";
-import { getOrganizations, getDatastores } from "admin/admin_rest_api";
 
 const { Step } = Steps;
 const FormItem = Form.Item;
@@ -35,7 +35,8 @@ const FormItem = Form.Item;
 type StateProps = {|
   activeUser: ?APIUser,
 |};
-type Props = StateProps;
+
+type Props = { ...StateProps, history: RouterHistory };
 
 type State = {
   currentStep: number,
@@ -252,6 +253,11 @@ class OnboardingView extends React.PureComponent<Props, State> {
   };
 
   componentDidMount() {
+    if (this.props.activeUser != null) {
+      this.props.history.push("/dashboard");
+      return;
+    }
+
     this.fetchData();
   }
 
@@ -521,4 +527,4 @@ const mapStateToProps = (state: OxalisState): StateProps => ({
   activeUser: state.activeUser,
 });
 
-export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(OnboardingView);
+export default connect<StateProps, {||}, _, _, _, _>(mapStateToProps)(withRouter(OnboardingView));


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- needs to be tested locally
- set autoverify=true for an organization
- use onboarding flow, select that organization, click "join", and register --> you should be redirected to the dashboard
- when using the onboarding flow to create a new organization, everything should work as usual

### Issues:
- fixes #3971 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
