### PR TITLE
Added set active tree action by name to api and cross origin api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 [Commits](https://github.com/scalableminds/webknossos/compare/19.11.0...HEAD)
 
 ### Added
--
+- Added an API to set a tree active by name. [#4317](https://github.com/scalableminds/webknossos/pull/4317)
 
 ### Changed
 -

--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -63,6 +63,7 @@ import {
   setNodeRadiusAction,
   setTreeNameAction,
   setActiveTreeAction,
+  setActiveTreeByNameAction,
   setTreeColorIndexAction,
   setTreeVisibilityAction,
   setTreeGroupAction,
@@ -284,6 +285,18 @@ class TracingApi {
     const { tracing } = Store.getState();
     assertSkeleton(tracing);
     Store.dispatch(setActiveTreeAction(treeId));
+  }
+
+  /**
+   * Makes the tree specified by name active. Within the tree, the node with the highest ID will be activated.
+   *
+   * @example
+   * api.tracing.setActiveTree("tree_1");
+   */
+  setActiveTreeByName(treeName: string) {
+    const { tracing } = Store.getState();
+    assertSkeleton(tracing);
+    Store.dispatch(setActiveTreeByNameAction(treeName));
   }
 
   /**

--- a/frontend/javascripts/oxalis/api/cross_origin_api.js
+++ b/frontend/javascripts/oxalis/api/cross_origin_api.js
@@ -27,6 +27,15 @@ const onMessage = event => {
       api.tracing.resetSkeletonTracing();
       break;
     }
+    case "setActiveTreeByName": {
+      const treeName = args[0];
+      if (_.isString(treeName)) {
+        api.tracing.setActiveTreeByName(treeName);
+      } else {
+        console.warn("The first argument needs to be the name of the tree.");
+      }
+      break;
+    }
     case "importNml": {
       const nmlAsString = args[0];
       if (_.isString(nmlAsString)) {

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
@@ -81,6 +81,7 @@ type AddTreesAndGroupsAction = {
 type DeleteTreeAction = { type: "DELETE_TREE", treeId?: number, timestamp: number };
 type ResetSkeletonTracingAction = { type: "RESET_SKELETON_TRACING" };
 type SetActiveTreeAction = { type: "SET_ACTIVE_TREE", treeId: number };
+type SetActiveTreeByNameAction = { type: "SET_ACTIVE_TREE_BY_NAME", treeName: string };
 type DeselectActiveTreeAction = { type: "DESELECT_ACTIVE_TREE" };
 type SetActiveGroupAction = { type: "SET_ACTIVE_GROUP", groupId: number };
 type DeselectActiveGroupAction = { type: "DESELECT_ACTIVE_GROUP" };
@@ -124,6 +125,7 @@ export type SkeletonTracingAction =
   | DeleteTreeAction
   | ResetSkeletonTracingAction
   | SetActiveTreeAction
+  | SetActiveTreeByNameAction
   | DeselectActiveTreeAction
   | MergeTreesAction
   | SetTreeNameAction
@@ -157,6 +159,7 @@ export const SkeletonTracingSaveRelevantActions = [
   "ADD_TREES_AND_GROUPS",
   "DELETE_TREE",
   "SET_ACTIVE_TREE",
+  "SET_ACTIVE_TREE_BY_NAME",
   "SET_TREE_NAME",
   "MERGE_TREES",
   "SELECT_NEXT_TREE",
@@ -328,6 +331,11 @@ export const toggleTreeGroupAction = (groupId: number): ToggleTreeGroupAction =>
 export const setActiveTreeAction = (treeId: number): SetActiveTreeAction => ({
   type: "SET_ACTIVE_TREE",
   treeId,
+});
+
+export const setActiveTreeByNameAction = (treeName: string): SetActiveTreeByNameAction => ({
+  type: "SET_ACTIVE_TREE_BY_NAME",
+  treeName,
 });
 
 export const deselectActiveTreeAction = (): DeselectActiveTreeAction => ({

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
@@ -373,13 +373,7 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
         case "SET_ACTIVE_TREE_BY_NAME": {
           const { treeName } = action;
           const { trees } = skeletonTracing;
-          let treeWithMatchingName = null;
-          Object.keys(trees).forEach(treeId => {
-            const treeIdAsNumber = ((treeId: any): number);
-            if (trees[treeIdAsNumber].name === treeName) {
-              treeWithMatchingName = trees[treeIdAsNumber];
-            }
-          });
+          const treeWithMatchingName = _.values(trees).find(tree => tree.name === treeName);
           if (!treeWithMatchingName) {
             return state;
           }

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.js
@@ -370,6 +370,31 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
             })
             .getOrElse(state);
         }
+        case "SET_ACTIVE_TREE_BY_NAME": {
+          const { treeName } = action;
+          const { trees } = skeletonTracing;
+          let treeWithMatchingName = null;
+          Object.keys(trees).forEach(treeId => {
+            const treeIdAsNumber = ((treeId: any): number);
+            if (trees[treeIdAsNumber].name === treeName) {
+              treeWithMatchingName = trees[treeIdAsNumber];
+            }
+          });
+          if (!treeWithMatchingName) {
+            return state;
+          }
+          const newActiveNodeId = _.max(treeWithMatchingName.nodes.map(el => el.id)) || null;
+
+          return update(state, {
+            tracing: {
+              skeleton: {
+                activeNodeId: { $set: newActiveNodeId },
+                activeTreeId: { $set: treeWithMatchingName.treeId },
+                activeGroupId: { $set: null },
+              },
+            },
+          });
+        }
 
         case "DESELECT_ACTIVE_TREE": {
           return update(state, {

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
@@ -176,6 +176,7 @@ export function* watchSkeletonTracingAsync(): Saga<void> {
   yield _takeEvery(
     [
       "SET_ACTIVE_TREE",
+      "SET_ACTIVE_TREE_BY_NAME",
       "SET_ACTIVE_NODE",
       "DELETE_NODE",
       "DELETE_BRANCHPOINT",


### PR DESCRIPTION
This PR adds an action to set a tree with a given name. active.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a skeleton tracing and create some trees.
- Then use the following script in your console to check whether the selection works:
`window.webknossos.apiReady(3).then(async (api) => { api.tracing.setActiveTreeByName(<tree_name>)});`

### Issues:
- This PR has no issue.

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
