### PR TITLE
Edit all selected users when clicking on the experience of a specific user

### DIFF
--- a/frontend/javascripts/admin/user/user_list_view.js
+++ b/frontend/javascripts/admin/user/user_list_view.js
@@ -437,11 +437,13 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
                   <Tag key={`experience_${user.id}_${domain}`}>
                     <span
                       onClick={() => {
-                        this.setState({
-                          singleSelectedUser: user,
+                        this.setState(prevState => ({
+                          // If no user is selected, set singleSelectedUser. Otherwise,
+                          // open the modal so that all selected users are edited.
+                          singleSelectedUser: prevState.selectedUserIds.length > 0 ? null : user,
                           isExperienceModalVisible: true,
                           domainToEdit: domain,
-                        });
+                        }));
                       }}
                     >
                       {domain} : {value}


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I tested it thoroughly for two users while selecting none/one/all of them and editing the experience domains by clicking on a experience domain (instead of the generic "edit experience domain" button)

### Issues:
- see https://discuss.webknossos.org/t/unselect-users-after-exp-domain-is-set/1540/3

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [ ] ~Updated [documentation](../blob/master/docs) if applicable~
- [ ] ~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [ ] ~Needs datastore update after deployment~
- [X] Ready for review
