### PR TITLE
Fix missing uint64 voxel type in evolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Cleaned up error reporting wording in case of dataset access failures (e.g. due to not being logged in). [#4301](https://github.com/scalableminds/webknossos/pull/4301)
+- Fixed handling of uint64 data layers in sql evolution. [4303](https://github.com/scalableminds/webknossos/pull/4303)
 
 ### Removed
 -

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -8,7 +8,7 @@ User-facing changes are documented in the [changelog](CHANGELOG.md).
 -
 
 ### Postgres Evolutions:
--
+- [046-fix-missing-voxel-type.sql](conf/evolutions/046-fix-missing-voxel-type.sql)
 
 ## [19.10.0](https://github.com/scalableminds/webknossos/releases/tag/19.10.0) - 2019-09-30
 ### Postgres Evolutions:

--- a/conf/evolutions/046-fix-missing-voxel-type.sql
+++ b/conf/evolutions/046-fix-missing-voxel-type.sql
@@ -7,6 +7,6 @@
 
 --unfortunately, in postgresql, ALTER TYPE ... ADD cannot run inside a transaction block, so no transaction here
 
-ALTER TYPE webknossos.DATASET_LAYER_ELEMENT_CLASS ADD VALUE 'int64';
+ALTER TYPE webknossos.DATASET_LAYER_ELEMENT_CLASS ADD VALUE 'uint64';
 
 UPDATE webknossos.releaseInformation SET schemaVersion = 46;

--- a/conf/evolutions/046-fix-missing-voxel-type.sql
+++ b/conf/evolutions/046-fix-missing-voxel-type.sql
@@ -1,0 +1,12 @@
+-- https://github.com/scalableminds/webknossos/pull/TODO
+
+-- fixes the line missing in evolution 038-more-voxel-types.sql – schema.sql actually includes this since then
+
+-- note that it is very complex to reverse this (which is why we don't do it), compare also
+-- https://www.postgresql.org/message-id/CANu8FiwwBxZZGX23%3DNa_7bc4DZ-yzd_poKhaoPmN3%2BSHG08MAg%40mail.gmail.com
+
+--unfortunately, in postgresql, ALTER TYPE ... ADD cannot run inside a transaction block, so no transaction here
+
+ALTER TYPE webknossos.DATASET_LAYER_ELEMENT_CLASS ADD VALUE 'int64';
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 46;

--- a/conf/evolutions/046-fix-missing-voxel-type.sql
+++ b/conf/evolutions/046-fix-missing-voxel-type.sql
@@ -1,4 +1,4 @@
--- https://github.com/scalableminds/webknossos/pull/TODO
+-- https://github.com/scalableminds/webknossos/pull/4303
 
 -- fixes the line missing in evolution 038-more-voxel-types.sql – schema.sql actually includes this since then
 

--- a/conf/evolutions/reversions/046-fix-missing-voxel-type.sql
+++ b/conf/evolutions/reversions/046-fix-missing-voxel-type.sql
@@ -1,0 +1,3 @@
+
+-- note that it is very complex to reverse this (which is why we don't do it), compare also
+-- https://www.postgresql.org/message-id/CANu8FiwwBxZZGX23%3DNa_7bc4DZ-yzd_poKhaoPmN3%2BSHG08MAg%40mail.gmail.com

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ START TRANSACTION;
 CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(45);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(46);
 COMMIT TRANSACTION;
 
 CREATE TABLE webknossos.analytics(


### PR DESCRIPTION
this was left out in https://github.com/scalableminds/webknossos/pull/3686

### Steps to test:
- add uint64 layer to a dataset (and add this to the datasource-properties.json), import this dataset in wk, you should be able to view it

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [x] Ready for review
