### PR TITLE
Support uint16 color layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Added
 - Volume tasks with only one finished instance can now be viewed as CompoundTask. [#4167](https://github.com/scalableminds/webknossos/pull/4167)
+- Added support for int16 and uint16 color layers. [#4152](https://github.com/scalableminds/webknossos/pull/4152)
 
 ### Changed
 - Volume project download zips are reorganized to contain a zipfile for each annotation (that in turn contains a data.zip and an nml file). [#4167](https://github.com/scalableminds/webknossos/pull/4167)

--- a/docs/data_formats.md
+++ b/docs/data_formats.md
@@ -7,7 +7,7 @@ webKnossos supports two data formats (WKW and KNOSSOS) for voxel datasets and NM
 * [KNOSSOS cubes](https://knossostool.org/). Dataset of 128x128x128 cubes.
 
 ### Image formats
-* Grayscale data (`uint8`), also referred to as `color` data
+* Grayscale data (8 Bit, 16 Bit, Float), also referred to as `color` data
 * RGB data (24 Bit)
 * Segmentation data (8 Bit, 16 Bit, 32 Bit)
 * Multi-channel data (multiple 8 Bit)

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
@@ -59,7 +59,7 @@ function _getMaxZoomStep(maybeDataset: ?APIDataset): number {
 
 export const getMaxZoomStep = memoizeOne(_getMaxZoomStep);
 
-function getDataLayers(dataset: APIDataset): DataLayerType[] {
+export function getDataLayers(dataset: APIDataset): DataLayerType[] {
   return dataset.dataSource.dataLayers;
 }
 

--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -44,7 +44,7 @@ import constants, {
 } from "oxalis/constants";
 import messages, { settings } from "messages";
 
-import Histogram from "./histogram_view";
+import Histogram, { isHistogramSupported } from "./histogram_view";
 
 const { Panel } = Collapse;
 const { Option } = Select;
@@ -135,7 +135,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
     const { alpha, color, intensityRange, isDisabled } = layer;
     let histogram = new Array(256).fill(0);
     if (this.state.histograms && this.state.histograms[layerName]) {
-      histogram = this.state.histograms[layerName].histogram;
+      ({ histogram } = this.state.histograms[layerName]);
     }
 
     return (
@@ -171,7 +171,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             {this.getFindDataButton(layerName, isDisabled)}
           </Col>
         </Row>
-        {!isDisabled && elementClass !== "float" ? (
+        {!isDisabled && isHistogramSupported(elementClass) ? (
           <Histogram
             data={histogram}
             min={intensityRange[0]}

--- a/frontend/javascripts/oxalis/view/settings/histogram_view.js
+++ b/frontend/javascripts/oxalis/view/settings/histogram_view.js
@@ -29,10 +29,7 @@ const canvasHeight = 100;
 const canvasWidth = 300;
 
 export function isHistogramSupported(elementClass: ElementClass): boolean {
-  if (["int8", "uint8"].includes(elementClass)) {
-    return true;
-  }
-  return false;
+  return ["int8", "uint8"].includes(elementClass);
 }
 
 class Histogram extends React.PureComponent<HistogramProps> {

--- a/frontend/javascripts/oxalis/view/settings/histogram_view.js
+++ b/frontend/javascripts/oxalis/view/settings/histogram_view.js
@@ -7,6 +7,7 @@ import type { Dispatch } from "redux";
 import { connect } from "react-redux";
 import { type DatasetLayerConfiguration } from "oxalis/store";
 import { updateLayerSettingAction } from "oxalis/model/actions/settings_actions";
+import { type ElementClass } from "admin/api_flow_types";
 
 type OwnProps = {|
   data: Array<number>,
@@ -26,6 +27,13 @@ type HistogramProps = {
 
 const canvasHeight = 100;
 const canvasWidth = 300;
+
+export function isHistogramSupported(elementClass: ElementClass): boolean {
+  if (["int8", "uint8"].includes(elementClass)) {
+    return true;
+  }
+  return false;
+}
 
 class Histogram extends React.PureComponent<HistogramProps> {
   canvasRef: ?HTMLCanvasElement;

--- a/frontend/javascripts/test/shaders/shader_syntax.spec.js
+++ b/frontend/javascripts/test/shaders/shader_syntax.spec.js
@@ -33,7 +33,7 @@ test("Shader syntax: Ortho Mode", t => {
 test("Shader syntax: Ortho Mode + Segmentation - Mapping", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0, segmentationLayer: 1.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: true,
     segmentationName: "segmentationLayer",
@@ -54,7 +54,7 @@ test("Shader syntax: Ortho Mode + Segmentation - Mapping", t => {
 test("Shader syntax: Ortho Mode + Segmentation + Mapping", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0, segmentationLayer: 1.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: true,
     segmentationName: "segmentationLayer",
@@ -96,7 +96,7 @@ test("Shader syntax: Arbitrary Mode (no segmentation available)", t => {
 test("Shader syntax: Arbitrary Mode (segmentation available)", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0, segmentationLayer: 1.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: true,
     segmentationName: "segmentationLayer",

--- a/frontend/javascripts/test/shaders/shader_syntax.spec.js
+++ b/frontend/javascripts/test/shaders/shader_syntax.spec.js
@@ -12,11 +12,10 @@ const DEFAULT_LOOK_UP_TEXTURE_WIDTH = getLookupBufferSize(constants.DEFAULT_GPU_
 test("Shader syntax: Ortho Mode", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    isRgbLayerLookup: { color_layer_1: false, color_layer_2: false },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: false,
     segmentationName: "",
-    segmentationPackingDegree: 1,
     isMappingSupported: true,
     dataTextureCountPerLayer: 3,
     resolutions,
@@ -34,11 +33,10 @@ test("Shader syntax: Ortho Mode", t => {
 test("Shader syntax: Ortho Mode + Segmentation - Mapping", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    isRgbLayerLookup: { color_layer_1: false, color_layer_2: false },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: true,
     segmentationName: "segmentationLayer",
-    segmentationPackingDegree: 1,
     isMappingSupported: false,
     dataTextureCountPerLayer: 3,
     resolutions,
@@ -56,11 +54,10 @@ test("Shader syntax: Ortho Mode + Segmentation - Mapping", t => {
 test("Shader syntax: Ortho Mode + Segmentation + Mapping", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    isRgbLayerLookup: { color_layer_1: false, color_layer_2: false },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: true,
     segmentationName: "segmentationLayer",
-    segmentationPackingDegree: 1,
     isMappingSupported: true,
     dataTextureCountPerLayer: 3,
     resolutions,
@@ -78,11 +75,10 @@ test("Shader syntax: Ortho Mode + Segmentation + Mapping", t => {
 test("Shader syntax: Arbitrary Mode (no segmentation available)", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    isRgbLayerLookup: { color_layer_1: false, color_layer_2: false },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: false,
     segmentationName: "",
-    segmentationPackingDegree: 1,
     isMappingSupported: true,
     dataTextureCountPerLayer: 3,
     resolutions,
@@ -100,11 +96,10 @@ test("Shader syntax: Arbitrary Mode (no segmentation available)", t => {
 test("Shader syntax: Arbitrary Mode (segmentation available)", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    isRgbLayerLookup: { color_layer_1: false, color_layer_2: false },
+    packingDegreeLookup: { color_layer_1: 4.0, color_layer_2: 4.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: false },
     hasSegmentation: true,
     segmentationName: "segmentationLayer",
-    segmentationPackingDegree: 1,
     isMappingSupported: true,
     dataTextureCountPerLayer: 3,
     resolutions,
@@ -122,11 +117,10 @@ test("Shader syntax: Arbitrary Mode (segmentation available)", t => {
 test("Shader syntax: Ortho Mode (rgb and float layer)", t => {
   const code = getMainFragmentShader({
     colorLayerNames: ["color_layer_1", "color_layer_2"],
-    isRgbLayerLookup: { color_layer_1: true, color_layer_2: false },
+    packingDegreeLookup: { color_layer_1: 1.0, color_layer_2: 4.0 },
     floatLayerLookup: { color_layer_1: false, color_layer_2: { min: 0, max: 255 } },
     hasSegmentation: false,
     segmentationName: "",
-    segmentationPackingDegree: 1,
     isMappingSupported: true,
     dataTextureCountPerLayer: 3,
     resolutions,


### PR DESCRIPTION
This PR adds uint16 color layer support. Histograms are not working correctly yet, very related to https://github.com/scalableminds/webknossos/issues/4095.

Backend ToDo (highest priority first):
- [x] ~~the backend doesn't send enough data for uint16 color layer buckets, looks like it automatically assumes uint8~~
- [ ] Histogram data for uint16 color layers is not correct yet. Can probably be done as part of #4095.
- [x] ~~the backend doesn't detect uint16 color layers correctly when importing the dataset (detects uint8 instead)~~

### URL of deployed dev instance (used for testing):
- https://supportuintcolor.webknossos.xyz

### Steps to test:
- Download the data_types dataset from our wiki which contains a uint16 layer.

### Issues:
- fixes #3781 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Updated [documentation](../blob/master/docs) if applicable
- [x] Ready for review
