### PR TITLE
Batch tree deletion actions when deleting a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 -
 
 ### Changed
--
+- Some user actions, like deleting a group with all subtrees, resulted in lots of entries in the undo stack (one for each deleted tree). Those actions are now handled as a single atomic change and can be undone with a single undo invocation. [#4312](https://github.com/scalableminds/webknossos/pull/4312)
 
 ### Fixed
 - Fixed broken sorting in the dataset table of the dashboard. [#4318](https://github.com/scalableminds/webknossos/pull/4318)

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -92,7 +92,7 @@ In order to restore the current window, a reload is necessary.`,
   "tracing.delete_initial_node": "Do you really want to delete the initial node?",
   "tracing.delete_tree": "Do you really want to delete the whole tree?",
   "tracing.delete_tree_with_initial_node":
-    "This tree contains the initial node. Do you really want to delete the whole tree?",
+    "The tree(s) you want to delete contain(s) the initial node. Do you really want to proceed with the deletion?",
   "tracing.delete_multiple_trees": _.template(
     "You have <%- countOfTrees %> trees selected, do you really want to delete all those trees?",
   ),

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
@@ -1,7 +1,6 @@
 // @flow
 import { Modal } from "antd";
 import React from "react";
-import { batchActions } from "redux-batched-actions";
 
 import type { ServerSkeletonTracing } from "admin/api_flow_types";
 import type { Vector3 } from "oxalis/constants";
@@ -173,6 +172,8 @@ export const SkeletonTracingSaveRelevantActions = [
   "TOGGLE_TREE_GROUP",
   "TOGGLE_ALL_TREES",
   "TOGGLE_INACTIVE_TREES",
+  // Composited actions, only dispatched using `batchActions`
+  "DELETE_GROUP_AND_TREES",
 ];
 
 const noAction = (): NoAction => ({
@@ -475,19 +476,4 @@ export const deleteTreeAsUserAction = (treeId?: number): NoAction => {
   // As Modal.confirm is async, return noAction() and the modal will dispatch the real action
   // if the user confirms
   return noAction();
-};
-
-export const deleteMultipleTreesAsUserAction = (treeIds: Array<number>): NoAction => {
-  const state = Store.getState();
-  const skeletonTracing = enforceSkeletonTracing(state.tracing);
-  const actions = treeIds.map(id => {
-    const tree = skeletonTracing.trees[id];
-    if (state.task != null && tree.nodes.has(1)) {
-      confirmDeletingInitialNode(id);
-      return noAction();
-    } else {
-      return deleteTreeAction(id);
-    }
-  });
-  return batchActions(actions, "DELETE_TREE");
 };

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
@@ -1,6 +1,7 @@
 // @flow
 import { Modal } from "antd";
 import React from "react";
+import { batchActions } from "redux-batched-actions";
 
 import type { ServerSkeletonTracing } from "admin/api_flow_types";
 import type { Vector3 } from "oxalis/constants";
@@ -479,13 +480,14 @@ export const deleteTreeAsUserAction = (treeId?: number): NoAction => {
 export const deleteMultipleTreesAsUserAction = (treeIds: Array<number>): NoAction => {
   const state = Store.getState();
   const skeletonTracing = enforceSkeletonTracing(state.tracing);
-  treeIds.forEach(id => {
+  const actions = treeIds.map(id => {
     const tree = skeletonTracing.trees[id];
     if (state.task != null && tree.nodes.has(1)) {
       confirmDeletingInitialNode(id);
+      return noAction();
     } else {
-      Store.dispatch(deleteTreeAction(id));
+      return deleteTreeAction(id);
     }
   });
-  return noAction();
+  return batchActions(actions, "DELETE_TREE");
 };

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.js
@@ -278,7 +278,7 @@ export function* saveTracingTypeAsync(tracingType: "skeleton" | "volume"): Saga<
 
   while (true) {
     if (tracingType === "skeleton") {
-      yield* take([...SkeletonTracingSaveRelevantActions, ...FlycamActions, "UNDO", "REDO"]);
+      yield* take([...SkeletonTracingSaveRelevantActions, ...FlycamActions, "SET_TRACING"]);
     } else {
       yield* take([...VolumeTracingSaveRelevantActions, ...FlycamActions]);
     }

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
@@ -181,6 +181,7 @@ export function* watchSkeletonTracingAsync(): Saga<void> {
       "DELETE_BRANCHPOINT",
       "SELECT_NEXT_TREE",
       "DELETE_TREE",
+      "DELETE_GROUP_AND_TREES",
       "UNDO",
       "REDO",
     ],

--- a/frontend/javascripts/oxalis/store.js
+++ b/frontend/javascripts/oxalis/store.js
@@ -5,6 +5,7 @@
 
 import { createStore, applyMiddleware, type Dispatch } from "redux";
 import createSagaMiddleware from "redux-saga";
+import { enableBatching } from "redux-batched-actions";
 
 import type {
   APIAllowedMode,
@@ -428,7 +429,7 @@ const combinedReducers = reduceReducers(
 );
 
 const store = createStore<OxalisState, Action, Dispatch<*>>(
-  combinedReducers,
+  enableBatching(combinedReducers),
   defaultState,
   applyMiddleware(actionLoggerMiddleware, overwriteActionMiddleware, sagaMiddleware),
 );

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -248,9 +248,10 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
     this.props.onDeleteGroup(groupId);
   }
 
-  handleDropdownClick = (params: { item: *, key: string }) => {
-    const { item, key } = params;
-    const { groupId } = item.props;
+  handleDropdownClick = (params: { domEvent: SyntheticMouseEvent<*>, key: string }) => {
+    const { domEvent, key } = params;
+    // $FlowFixMe .dataset is unknown to flow
+    const groupId = parseInt(domEvent.target.dataset.groupId, 10);
     if (key === "create") {
       this.createGroup(groupId);
     } else if (key === "delete") {
@@ -285,22 +286,22 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
     const hasSubgroup = anySatisfyDeep(node.children, child => child.type === TYPE_GROUP);
     const menu = (
       <Menu onClick={this.handleDropdownClick}>
-        <Menu.Item key="create" groupId={id}>
+        <Menu.Item key="create" data-group-id={id}>
           <Icon type="plus" />
           Create new group
         </Menu.Item>
-        <Menu.Item key="delete" groupId={id} disabled={isRoot}>
+        <Menu.Item key="delete" data-group-id={id} disabled={isRoot}>
           <Icon type="delete" />
           Delete
         </Menu.Item>
         {hasSubgroup ? (
-          <Menu.Item key="collapseSubgroups" groupId={id} disabled={!hasExpandedSubgroup}>
+          <Menu.Item key="collapseSubgroups" data-group-id={id} disabled={!hasExpandedSubgroup}>
             <Icon type="shrink" />
             Collapse all subgroups
           </Menu.Item>
         ) : null}
         {hasSubgroup ? (
-          <Menu.Item key="expandSubgroups" groupId={id} disabled={!hasCollapsedSubgroup}>
+          <Menu.Item key="expandSubgroups" data-group-id={id} disabled={!hasCollapsedSubgroup}>
             <Icon type="shrink" />
             Expand all subgroups
           </Menu.Item>

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "react-sortable-tree": "^2.1.1",
     "react-virtualized": "^9.20.1",
     "redux": "^3.6.0",
+    "redux-batched-actions": "^0.4.1",
     "redux-saga": "^1.0.0",
     "three": "^0.106.0",
     "tween.js": "^16.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10282,6 +10282,11 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
+redux-batched-actions@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/redux-batched-actions/-/redux-batched-actions-0.4.1.tgz#a8de8cef50a1db4f009d5222820c836515597e22"
+  integrity sha512-r6tLDyBP3U9cXNLEHs0n1mX5TQfmk6xE0Y9uinYZ5HOyAWDgIJxYqRRkU/bC6XrJ4nS7tasNbxaHJHVmf9UdkA==
+
 redux-mock-store@^1.2.2:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.3.tgz#1f10528949b7ce8056c2532624f7cafa98576c6d"


### PR DESCRIPTION
I batched the group-with-subtree deletion, mulitple tree deletion and multiple tree move user actions. The confirm group/tree/node-with-id-1 deletion code is pretty messy and should be consolidated, but I'll probably not do that as part of this PR. My changes should not make it much worse.
I also found a (minor) bug in the undo functionality where when only a single action was triggered, for example, `SET_TREE_GROUP`, and that was then undone, the save_saga would `take` the `UNDO` action and diff the tracing state, although the "undone" tracing state was not set in the store yet. We didn't notice this before, because usually there's a couple more flycam actions or so that follow, which trigger the differ again. To fix this, I changed the save_saga code to `take` the `SET_TRACING` action instead which is what undo/redo dispatch to set the new tracing state.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a skeletontracing with nested groups and trees. Delete a group that contains multiple trees. Use undo to restore the previous state. The deletion of trees within one group should be "atomic" and be restored with one undo action.
- Select multiple trees and delete/move them. Undo the change which should be "atomic".
- Create a task and check whether the "Are you sure you want to delete the tree with id 1"-warning is still properly shown.

### Issues:
- contributes to #4281 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review

Outdated, but for reference:
> I gave the [redux-batched-actions](https://github.com/reduxjs/redux/issues/911#issuecomment-149361073) lib a try and the easy case seems to work pretty well (batching multiple actions of the same type). However, group/tree/node deletion is rather complex in our code, triggering Modals with async responses, so using the batched actions in that scenario is not straight-forward. This is why in the current iteration only the DELETE_TREE actions deleting the trees of one group at a time are batched together.
Another problem would be if we wanted to batch actions of different types as redux-saga's take... methods then no longer work out of the box, because they don't know about batched actions. It would be possible to overwrite those take functions to unpack and match the batched actions but that would be rather involved I think.
I've read quite a bit in the issues sections of the library, but couldn't find a good solution yet.

> Let's discuss this tomorrow in person :)
