### PR TITLE
Allow to make a layer exclusively visible by pressing ctrl when changing visibility

### DIFF
--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -96,7 +96,17 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps> {
               <div style={{ display: "inline-block", marginRight: 8 }}>
                 <Switch
                   size="small"
-                  onChange={val => this.props.onChangeLayer(layerName, "isDisabled", !val)}
+                  onChange={(val, event) => {
+                    if (event.ctrlKey) {
+                      // If ctrl is pressed, make the visibility of all other layers
+                      // the negated visibility of the just changed layer.
+                      const { layers } = this.props.datasetConfiguration;
+                      Object.keys(layers).forEach(otherLayerName =>
+                        this.props.onChangeLayer(otherLayerName, "isDisabled", val),
+                      );
+                    }
+                    this.props.onChangeLayer(layerName, "isDisabled", !val);
+                  }}
                   checked={!isDisabled}
                 />
               </div>


### PR DESCRIPTION

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a dataset with multiple colors layers
- click the visibility switch while holding ctrl
- the layer should be the only visibile layer
- selecting another layer with ctrl should make that layer the only visible one
- using ctrl on the currently exclusively visible layer should make all layers visible again

the toggling behavior is the same as in GIMP (and I think other major image editors)

### Issues:
- fixes #3896

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [X] Ready for review
