### PR TITLE
Remove preventDefault from mousedown to allow iframe focus

### DIFF
--- a/frontend/javascripts/libs/input.js
+++ b/frontend/javascripts/libs/input.js
@@ -407,7 +407,6 @@ export class InputMouse {
   }
 
   mouseDown = (event: MouseEvent): void => {
-    event.preventDefault();
     isDragging = true;
     this.lastPosition = this.getRelativeMousePosition(event);
 


### PR DESCRIPTION
Debugging why keyboard shortcuts in a wK iframe don't work, I ended up at this line.
Because `preventDefault` is called on every mousedown event, the wK iframe cannot become focused if the user clicks on one of the viewports, which is why the keyboard shortcuts didn't work.
I traced this line back to https://github.com/scalableminds/webknossos/commit/f393590f7bc1016d3896cf84a130dfeca3f683dd so it's been there almost since the beginning (7 years ago :open_mouth:)

I didn't notice any faulty behavior after removing this line, maybe you know why it would be needed? (/cc @normanrz)

### URL of deployed dev instance (used for testing):
- https://fixiframefocus.webknossos.xyz

### Steps to test:
- Open `tools/test-iframe-page.html` and click on one of the viewports => `document.activeElement` should be the iframe
- Use mouse inputs in wK
  - rightclick on the viewports shouldn't work
  - setting and selecting nodes, volumetracing should work

------
- [x] Ready for review
