### PR TITLE
Don't reset zoom when doing a task hot swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 - Fixed a missing redirect after registering for an existing organization (with autoVerify=true) via the onboarding flow. [#3984](https://github.com/scalableminds/webknossos/pull/3984)
 - Fixed rendering artifacts which could occur under certain conditions. [#4015](https://github.com/scalableminds/webknossos/pull/4015)
+- Fixed that the zoom step was reset after switching to a new task. [#4049](https://github.com/scalableminds/webknossos/pull/4049)
 
 ### Removed
 - 

--- a/frontend/javascripts/oxalis/model_initialization.js
+++ b/frontend/javascripts/oxalis/model_initialization.js
@@ -135,7 +135,9 @@ export async function initialize(
   }
 
   const defaultState = determineDefaultState(UrlManager.initialState, tracing);
-  applyState(defaultState);
+
+  // Don't override zoom when swapping the task
+  applyState(defaultState, !initialFetch);
 
   return initializationInformation;
 }
@@ -470,7 +472,7 @@ function determineDefaultState(
   return { position, zoomStep, rotation, activeNode };
 }
 
-export function applyState(state: $Shape<UrlManagerState>) {
+export function applyState(state: $Shape<UrlManagerState>, ignoreZoom: boolean = false) {
   if (state.activeNode != null) {
     // Set the active node (without animating to its position) before setting the
     // position, since the position should take precedence.
@@ -479,7 +481,7 @@ export function applyState(state: $Shape<UrlManagerState>) {
   if (state.position != null) {
     Store.dispatch(setPositionAction(state.position));
   }
-  if (state.zoomStep != null) {
+  if (!ignoreZoom && state.zoomStep != null) {
     Store.dispatch(setZoomStepAction(state.zoomStep));
   }
   if (state.rotation != null) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I set up multiple tasks and made a hot swap between them --> the zoom value didn't change
- when opening a new task from the dashboard, the zoom value is properly initialized

### Issues:
- fixes #4048

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
