### PR TITLE
Allow isosurfaces for hybrid tracings when setting flag

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -1130,7 +1130,7 @@ export function computeIsosurface(
   return doWithToken(async token => {
     const { buffer, headers } = await Request.sendJSONReceiveArraybufferWithHeaders(
       `${datastoreUrl}/data/datasets/${datasetId.owningOrganization}/${datasetId.name}/layers/${
-        layer.name
+        layer.fallbackLayer != null ? layer.fallbackLayer : layer.name
       }/isosurface?token=${token}`,
       {
         data: {

--- a/frontend/javascripts/oxalis/model/data_layer.js
+++ b/frontend/javascripts/oxalis/model/data_layer.js
@@ -27,6 +27,7 @@ class DataLayer {
   activeMapping: ?string;
   layerRenderingManager: LayerRenderingManager;
   resolutions: Array<Vector3>;
+  fallbackLayer: ?string;
 
   constructor(
     layerInfo: DataLayerType,
@@ -36,6 +37,7 @@ class DataLayer {
   ) {
     this.connectionInfo = connectionInfo;
     this.name = layerInfo.name;
+    this.fallbackLayer = layerInfo.fallbackLayer != null ? layerInfo.fallbackLayer : null;
     this.resolutions = layerInfo.resolutions;
 
     const { dataset } = Store.getState();

--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -184,7 +184,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps> {
           onChange={_.partial(this.props.onChange, "highlightHoveredCellId")}
         />
 
-        {this.props.controlMode === ControlModeEnum.VIEW ? (
+        {this.props.controlMode === ControlModeEnum.VIEW || window.allowIsosurfaces ? (
           <SwitchSetting
             label="Render Isosurfaces (Beta)"
             value={this.props.datasetConfiguration.renderIsosurfaces}


### PR DESCRIPTION
For demo/screenshot this can be useful (@normanrz). Hidden behind `window.allowIsosurfaces` since the UX is not smooth right now (isosurface is only calculated using the segmentation layer and active cell can only be changed in brush/trace mode).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- set window.allowIsosurfaces to true
- change some settings, so that these are re-rendered and reveal the isosurface option
- select brush or trace tool
- select active cell with shift + click

### Issues:
- contributes to #3681

------
- [X] Ready for review
