### PR TITLE
Fix maximize and empty tree list

### DIFF
--- a/frontend/stylesheets/goldenlayout_overwrites.less
+++ b/frontend/stylesheets/goldenlayout_overwrites.less
@@ -25,7 +25,7 @@
   & > div > div {
     // Make sure that the wrapping divs within a content pane
     // have the same height as the pane.
-    height: inherit;
+    height: 100%;
   }
 
   & > div > div {
@@ -38,7 +38,7 @@
 
 .gl-dont-overflow {
   overflow: hidden;
-  height: inherit;
+  height: 100%;
 }
 
 .lm_tabdropdown_list {


### PR DESCRIPTION
:man_shrugging: 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open tracing and toggle maximize using the button and shortcut (`.`). The available height should be used.
- Change the height of some panes, move the tree tab to different panes and back. It should always fill in the available height.


### Issues:
- probably fixes https://discuss.webknossos.org/t/no-trees/1464
- fixes maximization

------
- [x] Ready for review
