### PR TITLE
Transparent datasource properties suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Heavily improved mapping creation/activation performance. [#4103](https://github.com/scalableminds/webknossos/pull/4103)
 - The NML parser now rounds floating point values in node coordinates. [#4045](https://github.com/scalableminds/webknossos/pull/4045)
 - The time tracking view now displays dates instead of hours when having more then one day selected. The display id's in the timeline diagram are not the task ids. The tooltip of the timeline diagram also got a rework. [#4028](https://github.com/scalableminds/webknossos/pull/4028)
+- Improved the editing of datasets. Changes suggested by webKnossos will be easier to recognize as suggestions. [4104](https://github.com/scalableminds/webknossos/pull/4104)
 
 ### Fixed
 - Fixed an issue where the 3D view was not rendered correctly after maximizing another pane. [#4098](https://github.com/scalableminds/webknossos/pull/4098)

--- a/frontend/javascripts/admin/api_flow_types.js
+++ b/frontend/javascripts/admin/api_flow_types.js
@@ -152,6 +152,7 @@ export type APISampleDataset = {
 
 export type APIDataSourceWithMessages = {
   +dataSource?: APIDataSource,
+  +previousDataSource?: APIDataSource,
   +messages: Array<APIMessage>,
 };
 

--- a/frontend/javascripts/dashboard/dataset/dataset_import_view.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_import_view.js
@@ -32,6 +32,8 @@ import SimpleAdvancedDataForm from "./simple_advanced_data_form";
 const { TabPane } = Tabs;
 const FormItem = Form.Item;
 
+const notImportedYetStatus = "Not imported yet.";
+
 type Props = {
   form: Object,
   datasetId: APIDatasetId,
@@ -161,6 +163,7 @@ class DatasetImportView extends React.PureComponent<Props, State> {
   getDatasourceDiffAlert() {
     if (
       this.state.previousDataSource == null ||
+      this.state.previousDataSource.status === notImportedYetStatus ||
       _.size(this.state.differenceBetweenDatasources) === 0
     ) {
       return null;
@@ -333,8 +336,8 @@ class DatasetImportView extends React.PureComponent<Props, State> {
     const { status } = this.state.dataset.dataSource;
     if (status != null) {
       messageElements.push(
-        // "Not imported yet." is only used, when the dataSource.json is missing.
-        status === "Not imported yet." ? (
+        // This status is only used, when the dataSource.json is missing.
+        status === notImportedYetStatus ? (
           <Alert
             key="datasourceStatus"
             message={<span>{messages["dataset.missing_datasource_json"]}</span>}

--- a/frontend/javascripts/dashboard/dataset/dataset_import_view.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_import_view.js
@@ -175,7 +175,7 @@ class DatasetImportView extends React.PureComponent<Props, State> {
         width: 800,
         content: (
           <Input.TextArea rows={20} style={jsonEditStyle}>
-            {JSON.stringify(object, null, 2)}
+            {jsonStringify(object)}
           </Input.TextArea>
         ),
       });

--- a/frontend/javascripts/dashboard/dataset/simple_advanced_data_form.js
+++ b/frontend/javascripts/dashboard/dataset/simple_advanced_data_form.js
@@ -20,11 +20,13 @@ export default function SimpleAdvancedDataForm({
   form,
   activeDataSourceEditMode,
   onChange,
+  additionalAlert,
 }: {
   isReadOnlyDataset: boolean,
   form: Object,
   activeDataSourceEditMode: "simple" | "advanced",
   onChange: ("simple" | "advanced") => void,
+  additionalAlert: ?React.Node,
 }) {
   const { getFieldDecorator } = form;
   const dataSource =
@@ -64,14 +66,9 @@ export default function SimpleAdvancedDataForm({
           type="warning"
           showIcon
         />
-      ) : (
-        <Alert
-          message="Please review the following properties. If you want to adjust the configuration described by
-            &ldquo;datasource-properties.json&rdquo;, please enable the &ldquo;Advanced&rdquo; mode in the top-right corner."
-          type="info"
-          showIcon
-        />
-      )}
+      ) : null}
+
+      {additionalAlert}
 
       <Hideable hidden={activeDataSourceEditMode !== "simple"}>
         <RetryingErrorBoundary>

--- a/frontend/javascripts/libs/utils.js
+++ b/frontend/javascripts/libs/utils.js
@@ -684,14 +684,13 @@ export function disableViewportMetatag() {
  * Source: https://gist.github.com/Yimiprod/7ee176597fef230d1451#gistcomment-2699388
  */
 export function diffObjects(object: Object, base: Object): Object {
-  function changes(object, base) {
+  function changes(_object, _base) {
     let arrayIndexCounter = 0;
-    return _.transform(object, (result, value, key) => {
-      if (!_.isEqual(value, base[key])) {
-        const resultKey = _.isArray(base) ? arrayIndexCounter++ : key;
+    return _.transform(_object, (result, value, key) => {
+      if (!_.isEqual(value, _base[key])) {
+        const resultKey = _.isArray(_base) ? arrayIndexCounter++ : key;
         result[resultKey] =
-          _.isObject(value) && _.isObject(base[key]) ? changes(value, base[key]) : value;
-        console.log("Result: " + JSON.stringify(result));
+          _.isObject(value) && _.isObject(_base[key]) ? changes(value, _base[key]) : value;
       }
     });
   }

--- a/frontend/javascripts/libs/utils.js
+++ b/frontend/javascripts/libs/utils.js
@@ -674,3 +674,26 @@ export function disableViewportMetatag() {
   }
   viewport.setAttribute("content", "");
 }
+
+/**
+ * Deep diff between two object, using lodash
+ * @param  {Object} object Object compared
+ * @param  {Object} base   Object to compare with
+ * @return {Object}        Return a new object who represent the diff
+ *
+ * Source: https://gist.github.com/Yimiprod/7ee176597fef230d1451#gistcomment-2699388
+ */
+export function diffObjects(object: Object, base: Object): Object {
+  function changes(object, base) {
+    let arrayIndexCounter = 0;
+    return _.transform(object, (result, value, key) => {
+      if (!_.isEqual(value, base[key])) {
+        const resultKey = _.isArray(base) ? arrayIndexCounter++ : key;
+        result[resultKey] =
+          _.isObject(value) && _.isObject(base[key]) ? changes(value, base[key]) : value;
+        console.log("Result: " + JSON.stringify(result));
+      }
+    });
+  }
+  return changes(object, base);
+}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -140,6 +140,7 @@ class DataSourceController @Inject()(
           Ok(
             Json.obj(
               "dataSource" -> dataSource,
+              "previousDataSource" -> previousDataSource,
               "messages" -> messages.map(m => Json.obj(m._1 -> m._2))
             ))
         }


### PR DESCRIPTION
@fm3 Can you double-check my small back end change please? A datastore update is needed for this, right?

- tell user that the server suggests a new datasource json. also allow to see the old version + diff
- removes the default "please review... use the advanced mode if you want to see the json" alert, since it felt a bit unnecessary to me (also, it's weird to have multiple alerts). the "simple" vs. "advanced" switch should be self-explanatory.

### URL of deployed dev instance (used for testing):
- https://showdatasourcechanges.webknossos.xyz

### Steps to test:
- edit a datasource properties json (e.g., remove a resolution)
- click on "refresh" on the datasets page and edit the dataset
- there should be an alert telling you that wk has inferred additional information
- clicking the links should render the old datasource-properties.json and the diff between new and old (the latter is more of a "pro feature", but I don't know if we can/should communicate this clearer)

### Issues:
- contributes to #4086 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [X] Needs datastore update after deployment
- [X] Ready for review
