### PR TITLE
Improve publication list rendering

### DIFF
--- a/frontend/stylesheets/_dashboard.less
+++ b/frontend/stylesheets/_dashboard.less
@@ -187,10 +187,11 @@
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   border-radius: 6px;
+  transform: translateZ(0);
 
   &:hover {
     box-shadow: 0 4px 6px hsla(0, 0%, 0%, 0.22), 0 5px 15px hsla(0, 0%, 0%, 0.1);
-    transform: translateY(-2px);
+    transform: translateY(-2px) translateZ(0);
 
     .dataset-thumbnail-image {
       transform: scale(1.1);


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- Makes each publication item in the gallery an own rendering layer (with `translateZ(0)`)

### Steps to test:
- Apply the changes in the dev console on webknossos.org

### Paint flashing
Before:
![Aug-22-2019 13-49-23](https://user-images.githubusercontent.com/335438/63512388-02cba980-c4e4-11e9-9f86-8a55b7e8bbba.gif)

After:
![Aug-22-2019 13-49-39](https://user-images.githubusercontent.com/335438/63512429-1c6cf100-c4e4-11e9-83fc-50dc61c76406.gif)

------
- [x] Ready for review
