### PR TITLE
Always update PRs

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -9,6 +9,6 @@ merge:
       body: summarize_commits
   delete_after_merge: true
 update:
-  whitelist:
-    labels: ["automerge"]
+  blacklist:
+    labels: ["no-update"]
 


### PR DESCRIPTION
This config change would always update PR branches, regardless of the `automerge` label. I think this could be useful, but I am looking for other opinions.

------
- [x] Ready for review
