### PR TITLE
Ensure that max zoom step is not exceeded when changing viewport area

### DIFF
--- a/frontend/javascripts/oxalis/model/accessors/flycam_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/flycam_accessor.js
@@ -216,7 +216,8 @@ export function getRequestLogZoomStep(state: OxalisState): number {
 
 export function getMaxZoomValue(state: OxalisState): number {
   const maximumZoomSteps = getMaximumZoomForAllResolutionsFromStore(state);
-  return _.last(maximumZoomSteps);
+  const lastZoomStep = _.last(maximumZoomSteps);
+  return lastZoomStep != null ? lastZoomStep : 1;
 }
 
 export function getMaxZoomValueForResolution(

--- a/frontend/javascripts/oxalis/model/reducers/flycam_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/flycam_reducer.js
@@ -117,11 +117,18 @@ function moveReducer(state: OxalisState, vector: Vector3): OxalisState {
 }
 
 export function zoomReducer(state: OxalisState, zoomStep: number): OxalisState {
-  return update(state, {
+  let newZoomStep = Utils.clamp(userSettings.zoom.minimum, zoomStep, getMaxZoomValue(state));
+  if (isNaN(newZoomStep)) {
+    newZoomStep = 1;
+  }
+
+  const newState = update(state, {
     flycam: {
-      zoomStep: { $set: Utils.clamp(userSettings.zoom.minimum, zoomStep, getMaxZoomValue(state)) },
+      zoomStep: { $set: newZoomStep },
     },
   });
+
+  return newState;
 }
 
 export function setDirectionReducer(state: OxalisState, direction: Vector3) {

--- a/frontend/javascripts/oxalis/model/reducers/view_mode_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/view_mode_reducer.js
@@ -7,6 +7,7 @@ import type { Action } from "oxalis/model/actions/actions";
 import { ArbitraryViewport, type Rect, type Viewport } from "oxalis/constants";
 import type { OxalisState, PartialCameraData } from "oxalis/store";
 import { getTDViewportSize } from "oxalis/model/accessors/view_mode_accessor";
+import { zoomReducer } from "oxalis/model/reducers/flycam_reducer";
 
 function ViewModeReducer(state: OxalisState, action: Action): OxalisState {
   switch (action.type) {
@@ -38,7 +39,8 @@ function ViewModeReducer(state: OxalisState, action: Action): OxalisState {
       return moveTDViewByVectorReducer(state, action.x, action.y);
     }
     case "SET_INPUT_CATCHER_RECT": {
-      return setInputCatcherRect(state, action.viewport, action.rect);
+      const newState = setInputCatcherRect(state, action.viewport, action.rect);
+      return zoomReducer(newState, newState.flycam.zoomStep);
     }
     case "SET_INPUT_CATCHER_RECTS": {
       const { viewportRects } = action;
@@ -47,7 +49,7 @@ function ViewModeReducer(state: OxalisState, action: Action): OxalisState {
         newState = setInputCatcherRect(newState, viewport, viewportRects[viewport]);
       }
 
-      return newState;
+      return zoomReducer(newState, newState.flycam.zoomStep);
     }
     default:
       return state;


### PR DESCRIPTION
I also added some validations to avoid NaN as zoomStep.

### URL of deployed dev instance (used for testing):
- https://adaptzoomonviewportchange.webknossos.xyz

### Steps to test:
- zoom out as far as possible
- hit . to maximize current pane
- zoom step should be adapted automatically so that max zoom step is not exceeded

### Issues:
- fixes #3945 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- [X] Ready for review
