### PR TITLE
Fix pane maximization breaking the 3D view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - The NML parser now rounds floating point values in node coordinates. [#4045](https://github.com/scalableminds/webknossos/pull/4045)
 
 ### Fixed
+- Fixed an issue where the 3D view was not rendered correctly after maximizing another pane. [#4098](https://github.com/scalableminds/webknossos/pull/4098)
 - The admin task list now only shows tasks belonging to a project one can administrate. [#4087](https://github.com/scalableminds/webknossos/pull/4087)
 
 ### Removed

--- a/frontend/javascripts/oxalis/controller/camera_controller.js
+++ b/frontend/javascripts/oxalis/controller/camera_controller.js
@@ -94,6 +94,9 @@ class CameraController extends React.PureComponent<Props> {
       const tdRect = inputCatcherRects[OrthoViews.TDView];
       const newAspectRatio = tdRect.width / tdRect.height;
 
+      // Do not update the tdCamera if the tdView is not visible (height === 0)
+      if (Number.isNaN(newAspectRatio)) return;
+
       const newWidth = (oldWidth * newAspectRatio) / oldAspectRatio;
 
       tdCamera.left = oldMid - newWidth / 2;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Maximize a data viewport and minimize it again -> The TD view should be rendered as usual
- Hide the TD view by moving it to another spot and switching tabs, then switch back to it -> Should be rendered as usual

### Issues:
- fixes #3882 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
