### PR TITLE
Log Annotation resetToBase, including old Tracing ID

### DIFF
--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -563,6 +563,8 @@ class AnnotationService @Inject()(annotationInformationProvider: AnnotationInfor
     case AnnotationType.Task if annotation.skeletonTracingId.isDefined =>
       for {
         task <- taskFor(annotation)
+        _ = logger.warn(
+          s"Resetting annotation ${annotation._id} to base, discarding skeleton tracing ${annotation.skeletonTracingId}")
         annotationBase <- baseForTask(task._id)
         dataSet <- dataSetDAO.findOne(annotationBase._dataSet)(GlobalAccessContext) ?~> "dataSet.notFound"
         (newSkeletonIdOpt, newVolumeIdOpt) <- tracingFromBase(annotationBase, dataSet)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://logreset.webknossos.xyz

### Steps to test:
- create a task, trace some, click “reset” in admin task list view
- backend logs should show the relevant IDs

------
- ~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- ~[ ] Needs datastore update after deployment~
- [x] Ready for review
