### PR TITLE
Added more space between tree names and checkbox

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -332,14 +332,18 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
       // Defining background color of current node
       const styleClass = this.getNodeStyleClassForBackground(node.id);
       nodeProps.title = (
-        <div data-id={node.id} onClick={this.onSelectTree} className={styleClass}>
+        <div className={styleClass}>
           <Checkbox
             checked={tree.isVisible}
             onChange={this.onCheck}
             node={node}
             style={CHECKBOX_STYLE}
           />
-          {` (${tree.nodes.size()}) ${tree.name}`}
+          <div
+            data-id={node.id}
+            style={{ marginLeft: 10, display: "inline" }}
+            onClick={this.onSelectTree}
+          >{` (${tree.nodes.size()}) ${tree.name}`}</div>
         </div>
       );
       nodeProps.className = "tree-type";


### PR DESCRIPTION
Issues #4120 describes that tree toggling moves the wK position. One speculation is, that the user is miss-clicking the checkbox for toggling a tree. Consequently, the tree is selected / clicked and wK jumps to the tree's position.

As a workaround, I added slightly more margin between the checkbox and tree name / text to avoid accidental misclicks. Hopefully this mitigates the issue somewhat.

### Steps to test:
- Start a skeleton tracing
- create a few tree
- click on the checkboxes to toggle the trees
- slightly miss-clicking the checkbox should not invoke a jump / select a tree

### Issues:
- potentially fixes #4120

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
