### PR TITLE
Remove different-dataset-warning when importing NML

### DIFF
--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -227,8 +227,6 @@ In order to restore the current window, a reload is necessary.`,
   "nml.edge_with_same_source_target":
     "NML contains <edge ...> with same source and target id: Edge",
   "nml.tree_not_connected": "NML contains tree that is not fully connected: Tree with id",
-  "nml.different_dataset":
-    "At least one NML file was originally created for a different dataset. Are you sure you want to continue with the import?",
   "merge.different_dataset":
     "The merge cannot be executed, because the underlying datasets are not the same.",
   "merge.volume_unsupported": "Merging is not supported for volume tracings.",

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -1,7 +1,4 @@
-/**
- * list_tree_view.js
- * @flow
- */
+// @flow
 import { Alert, Button, Dropdown, Input, Menu, Icon, Spin, Modal, Tooltip } from "antd";
 import type { Dispatch } from "redux";
 import { connect } from "react-redux";
@@ -9,7 +6,6 @@ import { saveAs } from "file-saver";
 import * as React from "react";
 import _ from "lodash";
 import memoizeOne from "memoize-one";
-import { binaryConfirm } from "libs/async_confirm";
 import {
   createGroupToTreesMap,
   callDeep,
@@ -125,17 +121,6 @@ export async function importNmls(files: Array<File>, createGroupForEachFile: boo
 
     if (errors.length > 0) {
       throw errors;
-    }
-
-    const currentDatasetName = Store.getState().dataset.name;
-    const doDatasetNamesDiffer = importActionsWithDatasetNames
-      .map(el => el.datasetName)
-      .some(name => name !== "" && name != null && name !== currentDatasetName);
-    if (doDatasetNamesDiffer) {
-      const shouldImport = await binaryConfirm("Are you sure?", messages["nml.different_dataset"]);
-      if (!shouldImport) {
-        return;
-      }
     }
 
     // Dispatch the actual actions as the very last step, so that


### PR DESCRIPTION
The "are you sure" message is quite annoying and has a quite high false-positive rate for me personally. I think it's alright to remove the message. Do you agree @normanrz and @daniel-wer ?

### URL of deployed dev instance (used for testing):
- https://removenmlimportwarning.webknossos.xyz

### Steps to test:
- import NML

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
