### PR TITLE
Always activate group after creating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 - Renamed "Expected Time" to "Time Limit" in the project table. [#4278](https://github.com/scalableminds/webknossos/pull/4278)
 - Clicking on an experience domain of a user, while multiple users are selected will edit the domain of all selected users (instead of only the domain of the clicked row). [#4280](https://github.com/scalableminds/webknossos/pull/4280)
+- Creating a new group will always activate that group. [#4282](https://github.com/scalableminds/webknossos/pull/4282)
 
 ### Fixed
 - When creating tasks from zip, the individual nml names are used again, rather than the zip name. [#4277](https://github.com/scalableminds/webknossos/pull/4277)

--- a/frontend/javascripts/oxalis/view/right-menu/delete_group_modal_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/delete_group_modal_view.js
@@ -20,22 +20,18 @@ export default function DeleteGroupModalView({
       title={messages["tracing.group_deletion_message"]}
       onOk={onJustDeleteGroup}
       onCancel={onCancel}
+      width={620}
       footer={[
-        <Button key="back" onClick={onCancel}>
-          Cancel
-        </Button>,
         <Button key="submit-all" onClick={onDeleteGroupAndTrees}>
-          Remove group recursively
+          Remove group including all children
         </Button>,
         <Button key="submit-groups-only" type="primary" onClick={onJustDeleteGroup}>
-          Remove group only
+          Remove group and keep children
         </Button>,
       ]}
     >
-      Do you really want to remove the selected group? If you want to remove the group with all its
-      trees and subgroups recursively, select &quot;Remove group recursively&quot;. If you want to
-      remove just the group and keep the subtrees and subgroups select &quot;Remove group
-      only&quot;.
+      When selecting &quot;Remove group and keep children&quot;, the children will be moved to the
+      level of the original group.
     </Modal>
   );
 }

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -149,26 +149,27 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
     }
   };
 
+  selectGroupById = (groupId: number) => {
+    this.props.deselectAllTrees();
+    this.props.onSetActiveGroup(groupId);
+  };
+
   onSelectGroup = (evt: SyntheticMouseEvent<*>) => {
     // $FlowFixMe .dataset is unknown to flow
     const groupId = parseInt(evt.target.dataset.id, 10);
     const numberOfSelectedTrees = this.props.selectedTrees.length;
-    const selectGroup = () => {
-      this.props.deselectAllTrees();
-      this.props.onSetActiveGroup(groupId);
-    };
     if (numberOfSelectedTrees > 0) {
       Modal.confirm({
         title: "Do you really want to select this group?",
         content: `You have ${numberOfSelectedTrees} selected Trees. Do you really want to select this group?
         This will deselect all selected trees.`,
         onOk() {
-          selectGroup();
+          this.selectGroupById(groupId);
         },
         onCancel() {},
       });
     } else {
-      selectGroup();
+      this.selectGroupById(groupId);
     }
   };
 
@@ -240,6 +241,7 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
       });
     }
     this.props.onUpdateTreeGroups(newTreeGroups);
+    this.selectGroupById(newGroupId);
   }
 
   deleteGroup(groupId: number) {


### PR DESCRIPTION
After creating a new group, it should always be selected (no trees should be selected).
I also made the wording in the "delete tree group" modal a bit more concise.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I created a new group and ensured that it's activated and no other tree is activated
- I also tested multi-selecting trees and created a group -> in that case, the tree selection should also be cleared

### Issues:
- fixes https://discuss.webknossos.org/t/automatically-activate-select-newly-created-group/1541/2

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
