### PR TITLE
Allow magnification restriction for volume tasks

### DIFF
--- a/frontend/javascripts/admin/tasktype/task_type_create_view.js
+++ b/frontend/javascripts/admin/tasktype/task_type_create_view.js
@@ -278,49 +278,49 @@ class TaskTypeCreateView extends React.PureComponent<Props, State> {
                   valuePropName: "checked",
                 })(<Checkbox>Allow Branchpoints</Checkbox>)}
               </FormItem>
+            </div>
 
-              <FormItem style={{ marginBottom: 6 }}>
-                {getFieldDecorator("settings.allowedMagnifications.shouldRestrict", {
-                  valuePropName: "checked",
-                })(
-                  <Checkbox>
-                    Restrict Magnifications{" "}
-                    <Tooltip
-                      title="The magnifications should be specified as power-of-two numbers. For example, if users should only be able to trace in the best and second best magnification, the minimum should be 1 and the maximum should be 2. The third and fourth magnifications can be addressed with 4 and 8."
-                      placement="right"
-                    >
-                      <Icon type="info-circle" />
-                    </Tooltip>
-                  </Checkbox>,
-                )}
-              </FormItem>
+            <FormItem style={{ marginBottom: 6 }}>
+              {getFieldDecorator("settings.allowedMagnifications.shouldRestrict", {
+                valuePropName: "checked",
+              })(
+                <Checkbox>
+                  Restrict Magnifications{" "}
+                  <Tooltip
+                    title="The magnifications should be specified as power-of-two numbers. For example, if users should only be able to trace in the best and second best magnification, the minimum should be 1 and the maximum should be 2. The third and fourth magnifications can be addressed with 4 and 8."
+                    placement="right"
+                  >
+                    <Icon type="info-circle" />
+                  </Tooltip>
+                </Checkbox>,
+              )}
+            </FormItem>
 
-              <div
-                style={{
-                  marginLeft: 24,
-                  display: this.props.form.getFieldValue(
-                    "settings.allowedMagnifications.shouldRestrict",
-                  )
-                    ? "block"
-                    : "none",
-                }}
-              >
-                <div>
-                  <FormItem hasFeedback style={{ marginBottom: 6 }}>
-                    Minimum:{" "}
-                    {getFieldDecorator("settings.allowedMagnifications.min", {
-                      rules: [{ validator: isValidMagnification }],
-                    })(<InputNumber min={1} size="small" />)}
-                  </FormItem>
-                </div>
-                <div>
-                  <FormItem hasFeedback>
-                    Maximum:{" "}
-                    {getFieldDecorator("settings.allowedMagnifications.max", {
-                      rules: [{ validator: isValidMagnification }],
-                    })(<InputNumber min={1} size="small" />)}
-                  </FormItem>
-                </div>
+            <div
+              style={{
+                marginLeft: 24,
+                display: this.props.form.getFieldValue(
+                  "settings.allowedMagnifications.shouldRestrict",
+                )
+                  ? "block"
+                  : "none",
+              }}
+            >
+              <div>
+                <FormItem hasFeedback style={{ marginBottom: 6 }}>
+                  Minimum:{" "}
+                  {getFieldDecorator("settings.allowedMagnifications.min", {
+                    rules: [{ validator: isValidMagnification }],
+                  })(<InputNumber min={1} size="small" />)}
+                </FormItem>
+              </div>
+              <div>
+                <FormItem hasFeedback>
+                  Maximum:{" "}
+                  {getFieldDecorator("settings.allowedMagnifications.max", {
+                    rules: [{ validator: isValidMagnification }],
+                  })(<InputNumber min={1} size="small" />)}
+                </FormItem>
               </div>
             </div>
 


### PR DESCRIPTION
Review with the `Hide whitespace changes` option activated. I simply moved the setting out of the skeleton-only block. Not sure whether it was intentional to only have this setting for skeleton tasks or by accident. In my testing it worked perfectly well for volume tasks.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a volume task type with restricted magnifications, create a task and trace it.
- Look at the info tab to see the current magnification and zoom in/out -> you should stay within the restricted magnification range

### Issues:
- fixes https://discuss.webknossos.org/t/how-to-ask-a-user-to-trace-in-specific-mag-level/1467/9

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
