### PR TITLE
Prefix local storage access with user email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed a bug where for uint24 color layers, scrambled data was shown for missing magnifications. [#4188](https://github.com/scalableminds/webknossos/pull/4188)
 - Fixed a bug where collapsing/expanding all tree groups would trigger when toggling a single tree [#4178](https://github.com/scalableminds/webknossos/pull/4178)
 - Fixed performance for time logging. [#4196](https://github.com/scalableminds/webknossos/pull/4196)
+- Personal tracing layouts are saved per user now. [#4217](https://github.com/scalableminds/webknossos/pull/4217)
 
 ### Removed
 -

--- a/frontend/javascripts/dashboard/dashboard_view.js
+++ b/frontend/javascripts/dashboard/dashboard_view.js
@@ -14,6 +14,7 @@ import DatasetView from "dashboard/dataset_view";
 import ExplorativeAnnotationsView from "dashboard/explorative_annotations_view";
 import NmlUploadZoneContainer from "oxalis/view/nml_upload_zone_container";
 import Request from "libs/request";
+import UserLocalStorage from "libs/user_local_storage";
 
 const { TabPane } = Tabs;
 
@@ -45,7 +46,7 @@ class DashboardView extends React.PureComponent<PropsWithRouter, State> {
 
     const validTabKeys = this.getValidTabKeys();
     const { initialTabKey } = this.props;
-    const lastUsedTabKey = localStorage.getItem("lastUsedDashboardTab");
+    const lastUsedTabKey = UserLocalStorage.getItem("lastUsedDashboardTab");
     const defaultTabKey = this.props.isAdminView ? "tasks" : "datasets";
 
     // Flow doesn't allow validTabKeys[key] where key may be null, so check that first
@@ -132,7 +133,7 @@ class DashboardView extends React.PureComponent<PropsWithRouter, State> {
       const tabKeyToURLMap = _.invert(urlTokenToTabKeyMap);
       const url = tabKeyToURLMap[activeTabKey];
       if (url) {
-        localStorage.setItem("lastUsedDashboardTab", activeTabKey);
+        UserLocalStorage.setItem("lastUsedDashboardTab", activeTabKey);
         if (!this.props.isAdminView) {
           this.props.history.push(`/dashboard/${url}`);
         }

--- a/frontend/javascripts/dashboard/dataset_view.js
+++ b/frontend/javascripts/dashboard/dataset_view.js
@@ -14,6 +14,7 @@ import Persistence from "libs/persistence";
 import SampleDatasetsModal from "dashboard/dataset/sample_datasets_modal";
 import * as Utils from "libs/utils";
 import renderIndependently from "libs/render_independently";
+import UserLocalStorage from "libs/user_local_storage";
 
 const { Search, Group: InputGroup } = Input;
 
@@ -46,13 +47,13 @@ const persistence: Persistence<State> = new Persistence(
 export const wkDatasetsCacheKey = "wk.datasets";
 export const datasetCache = {
   set(datasets: APIMaybeUnimportedDataset[]): void {
-    localStorage.setItem(wkDatasetsCacheKey, JSON.stringify(datasets));
+    UserLocalStorage.setItem(wkDatasetsCacheKey, JSON.stringify(datasets));
   },
   get(): APIMaybeUnimportedDataset[] {
-    return Utils.parseAsMaybe(localStorage.getItem(wkDatasetsCacheKey)).getOrElse([]);
+    return Utils.parseAsMaybe(UserLocalStorage.getItem(wkDatasetsCacheKey)).getOrElse([]);
   },
   clear(): void {
-    localStorage.removeItem(wkDatasetsCacheKey);
+    UserLocalStorage.removeItem(wkDatasetsCacheKey);
   },
 };
 

--- a/frontend/javascripts/dashboard/explorative_annotations_view.js
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.js
@@ -30,6 +30,7 @@ import Toast from "libs/toast";
 import * as Utils from "libs/utils";
 import messages from "messages";
 import { trackAction } from "oxalis/model/helpers/analytics";
+import UserLocalStorage from "libs/user_local_storage";
 
 const { Column } = Table;
 const { Search } = Input;
@@ -99,7 +100,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
 
   restoreSearchTags() {
     // restore the search query tags from the last session
-    const searchTagString = localStorage.getItem("lastDashboardSearchTags");
+    const searchTagString = UserLocalStorage.getItem("lastDashboardSearchTags");
     if (searchTagString) {
       try {
         const searchTags = JSON.parse(searchTagString);
@@ -297,7 +298,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
     if (!this.state.tags.includes(tag)) {
       this.setState(prevState => {
         const newTags = update(prevState.tags, { $push: [tag] });
-        localStorage.setItem("lastDashboardSearchTags", JSON.stringify(newTags));
+        UserLocalStorage.setItem("lastDashboardSearchTags", JSON.stringify(newTags));
         return { tags: newTags };
       });
     }
@@ -306,7 +307,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
   removeTagFromSearch = (tag: string): void => {
     this.setState(prevState => {
       const newTags = prevState.tags.filter(t => t !== tag);
-      localStorage.setItem("lastDashboardSearchTags", JSON.stringify(newTags));
+      UserLocalStorage.setItem("lastDashboardSearchTags", JSON.stringify(newTags));
       return { tags: newTags };
     });
   };

--- a/frontend/javascripts/libs/user_local_storage.js
+++ b/frontend/javascripts/libs/user_local_storage.js
@@ -1,0 +1,32 @@
+// @flow
+
+import Store from "oxalis/store";
+
+function prefixKey(key) {
+  const { activeUser } = Store.getState();
+  console.log("activeUser", activeUser);
+  const prefix = !activeUser ? "Anonymous" : activeUser.email;
+  return `${prefix}-${key}`;
+}
+
+const UserLocalStorage = {
+  getItem(key: string): ?string {
+    console.log("getting", key);
+    return localStorage.getItem(prefixKey(key));
+  },
+
+  setItem(key: string, value: string): void {
+    console.log("setting", key);
+    return localStorage.setItem(prefixKey(key), value);
+  },
+
+  clear(): void {
+    localStorage.clear();
+  },
+
+  removeItem(key: string): void {
+    return localStorage.removeItem(key);
+  },
+};
+
+export default UserLocalStorage;

--- a/frontend/javascripts/libs/user_local_storage.js
+++ b/frontend/javascripts/libs/user_local_storage.js
@@ -17,12 +17,12 @@ const UserLocalStorage = {
     return localStorage.setItem(prefixKey(key), value);
   },
 
-  clear(): void {
-    localStorage.clear();
+  removeItem(key: string): void {
+    return localStorage.removeItem(prefixKey(key));
   },
 
-  removeItem(key: string): void {
-    return localStorage.removeItem(key);
+  clear(): void {
+    localStorage.clear();
   },
 };
 

--- a/frontend/javascripts/libs/user_local_storage.js
+++ b/frontend/javascripts/libs/user_local_storage.js
@@ -4,19 +4,16 @@ import Store from "oxalis/store";
 
 function prefixKey(key) {
   const { activeUser } = Store.getState();
-  console.log("activeUser", activeUser);
   const prefix = !activeUser ? "Anonymous" : activeUser.email;
   return `${prefix}-${key}`;
 }
 
 const UserLocalStorage = {
   getItem(key: string): ?string {
-    console.log("getting", key);
     return localStorage.getItem(prefixKey(key));
   },
 
   setItem(key: string, value: string): void {
-    console.log("setting", key);
     return localStorage.setItem(prefixKey(key), value);
   },
 

--- a/frontend/javascripts/oxalis/view/action-bar/add_new_layout_modal.js
+++ b/frontend/javascripts/oxalis/view/action-bar/add_new_layout_modal.js
@@ -18,16 +18,18 @@ class AddNewLayoutModal extends React.PureComponent<Props, State> {
     value: "",
   };
 
+  onConfirm = () => {
+    const value = this.state.value;
+    this.setState({ value: "" });
+    this.props.addLayout(value);
+  };
+
   render() {
     return (
       <Modal
         title="Add a new layout"
         visible={this.props.visible}
-        onOk={() => {
-          const value = this.state.value;
-          this.setState({ value: "" });
-          this.props.addLayout(value);
-        }}
+        onOk={this.onConfirm}
         onCancel={this.props.onCancel}
       >
         <Input
@@ -36,6 +38,8 @@ class AddNewLayoutModal extends React.PureComponent<Props, State> {
           onChange={evt => {
             this.setState({ value: evt.target.value });
           }}
+          autoFocus
+          onPressEnter={this.onConfirm}
         />
       </Modal>
     );

--- a/frontend/javascripts/oxalis/view/layouting/layout_persistence.js
+++ b/frontend/javascripts/oxalis/view/layouting/layout_persistence.js
@@ -85,7 +85,6 @@ function readStoredLayoutConfigs() {
 listenToStoreProperty(
   storeState => storeState.activeUser,
   () => {
-    console.log("Dispatching setStoredLayoutsAction");
     Store.dispatch(setStoredLayoutsAction(readStoredLayoutConfigs()));
   },
   true,

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -95,7 +95,7 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
     ) {
       lastActiveLayout = props.storedLayouts.LastActiveLayouts[layoutType];
     } else {
-      // added as a valide fallback when there are no stored last active layouts
+      // added as a fallback when there are no stored last active layouts
       const firstStoredLayout = Object.keys(props.storedLayouts[layoutType])[0];
       lastActiveLayout = firstStoredLayout;
     }


### PR DESCRIPTION
According to `main.js`, the entire rendering of views is blocked by loading the active user. So, simply depending on the store synchronously should work pretty well. For the layouts, my testing showed that everything works as expected, except for logging in on a tracing page without reloading. One could expect that the layout is changed automatically (to the last layout used by the logged in user). However, the layout code itself is quite brittle which is why I didn't want to touch that. Also, the impact isn't really big. What happens now is that the layout stays the same, but after reloading the last active layout (by the user) is loaded again.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- change the layout while being logged in (and off)
- log in / out and check that the layouts are persisted 

### Issues:
- fixes #4190 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
