### PR TITLE
Always send Datastore Access Errors as Json

### DIFF
--- a/app/models/binary/DataStore.scala
+++ b/app/models/binary/DataStore.scala
@@ -44,7 +44,7 @@ class DataStoreService @Inject()(dataStoreDAO: DataStoreDAO)(implicit ec: Execut
       key <- request.getQueryString("key").toFox
       _ <- bool2Fox(key == dataStore.key)
       result <- block(dataStore)
-    } yield result).getOrElse(Forbidden(Messages("dataStore.notFound")))
+    } yield result).getOrElse(Forbidden(Json.obj("granted" -> false, "msg" -> Messages("dataStore.notFound"))))
 
 }
 


### PR DESCRIPTION
This to enable wkconnect to bubble up the error message. (Before, the user-facing error was about parsing json with non-json-mimetype, rather than about what actually happened)

- Fixes #3983

- [x] Ready for review
