### PR TITLE
Suppress ResizeObserver loop errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed a bug where for uint24 color layers, scrambled data was shown for missing magnifications. [#4188](https://github.com/scalableminds/webknossos/pull/4188)
 - Fixed a bug where collapsing/expanding all tree groups would trigger when toggling a single tree [#4178](https://github.com/scalableminds/webknossos/pull/4178)
 - Fixed performance for time logging. [#4196](https://github.com/scalableminds/webknossos/pull/4196)
+- Fixed an error message when quickly resizing the browser window. [#4205](https://github.com/scalableminds/webknossos/pull/4205)
 
 ### Removed
 -

--- a/frontend/javascripts/libs/error_handling.js
+++ b/frontend/javascripts/libs/error_handling.js
@@ -13,6 +13,7 @@ import window, { document, location } from "libs/window";
 
 // No more than MAX_NUM_ERRORS will be reported to airbrake
 const MAX_NUM_ERRORS = 50;
+const BLACKLISTED_ERROR_MESSAGES = ["ResizeObserver loop limit exceeded"];
 
 type ErrorHandlingOptions = {
   throwAssertions: boolean,
@@ -116,6 +117,10 @@ class ErrorHandling {
     });
 
     window.onerror = (message: string, file: string, line: number, colno: number, error: Error) => {
+      if (BLACKLISTED_ERROR_MESSAGES.indexOf(message) > -1) {
+        console.warn("Ignoring", message);
+        return;
+      }
       if (error == null) {
         // older browsers don't deliver the error parameter
         error = new Error(message);


### PR DESCRIPTION
See https://stackoverflow.com/a/50387233/896760.
I don't know from where exactly the error is coming from (multiple of the required npm packages use that observer, e.g. antd), but in the end it doesn't really matter since we are suppressing it, anyway. In my browser, the "message" attribute was the only usable identifier for the error, which is why I used that for blacklisting.

### URL of deployed dev instance (used for testing):
- https://suppressresizeobservererrors.webknossos.xyz

### Steps to test:
- go to the statistics > time tracking view
- load up some time data
- resize the browser as if you were on fire
- --> only a warning should be logged to the console

### Issues:
- see https://discuss.webknossos.org/t/a-few-updates-for-the-time-tracking-tool/1374/18

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- ~[ ] Needs datastore update after deployment~
- [X] Ready for review
