### PR TITLE
Only re-compute bounding sphere of skeletons if something changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - 
 
 ### Changed
-- 
+- Improved performance for large tracings. [#3995](https://github.com/scalableminds/webknossos/pull/3995)
 
 ### Fixed
 - Fixed a missing redirect after registering for an existing organization (with autoVerify=true) via the onboarding flow. [#3984](https://github.com/scalableminds/webknossos/pull/3984)

--- a/frontend/javascripts/oxalis/geometries/skeleton.js
+++ b/frontend/javascripts/oxalis/geometries/skeleton.js
@@ -359,12 +359,14 @@ class Skeleton {
       }
     }
 
-    // compute bounding sphere to make ThreeJS happy
-    for (const nodes of this.nodes.buffers) {
-      nodes.geometry.computeBoundingSphere();
-    }
-    for (const edges of this.edges.buffers) {
-      edges.geometry.computeBoundingSphere();
+    if (diff.length > 0) {
+      // compute bounding sphere to make ThreeJS happy
+      for (const nodes of this.nodes.buffers) {
+        nodes.geometry.computeBoundingSphere();
+      }
+      for (const edges of this.edges.buffers) {
+        edges.geometry.computeBoundingSphere();
+      }
     }
 
     // Uniforms


### PR DESCRIPTION
This is a perf optimization which hopefully improves https://discuss.webknossos.org/t/performance-regression-additional-lag/1441 a bit.

I noticed that simply moving through a dataset always re-computed the bounding spheres of the buffer geometries of skeletons. For a big tracing, this took up to 20% of the entire scripting time.

I think the change makes sense, however, I'm not 100% sure if there originally was a rationale behind always re-computing the bounding spheres? @daniel-wer Does something come to your mind here?

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a tracing with skeletons and ensure that everything works as expected

### Issues:
- improves performance

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
