### PR TITLE
Make isDisabled optional and added alpha to schema

### DIFF
--- a/frontend/javascripts/libs/datasource.schema.json
+++ b/frontend/javascripts/libs/datasource.schema.json
@@ -131,9 +131,10 @@
           "brightness": { "type": "number" },
           "contrast": { "type": "number" },
           "color": { "$ref": "#/definitions/types::Vector3" },
-          "isDisabled": { "type": "boolean" }
+          "isDisabled": { "type": "boolean" },
+          "alpha": {"type": "number"}
         },
-        "required": ["brightness", "contrast", "color", "isDisabled"]
+        "required": ["brightness", "contrast", "color"]
       }
     }
   }


### PR DESCRIPTION
This PR makes the new `isDisabled` option for color layers optional and also adds the `alpha` property. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Edit a dataset and got to the view options. There should not be any warning about missing "isDisabled" property anymore.

### Issues:
- none

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
