### PR TITLE
Allow to disable saving in an explorative tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Added
 - Added support for importing tracings in a binary protobuf format via drag and drop. [#4320](https://github.com/scalableminds/webknossos/pull/4320)
 - Added an API to set a tree active by name. [#4317](https://github.com/scalableminds/webknossos/pull/4317)
+- Added possibility to disable saving in an explorative annotation. This feature can save a lot of resources when dealing with very large NMLs which don't need to be persisted. [#4321](https://github.com/scalableminds/webknossos/pull/4321)
 
 ### Changed
 -

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -128,6 +128,9 @@ In order to restore the current window, a reload is necessary.`,
   "task.domain_does_not_exist":
     "No matching experience domain. Assign this domain to a user to add it to the listed options.",
   "annotation.reset_success": "Annotation was successfully reset.",
+  "annotation.disable_saving": "Are you sure you want to disable saving?",
+  "annotation.disable_saving.content":
+    "This can only be undone by refreshing the page. All unsaved changes will be lost. Only use this for large, temporary tracings to save resources.",
   "task.bulk_create_invalid":
     "Can not parse task specification. It includes at least one invalid task.",
   "task.recommended_configuration": "The author of this task suggests to use these settings:",

--- a/frontend/javascripts/oxalis/model/actions/save_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/save_actions.js
@@ -31,6 +31,7 @@ type SetVersionNumberAction = {
 };
 type UndoAction = { type: "UNDO" };
 type RedoAction = { type: "REDO" };
+type DisableSavingAction = { type: "DISABLE_SAVING" };
 export type SaveAction =
   | PushSaveQueueTransaction
   | SaveNowAction
@@ -40,7 +41,8 @@ export type SaveAction =
   | SetLastSaveTimestampAction
   | SetVersionNumberAction
   | UndoAction
-  | RedoAction;
+  | RedoAction
+  | DisableSavingAction;
 
 export const pushSaveQueueTransaction = (
   items: Array<UpdateAction>,
@@ -97,4 +99,8 @@ export const undoAction = (): UndoAction => ({
 
 export const redoAction = (): RedoAction => ({
   type: "REDO",
+});
+
+export const disableSavingAction = (): DisableSavingAction => ({
+  type: "DISABLE_SAVING",
 });

--- a/frontend/javascripts/oxalis/model/reducers/save_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/save_reducer.js
@@ -13,6 +13,7 @@ import { getStats } from "oxalis/model/accessors/skeletontracing_accessor";
 import { maximumActionCountPerBatch } from "oxalis/model/sagas/save_saga_constants";
 import Date from "libs/date";
 import * as Utils from "libs/utils";
+import { updateKey2 } from "oxalis/model/helpers/deep_update";
 
 function SaveReducer(state: OxalisState, action: Action): OxalisState {
   switch (action.type) {
@@ -113,6 +114,16 @@ function SaveReducer(state: OxalisState, action: Action): OxalisState {
     case "SET_VERSION_NUMBER": {
       return update(state, {
         tracing: { [action.tracingType]: { version: { $set: action.version } } },
+      });
+    }
+
+    case "DISABLE_SAVING": {
+      if (state.task != null) {
+        // Don't disable saving in a task, even when this action was dispatched somehow.
+        return state;
+      }
+      return updateKey2(state, "tracing", "restrictions", {
+        allowSave: false,
       });
     }
 

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -13,7 +13,7 @@ import {
 import { copyAnnotationToUserAccount, downloadNml, finishAnnotation } from "admin/admin_rest_api";
 import { location } from "libs/window";
 import { setVersionRestoreVisibilityAction } from "oxalis/model/actions/ui_actions";
-import { undoAction, redoAction } from "oxalis/model/actions/save_actions";
+import { undoAction, redoAction, disableSavingAction } from "oxalis/model/actions/save_actions";
 import ButtonComponent from "oxalis/view/components/button_component";
 import Constants from "oxalis/constants";
 import MergeModalView from "oxalis/view/action-bar/merge_modal_view";
@@ -217,6 +217,16 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     });
   };
 
+  handleDisableSaving = () => {
+    Modal.confirm({
+      title: messages["annotation.disable_saving"],
+      content: messages["annotation.disable_saving.content"],
+      onOk: () => {
+        Store.dispatch(disableSavingAction());
+      },
+    });
+  };
+
   handleShareOpen = () => {
     this.setState({ isShareModalOpen: true });
   };
@@ -283,7 +293,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
           ) : (
             <Tooltip
               placement="bottom"
-              title="This tracing was opened in sandbox mode. You can edit it, but changes cannot be saved. Log in to save tracings."
+              title="This tracing was opened in sandbox mode. You can edit it, but changes cannot be saved. Ensure that you are logged in and refresh the page to exit this mode."
               key="sandbox-tooltip"
             >
               <Button disabled type="primary" icon="code-sandbox">
@@ -322,6 +332,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
         </Menu.Item>,
       );
     }
+
     if (restrictions.allowDownload) {
       elements.push(
         <Menu.Item key="download-button" onClick={this.handleDownload}>
@@ -387,6 +398,15 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     );
 
     elements.push(this.props.layoutMenu);
+
+    if (restrictions.allowSave && !this.props.task) {
+      elements.push(
+        <Menu.Item key="disable-saving" onClick={this.handleDisableSaving}>
+          <Icon type="stop-o" />
+          Disable saving
+        </Menu.Item>,
+      );
+    }
 
     const menu = <Menu>{elements}</Menu>;
 


### PR DESCRIPTION
See #4319 

### URL of deployed dev instance (used for testing):
- https://disablesaving.webknossos.xyz

### Steps to test:
- open a tracing for which you have write-permissions and select "disable saving" in the dropdown next to the save button
- all changes which were not saved until that point and which are made afterwards should not be persisted
- open a task and ensure that this "disable saving" option cannot be used (shouldn't appear)

### Issues:
- fixes #4319 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [ ] ~Updated [documentation](../blob/master/docs) if applicable~
- [ ] ~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [ ] ~Needs datastore update after deployment~
- [x] Ready for review
