### PR TITLE
Do not load data for disabled or invisible layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 -
 
 ### Fixed
--
+- Data for disabled or invisible layers will no longer be downloaded, saving bandwidth and speeding up webKnossos in general. [#4202](https://github.com/scalableminds/webknossos/pull/4202)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
@@ -10,9 +10,14 @@ import type {
   APISegmentationLayer,
   ElementClass,
 } from "admin/api_flow_types";
-import type { Settings, DataLayerType } from "oxalis/store";
+import type { Settings, DataLayerType, DatasetConfiguration } from "oxalis/store";
 import ErrorHandling from "libs/error_handling";
-import constants, { ViewModeValues, type Vector3, Vector3Indicies } from "oxalis/constants";
+import constants, {
+  ViewModeValues,
+  type Vector3,
+  Vector3Indicies,
+  type ViewMode,
+} from "oxalis/constants";
 import { aggregateBoundingBox } from "libs/utils";
 import { formatExtentWithLength, formatNumberToLength } from "libs/format_utils";
 import messages from "messages";
@@ -308,6 +313,22 @@ const keyResolutionsByMax = memoizeOne(_keyResolutionsByMax);
 export function getResolutionByMax(dataset: APIDataset, maxDim: number): Vector3 {
   const keyedResolutionsByMax = keyResolutionsByMax(dataset);
   return keyedResolutionsByMax[maxDim];
+}
+
+export function isLayerVisible(
+  dataset: APIDataset,
+  layerName: string,
+  datasetConfiguration: DatasetConfiguration,
+  viewMode: ViewMode,
+): boolean {
+  const isPlaneMode = constants.MODES_PLANE.includes(viewMode);
+  if (isSegmentationLayer(dataset, layerName)) {
+    // Segmentation layers are only displayed in plane mode for now
+    return datasetConfiguration.segmentationOpacity > 0 && isPlaneMode;
+  } else {
+    const layerConfig = datasetConfiguration.layers[layerName];
+    return !layerConfig.isDisabled && layerConfig.alpha > 0;
+  }
 }
 
 export default {};

--- a/frontend/javascripts/oxalis/model/data_layer.js
+++ b/frontend/javascripts/oxalis/model/data_layer.js
@@ -64,7 +64,6 @@ class DataLayer {
       this.cube,
       textureWidth,
       dataTextureCount,
-      isSegmentation,
     );
   }
 

--- a/frontend/javascripts/oxalis/shaders/main_data_fragment.glsl.js
+++ b/frontend/javascripts/oxalis/shaders/main_data_fragment.glsl.js
@@ -161,6 +161,8 @@ void main() {
   // Get Color Value(s)
   vec3 data_color = vec3(0.0);
   vec3 color_value  = vec3(0.0);
+  vec3 range  = vec3(0.0);
+  vec3 rangeMin  = vec3(0.0);
   <% _.each(colorLayerNames, function(name, layerIndex){ %>
 
     // Get grayscale value for <%= name %>
@@ -177,8 +179,8 @@ void main() {
 
     <% if (floatLayerLookup[name]) { %>
       // Adjust the value range of the float values
-      vec3 range = vec3(<%= formatNumberAsGLSLFloat(floatLayerLookup[name].max - floatLayerLookup[name].min) %>);
-      vec3 rangeMin = vec3(<%= formatNumberAsGLSLFloat(floatLayerLookup[name].min) %>);
+      range = vec3(<%= formatNumberAsGLSLFloat(floatLayerLookup[name].max - floatLayerLookup[name].min) %>);
+      rangeMin = vec3(<%= formatNumberAsGLSLFloat(floatLayerLookup[name].min) %>);
       color_value = (color_value + rangeMin) / range;
     <% } else { %>
 


### PR DESCRIPTION
/cc @MichaelBuessemeyer This is somewhat relevant for your issue #4044 as well, so you could have a look at this PR as well :)

Also, I fixed a bug where the shader crashed when there were multiple float layers :see_no_evil: (Will be obsolete with the Histogram PR as well, though) :)

### URL of deployed dev instance (used for testing):
- https://savebandwidth.webknossos.xyz

### Steps to test:
- Open a dataset with many layers, disable some of them or set alpha to 0. Move around - data should quicker than when all layers were enabled and you should only see bucket requests for visible layers in the network tab.
- Open a dataset with a segmentation layer. Switch to arbitrary mode. - You should see no requests for segmentation buckets in the network tab.

### Issues:
- fixes #3671 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
