### PR TITLE
check more files when guessing dataset type

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -37,7 +37,7 @@ class DataSourceService @Inject()(
   override protected lazy val enabled: Boolean = config.Braingames.Binary.ChangeHandler.enabled
   protected lazy val tickerInterval: FiniteDuration = config.Braingames.Binary.ChangeHandler.tickerInterval
 
-  private val MaxNumberOfFilesForDataFormatGuessing = 10
+  private val MaxNumberOfFilesForDataFormatGuessing = 50
   val dataBaseDir = Paths.get(config.Braingames.Binary.baseFolder)
 
   private val propertiesFileName = Paths.get("datasource-properties.json")


### PR DESCRIPTION
Datasets with many layers got miscategorized as knossos because the check only looked at directories, and didn’t get to any wkw files. The limit is to avoid massive performance drops if huge numbers of files are in a directory. That should still be guaranteed if we raise it to 50

------
- ~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [x] Needs datastore update after deployment
- [x] Ready for review
