### PR TITLE
[bugfix] health check: use localhost for internal data- and tracingstore

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -51,7 +51,7 @@ class Application @Inject()(analyticsDAO: AnalyticsDAO,
     def checkDatastoreHealthIfEnabled: Fox[Unit] =
       if (conf.Datastore.enabled) {
         for {
-          response <- rpc(s"${conf.Http.uri}/data/health").get
+          response <- rpc("http://localhost/data/health").get
           if response.status == 200
         } yield ()
       } else {
@@ -61,7 +61,7 @@ class Application @Inject()(analyticsDAO: AnalyticsDAO,
     def checkTracingstoreHealthIfEnabled: Fox[Unit] =
       if (conf.Tracingstore.enabled) {
         for {
-          response <- rpc(s"${conf.Http.uri}/tracings/health").get
+          response <- rpc("http://localhost/tracings/health").get
           if response.status == 200
         } yield ()
       } else {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -51,7 +51,7 @@ class Application @Inject()(analyticsDAO: AnalyticsDAO,
     def checkDatastoreHealthIfEnabled: Fox[Unit] =
       if (conf.Datastore.enabled) {
         for {
-          response <- rpc("http://localhost/data/health").get
+          response <- rpc(s"http://localhost:${conf.Http.port}/data/health").get
           if response.status == 200
         } yield ()
       } else {
@@ -61,7 +61,7 @@ class Application @Inject()(analyticsDAO: AnalyticsDAO,
     def checkTracingstoreHealthIfEnabled: Fox[Unit] =
       if (conf.Tracingstore.enabled) {
         for {
-          response <- rpc("http://localhost/tracings/health").get
+          response <- rpc(s"http://localhost:${conf.Http.port}/tracings/health").get
           if response.status == 200
         } yield ()
       } else {

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -30,6 +30,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader {
 
   object Http {
     val uri = get[String]("http.uri")
+    val port = get[Int]("http.port")
   }
 
   object Mail {


### PR DESCRIPTION
The current health check tests the webknossos instance via its public domain. It should use localhost instead, as we use that health-check to activate the domain. This leads to failure for new k8s instances, and only checks health on old instances in the case of upgrades.
We should cherry-pick this fix for the current release. The problem was introduced in #4025

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- dev-instance starts with activated health check on `/api/health`

------
- [x] Ready for review
