### PR TITLE
Allow to import protobuf tracings per drag'n'drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 [Commits](https://github.com/scalableminds/webknossos/compare/19.11.0...HEAD)
 
 ### Added
--
+- Added support for importing tracings in a binary protobuf format via drag and drop. [#4320](https://github.com/scalableminds/webknossos/pull/4320)
 
 ### Changed
 -

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
@@ -270,11 +270,11 @@ export const createTreeAction = (timestamp: number = Date.now()): CreateTreeActi
 
 export const addTreesAndGroupsAction = (
   trees: TreeMap,
-  treeGroups: Array<TreeGroup>,
+  treeGroups: ?Array<TreeGroup>,
 ): AddTreesAndGroupsAction => ({
   type: "ADD_TREES_AND_GROUPS",
   trees,
-  treeGroups,
+  treeGroups: treeGroups || [],
 });
 
 export const deleteTreeAction = (

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -401,11 +401,12 @@ function getEdgeHash(source: number, target: number) {
   return source < target ? `${source}-${target}` : `${target}-${source}`;
 }
 
-function wrapInNewGroup(
+export function wrapInNewGroup(
   originalTrees: TreeMap,
-  originalTreeGroups: Array<TreeGroup>,
+  _originalTreeGroups: ?Array<TreeGroup>,
   wrappingGroupName: string,
 ): [TreeMap, Array<TreeGroup>] {
+  const originalTreeGroups = _originalTreeGroups || [];
   // It does not matter whether the group id is used in the active tracing, since
   // this case will be handled during import, anyway. The group id just shouldn't clash
   // with the nml itself.
@@ -429,7 +430,6 @@ function wrapInNewGroup(
 
 export function parseNml(
   nmlString: string,
-  wrappingGroupName?: ?string,
 ): Promise<{ trees: TreeMap, treeGroups: Array<TreeGroup>, datasetName: ?string }> {
   return new Promise((resolve, reject) => {
     const parser = new Saxophone();
@@ -611,20 +611,7 @@ export function parseNml(
         }
       })
       .on("end", () => {
-        if (wrappingGroupName != null) {
-          const [wrappedTrees, wrappedTreeGroups] = wrapInNewGroup(
-            trees,
-            treeGroups,
-            wrappingGroupName,
-          );
-          resolve({
-            trees: wrappedTrees,
-            treeGroups: wrappedTreeGroups,
-            datasetName,
-          });
-        } else {
-          resolve({ trees, treeGroups, datasetName });
-        }
+        resolve({ trees, treeGroups, datasetName });
       })
       .on("error", reject);
 

--- a/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.js
@@ -31,7 +31,7 @@ type StateProps = {|
   annotationType: string,
 |};
 type DispatchProps = {|
-  addTreesAndGroupsAction: (TreeMap, Array<TreeGroup>) => void,
+  addTreesAndGroupsAction: (TreeMap, ?Array<TreeGroup>) => void,
 |};
 type Props = {| ...OwnProps, ...StateProps, ...DispatchProps |};
 
@@ -169,7 +169,7 @@ class MergeModalView extends PureComponent<Props, MergeModalViewState> {
     this.setState({ isUploading: true });
     // Wait for an animation frame so that the loading animation is kicked off
     await Utils.animationFrame();
-    this.props.addTreesAndGroupsAction(createTreeMapFromTreeArray(trees), treeGroups || []);
+    this.props.addTreesAndGroupsAction(createTreeMapFromTreeArray(trees), treeGroups);
     this.setState({ isUploading: false });
     Toast.success(messages["tracing.merged"]);
     this.props.onOk();
@@ -263,7 +263,7 @@ function mapStateToProps(state: OxalisState): StateProps {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
-  addTreesAndGroupsAction(trees: TreeMap, treeGroups: Array<TreeGroup>) {
+  addTreesAndGroupsAction(trees: TreeMap, treeGroups: ?Array<TreeGroup>) {
     dispatch(addTreesAndGroupsAction(trees, treeGroups));
   },
 });

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -29,7 +29,7 @@ import MergerModeController from "oxalis/controller/merger_mode_controller";
 import TDViewControls from "oxalis/view/td_view_controls";
 import Toast from "libs/toast";
 import TracingView from "oxalis/view/tracing_view";
-import TreesTabView, { importNmls } from "oxalis/view/right-menu/trees_tab_view";
+import TreesTabView, { importTracingFiles } from "oxalis/view/right-menu/trees_tab_view";
 import VersionView from "oxalis/view/version_view";
 import messages from "messages";
 import window, { document, location } from "libs/window";
@@ -168,7 +168,7 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
     const { displayScalebars, isDatasetOnScratchVolume, isUpdateTracingAllowed } = this.props;
 
     return (
-      <NmlUploadZoneContainer onImport={importNmls} isAllowed={isUpdateTracingAllowed}>
+      <NmlUploadZoneContainer onImport={importTracingFiles} isAllowed={isUpdateTracingAllowed}>
         <OxalisController
           initialAnnotationType={this.props.initialAnnotationType}
           initialCommandType={this.props.initialCommandType}

--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
@@ -139,7 +139,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
     );
   }
 
-  importNmls = async () => {
+  importTracingFiles = async () => {
     this.setState({ isImporting: true });
     try {
       await this.props.onImport(
@@ -196,7 +196,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
         footer={
           <React.Fragment>
             {this.state.files.length > 1 ? createGroupsCheckbox : null}
-            <Button key="submit" type="primary" onClick={this.importNmls}>
+            <Button key="submit" type="primary" onClick={this.importTracingFiles}>
               Import
             </Button>
           </React.Fragment>

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -121,6 +121,12 @@ export async function importTracingFiles(files: Array<File>, createGroupForEachF
             const nmlProtoBuffer = await readFileAsArrayBuffer(file);
             const parsedTracing = parseProtoTracing(nmlProtoBuffer, "skeleton");
 
+            if (!parsedTracing.trees) {
+              // This check is only for flow to realize that we have a skeleton tracing
+              // on our hands.
+              throw new Error("Skeleton tracing doesn't contain trees");
+            }
+
             return {
               importAction: addTreesAndGroupsAction(
                 createTreeMapFromTreeArray(parsedTracing.trees),

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -101,7 +101,7 @@ type State = {
   groupToDelete: ?number,
 };
 
-export async function importNmls(files: Array<File>, createGroupForEachFile: boolean) {
+export async function importTracingFiles(files: Array<File>, createGroupForEachFile: boolean) {
   try {
     const { successes: importActionsWithDatasetNames, errors } = await Utils.promiseAllWithErrors(
       files.map(async file => {

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -107,7 +107,7 @@ export async function importTracingFiles(files: Array<File>, createGroupForEachF
       files.map(async file => {
         const ext = _.last(file.name.split("."));
         try {
-          if (ext == "nml") {
+          if (ext === "nml") {
             const nmlString = await readFileAsText(file);
             const { trees, treeGroups, datasetName } = await parseNml(
               nmlString,
@@ -131,7 +131,7 @@ export async function importTracingFiles(files: Array<File>, createGroupForEachF
           }
         } catch (e) {
           throw new Error(
-            `"${file.name}" could not be parsed as ${ext == "nml" ? "NML" : "protobuf"}. ${
+            `"${file.name}" could not be parsed as ${ext === "nml" ? "NML" : "protobuf"}. ${
               e.message
             }`,
           );

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -11,11 +11,13 @@ import {
   callDeep,
   MISSING_GROUP_ID,
 } from "oxalis/view/right-menu/tree_hierarchy_view_helpers";
+import { parseProtoTracing } from "oxalis/model/helpers/proto_helpers";
 import { getActiveTree, getActiveGroup } from "oxalis/model/accessors/skeletontracing_accessor";
 import { getBuildInfo } from "admin/admin_rest_api";
-import { readFileAsText } from "libs/read_file";
+import { readFileAsText, readFileAsArrayBuffer } from "libs/read_file";
 import { serializeToNml, getNmlName, parseNml } from "oxalis/model/helpers/nml_helpers";
 import { setDropzoneModalVisibilityAction } from "oxalis/model/actions/ui_actions";
+import { createTreeMapFromTreeArray } from "oxalis/model/reducers/skeletontracing_reducer_helpers";
 import {
   setTreeNameAction,
   createTreeAction,
@@ -103,18 +105,36 @@ export async function importNmls(files: Array<File>, createGroupForEachFile: boo
   try {
     const { successes: importActionsWithDatasetNames, errors } = await Utils.promiseAllWithErrors(
       files.map(async file => {
-        const nmlString = await readFileAsText(file);
+        const ext = _.last(file.name.split("."));
         try {
-          const { trees, treeGroups, datasetName } = await parseNml(
-            nmlString,
-            createGroupForEachFile ? file.name : null,
-          );
-          return {
-            importAction: addTreesAndGroupsAction(trees, treeGroups),
-            datasetName,
-          };
+          if (ext == "nml") {
+            const nmlString = await readFileAsText(file);
+            const { trees, treeGroups, datasetName } = await parseNml(
+              nmlString,
+              createGroupForEachFile ? file.name : null,
+            );
+            return {
+              importAction: addTreesAndGroupsAction(trees, treeGroups),
+              datasetName,
+            };
+          } else {
+            const nmlProtoBuffer = await readFileAsArrayBuffer(file);
+            const parsedTracing = parseProtoTracing(nmlProtoBuffer, "skeleton");
+
+            return {
+              importAction: addTreesAndGroupsAction(
+                createTreeMapFromTreeArray(parsedTracing.trees),
+                parsedTracing.treeGroups,
+              ),
+              datasetName: parsedTracing.dataSetName,
+            };
+          }
         } catch (e) {
-          throw new Error(`"${file.name}" could not be parsed. ${e.message}`);
+          throw new Error(
+            `"${file.name}" could not be parsed as ${ext == "nml" ? "NML" : "protobuf"}. ${
+              e.message
+            }`,
+          );
         }
       }),
     );


### PR DESCRIPTION
I didn't update the UI labels ("Import NMLs or protobuf tracings" might be intimidating and confusing to non-pro users). I think, for now, it's alright, if the import is supported but not explicitly advertised.

### URL of deployed dev instance (used for testing):
- https://dndprotobufimport.webknossos.xyz

### Steps to test:
- drop a protobuf tracing into the tracing view
- you can use the following file. I'd rename it to `*.bin` instead of `*.zip` (or another extension which is not NML). github only supports the upload for certain file types which is why I had to resort to zip.
[protobuf.zip](https://github.com/scalableminds/webknossos/files/3837285/protobuf.zip)


### Issues:
- fixes #4311 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [ ] ~Updated [documentation](../blob/master/docs) if applicable~
- [ ] ~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [ ] ~Needs datastore update after deployment~
- [X] Ready for review
