### PR TITLE
Re-fetch buckets if fetching them failed

### DIFF
--- a/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.js
@@ -197,7 +197,7 @@ export class DataBucket {
     }
   }
 
-  pullFailed(isMissing: boolean): void {
+  markAsFailed(isMissing: boolean): void {
     switch (this.state) {
       case BucketStateEnum.REQUESTED:
         this.state = isMissing ? BucketStateEnum.MISSING : BucketStateEnum.UNREQUESTED;

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/pullqueue.js
@@ -106,7 +106,7 @@ class PullQueue {
           continue;
         }
         if (bucketBuffer == null && !renderMissingDataBlack) {
-          bucket.pullFailed(true);
+          bucket.markAsFailed(true);
         } else {
           const bucketData = bucketBuffer || new Uint8Array(bucket.BUCKET_LENGTH);
           this.handleBucket(layerInfo, bucketAddress, bucketData);
@@ -116,7 +116,7 @@ class PullQueue {
       for (const bucketAddress of batch) {
         const bucket = this.cube.getBucket(bucketAddress);
         if (bucket.type === "data") {
-          bucket.pullFailed(false);
+          bucket.markAsFailed(false);
           if (bucket.dirty) {
             this.add({
               bucket: bucketAddress,


### PR DESCRIPTION
I decided against a `setTimeout` for the `markAsFailed(false)`, because buckets cannot be collected if their state is "REQUESTED". The scheduling of the re-fetching would, therefore, mess with the garbage collection. As far as we know, bucket requests to the server only fail if the server is not ready yet (in dev mode) or if the user if offline. Also, buckets are only re-fetched when moving.

I traced back the catch clause to the separation of the datastore and tracingstore, so it was introduced to allow the "retry-fetching-from-the-fallback-layer" logic. As the server reports missing buckets using the explicit header for all layers now, we're merely restoring the status quo from before that change :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a volume tracing with a fallback layer. You should see the segmentation.
- Open any tracing. Go offline and move. If you have "Progressive Data Loading" activated, you should see data from a worse zoomstep. Now go online again and move a tiny bit, you should see the data in the best resolution again, because the buckets are re-fetched.

### Issues:
- fixes #3800 

------
- [x] Ready for review
