### PR TITLE
Fix dropdown login padding

### DIFF
--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -21,7 +21,6 @@ type Props = {
 
 function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
   const { getFieldDecorator } = form;
-  const resetStyle = layout === "horizontal" ? { float: "right" } : null;
   const linkStyle = layout === "inline" ? { paddingLeft: 10 } : null;
 
   const handleSubmit = (event: SyntheticInputEvent<>) => {
@@ -87,10 +86,16 @@ function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
         {hideFooter ? null : (
           <FormItem style={{ marginBottom: 4 }}>
             <div style={{ display: "flex" }}>
-              <Link to="/auth/register" style={{ ...linkStyle, marginRight: 10, flexGrow: 1 }}>
+              <Link
+                to="/auth/register"
+                style={{ ...linkStyle, marginRight: 10, flexGrow: 1, whiteSpace: "nowrap" }}
+              >
                 Register Now
               </Link>
-              <Link to="/auth/resetPassword" style={Object.assign({}, linkStyle, resetStyle)}>
+              <Link
+                to="/auth/resetPassword"
+                style={Object.assign({ whiteSpace: "nowrap" }, linkStyle)}
+              >
                 Forgot Password
               </Link>
             </div>

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -85,13 +85,15 @@ function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
           </Button>
         </FormItem>
         {hideFooter ? null : (
-          <FormItem style={{ marginBottom: 4, display: "flex" }}>
-            <Link to="/auth/register" style={{ ...linkStyle, marginRight: 10, flexGrow: 1 }}>
-              Register Now
-            </Link>
-            <Link to="/auth/resetPassword" style={Object.assign({flexGrow: 1}, linkStyle, resetStyle)}>
-              Forgot Password
-            </Link>
+          <FormItem style={{ marginBottom: 4 }}>
+            <div style={{ display: "flex" }}>
+              <Link to="/auth/register" style={{ ...linkStyle, marginRight: 10, flexGrow: 1 }}>
+                Register Now
+              </Link>
+              <Link to="/auth/resetPassword" style={Object.assign({}, linkStyle, resetStyle)}>
+                Forgot Password
+              </Link>
+            </div>
           </FormItem>
         )}
       </Form>

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -85,11 +85,11 @@ function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
           </Button>
         </FormItem>
         {hideFooter ? null : (
-          <FormItem style={{ marginBottom: 4 }}>
-            <Link to="/auth/register" style={{ ...linkStyle, marginRight: 10 }}>
+          <FormItem style={{ marginBottom: 4, display: "flex" }}>
+            <Link to="/auth/register" style={{ ...linkStyle, marginRight: 10, flexGrow: 1 }}>
               Register Now
             </Link>
-            <Link to="/auth/resetPassword" style={Object.assign({}, linkStyle, resetStyle)}>
+            <Link to="/auth/resetPassword" style={Object.assign({flexGrow: 1}, linkStyle, resetStyle)}>
               Forgot Password
             </Link>
           </FormItem>

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -86,7 +86,7 @@ function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
         </FormItem>
         {hideFooter ? null : (
           <FormItem style={{ marginBottom: 4 }}>
-            <Link to="/auth/register" style={linkStyle}>
+            <Link to="/auth/register" style={{...linkStyle, marginRight: 10}}>
               Register Now
             </Link>
             <Link to="/auth/resetPassword" style={Object.assign({}, linkStyle, resetStyle)}>

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -92,10 +92,7 @@ function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
               >
                 Register Now
               </Link>
-              <Link
-                to="/auth/resetPassword"
-                style={Object.assign({ whiteSpace: "nowrap" }, linkStyle)}
-              >
+              <Link to="/auth/resetPassword" style={{ ...linkStyle, whiteSpace: "nowrap" }}>
                 Forgot Password
               </Link>
             </div>

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -86,7 +86,7 @@ function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
         </FormItem>
         {hideFooter ? null : (
           <FormItem style={{ marginBottom: 4 }}>
-            <Link to="/auth/register" style={{...linkStyle, marginRight: 10}}>
+            <Link to="/auth/register" style={{ ...linkStyle, marginRight: 10 }}>
               Register Now
             </Link>
             <Link to="/auth/resetPassword" style={Object.assign({}, linkStyle, resetStyle)}>

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -249,6 +249,7 @@ function AnonymousAvatar() {
       placement="bottomRight"
       content={<LoginForm layout="horizontal" style={{ maxWidth: 500 }} />}
       trigger="click"
+      style={{position: "fixed"}}
     >
       <Badge dot>
         <Avatar className="hover-effect-via-opacity" icon="user" style={{ marginLeft: 8 }} />

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -249,7 +249,7 @@ function AnonymousAvatar() {
       placement="bottomRight"
       content={<LoginForm layout="horizontal" style={{ maxWidth: 500 }} />}
       trigger="click"
-      style={{position: "fixed"}}
+      style={{ position: "fixed" }}
     >
       <Badge dot>
         <Avatar className="hover-effect-via-opacity" icon="user" style={{ marginLeft: 8 }} />


### PR DESCRIPTION
This PR adds a margin between the `forgot password` and `Register Now` in the login dropdown and thus ensures some space between them. I also made the position of the dropdown fixed so that it does not scroll away anymore.

### URL of deployed dev instance (used for testing):
- [https://fixdropdownloginissue.webknossos.xyz](https://fixdropdownloginissue.webknossos.xyz)

### Steps to test:
- logout and open the dropdown. Resize the window and try to get the two options `forgot password` and `Register Now` together. There should be at least some space between them. 
- Testing that the dropdown does not scroll away: add some `margin-bottom` to the main container so that it becomes scrollable :)

### Issues:
- fixes #3956

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
