### PR TITLE
cheap uint64 support for segmentation layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Added
 - Indicating active nml downloads with a loading icon. [#4228](https://github.com/scalableminds/webknossos/pull/4228)
 - Added possibility for users to see their own time statistics. [#4220](https://github.com/scalableminds/webknossos/pull/4220)
+- Added limited support for `uint64` segmentation layer by using the lower 4 bytes. [#4233](https://github.com/scalableminds/webknossos/pull/4233)
 
 ### Changed
 - Each of the  columns of the dataset table and explorative annotations table in the dashboard now have an individual fixed width, so the tables become scrollable on smaller screens. [#4207](https://github.com/scalableminds/webknossos/pull/4207)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -66,7 +66,7 @@ object ElementClass extends Enumeration {
     case ElementClass.uint8  => 1L << 8L
     case ElementClass.uint16 => 1L << 16L
     case ElementClass.uint32 => 1L << 32L
-    case ElementClass.uint64 => 1L << 64L
+    case ElementClass.uint64 => (1L << 63L) - 1
   }
 
   def fromString(s: String): Option[Value] = values.find(_.toString == s)
@@ -211,13 +211,15 @@ case class AbstractSegmentationLayer(
 object AbstractSegmentationLayer {
 
   def from(layer: SegmentationLayerLike): AbstractSegmentationLayer =
-    AbstractSegmentationLayer(layer.name,
-                              layer.category,
-                              layer.boundingBox,
-                              layer.resolutions,
-                              layer.elementClass,
-                              layer.largestSegmentId,
-                              layer.mappings)
+    AbstractSegmentationLayer(
+      layer.name,
+      layer.category,
+      layer.boundingBox,
+      layer.resolutions,
+      layer.elementClass,
+      layer.largestSegmentId,
+      layer.mappings
+    )
 
   implicit val abstractSegmentationLayerFormat = Json.format[AbstractSegmentationLayer]
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- add dataset with `uint64` layer
- frontend should report a `uint32` layer and watching it should be possible

### Issues:
- fixes #4163 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [x] Updated [documentation](../blob/master/docs) if applicable
- [x] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [x] Needs datastore update after deployment
- [x] Ready for review
