### PR TITLE
Batch merger mode to make it work with large tracings, add progress

### DIFF
--- a/frontend/javascripts/oxalis/view/settings/merger_mode_modal_view.js
+++ b/frontend/javascripts/oxalis/view/settings/merger_mode_modal_view.js
@@ -5,9 +5,10 @@ import { Modal, Button, Spin, Tooltip } from "antd";
 type Props = {
   isCloseable: boolean,
   onClose: () => void,
+  progress: number,
 };
 
-export default function MergerModeModalView({ isCloseable, onClose }: Props) {
+export default function MergerModeModalView({ isCloseable, onClose, progress }: Props) {
   const closeButton = (
     <Button type="primary" onClick={onClose} disabled={!isCloseable}>
       Close
@@ -53,7 +54,7 @@ export default function MergerModeModalView({ isCloseable, onClose }: Props) {
       </table>
       {!isCloseable ? (
         <div className="centered-children">
-          <Spin style={{ marginTop: 16 }} />
+          <Spin style={{ marginTop: 16 }} tip={`${Math.round(progress)} %`} />
         </div>
       ) : null}
     </Modal>

--- a/frontend/javascripts/oxalis/view/settings/user_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/user_settings_view.js
@@ -80,6 +80,7 @@ type UserSettingsViewProps = {
 type State = {
   isMergerModeModalVisible: boolean,
   isMergerModeModalClosable: boolean,
+  mergerModeProgress: number,
 };
 
 class UserSettingsView extends PureComponent<UserSettingsViewProps, State> {
@@ -87,6 +88,7 @@ class UserSettingsView extends PureComponent<UserSettingsViewProps, State> {
   state = {
     isMergerModeModalVisible: false,
     isMergerModeModalClosable: false,
+    mergerModeProgress: 0,
   };
 
   componentWillMount() {
@@ -102,8 +104,10 @@ class UserSettingsView extends PureComponent<UserSettingsViewProps, State> {
       this.setState({
         isMergerModeModalVisible: true,
         isMergerModeModalClosable: false,
+        mergerModeProgress: 0,
       });
-      await enableMergerMode();
+      const onUpdateProgress = mergerModeProgress => this.setState({ mergerModeProgress });
+      await enableMergerMode(onUpdateProgress);
       // The modal is only closeable after the merger mode is fully enabled
       // and finished preprocessing
       this.setState({ isMergerModeModalClosable: true });
@@ -431,6 +435,7 @@ class UserSettingsView extends PureComponent<UserSettingsViewProps, State> {
           <MergerModeModalView
             isCloseable={isMergerModeModalClosable}
             onClose={() => this.setState({ isMergerModeModalVisible: false })}
+            progress={this.state.mergerModeProgress}
           />
         ) : null}
       </React.Fragment>


### PR DESCRIPTION
The merger mode didn't complete for large tracings, probably due to too many buckets that were requested "in parallel", leading to a very full pullqueue and buckets being discarded again before the merger mode could read the requested segmentation value. This is no problem in the traditional merger mode script, because buckets are fetched and processed sequentially there.

I fixed this by batching the merger mode. The speed impact of the batching seems to be negligible.
I've also added a progress percentage while I was at it :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I tested locally with the tracing from the bug report in discuss.
  - Change line 216 in `merger_mode.js` to
    ```javascript
    const pos = [
      Math.floor(Math.random() * 1024),
      Math.floor(Math.random() * 1024),
      Math.floor(Math.random() * 1024),
    ];
    ```
     where 1024 is the size of the segmentation layer you'll be using for the test.
  - the merger mode should finish and show a percentage while processing the existing nodes.

### Issues:
- fixes https://discuss.webknossos.org/t/new-merger-mode-does-not-load/1469
- fixes https://discuss.webknossos.org/t/loading-status-for-internal-merger-mode/1470

------
- [x] Ready for review
