### PR TITLE
newer circleci machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   build_test_deploy:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     environment:
       USER_NAME: circleci
       USER_UID: 1001


### PR DESCRIPTION
- Uses a newer CircleCI machine image with Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1

------
- [x] Ready for review
