### PR TITLE
Changed keyboard shortcut 3 to toggle segmentation visibility

### DIFF
--- a/frontend/javascripts/admin/help/keyboardshortcut_view.js
+++ b/frontend/javascripts/admin/help/keyboardshortcut_view.js
@@ -115,7 +115,7 @@ const KeyboardShortcutView = () => {
     },
     {
       keybinding: "3",
-      action: "Toggle Segmentation Opacity",
+      action: "Toggle Segmentation Visibility",
     },
     {
       keybinding: "Shift + Mousewheel",


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://disablesegmentationlayerwithshortcut.webknossos.xyz

### Steps to test:
- Open a dataset in tracing / viewmode that has a segmentation layer. Use 3 to toggle the visibility of the segmentation layer. The changes should also be visible in the dataset settings.

### Issues:
- fixes #4254

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
