### PR TITLE
Add loading indicator for find data and refactor async clickables to use react hooks

### DIFF
--- a/frontend/javascripts/components/async_clickables.js
+++ b/frontend/javascripts/components/async_clickables.js
@@ -1,98 +1,69 @@
 // @flow
 /* eslint-disable react/jsx-no-bind  */
-import { Button, Icon, Spin } from "antd";
+import { Button, Icon } from "antd";
 import * as React from "react";
-
-const onClick = async function(event: SyntheticInputEvent<>) {
-  this.setState({ isLoading: true });
-  try {
-    await this.props.onClick(event);
-  } finally {
-    if (this._isMounted) {
-      this.setState({ isLoading: false });
-    }
-  }
-};
+const { useState, useEffect, useRef } = React;
 
 type Props = {
   onClick: (SyntheticInputEvent<>) => Promise<any>,
 };
 
-type State = { isLoading: boolean };
+function useLoadingClickHandler(originalOnClick) {
+  const [isLoading, setIsLoading] = useState(false);
+  const wasUnmounted = useRef(false);
 
-export class AsyncButton extends React.PureComponent<Props, State> {
-  _isMounted: boolean;
-  state = { isLoading: false };
+  useEffect(
+    () => () => {
+      wasUnmounted.current = true;
+    },
+    [],
+  );
 
-  componentDidMount() {
-    this._isMounted = true;
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  render() {
-    return <Button {...this.props} loading={this.state.isLoading} onClick={onClick.bind(this)} />;
-  }
-}
-
-export class AsyncIconButton extends React.PureComponent<{ ...Props, type: string }, State> {
-  _isMounted: boolean;
-  state = { isLoading: false };
-
-  componentDidMount() {
-    this._isMounted = true;
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  render() {
-    const { type } = this.props;
-    return (
-      <Icon
-        {...this.props}
-        type={this.state.isLoading ? "loading" : type}
-        onClick={onClick.bind(this)}
-      />
-    );
-  }
-}
-
-export class AsyncLink extends React.PureComponent<Props & { children: React.Node }, State> {
-  _isMounted: boolean;
-  static defaultProps = {
-    children: [],
-  };
-
-  state = { isLoading: false };
-
-  componentDidMount() {
-    this._isMounted = true;
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  render() {
-    let content;
-    if (this.state.isLoading) {
-      const children = React.Children.toArray(this.props.children);
-      const childrenWithoutIcon = children.filter(child => !child.type || child.type !== "i");
-      content = [<Spin key="icon" />, childrenWithoutIcon];
-    } else {
-      content = this.props.children;
+  const onClick = async (event: SyntheticInputEvent<>) => {
+    setIsLoading(true);
+    try {
+      await originalOnClick(event);
+    } finally {
+      if (!wasUnmounted.current) {
+        setIsLoading(false);
+      }
     }
+  };
+  return [isLoading, onClick];
+}
 
-    return (
-      <a {...this.props} onClick={onClick.bind(this)}>
-        {content}
-      </a>
-    );
+export function AsyncButton(props: Props) {
+  const [isLoading, onClick] = useLoadingClickHandler(props.onClick);
+  return <Button {...props} loading={isLoading} onClick={onClick} />;
+}
+
+export function AsyncIconButton(allProps: Props) {
+  const { type, ...props } = allProps;
+  const [isLoading, onClick] = useLoadingClickHandler(props.onClick);
+  return <Icon {...props} type={isLoading ? "loading" : type} onClick={onClick} />;
+}
+
+export function AsyncLink(props: Props & { children: React.Node }) {
+  const [isLoading, onClick] = useLoadingClickHandler(props.onClick);
+  let content;
+  if (isLoading) {
+    const children = React.Children.toArray(props.children);
+    const childrenWithoutIcon = children.filter(child => {
+      if (child.type == null) {
+        return true;
+      }
+      return child.type !== "i" && child.type.name !== "Icon";
+    });
+    content = [<Icon type="loading" key="loading-icon" />, childrenWithoutIcon];
+  } else {
+    content = props.children;
   }
+
+  return (
+    <a {...props} onClick={onClick}>
+      {content}
+    </a>
+  );
 }
 
 export default {};

--- a/frontend/javascripts/components/async_clickables.js
+++ b/frontend/javascripts/components/async_clickables.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-disable react/jsx-no-bind  */
-import { Button, Spin } from "antd";
+import { Button, Icon, Spin } from "antd";
 import * as React from "react";
 
 const onClick = async function(event: SyntheticInputEvent<>) {
@@ -34,6 +34,30 @@ export class AsyncButton extends React.PureComponent<Props, State> {
 
   render() {
     return <Button {...this.props} loading={this.state.isLoading} onClick={onClick.bind(this)} />;
+  }
+}
+
+export class AsyncIconButton extends React.PureComponent<{ ...Props, type: string }, State> {
+  _isMounted: boolean;
+  state = { isLoading: false };
+
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  render() {
+    const { type } = this.props;
+    return (
+      <Icon
+        {...this.props}
+        type={this.state.isLoading ? "loading" : type}
+        onClick={onClick.bind(this)}
+      />
+    );
   }
 }
 

--- a/frontend/javascripts/components/async_clickables.js
+++ b/frontend/javascripts/components/async_clickables.js
@@ -7,7 +7,7 @@ type Props = {
   onClick: (SyntheticInputEvent<>) => Promise<any>,
 };
 
-function useLoadingClickHandler(originalOnClick) {
+function useLoadingClickHandler(originalOnClick: (SyntheticInputEvent<>) => Promise<any>) {
   const [isLoading, setIsLoading] = useState(false);
   const wasUnmounted = useRef(false);
 
@@ -36,7 +36,7 @@ export function AsyncButton(props: Props) {
   return <Button {...props} loading={isLoading} onClick={onClick} />;
 }
 
-export function AsyncIconButton(allProps: Props) {
+export function AsyncIconButton(allProps: Props & { type: string }) {
   const { type, ...props } = allProps;
   const [isLoading, onClick] = useLoadingClickHandler(props.onClick);
   return <Icon {...props} type={isLoading ? "loading" : type} onClick={onClick} />;

--- a/frontend/javascripts/components/async_clickables.js
+++ b/frontend/javascripts/components/async_clickables.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/jsx-no-bind  */
 import { Button, Icon } from "antd";
 import * as React from "react";
 const { useState, useEffect, useRef } = React;

--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -101,7 +101,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
     <Tooltip title="If you are having trouble finding your data, webKnossos can try to find a position which contains data.">
       <AsyncIconButton
         type="scan"
-        onClick={!isDisabled ? () => this.handleFindData(layerName) : () => {}}
+        onClick={!isDisabled ? () => this.handleFindData(layerName) : () => Promise.resolve()}
         style={{
           float: "right",
           marginTop: 4,

--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -10,6 +10,7 @@ import * as React from "react";
 import _ from "lodash";
 
 import type { APIDataset, APIHistogramData } from "admin/api_flow_types";
+import { AsyncIconButton } from "components/async_clickables";
 import {
   SwitchSetting,
   NumberSliderSetting,
@@ -17,8 +18,8 @@ import {
   ColorSetting,
 } from "oxalis/view/settings/setting_input_views";
 import { findDataPositionForLayer, getHistogramForLayer } from "admin/admin_rest_api";
-import { getMaxZoomValueForResolution } from "oxalis/model/accessors/flycam_accessor";
 import { getGpuFactorsWithLabels } from "oxalis/model/bucket_data_handling/data_rendering_logic";
+import { getMaxZoomValueForResolution } from "oxalis/model/accessors/flycam_accessor";
 import { hasSegmentation, getElementClass } from "oxalis/model/accessors/dataset_accessor";
 import { setPositionAction, setZoomStepAction } from "oxalis/model/actions/flycam_actions";
 import {
@@ -26,6 +27,7 @@ import {
   updateLayerSettingAction,
   updateUserSettingAction,
 } from "oxalis/model/actions/settings_actions";
+import Model from "oxalis/model";
 import Store, {
   type DatasetConfiguration,
   type DatasetLayerConfiguration,
@@ -40,8 +42,8 @@ import constants, {
   type ViewMode,
   type Vector3,
 } from "oxalis/constants";
-import Model from "oxalis/model";
 import messages, { settings } from "messages";
+
 import Histogram from "./histogram_view";
 
 const { Panel } = Collapse;
@@ -97,7 +99,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
 
   getFindDataButton = (layerName: string, isDisabled: boolean) => (
     <Tooltip title="If you are having trouble finding your data, webKnossos can try to find a position which contains data.">
-      <Icon
+      <AsyncIconButton
         type="scan"
         onClick={!isDisabled ? () => this.handleFindData(layerName) : () => {}}
         style={{


### PR DESCRIPTION
This PR
- adds loading indicator for find data
- refactors the async clickables
- adds an AsyncIconButton component
- beautifies the loading indicator for AsyncLinks (before the spinner was quite ugly)

### URL of deployed dev instance (used for testing):
- https://loadingindicatorfinddata.webknossos.xyz

### Steps to test:
I tested
- AsyncButton for get new task
- AsyncLink for "archive" explorative annotation
- AsyncIconButton for "find data"

------
- [X] Ready for review
