### PR TITLE
Allow to remove isosurfaces with ctrl click in 3D viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Added
 - Volume tasks with only one finished instance can now be viewed as CompoundTask. [#4167](https://github.com/scalableminds/webknossos/pull/4167)
+- Added the possibility to remove isosurfaces from the 3D viewport by CTRL+Clicking it. [#4185](https://github.com/scalableminds/webknossos/pull/4185)
 
 ### Changed
 - Volume project download zips are reorganized to contain a zipfile for each annotation (that in turn contains a data.zip and an nml file). [#4167](https://github.com/scalableminds/webknossos/pull/4167)

--- a/docs/mesh_visualization.md
+++ b/docs/mesh_visualization.md
@@ -12,6 +12,7 @@ To activate a cell, use shift+click on a segment in the tracing view.
 The isosurface is computed in chunks, which is why the isosurface is likely to appear bit by bit.
 When hovering over an isosurface in the 3D viewport, the cell will also be highlighted in the other viewports.
 Shift + Click on an isosurface in the 3D viewport will change the active position to where you clicked.
+CTRL + Click on an isosurface will remove that isosurface again.
 
 ![Generating isosurfaces for specific cell ids via shift+click](./images/isosurface-demo.gif)
 

--- a/frontend/javascripts/oxalis/controller/scene_controller.js
+++ b/frontend/javascripts/oxalis/controller/scene_controller.js
@@ -197,6 +197,16 @@ class SceneController {
     this.isosurfacesGroupsPerSegmentationId[segmentationId].add(mesh);
   }
 
+  removeIsosurfaceById(segmentationId): void {
+    if (this.isosurfacesGroupsPerSegmentationId[segmentationId] == null) {
+      return;
+    }
+
+    const group = this.isosurfacesGroupsPerSegmentationId[segmentationId];
+    this.isosurfacesRootGroup.remove(group);
+    this.isosurfacesGroupsPerSegmentationId[segmentationId] = null;
+  }
+
   addLights(): void {
     // At the moment, we only attach an AmbientLight for the isosurfaces group.
     // The PlaneView attaches a directional light directly to the TD camera,

--- a/frontend/javascripts/oxalis/controller/td_controller.js
+++ b/frontend/javascripts/oxalis/controller/td_controller.js
@@ -31,6 +31,7 @@ import Store, { type CameraData, type Flycam, type OxalisState, type Tracing } f
 import TrackballControls from "libs/trackball_controls";
 import * as Utils from "libs/utils";
 import * as skeletonController from "oxalis/controller/combinations/skeletontracing_plane_controller";
+import { removeIsosurfaceAction } from "oxalis/model/actions/annotation_actions";
 
 export function threeCameraToCameraData(camera: THREE.OrthographicCamera): CameraData {
   const { position, up, near, far, lookAt, left, right, top, bottom } = camera;
@@ -138,7 +139,7 @@ class TDController extends React.PureComponent<Props> {
               Store.dispatch(setMousePositionAction([position.x, position.y]));
             },
             leftClick: (_pos: Point2, _plane: OrthoView, event: MouseEvent) => {
-              if (this.props.planeView == null || !event.shiftKey) {
+              if (this.props.planeView == null) {
                 return;
               }
               const hitPosition = this.props.planeView.performIsosurfaceHitTest();
@@ -147,7 +148,14 @@ class TDController extends React.PureComponent<Props> {
               }
 
               const unscaledPosition = V3.divide3(hitPosition.toArray(), this.props.scale);
-              Store.dispatch(setPositionAction(unscaledPosition));
+
+              if (event.shiftKey) {
+                Store.dispatch(setPositionAction(unscaledPosition));
+              } else if (event.ctrlKey) {
+                const storeState = Store.getState();
+                const { hoveredIsosurfaceId } = storeState.temporaryConfiguration;
+                Store.dispatch(removeIsosurfaceAction(hoveredIsosurfaceId));
+              }
             },
           };
 

--- a/frontend/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/annotation_actions.js
@@ -74,6 +74,11 @@ export type ImportIsosurfaceFromStlAction = {
   buffer: ArrayBuffer,
 };
 
+export type RemoveIsosurfaceAction = {
+  type: "REMOVE_ISOSURFACE",
+  cellId: number,
+};
+
 export type AnnotationActionTypes =
   | InitializeAnnotation
   | SetAnnotationNameAction
@@ -87,7 +92,8 @@ export type AnnotationActionTypes =
   | CreateMeshFromBufferAction
   | UpdateLocalMeshMetaDataAction
   | TriggerIsosurfaceDownloadAction
-  | ImportIsosurfaceFromStlAction;
+  | ImportIsosurfaceFromStlAction
+  | RemoveIsosurfaceAction;
 
 export const initializeAnnotationAction = (annotation: APIAnnotation): InitializeAnnotation => ({
   type: "INITIALIZE_ANNOTATION",
@@ -173,4 +179,9 @@ export const importIsosurfaceFromStlAction = (
 ): ImportIsosurfaceFromStlAction => ({
   type: "IMPORT_ISOSURFACE_FROM_STL",
   buffer,
+});
+
+export const removeIsosurfaceAction = (cellId: number): RemoveIsosurfaceAction => ({
+  type: "REMOVE_ISOSURFACE",
+  cellId,
 });


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://deleteisosurfaces.webknossos.xyz

### Steps to test:
- open a dataset with a segmentation in view mode
- enable isosurface option in dataset settings
- load isosurfaces via shift+click
- hide isosurfaces by ctrl+clicking an isosurface in the 3D viewport

### Issues:
- fixes #4140

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
~- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [x] Updated [documentation](../blob/master/docs) if applicable
~- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
~- [ ] Needs datastore update after deployment~
- [X] Ready for review
