### PR TITLE
Fix sorting in antd dataset table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 -
 
 ### Fixed
--
+- Fixed broken sorting in the dataset table of the dashboard. [#4318](https://github.com/scalableminds/webknossos/pull/4318)
 
 ### Removed
 -
@@ -30,7 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Cleaned up error reporting wording in case of dataset access failures (e.g. due to not being logged in). [#4301](https://github.com/scalableminds/webknossos/pull/4301)
-- Fixed handling of uint64 data layers in sql evolution. [4303](https://github.com/scalableminds/webknossos/pull/4303)
+- Fixed handling of uint64 data layers in sql evolution. [#4303](https://github.com/scalableminds/webknossos/pull/4303)
 
 
 ## [19.10.0](https://github.com/scalableminds/webknossos/releases/tag/19.10.0) - 2019-09-30

--- a/frontend/javascripts/components/fixed_expandable_table.js
+++ b/frontend/javascripts/components/fixed_expandable_table.js
@@ -3,7 +3,7 @@ import { Table } from "antd";
 import * as React from "react";
 
 type Props = {
-  children: React.Node,
+  children: Array<React.Element<typeof Table.Column>>,
   expandedRowRender: Function,
 };
 
@@ -26,7 +26,11 @@ export default class FixedExpandableTable extends React.PureComponent<Props, Sta
   render() {
     const { expandedColumns } = this.state;
     const { children, ...restProps } = this.props;
-    const columnsWithAdjustedFixedProp = React.Children.map(children, child => {
+
+    // Don't use React.Children.map here, since this adds .$ prefixes
+    // to the keys. However, the keys are needed when managing the sorters
+    // of the table.
+    const columnsWithAdjustedFixedProp = children.map(child => {
       const columnFixed = expandedColumns.length > 0 ? false : child.props.fixed;
       return React.cloneElement(child, { fixed: columnFixed });
     });

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -287,7 +287,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
               key="sandbox-tooltip"
             >
               <Button disabled type="primary" icon="code-sandbox">
-                Sandbox
+                <span className="hide-on-small-screen">Sandbox</span>
               </Button>
             </Tooltip>
           ),


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixsort.webknossos.xyz

### Steps to test:
- sort dataset table and also make use of the expand/collapse feature (the sticky action column should turn un-sticky if something is expanded)

### Issues:
- fixes #4292 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- ~[ ] Needs datastore update after deployment~
- [X] Ready for review
