### PR TITLE
Improve fossildb conflict error message 

### DIFF
--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -52,7 +52,9 @@ export default {
   "datastore.version.too_old": _.template(
     "The datastore server at (<%- url %>) supplies an older API version (<%- suppliedDatastoreApiVersion %>) than this webKnossos expects (<%- expectedDatastoreApiVersion %>). Please contact the admins of the remote data store to upgrade.",
   ),
-  "save.failed_simultaneous_tracing": `It seems that you edited the tracing simultaneously in different windows.
+  "save.failed_simultaneous_tracing": `The tracing couldn't be processed correctly.
+
+This might be caused by editing the tracing simultaneously in different windows.
 Editing should be done in a single window only.
 
 In order to restore the current window, a reload is necessary.`,


### PR DESCRIPTION
I rephrased the error message but still left the part of editing the tracing simultaneously as main reason for the error because 1) the user can influence it and 2) the new configuration should prevent such fossildb update losses.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### Issues:
- fixes #4263 

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
