### PR TITLE
Advanced search for comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Added
 - Indicating active nml downloads with a loading icon. [#4228](https://github.com/scalableminds/webknossos/pull/4228)
 - Added possibility for users to see their own time statistics. [#4220](https://github.com/scalableminds/webknossos/pull/4220)
+- The segmentation layer can now be turned invisible and also supports the find data feature. [#4232](https://github.com/scalableminds/webknossos/pull/4232)
 
 ### Changed
 - Each of the  columns of the dataset table and explorative annotations table in the dashboard now have an individual fixed width, so the tables become scrollable on smaller screens. [#4207](https://github.com/scalableminds/webknossos/pull/4207)
 - When uploading a zipped annotation (such as volume / hybrid / collection), the zip name is used for the resulting explorative annotation, rather than the name of the contained NML file. [#4222](https://github.com/scalableminds/webknossos/pull/4222)
+- Color and segmentation layer are not longer treated separately in the dataset settings in tracing/view mode.  [#4232](https://github.com/scalableminds/webknossos/pull/4232)
 
 ### Fixed
 - Data for disabled or invisible layers will no longer be downloaded, saving bandwidth and speeding up webKnossos in general. [#4202](https://github.com/scalableminds/webknossos/pull/4202)

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -17,7 +17,7 @@ export const settings = {
   fourBit: "4 Bit",
   interpolation: "Interpolation",
   quality: "Quality",
-  segmentationOpacity: "Segmentation Opacity",
+  segmentationOpacity: "Opacity",
   highlightHoveredCellId: "Highlight Hovered Cells",
   zoom: "Zoom",
   renderMissingDataBlack: "Render Missing Data Black",

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -17,7 +17,6 @@ export const settings = {
   fourBit: "4 Bit",
   interpolation: "Interpolation",
   quality: "Quality",
-  segmentationOpacity: "Opacity",
   highlightHoveredCellId: "Highlight Hovered Cells",
   zoom: "Zoom",
   renderMissingDataBlack: "Render Missing Data Black",

--- a/frontend/javascripts/oxalis/controller/scene_controller.js
+++ b/frontend/javascripts/oxalis/controller/scene_controller.js
@@ -413,6 +413,12 @@ class SceneController {
     }
   }
 
+  setSegmentationVisibility(isVisible: boolean): void {
+    for (const plane of _.values(this.planes)) {
+      plane.setSegmentationVisibility(isVisible);
+    }
+  }
+
   setIsMappingEnabled(isMappingEnabled: boolean): void {
     for (const plane of _.values(this.planes)) {
       plane.setIsMappingEnabled(isMappingEnabled);
@@ -455,6 +461,11 @@ class SceneController {
     listenToStoreProperty(
       storeState => storeState.datasetConfiguration.segmentationOpacity,
       segmentationOpacity => this.setSegmentationAlpha(segmentationOpacity),
+    );
+
+    listenToStoreProperty(
+      storeState => storeState.datasetConfiguration.isSegmentationDisabled,
+      isSegmentationDisabled => this.setSegmentationVisibility(!isSegmentationDisabled),
     );
 
     listenToStoreProperty(

--- a/frontend/javascripts/oxalis/default_state.js
+++ b/frontend/javascripts/oxalis/default_state.js
@@ -39,7 +39,7 @@ const defaultState: OxalisState = {
     interpolation: false,
     layers: {},
     quality: 0,
-    isSegmentationDisabled: true,
+    isSegmentationDisabled: false,
     loadingStrategy: "PROGRESSIVE_QUALITY",
     segmentationOpacity: 20,
     highlightHoveredCellId: true,

--- a/frontend/javascripts/oxalis/default_state.js
+++ b/frontend/javascripts/oxalis/default_state.js
@@ -39,6 +39,7 @@ const defaultState: OxalisState = {
     interpolation: false,
     layers: {},
     quality: 0,
+    isSegmentationDisabled: true,
     loadingStrategy: "PROGRESSIVE_QUALITY",
     segmentationOpacity: 20,
     highlightHoveredCellId: true,

--- a/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.js
+++ b/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.js
@@ -300,6 +300,12 @@ class PlaneMaterialFactory {
       this.uniforms.alpha.value = alpha / 100;
     };
 
+    this.material.setSegmentationVisibility = isVisible => {
+      this.uniforms.alpha.value = isVisible
+        ? Store.getState().datasetConfiguration.segmentationOpacity / 100
+        : 0;
+    };
+
     this.material.setUseBilinearFiltering = isEnabled => {
       this.uniforms.useBilinearFiltering.value = isEnabled;
     };

--- a/frontend/javascripts/oxalis/geometries/plane.js
+++ b/frontend/javascripts/oxalis/geometries/plane.js
@@ -169,6 +169,10 @@ class Plane {
     this.plane.material.setSegmentationAlpha(alpha);
   }
 
+  setSegmentationVisibility(isVisible: boolean): void {
+    this.plane.material.setSegmentationVisibility(isVisible);
+  }
+
   getMeshes = () => [this.plane, this.TDViewBorders, this.crosshair[0], this.crosshair[1]];
 
   setLinearInterpolationEnabled = (enabled: boolean) => {

--- a/frontend/javascripts/oxalis/store.js
+++ b/frontend/javascripts/oxalis/store.js
@@ -227,6 +227,7 @@ export type DatasetConfiguration = {|
   },
   +quality: 0 | 1 | 2,
   +segmentationOpacity: number,
+  +isSegmentationDisabled: boolean,
   +highlightHoveredCellId: boolean,
   +renderIsosurfaces: boolean,
   +position?: Vector3,

--- a/frontend/javascripts/oxalis/view/right-menu/advanced_search_popover.js
+++ b/frontend/javascripts/oxalis/view/right-menu/advanced_search_popover.js
@@ -128,7 +128,13 @@ export default class AdvancedSearchPopover<S: Object> extends React.PureComponen
                     style={{ width: "calc(100% - 100px)", ...additionalInputStyle }}
                     value={searchQuery}
                     placeholder="Enter your search keywords"
-                    onPressEnter={this.selectNextOption}
+                    onPressEnter={event => {
+                      if (event.shiftKey) {
+                        this.selectPreviousOption();
+                      } else {
+                        this.selectNextOption();
+                      }
+                    }}
                     onChange={evt =>
                       this.setState({ searchQuery: evt.target.value, currentPosition: null })
                     }

--- a/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
@@ -32,7 +32,7 @@ import Store, {
 import TreeWithComments from "oxalis/view/right-menu/comment_tab/tree_with_comments";
 import messages from "messages";
 
-import SearchPopover from "../search_popover";
+import AdvancedSearchPopover from "../advanced_search_popover";
 
 const InputGroup = Input.Group;
 
@@ -343,20 +343,18 @@ class CommentTabView extends React.PureComponent<PropsWithSkeleton, CommentTabSt
       this.state.data,
       activeCommentMaybe.isJust ? findCommentIndexFn : findTreeIndexFn,
     );
-
     return (
       <div className="flex-column padded-tab-content" style={{ height: "inherit" }}>
         {this.renderMarkdownModal()}
         <InputGroup compact>
-          <SearchPopover
-            onSelect={nodeIdString => this.props.setActiveNode(parseInt(nodeIdString, 10))}
+          <AdvancedSearchPopover
+            onSelect={comment => this.props.setActiveNode(comment.nodeId)}
             data={_.flatMap(this.props.skeletonTracing.trees, tree => tree.comments)}
-            idKey="nodeId"
             searchKey="content"
-            maxSearchResults={10}
+            provideShortcut
           >
             <ButtonComponent icon="search" title="Open the search via CTRL + Shift + F" />
-          </SearchPopover>
+          </AdvancedSearchPopover>
           <ButtonComponent
             title="Jump to previous comment"
             onClick={this.previousComment}

--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -257,8 +257,8 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
                 onChange={_.partial(this.props.onChange, "highlightHoveredCellId")}
               />
             )}
-            {(!isColorLayer && this.props.controlMode === ControlModeEnum.VIEW) ||
-            window.allowIsosurfaces ? (
+            {!isColorLayer && (this.props.controlMode === ControlModeEnum.VIEW ||
+            window.allowIsosurfaces) ? (
               <SwitchSetting
                 label="Render Isosurfaces (Beta)"
                 value={this.props.datasetConfiguration.renderIsosurfaces}

--- a/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
@@ -103,6 +103,7 @@ const datasetConfigOverrides: { [key: string]: DatasetConfiguration } = {
     },
     quality: 0,
     segmentationOpacity: 0,
+    isSegmentationDisabled: false,
     highlightHoveredCellId: true,
     renderIsosurfaces: false,
     renderMissingDataBlack: false,


### PR DESCRIPTION
Replaced the search in comments tab with the new advanced search. I also added the `enter+shift` shortcut to cycle backward through the results. Previously only the `enter` shortcut to cycle forward existed. As far as I con remember the `enter+shift` shortcut is common for all kind of search functionalities and therefore should be more or less discoverable.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a skeleton/hybrid tracing and create some trees with nodes.
- Then open the comment tab and add comments to the nodes.
- Then open up the search via the shortcut (`shift+crtl+f`) and via button. Both should work out fine.
- Then just use the search as any other search. Everything should work as expected. This also counts for the `enter` and `shift+enter` shortcut.

### TODO:
- [ ] Bug: when the comments tab is invisible the shortcut to open the search (`shift+crtl+f`) still opens up the search ... :/


### Issues:
- fixes #123

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- ~~[ ] Needs datastore update after deployment~~
- [ ] Ready for review
