### PR TITLE
Overlay Settings Menu

### DIFF
--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -20,6 +20,7 @@ Find all available keyboard shortcuts for webKnossos listed below.
 | G                             | Decrease the Move Value                     |
 | Q                             | Download Screenshot(s) of Viewport(s)       |
 | .                             | Toggle Viewport Maximization                |
+| -                             | Toggle Settings Menu                        |
 
 ## Skeleton Tracings
 

--- a/flow-typed/npm/antd_vx.x.x.js
+++ b/flow-typed/npm/antd_vx.x.x.js
@@ -21,6 +21,7 @@ declare module "antd" {
     static RangePicker: typeof DatePickerRangePicker;
   }
   declare export class Divider<P> extends React$Component<P> {}
+  declare export class Drawer<P> extends React$Component<P> {}
   declare export class Dropdown<P> extends React$Component<P> {}
   declare export class Icon<P> extends React$Component<P> {}
   declare class InputGroup<P> extends React$Component<P> {}

--- a/frontend/javascripts/admin/help/keyboardshortcut_view.js
+++ b/frontend/javascripts/admin/help/keyboardshortcut_view.js
@@ -137,6 +137,10 @@ const KeyboardShortcutView = () => {
       keybinding: ".",
       action: "Toggle Viewport Maximization",
     },
+    {
+      keybinding: "-",
+      action: "Toggle Settings Menu",
+    },
   ];
 
   const flightModeShortcuts = [

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -34,6 +34,7 @@ import messages from "messages";
 import window, { document, location } from "libs/window";
 import ErrorHandling from "libs/error_handling";
 import CrossOriginApi from "oxalis/api/cross_origin_api";
+import Shortcut from "libs/shortcut_component";
 
 import { GoldenLayoutAdapter } from "./golden_layout_adapter";
 import { determineLayout } from "./default_layout_configs";
@@ -224,6 +225,7 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
             </div>
           </RenderToPortal>
           <Layout style={{ display: "flex" }}>
+            <Shortcut keys="-" onTrigger={this.handleSettingsCollapse} />
             <Drawer
               placement="left"
               visible={!this.state.isSettingsCollapsed}

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -3,7 +3,7 @@
  * @flow
  */
 
-import { Alert, Icon, Layout, Tooltip } from "antd";
+import { Alert, Icon, Layout, Drawer, Tooltip } from "antd";
 import type { Dispatch } from "redux";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
@@ -224,17 +224,17 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
             </div>
           </RenderToPortal>
           <Layout style={{ display: "flex" }}>
-            <Sider
-              collapsible
-              trigger={null}
-              collapsed={this.state.isSettingsCollapsed}
-              collapsedWidth={0}
+            <Drawer
+              placement="left"
+              visible={!this.state.isSettingsCollapsed}
               width={350}
-              style={{ zIndex: 100, marginRight: this.state.isSettingsCollapsed ? 0 : 8 }}
+              bodyStyle={{ padding: "24px 0px" }}
+              mask={false}
+              onClose={this.handleSettingsCollapse}
             >
               {/* Don't render SettingsView if it's hidden to improve performance */}
               {!this.state.isSettingsCollapsed ? <SettingsView /> : null}
-            </Sider>
+            </Drawer>
 
             <div id={canvasAndLayoutContainerID} style={{ position: "relative" }}>
               <TracingView />


### PR DESCRIPTION
This was bugging me for a while. I moved the settings into a `Drawer` component. Now the settings menu will overlay of the workbench instead of pushing the content to the right.

![2019-06-28 12 36 14](https://user-images.githubusercontent.com/1105056/60337515-90d35a00-99a3-11e9-8c76-d0dd2778a457.gif)

### URL of deployed dev instance (used for testing):
- https://drawer.webknossos.xyz

### Steps to test:
- Open settings
- do something with settings / change brightness etc
- work in wk
- close settings

### Issues:
- fixes #3934

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
