### PR TITLE
API: Send error chain also with ParamFailures

### DIFF
--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -19,8 +19,8 @@ trait ResultBox extends I18nSupport {
   def asResult[T <: Result](b: Box[T])(implicit messages: MessagesProvider): Result = b match {
     case Full(result) =>
       result
-    case ParamFailure(msg, _, _, statusCode: Int) =>
-      new JsonResult(statusCode)(Messages(msg))
+    case ParamFailure(msg, _, chain, statusCode: Int) =>
+      new JsonResult(statusCode)(Messages(msg), formatChainOpt(chain))
     case ParamFailure(msg, _, _, msgs: JsArray) =>
       new JsonResult(BAD_REQUEST)(jsonMessages(msgs))
     case Failure(msg, _, chain) =>


### PR DESCRIPTION
In case of `~> ERROR_CODE` the Fox is turned into a ParamFailure Fox. Our controllers now send the error chain in this case too.

### URL of deployed dev instance (used for testing):
- https://paramfailurechain.webknossos.xyz

### Steps to test:
- provoke an error that should have a chain and a non-400 error code (e.g. compoundView multiple finished volume tasks)
- error json should have a chain AND have its non-400 error code, (e.g. 404 in the above exmaple)

### Issues:
- fixes #4165 
- fixes #4148 

------
- ~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [x] Needs datastore update after deployment
- [x] Ready for review
