### PR TITLE
Add cross origin api ready message

### DIFF
--- a/frontend/javascripts/oxalis/api/cross_origin_api.js
+++ b/frontend/javascripts/oxalis/api/cross_origin_api.js
@@ -56,6 +56,13 @@ const CrossOriginApi = () => {
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
   }, []);
+  useEffect(() => {
+    if (window.webknossos && window.parent) {
+      window.webknossos.apiReady().then(() => {
+        window.parent.postMessage({ message: "api ready" }, "*");
+      });
+    }
+  }, [window.webknossos]);
 
   return null;
 };


### PR DESCRIPTION
This PR adds a notification to the parent window, when the cross origin api is ready for use.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- add the following to `tools/test-iframe-page.html`:
```
  <script>
    const onReceiveMessage = message => {
      if (message.data.message == "api ready") {
        alert("Wuhu api is ready for use :D");
      }
    };
    window.addEventListener("message", onReceiveMessage);
  </script>
```
- This might help with the testing.

### Issues:
- This PR is connected to this [issue](https://github.com/scalableminds/connectome-viewer/issues/29)

------
- ~~[ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)~~ I think this is not needed
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
