### PR TITLE
Ensure that the timetracking tooltip is removed when the mouse leaves diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Data for disabled or invisible layers will no longer be downloaded, saving bandwidth and speeding up webKnossos in general. [#4202](https://github.com/scalableminds/webknossos/pull/4202)
+- Fixed tooltip not disappearing in the statistics view in certain circumstances. [#4219](https://github.com/scalableminds/webknossos/pull/4219)
 
 ### Removed
 -

--- a/frontend/javascripts/admin/time/time_line_chart_view.js
+++ b/frontend/javascripts/admin/time/time_line_chart_view.js
@@ -26,8 +26,10 @@ export default class TimeTrackingChart extends React.PureComponent<Props> {
   chartScrollElement: ?HTMLElement = null;
 
   componentWillUnmount() {
-    if (this.chartScrollElement) {
-      this.chartScrollElement.removeEventListener("mousemove", this.adjustTooltipPosition);
+    const { chartScrollElement } = this;
+    if (chartScrollElement) {
+      chartScrollElement.removeEventListener("mousemove", this.adjustTooltipPosition);
+      chartScrollElement.removeEventListener("mouseleave", this.removeTooltip);
     }
   }
 
@@ -38,11 +40,21 @@ export default class TimeTrackingChart extends React.PureComponent<Props> {
    * coordinates of the mouse of the whole window (clientX/Y) and manipulating the style of the tooltip directly. */
   applyTooltipPositioningFix = () => {
     // TimeLineGraph is the name of the chart given by the library.
-    this.chartScrollElement = document.querySelector(
+    const chartScrollElement = document.querySelector(
       "#TimeLineGraph > div > div:first-child > div",
     );
-    if (this.chartScrollElement) {
-      this.chartScrollElement.addEventListener("mousemove", this.adjustTooltipPosition);
+    if (chartScrollElement) {
+      chartScrollElement.addEventListener("mousemove", this.adjustTooltipPosition);
+      chartScrollElement.addEventListener("mouseleave", this.removeTooltip);
+    }
+    this.chartScrollElement = chartScrollElement;
+  };
+
+  removeTooltip = () => {
+    const tooltip = document.getElementsByClassName("google-visualization-tooltip")[0];
+    if (tooltip != null && tooltip.parentElement != null) {
+      console.log("remove");
+      tooltip.parentElement.removeChild(tooltip);
     }
   };
 

--- a/frontend/javascripts/admin/time/time_line_chart_view.js
+++ b/frontend/javascripts/admin/time/time_line_chart_view.js
@@ -29,7 +29,6 @@ export default class TimeTrackingChart extends React.PureComponent<Props> {
     const { chartScrollElement } = this;
     if (chartScrollElement) {
       chartScrollElement.removeEventListener("mousemove", this.adjustTooltipPosition);
-      chartScrollElement.removeEventListener("mouseleave", this.removeTooltip);
     }
   }
 
@@ -45,22 +44,26 @@ export default class TimeTrackingChart extends React.PureComponent<Props> {
     );
     if (chartScrollElement) {
       chartScrollElement.addEventListener("mousemove", this.adjustTooltipPosition);
-      chartScrollElement.addEventListener("mouseleave", this.removeTooltip);
     }
     this.chartScrollElement = chartScrollElement;
-  };
-
-  removeTooltip = () => {
-    const tooltip = document.getElementsByClassName("google-visualization-tooltip")[0];
-    if (tooltip != null && tooltip.parentElement != null) {
-      console.log("remove");
-      tooltip.parentElement.removeChild(tooltip);
-    }
   };
 
   adjustTooltipPosition = (event: MouseEvent) => {
     const tooltip = document.getElementsByClassName("google-visualization-tooltip")[0];
     if (tooltip != null) {
+      const { target } = event;
+      const isTargetNotATimeEntry =
+        // $FlowIgnore
+        (target != null && target.tagName != null && target.tagName !== "rect") ||
+        // $FlowIgnore
+        target.getAttribute("stroke") !== "none";
+      if (isTargetNotATimeEntry) {
+        if (tooltip.parentElement) {
+          tooltip.parentElement.removeChild(tooltip);
+        }
+        return;
+      }
+
       const { clientX, clientY } = event;
       const [clientWidth, clientHeight] = getWindowBounds();
       const { offsetHeight, offsetWidth } = tooltip;


### PR DESCRIPTION
The chart library seems to be a bit buggy. In addition, to the position fix, we now have a new issue. When zooming in and out while the tooltip is visible, the tooltip won't disappear afterwards (also the content will not change anymore).

As a dirty fix, I added code to the mouse move listener which simply checks whether we are hovering a time entry element (recognizable because it's a rect with a stroke color). If not, the tooltip is removed. Not elegant, but it at least works :roll_eyes: 

### URL of deployed dev instance (used for testing):
- https://fixstickytooltip.webknossos.xyz

### Steps to test:
- hover over time statistics and zoom in and out while the tooltip is visible
- the tooltip should hide/appear as expected

### Issues:
- contributes to #4076 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
