### PR TITLE
remove redundant access check for timespan update

### DIFF
--- a/app/models/user/time/TimeSpan.scala
+++ b/app/models/user/time/TimeSpan.scala
@@ -158,7 +158,6 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
 
   def updateOne(t: TimeSpan)(implicit ctx: DBAccessContext): Fox[Unit] =
     for { //note that t.created is skipped
-      _ <- assertUpdateAccess(t._id) ?~> "FAILED: TimeSpanSQLDAO.assertUpdateAccess"
       r <- run(sqlu"""update webknossos.timespans
                 set
                   _user = ${t._user.id},

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -231,7 +231,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
     val updated = timeSpan.addTime(duration, timestamp)
 
     for {
-      _ <- timeSpanDAO.updateOne(updated)(ctx) ?~> "FAILED: TimeSpanDAO.update"
+      _ <- timeSpanDAO.updateOne(updated)(ctx) ?~> "FAILED: TimeSpanDAO.updateOne"
       _ <- logTimeToAnnotation(duration, updated._annotation) ?~> "FAILED: TimeSpanService.logTimeToAnnotation"
       annotation <- getAnnotation(updated._annotation)
       _ <- logTimeToTask(duration, annotation) ?~> "FAILED: TimeSpanService.logTimeToTask"


### PR DESCRIPTION
This check was redundant as the readAccessQ is just `true` yet it sometimes failed (resulting in an unexplained error toast for the user) if the timespan had only just been created directly before and was still not committed in the DB. This race condition is not fixed by this PR, but it is also not harmful, since the error case will usually drop less than a second.

### Issues:
- might help for #3544 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
