### PR TITLE
default to guessing wkw as dataformat

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -186,7 +186,7 @@ class DataSourceService @Inject()(
   }
 
   private def guessDataFormat(path: Path): Box[DataSourceImporter] = {
-    val dataFormats = List(KnossosDataFormat, WKWDataFormat)
+    val dataFormats = List(WKWDataFormat, KnossosDataFormat)
 
     PathUtils.lazyFileStreamRecursive(path) { files =>
       val fileNames = files.take(MaxNumberOfFilesForDataFormatGuessing).map(_.getFileName.toString).toList


### PR DESCRIPTION
When hitting “edit” on a dataset, the backend explores the properties of this dataset, suggesting new values for the datasource-properties.json. To do this, it first guesses the dataset type (wkw vs knossos) using a heuristic that looks at a number of files an counts if more “.wkw” or more ”.raw” files are present. This heuristic fails if there are many debugging files in the dataste directory. A quick fix is to default to wkw rather than knossos in this case, since we know of nobody who still uses knossos datasets.

### Steps to test:
- add a directory with at least 30 non-dataset files to a dataset directory
- edit view should still list the valid layers as such (despite showing errors about the non-layer)

### Issues:
- fixes #4139

------
- ~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [x] Needs datastore update after deployment
- [x] Ready for review
