### PR TITLE
speed up refresh speed for dataset reports

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,10 +5,11 @@ This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.md).
 
 ## Unreleased
-- 
+-
 
 ### Postgres Evolutions:
-- [042-043-annotationsettings-allowedMagnifications.sql](conf/evolutions/043-annotationsettings-allowedMagnifications.sql) 
+- [043-annotationsettings-allowedMagnifications.sql](conf/evolutions/043-annotationsettings-allowedMagnifications.sql)
+- [044-datasource-hash.sql](conf/evolutions/044-datasource-hash.sql)
 
 
 ## [19.06.0](https://github.com/scalableminds/webknossos/releases/tag/19.06.0) - 2019-05-27

--- a/app/controllers/WKDataStoreController.scala
+++ b/app/controllers/WKDataStoreController.scala
@@ -1,12 +1,11 @@
 package controllers
 
 import javax.inject.Inject
-
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.{InboxDataSourceLike => InboxDataSource}
 import com.scalableminds.webknossos.datastore.services.DataStoreStatus
 import com.scalableminds.util.accesscontext.GlobalAccessContext
-import com.scalableminds.util.tools.Fox
+import com.scalableminds.util.tools.{Fox, TimeLogger}
 import com.typesafe.scalalogging.LazyLogging
 import models.binary._
 import play.api.libs.json.{JsError, JsObject, JsSuccess}
@@ -53,11 +52,11 @@ class WKDataStoreController @Inject()(dataSetService: DataSetService,
 
   def updateAll(name: String) = Action.async(parse.json) { implicit request =>
     dataStoreService.validateAccess(name) { dataStore =>
-      request.body.validate[List[InboxDataSource]] match {
+      TimeLogger.logTime("parsing datasource jsons",logger)(request.body.validate[List[InboxDataSource]]) match {
         case JsSuccess(dataSources, _) =>
           for {
-            _ <- dataSetService.deactivateUnreportedDataSources(dataStore.name, dataSources)(GlobalAccessContext)
-            _ <- dataSetService.updateDataSources(dataStore, dataSources)(GlobalAccessContext)
+            _ <- TimeLogger.logTimeF("deactivateUnreported",logger)(dataSetService.deactivateUnreportedDataSources(dataStore.name, dataSources)(GlobalAccessContext))
+            _ <- TimeLogger.logTimeF("updateDatasources",logger)(dataSetService.updateDataSources(dataStore, dataSources)(GlobalAccessContext))
           } yield {
             JsonOk
           }

--- a/app/controllers/WKDataStoreController.scala
+++ b/app/controllers/WKDataStoreController.scala
@@ -52,11 +52,14 @@ class WKDataStoreController @Inject()(dataSetService: DataSetService,
 
   def updateAll(name: String) = Action.async(parse.json) { implicit request =>
     dataStoreService.validateAccess(name) { dataStore =>
-      TimeLogger.logTime("parsing datasource jsons",logger)(request.body.validate[List[InboxDataSource]]) match {
+      TimeLogger
+        .logTime("parsing reported datasource jsons", logger)(request.body.validate[List[InboxDataSource]]) match {
         case JsSuccess(dataSources, _) =>
           for {
-            _ <- TimeLogger.logTimeF("deactivateUnreported",logger)(dataSetService.deactivateUnreportedDataSources(dataStore.name, dataSources)(GlobalAccessContext))
-            _ <- TimeLogger.logTimeF("updateDatasources",logger)(dataSetService.updateDataSources(dataStore, dataSources)(GlobalAccessContext))
+            _ <- TimeLogger.logTimeF("deactivate unreported", logger)(
+              dataSetService.deactivateUnreportedDataSources(dataStore.name, dataSources)(GlobalAccessContext))
+            _ <- TimeLogger.logTimeF("update datasources", logger)(
+              dataSetService.updateDataSources(dataStore, dataSources)(GlobalAccessContext))
           } yield {
             JsonOk
           }

--- a/app/models/binary/DataSet.scala
+++ b/app/models/binary/DataSet.scala
@@ -3,8 +3,19 @@ package models.binary
 import com.scalableminds.util.geometry.{BoundingBox, Point3D, Scale}
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
-import com.scalableminds.webknossos.datastore.models.datasource.inbox.{UnusableDataSource, InboxDataSourceLike => InboxDataSource}
-import com.scalableminds.webknossos.datastore.models.datasource.{AbstractDataLayer, AbstractSegmentationLayer, Category, DataSourceId, ElementClass, GenericDataSource, DataLayerLike => DataLayer}
+import com.scalableminds.webknossos.datastore.models.datasource.inbox.{
+  UnusableDataSource,
+  InboxDataSourceLike => InboxDataSource
+}
+import com.scalableminds.webknossos.datastore.models.datasource.{
+  AbstractDataLayer,
+  AbstractSegmentationLayer,
+  Category,
+  DataSourceId,
+  ElementClass,
+  GenericDataSource,
+  DataLayerLike => DataLayer
+}
 import com.scalableminds.webknossos.schema.Tables._
 import javax.inject.Inject
 import models.configuration.DataSetConfiguration
@@ -125,12 +136,11 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
       parsed <- Fox.combined(r.toList.map(parse))
     } yield parsed
 
-  def isEmpty(implicit ctx: DBAccessContext): Fox[Boolean] = {
+  def isEmpty(implicit ctx: DBAccessContext): Fox[Boolean] =
     for {
       r <- run(sql"select count(*) from #${existingCollectionName} limit 1".as[Int])
       firstRow <- r.headOption
     } yield firstRow == 0
-  }
 
   def countAllForOrganization(organizationId: ObjectId)(implicit ctx: DBAccessContext): Fox[Int] =
     for {
@@ -140,14 +150,14 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
     } yield r
 
   def findOneByNameAndOrganizationName(name: String, organizationName: String)(
-    implicit ctx: DBAccessContext): Fox[DataSet] =
+      implicit ctx: DBAccessContext): Fox[DataSet] =
     for {
       organization <- organizationDAO.findOneByName(organizationName)(GlobalAccessContext) ?~> ("organization.notFound " + organizationName)
       dataset <- findOneByNameAndOrganization(name, organization._id)
     } yield dataset
 
   def findOneByNameAndOrganization(name: String, organizationId: ObjectId)(
-    implicit ctx: DBAccessContext): Fox[DataSet] =
+      implicit ctx: DBAccessContext): Fox[DataSet] =
     for {
       accessQuery <- readAccessQuery
       rList <- run(
@@ -158,20 +168,18 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
     } yield parsed
 
   def findAllByNamesAndOrganizationName(names: List[String], organizationName: String)(
-    implicit ctx: DBAccessContext): Fox[List[DataSet]] =
+      implicit ctx: DBAccessContext): Fox[List[DataSet]] =
     for {
       organization <- organizationDAO.findOneByName(organizationName)(GlobalAccessContext) ?~> ("organization.notFound " + organizationName)
       datasets <- findAllByNamesAndOrganization(names, organization._id)
     } yield datasets
 
-  def findAllByNamesAndOrganization(names: List[String], organizationId: ObjectId) (
-    implicit ctx: DBAccessContext): Fox[List[DataSet]] =
+  def findAllByNamesAndOrganization(names: List[String], organizationId: ObjectId)(
+      implicit ctx: DBAccessContext): Fox[List[DataSet]] =
     for {
       accessQuery <- readAccessQuery
-      rows <- run(
-        sql"select #${columns} from #${existingCollectionName} where name in #${writeStructTupleWithQuotes(names.map(sanitize))} and _organization = ${organizationId} and #${accessQuery}"
-          .as[DatasetsRow])
-          .map(_.toList)
+      rows <- run(sql"select #${columns} from #${existingCollectionName} where name in #${writeStructTupleWithQuotes(
+        names.map(sanitize))} and _organization = ${organizationId} and #${accessQuery}".as[DatasetsRow]).map(_.toList)
       parsed <- Fox.combined(rows.map(parse))
     } yield parsed
 
@@ -249,7 +257,8 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
         sqlu"""insert into webknossos.dataSets(_id, _dataStore, _organization, _publication, inboxSourceHash, defaultConfiguration, description, displayName,
                                                              isPublic, isUsable, name, scale, status, sharingToken, sortingKey, details, created, isDeleted)
                values(${d._id.id}, ${d._dataStore}, ${d._organization.id}, #${optionLiteral(d._publication.map(_.id))},
-                #${optionLiteral(d.inboxSourceHash.map(_.toString))}, #${optionLiteral(defaultConfiguration.map(sanitize))},
+                #${optionLiteral(d.inboxSourceHash.map(_.toString))}, #${optionLiteral(
+          defaultConfiguration.map(sanitize))},
                 ${d.description}, ${d.displayName}, ${d.isPublic}, ${d.isUsable},
                       ${d.name}, #${optionLiteral(d.scale.map(s => writeScaleLiteral(s)))}, ${d.status
           .take(1024)}, ${d.sharingToken}, ${new java.sql.Timestamp(d.sortingKey)}, #${optionLiteral(

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -311,7 +311,7 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
     for {
       organization <- organizationDAO.findOne(dataSet._organization)(GlobalAccessContext) ?~> "organization.notFound"
       teams <- allowedTeamsFor(dataSet._id, requestingUserOpt)
-      teamsJs <- Fox.serialCombined(teams)(t => teamService.publicWrites(t))
+      teamsJs <- Fox.serialCombined(teams)(t => teamService.publicWrites(t, Some(organization)))
       logoUrl <- logoUrlFor(dataSet, Some(organization))
       isEditable <- isEditableBy(dataSet, requestingUserOpt, requestingUserTeamManagerMemberships)
       lastUsedByUser <- lastUsedTimeFor(dataSet._id, requestingUserOpt)

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -3,21 +3,14 @@ package models.binary
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
-import com.scalableminds.webknossos.datastore.models.datasource.{
-  DataSourceId,
-  GenericDataSource,
-  DataLayerLike => DataLayer
-}
-import com.scalableminds.webknossos.datastore.models.datasource.inbox.{
-  UnusableDataSource,
-  InboxDataSourceLike => InboxDataSource
-}
+import com.scalableminds.webknossos.datastore.models.datasource.{DataSourceId, GenericDataSource, DataLayerLike => DataLayer}
+import com.scalableminds.webknossos.datastore.models.datasource.inbox.{UnusableDataSource, InboxDataSourceLike => InboxDataSource}
 import com.scalableminds.webknossos.datastore.storage.TemporaryStore
 import com.typesafe.scalalogging.LazyLogging
 import javax.inject.Inject
 import models.team._
 import models.user.{User, UserService}
-import net.liftweb.common.Full
+import net.liftweb.common.{Box, Full}
 import oxalis.security.{CompactRandomIDGenerator, URLSharing}
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.i18n.Messages.Implicits._
@@ -25,7 +18,7 @@ import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSResponse
 import utils.{ObjectId, WkConf}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class DataSetService @Inject()(organizationDAO: OrganizationDAO,
                                dataSetDAO: DataSetDAO,
@@ -74,6 +67,7 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
               dataStore.name,
               organization._id,
               publication,
+              Some(dataSource.hashCode()),
               None,
               None,
               None,
@@ -116,55 +110,95 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
     } yield ()
   }
 
-  def updateDataSource(
+
+  def updateDataSources(dataStore: DataStore, dataSources: List[InboxDataSource])(implicit ctx: DBAccessContext): Fox[List[Unit]] = {
+    logger.info(
+      s"[${dataStore.name}] Available datasets: " +
+        s"${dataSources.count(_.isUsable)} (usable), ${dataSources.count(!_.isUsable)} (unusable)")
+
+    val groupedByOrga = dataSources.groupBy(_.id.team).toList
+
+    Fox.serialCombined(groupedByOrga) { orgaTuple: (String, List[InboxDataSource]) =>
+      for {
+        foundDatasets <- dataSetDAO.findAllByNamesAndOrganizationName(orgaTuple._2.map(_.id.name), orgaTuple._1)
+        foundDatasetsByName = foundDatasets.groupBy(_.name)
+        _ <- Fox.serialSequence(orgaTuple._2)(dataSource => updateDataSource(dataStore, dataSource, foundDatasetsByName))
+      } yield ()
+    }
+  }
+
+  private def updateDataSource(
       dataStore: DataStore,
-      dataSource: InboxDataSource
-  )(implicit ctx: DBAccessContext): Fox[Unit] =
-    dataSetDAO
-      .findOneByNameAndOrganizationName(dataSource.id.name, dataSource.id.team)(GlobalAccessContext)
-      .futureBox
-      .flatMap {
-        case Full(dataSet) if dataSet._dataStore == dataStore.name =>
-          dataSetDAO
-            .updateDataSourceByNameAndOrganizationName(dataSource.id.name,
-                                                       dataStore.name,
-                                                       dataSource,
-                                                       dataSource.isUsable)(GlobalAccessContext)
-            .futureBox
-        case Full(foundDataSet) =>
-          // The dataSet is already present (belonging to the same organization), but reported from a different datastore
-          (for {
-            originalDataStore <- dataStoreDAO.findOneByName(foundDataSet._dataStore)
-          } yield {
-            if (originalDataStore.isScratch && !dataStore.isScratch) {
-              logger.info(
-                s"Replacing dataset ${foundDataSet.name} from scratch datastore ${originalDataStore.name} by the one from ${dataStore.name}")
-              dataSetDAO.updateDataSourceByNameAndOrganizationName(dataSource.id.name,
-                                                                   dataStore.name,
-                                                                   dataSource,
-                                                                   dataSource.isUsable)(GlobalAccessContext)
-            } else {
-              logger.info(
-                s"Dataset ${foundDataSet.name}, as reported from ${dataStore.name} is already present from datastore ${originalDataStore.name} and will not be replaced.")
-              Fox.failure("dataset.name.alreadyInUse")
-            }
-          }).flatten.futureBox
-        case _ =>
-          dataSetDAO.findAll(GlobalAccessContext).flatMap { datasets =>
-            val publication =
-              if (conf.Application.insertInitialData && datasets.isEmpty) Some(ObjectId("5c766bec6c01006c018c7459"))
-              else None
-            createDataSet(dataSource.id.name,
-                          dataStore,
-                          dataSource.id.team,
-                          dataSource,
-                          publication,
-                          dataSource.isUsable).futureBox
-          }
+      dataSource: InboxDataSource,
+      foundDatasets: Map[String, List[DataSet]]
+  )(implicit ctx: DBAccessContext): Fox[Unit] = {
+    val foundDataSetOpt = foundDatasets.get(dataSource.id.name).flatMap(_.headOption)
+    foundDataSetOpt match {
+      case Some(foundDataSet) if foundDataSet._dataStore == dataStore.name =>
+        updateKnownDataSource(foundDataSet, dataSource, dataStore)
+      case Some(foundDataSet) =>
+        updateDataSourceDifferentDataStore(foundDataSet, dataSource, dataStore)
+      case _ =>
+        insertNewDataSet(dataSource, dataStore)
+    }
+  }
+
+  private def updateKnownDataSource(foundDataSet: DataSet, dataSource: InboxDataSource, dataStore: DataStore)(implicit ctx: DBAccessContext): Future[Box[Unit]] = {
+    if (foundDataSet.inboxSourceHash.contains(dataSource.hashCode))
+      Fox.successful(())
+    else
+      dataSetDAO
+        .updateDataSourceByNameAndOrganizationName(foundDataSet._id,
+          dataStore.name,
+          dataSource.hashCode,
+          dataSource,
+          dataSource.isUsable)(GlobalAccessContext)
+  }
+
+  private def updateDataSourceDifferentDataStore(foundDataSet: DataSet, dataSource: InboxDataSource, dataStore: DataStore)(implicit ctx: DBAccessContext): Future[Box[Unit]] = {
+    // The dataSet is already present (belonging to the same organization), but reported from a different datastore
+    (for {
+      originalDataStore <- dataStoreDAO.findOneByName(foundDataSet._dataStore)
+    } yield {
+      if (originalDataStore.isScratch && !dataStore.isScratch) {
+        logger.info(
+          s"Replacing dataset ${foundDataSet.name} from scratch datastore ${originalDataStore.name} by the one from ${dataStore.name}")
+        dataSetDAO.updateDataSourceByNameAndOrganizationName(foundDataSet._id,
+          dataStore.name,
+          dataSource.hashCode,
+          dataSource,
+          dataSource.isUsable)(GlobalAccessContext)
+      } else {
+        logger.info(
+          s"Dataset ${foundDataSet.name}, as reported from ${dataStore.name} is already present from datastore ${originalDataStore.name} and will not be replaced.")
+        Fox.failure("dataset.name.alreadyInUse")
       }
+    }).flatten.futureBox
+  }
+
+  private def insertNewDataSet(dataSource: InboxDataSource, dataStore: DataStore) =
+    publicationForFirstDataset.flatMap { publicationId: Option[ObjectId] =>
+      createDataSet(dataSource.id.name,
+        dataStore,
+        dataSource.id.team,
+        dataSource,
+        publicationId,
+        dataSource.isUsable)
+    }.futureBox
+
+  private def publicationForFirstDataset: Fox[Option[ObjectId]] = {
+    if (conf.Application.insertInitialData) {
+      dataSetDAO.isEmpty(GlobalAccessContext).map { isEmpty =>
+        if (isEmpty)
+          Some(ObjectId("5c766bec6c01006c018c7459"))
+        else
+          None
+      }
+    } else Fox.successful(None)
+  }
 
   def deactivateUnreportedDataSources(dataStoreName: String, dataSources: List[InboxDataSource])(
-      implicit ctx: DBAccessContext) = {
+      implicit ctx: DBAccessContext): Fox[List[Unit]] = {
     val dataSourcesByOrganizationName: Map[String, List[InboxDataSource]] = dataSources.groupBy(_.id.team)
     Fox.serialCombined(dataSourcesByOrganizationName.keys.toList) { organizationName =>
       for {
@@ -181,15 +215,6 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
           }
         }
       } yield ()
-    }
-  }
-
-  def updateDataSources(dataStore: DataStore, dataSources: List[InboxDataSource])(implicit ctx: DBAccessContext) = {
-    logger.info(
-      s"[${dataStore.name}] Available datasets: " +
-        s"${dataSources.count(_.isUsable)} (usable), ${dataSources.count(!_.isUsable)} (unusable)")
-    Fox.serialSequence(dataSources) { dataSource =>
-      updateDataSource(dataStore, dataSource)
     }
   }
 

--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -28,9 +28,9 @@ case class Team(
 
 class TeamService @Inject()(organizationDAO: OrganizationDAO)(implicit ec: ExecutionContext) {
 
-  def publicWrites(team: Team)(implicit ctx: DBAccessContext): Fox[JsObject] =
+  def publicWrites(team: Team, organizationOpt: Option[Organization] = None)(implicit ctx: DBAccessContext): Fox[JsObject] =
     for {
-      organization <- organizationDAO.findOne(team._organization)(GlobalAccessContext)
+      organization <- Fox.fillOption(organizationOpt)(organizationDAO.findOne(team._organization)(GlobalAccessContext))
     } yield {
       Json.obj(
         "id" -> team._id.toString,

--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -28,7 +28,8 @@ case class Team(
 
 class TeamService @Inject()(organizationDAO: OrganizationDAO)(implicit ec: ExecutionContext) {
 
-  def publicWrites(team: Team, organizationOpt: Option[Organization] = None)(implicit ctx: DBAccessContext): Fox[JsObject] =
+  def publicWrites(team: Team, organizationOpt: Option[Organization] = None)(
+      implicit ctx: DBAccessContext): Fox[JsObject] =
     for {
       organization <- Fox.fillOption(organizationOpt)(organizationDAO.findOne(team._organization)(GlobalAccessContext))
     } yield {

--- a/conf/evolutions/044-datasource-hash.sql
+++ b/conf/evolutions/044-datasource-hash.sql
@@ -1,0 +1,12 @@
+-- https://github.com/scalableminds/webknossos/pull/4135
+
+START TRANSACTION;
+
+DROP VIEW webknossos.dataSets_;
+ALTER TABLE webknossos.dataSets ADD COLUMN inboxSourceHash INT;
+
+CREATE VIEW webknossos.dataSets_ AS SELECT * FROM webknossos.dataSets WHERE NOT isDeleted;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 44;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/044-datasource-hash.sql
+++ b/conf/evolutions/reversions/044-datasource-hash.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+DROP VIEW webknossos.dataSets_;
+ALTER TABLE webknossos.dataSets DROP inboxSourceHash;
+
+CREATE VIEW webknossos.dataSets_ AS SELECT * FROM webknossos.dataSets WHERE NOT isDeleted;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 43;
+
+COMMIT TRANSACTION;

--- a/test/db/dataSets.csv
+++ b/test/db/dataSets.csv
@@ -1,7 +1,7 @@
-_id,_dataStore,_organization,_publication,defaultConfiguration,description,displayName,isPublic,isUsable,name,scale,status,sharingToken,logoUrl,sortingKey,details,created,isDeleted
-'570b9f4e4bb848d0885ee711','localhost','5ab0c6a674d0af7b003b23ac',,,,,f,f,'2012-06-28_Cortex',,'No longer available on datastore.',,,'2016-04-11T12:57:50.082Z',,'2016-04-11T12:57:50.082Z',f
-'570b9f4e4bb848d0885ee712','localhost','5ab0c6a674d0af7b003b23ac',,,,,f,f,'Experiment_001',,'No longer available on datastore.',,,'2016-04-11T12:57:50.079Z',,'2016-04-11T12:57:50.079Z',f
-'570b9f4e4bb848d0885ee713','localhost','5ab0c6a674d0af7b003b23ac',,,,,f,f,'2012-09-28_ex145_07x2',,'No longer available on datastore.',,,'2016-04-11T12:57:50.080Z',,'2016-04-11T12:57:50.080Z',f
-'570b9fd34bb848d0885ee716','localhost','5ab0c6a674d0af7b003b23ac',,,,,f,f,'rgb',,'No longer available on datastore.',,,'2016-04-11T13:00:03.792Z',,'2016-04-11T13:00:03.792Z',f
-'59e9cfbdba632ac2ab8b23b3','localhost','5ab0c6a674d0af7b003b23ac',,,,,f,t,'confocal-multi_knossos','(22,22,44.599998474121094)','',,,'2017-10-20T10:28:13.763Z',,'2017-10-20T10:28:13.763Z',f
-'59e9cfbdba632ac2ab8b23b5','localhost','5ab0c6a674d0af7b003b23ac',,,,,f,t,'e2006_knossos','(16.5,16.5,25)','',,,'2017-10-20T10:28:13.789Z',,'2017-10-20T10:28:13.789Z',f
+_id,_dataStore,_organization,_publication,inboxSourceHash,defaultConfiguration,description,displayName,isPublic,isUsable,name,scale,status,sharingToken,logoUrl,sortingKey,details,created,isDeleted
+'570b9f4e4bb848d0885ee711','localhost','5ab0c6a674d0af7b003b23ac',,,,,,f,f,'2012-06-28_Cortex',,'No longer available on datastore.',,,'2016-04-11T12:57:50.082Z',,'2016-04-11T12:57:50.082Z',f
+'570b9f4e4bb848d0885ee712','localhost','5ab0c6a674d0af7b003b23ac',,,,,,f,f,'Experiment_001',,'No longer available on datastore.',,,'2016-04-11T12:57:50.079Z',,'2016-04-11T12:57:50.079Z',f
+'570b9f4e4bb848d0885ee713','localhost','5ab0c6a674d0af7b003b23ac',,,,,,f,f,'2012-09-28_ex145_07x2',,'No longer available on datastore.',,,'2016-04-11T12:57:50.080Z',,'2016-04-11T12:57:50.080Z',f
+'570b9fd34bb848d0885ee716','localhost','5ab0c6a674d0af7b003b23ac',,,,,,f,f,'rgb',,'No longer available on datastore.',,,'2016-04-11T13:00:03.792Z',,'2016-04-11T13:00:03.792Z',f
+'59e9cfbdba632ac2ab8b23b3','localhost','5ab0c6a674d0af7b003b23ac',,,,,,f,t,'confocal-multi_knossos','(22,22,44.599998474121094)','',,,'2017-10-20T10:28:13.763Z',,'2017-10-20T10:28:13.763Z',f
+'59e9cfbdba632ac2ab8b23b5','localhost','5ab0c6a674d0af7b003b23ac',,,,,,f,t,'e2006_knossos','(16.5,16.5,25)','',,,'2017-10-20T10:28:13.789Z',,'2017-10-20T10:28:13.789Z',f

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ START TRANSACTION;
 CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(43);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(44);
 COMMIT TRANSACTION;
 
 CREATE TABLE webknossos.analytics(

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -85,6 +85,7 @@ CREATE TABLE webknossos.dataSets(
   _dataStore CHAR(256) NOT NULL,
   _organization CHAR(24) NOT NULL,
   _publication CHAR(24),
+  inboxSourceHash INT,
   defaultConfiguration JSONB,
   description TEXT,
   displayName VARCHAR(256),

--- a/util/src/main/scala/com/scalableminds/util/tools/TimeLogger.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/TimeLogger.scala
@@ -1,19 +1,21 @@
 package com.scalableminds.util.tools
 
+import com.typesafe.scalalogging.Logger
+
 import scala.concurrent.ExecutionContext
 
 object TimeLogger {
-  def logTime[A](caption: String, log: String => Unit)(op: => A): A = {
+  def logTime[A](caption: String, logger: Logger)(op: => A): A = {
     val t = System.currentTimeMillis()
     val result = op
-    log(s"TIMELOG | $caption took ${System.currentTimeMillis - t} ms")
+    logger.info(s"TIMELOG | $caption took ${System.currentTimeMillis - t} ms")
     result
   }
 
-  def logTimeF[A](caption: String, log: String => Unit)(op: => Fox[A])(implicit ec: ExecutionContext): Fox[A] = {
+  def logTimeF[A](caption: String, logger: Logger)(op: => Fox[A])(implicit ec: ExecutionContext): Fox[A] = {
     val t = System.currentTimeMillis()
     val result = op
-    result.futureBox.onComplete(_ => log(s"TIMELOG | $caption took ${System.currentTimeMillis - t} ms"))
+    result.futureBox.onComplete(_ => logger.info(s"TIMELOG | $caption took ${System.currentTimeMillis - t} ms"))
     result
   }
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -47,11 +47,12 @@ class DataSourceService @Inject()(
   def checkInbox(): Fox[Unit] = {
     logger.info(s"Scanning inbox at: $dataBaseDir")
     for {
-      _ <- TimeLogger.logTime(s"listdir on $dataBaseDir",logger){PathUtils.listDirectories(dataBaseDir)} match {
+      _ <- TimeLogger.logTime(s"listdir on $dataBaseDir", logger) { PathUtils.listDirectories(dataBaseDir) } match {
         case Full(dirs) =>
           for {
             _ <- Fox.successful(())
-            foundInboxSources = TimeLogger.logTime("read datasource-properties.json files", logger)(dirs.flatMap(teamAwareInboxSources))
+            foundInboxSources = TimeLogger.logTime("read datasource-properties.json files", logger)(
+              dirs.flatMap(teamAwareInboxSources))
             dataSourceString = foundInboxSources.map { ds =>
               s"'${ds.id.team}/${ds.id.name}' (${if (ds.isUsable) "active" else "inactive"})"
             }.mkString(", ")


### PR DESCRIPTION
The refresh button triggers two requests. One lets the datastore report its datasource jsons to wk, the second is a GET to wK, to get the dataset info from wk to the frontend. Both requests are optimized here.
For the first request, the number of update queries in wK is reduced by introducing a hash. Only update queries for datasets with changed datasources are run. The second request also runs less redundant db queries by grouping datasets by orga and datastore, and by adding some small tweaks.
Also added are a few time logging outputs to see if there are additional bottlenecks that didn’t occur in my test environment. I’m seeing about 60% speedup in my 30-dataset setup (when most datasets didn’t change)

### URL of deployed dev instance (used for testing):
- https://speeduprefresh.webknossos.xyz

### Steps to test:
- hit “refresh” button in dataset view. should be faster than in master
- should also still actually report new datasets, set deleted to “no longer available” and update properties of changed ones (change the datasource-properties.json)

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- [x] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [x] Needs datastore update after deployment
- [x] Ready for review
