### PR TITLE
Reduce space between rows in project progress view

### DIFF
--- a/frontend/javascripts/admin/statistic/project_progress_report_view.js
+++ b/frontend/javascripts/admin/statistic/project_progress_report_view.js
@@ -102,7 +102,6 @@ class ProjectProgressReportView extends React.PureComponent<{}, State> {
             rowKey="projectName"
             style={{ marginTop: 30, marginBotton: 30 }}
             size="small"
-            scroll={{ x: "max-content" }}
             className="large-table"
           >
             <Column


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Just open the project progress view and look at the space between the rows.

### Issues:
- [discuss request](https://discuss.webknossos.org/t/project-progress-tracing-time/1515/11)

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
