### PR TITLE
Round coordinates when exporting NML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed tooltip not disappearing in the statistics view in certain circumstances. [#4219](https://github.com/scalableminds/webknossos/pull/4219)
 - Fixed the error messages when trying to access a dataset with insufficient permissions. [#4244](https://github.com/scalableminds/webknossos/pull/4244)
 - Fixed the upload of volume tracings by recognizing the correct format of the fallback layer. [#4248](https://github.com/scalableminds/webknossos/pull/4248)
+- Fixed an imprecision when exporting an NML via the front-end. [#4262](https://github.com/scalableminds/webknossos/pull/4262)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -249,7 +249,7 @@ function serializeTrees(trees: Array<Tree>): Array<string> {
 
 function serializeNodes(nodes: NodeMap): Array<string> {
   return nodes.map(node => {
-    const position = node.position.map(Math.round);
+    const position = node.position.map(Math.floor);
     return serializeTag("node", {
       id: node.id,
       radius: node.radius,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- should be obvious

### Issues:
- When viewing a dataset, the current position is a floating point vector3 which is floored for rendering. Consequentially, the node positions have to be floored, as well. Otherwise, we would store positions which don't necessarily exist (for example, if a z slice only exists for 0-31 and you trace on 31.5, z should be 31).

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
