### PR TITLE
Ensure a warning is shown when segmentation is disappearing due to layout changes

### DIFF
--- a/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
@@ -1,6 +1,13 @@
 // @flow
 import { type EditableAnnotation, editAnnotation } from "admin/admin_rest_api";
-import { type Saga, _takeEvery, call, select, take } from "oxalis/model/sagas/effect-generators";
+import {
+  type Saga,
+  _takeEvery,
+  call,
+  select,
+  take,
+  _delay,
+} from "oxalis/model/sagas/effect-generators";
 import {
   isVolumeTracingDisallowed,
   isSegmentationMissingForZoomstep,
@@ -54,6 +61,8 @@ export function* warnAboutSegmentationOpacity(): Saga<void> {
   }
 
   yield* take("WK_READY");
+  // Wait before showing the initial warning. Due to initialization lag it may only be visible very briefly, otherwise.
+  yield _delay(5000);
   yield* warnMaybe();
 
   while (true) {

--- a/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
@@ -53,7 +53,7 @@ export function* warnAboutSegmentationOpacity(): Saga<void> {
     }
   }
 
-  yield* take("INITIALIZE_SETTINGS");
+  yield* take("WK_READY");
   yield* warnMaybe();
 
   while (true) {
@@ -62,6 +62,7 @@ export function* warnAboutSegmentationOpacity(): Saga<void> {
       "ZOOM_OUT",
       "ZOOM_BY_DELTA",
       "SET_ZOOM_STEP",
+      "SET_STORED_LAYOUTS",
       action =>
         action.type === "UPDATE_DATASET_SETTING" && action.propertyName === "segmentationOpacity",
     ]);


### PR DESCRIPTION
Also fixed that the warning was not displayed immediately when loading the tracing.

### URL of deployed dev instance (used for testing):
- https://showsegmentationwarning.webknossos.xyz

### Steps to test:
- Open a volume tracing with existing segmentation. Zoom out so the segmentation is not displayed. Reload the page - the warning should be displayed without having to zoom first.
- Open a volume tracing with existing segmentation. Zoom out so you are at the edge of the segmentation disappearing (you should see the segmentation). Now enlarge the data viewports until the segmentation disappears (due to the active resolution changing) - the warning should be displayed.

### Issues:
- fixes #4181 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- [x] Ready for review
