### PR TITLE
Don't provide shortcut for comment search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 - When creating tasks from zip, the individual nml names are used again, rather than the zip name. [#4277](https://github.com/scalableminds/webknossos/pull/4277)
 
+### Removed
+- Removed the Search shortcut (Ctrl+Shift+F) for comments in the tracing view, since that shortcut collides with the tree search. [#4291](https://github.com/scalableminds/webknossos/pull/4291)
 
 ## [19.09.0](https://github.com/scalableminds/webknossos/releases/tag/19.09.0) - 2019-08-28
 [Commits](https://github.com/scalableminds/webknossos/compare/19.08.0...19.09.0)

--- a/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
@@ -353,7 +353,6 @@ class CommentTabView extends React.PureComponent<PropsWithSkeleton, CommentTabSt
             onSelect={comment => this.props.setActiveNode(comment.nodeId)}
             data={_.flatMap(this.props.skeletonTracing.trees, tree => tree.comments)}
             searchKey="content"
-            provideShortcut
             targetId={commentListId}
           >
             <ButtonComponent icon="search" title="Open the search via CTRL + Shift + F" />

--- a/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
@@ -355,7 +355,7 @@ class CommentTabView extends React.PureComponent<PropsWithSkeleton, CommentTabSt
             searchKey="content"
             targetId={commentListId}
           >
-            <ButtonComponent icon="search" title="Open the search via CTRL + Shift + F" />
+            <ButtonComponent icon="search" title="Search through comments" />
           </AdvancedSearchPopover>
           <ButtonComponent
             title="Jump to previous comment"


### PR DESCRIPTION
… to avoid clash with tree-search shortcut. Originally, the idea was to remember which search was used most recently, but the implementation for that would be quite a bit more involved. I think, the solution in this PR is fine, too. The comment search functionality was only added recently and context-sensitive shortcuts might be a bad idea, anyway. Do you agree, @daniel-wer ?

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- place comments and tree tab next to each other and use ctrl+shift+f shortcut. only the search for trees should open

### Issues:
- fixes #4272 

------
- [X] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [ ] ~Updated [documentation](../blob/master/docs) if applicable~
- [ ] ~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [ ] ~Needs datastore update after deployment~
- [X] Ready for review
