### PR TITLE
Fixed Bug with Collapse/Expand All Tree Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Fixed a bug where volume tracings could not be converted to hybrid. [#4159](https://github.com/scalableminds/webknossos/pull/4159)
+- Fixed a bug where collapsing/expanding all tree groups would trigger when toggling a single tree [#4178](https://github.com/scalableminds/webknossos/pull/4178)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -181,18 +181,23 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
   };
 
   setExpansionOfAllSubgroupsTo = (groupId: number, expanded: boolean) => {
+    const newExpandedGroupIds = Object.assign({}, this.state.expandedGroupIds);
     const collapseAllGroups = groupTree => {
       const copyOfGroupTree = _.cloneDeep(groupTree);
       findTreeNode(copyOfGroupTree, groupId, item => {
         forEachTreeNode(item.children, node => {
           if (node.type === TYPE_GROUP) {
             node.expanded = expanded;
+            newExpandedGroupIds[node.id] = expanded;
           }
         });
       });
       return copyOfGroupTree;
     };
-    this.setState(prevState => ({ groupTree: collapseAllGroups(prevState.groupTree) }));
+    this.setState(prevState => ({
+      groupTree: collapseAllGroups(prevState.groupTree),
+      expandedGroupIds: newExpandedGroupIds,
+    }));
   };
 
   onMoveNode = (params: {


### PR DESCRIPTION
This PR fixes the inconsistencies when collapsing/expanding all tree groups or sub-groups introduced by PR #4143. See issue description:  #4162

It looks like the expansion state of each node/group is saved in two different places: 
1. The `node` itself: `node.expanded`
2. And in the component's state: `this.state.expandedGroupIds

As far as I can tell, adding `expandedGroupIds` to the `setExpansionOfAllSubgroupsTo` solves this issue.

### URL of deployed dev instance (used for testing):
- https://expandall.webknossos.xyz

### Steps to test:
- Valentin already tested the fix 

### Issues:
- fixes #4162

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
