### PR TITLE
Rename CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,13 +274,13 @@ jobs:
 
 workflows:
   version: 2
-  default:
+  circleci_build:
     jobs:
       - build_test_deploy:
           filters:
             tags:
               only: /.*/
-  nightly:
+  circleci_nightly:
     jobs:
       - nightly
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
             docker logout
       - run:
           name: Report coverage
-          command: .circleci/not-on-master.sh docker-compose run base yarn coverage
+          command: .circleci/not-on-master.sh docker-compose run base yarn coverage || true
       - run:
           name: Send Slack notification (master only)
           command: .circleci/slack-notification.sh


### PR DESCRIPTION
Github's status checks now only show the workflow name (i.e. default) which I find a bit undescriptive. This PR provides a better name.