### PR TITLE
Improved initial data and configs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 package.json
+CHANGELOG.md
+README.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,2 @@
 package.json
-CHANGELOG.md
-README.md
-MIGRATIONS.md
+*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 package.json
 CHANGELOG.md
 README.md
+MIGRATIONS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Changed
 - Consolidates URI handling in the config. Pairs of `uri` and `secured` entries are now specified as just `uri` and require either `http://` or `https://` prefix. [#4368](https://github.com/scalableminds/webknossos/pull/4368)
-- Renamed initial organization for the dev deployment to `sample`. [#4368](https://github.com/scalableminds/webknossos/pull/4368)
+- Renamed initial organization for the dev deployment to `sample_organization`. [#4368](https://github.com/scalableminds/webknossos/pull/4368)
 
 ### Fixed
 - Fixed an issue where webKnossos would complain in certain scenarios when resolutions of datasets were not complete. [#4344](https://github.com/scalableminds/webknossos/pull/4344)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 [Commits](https://github.com/scalableminds/webknossos/compare/19.12.0...HEAD)
 
 ### Added
+- Added `publicUri` configs for datastore and tracingstore for initial setup. [#](https://github.com/scalableminds/webknossos/pull/)
 - Added a scale to the y-axis of histograms to indicate the logarithmic representation. Additionally, small histogram values are smoothed out. [#4349](https://github.com/scalableminds/webknossos/pull/4349)
 - Added a new way of sharing annotations. You can share your annotations with selected teams. These annotations appear in the Shared Annotations Tab in the dashboard. [#4304](https://github.com/scalableminds/webknossos/pull/4304)
 
 ### Changed
--
+- Consolidates URI handling in the config. Pairs of `uri` and `secured` entries are now specified as just `uri` and require either `http://` or `https://` prefix. [#](https://github.com/scalableminds/webknossos/pull/)
+- Renamed initial organization for the dev deployment to `sample`. [#](https://github.com/scalableminds/webknossos/pull/)
 
 ### Fixed
 - Fixed an issue where webKnossos would complain in certain scenarios when resolutions of datasets were not complete. [#4344](https://github.com/scalableminds/webknossos/pull/4344)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 [Commits](https://github.com/scalableminds/webknossos/compare/19.12.0...HEAD)
 
 ### Added
-- Added `publicUri` configs for datastore and tracingstore for initial setup. [#](https://github.com/scalableminds/webknossos/pull/)
+- Added `publicUri` configs for datastore and tracingstore for initial setup. [#4368](https://github.com/scalableminds/webknossos/pull/4368)
 - Added a scale to the y-axis of histograms to indicate the logarithmic representation. Additionally, small histogram values are smoothed out. [#4349](https://github.com/scalableminds/webknossos/pull/4349)
 - Added a new way of sharing annotations. You can share your annotations with selected teams. These annotations appear in the Shared Annotations Tab in the dashboard. [#4304](https://github.com/scalableminds/webknossos/pull/4304)
 
 ### Changed
-- Consolidates URI handling in the config. Pairs of `uri` and `secured` entries are now specified as just `uri` and require either `http://` or `https://` prefix. [#](https://github.com/scalableminds/webknossos/pull/)
-- Renamed initial organization for the dev deployment to `sample`. [#](https://github.com/scalableminds/webknossos/pull/)
+- Consolidates URI handling in the config. Pairs of `uri` and `secured` entries are now specified as just `uri` and require either `http://` or `https://` prefix. [#4368](https://github.com/scalableminds/webknossos/pull/4368)
+- Renamed initial organization for the dev deployment to `sample`. [#4368](https://github.com/scalableminds/webknossos/pull/4368)
 
 ### Fixed
 - Fixed an issue where webKnossos would complain in certain scenarios when resolutions of datasets were not complete. [#4344](https://github.com/scalableminds/webknossos/pull/4344)

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,7 +5,9 @@ This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.md).
 
 ## Unreleased
--
+- The initial organization was renamed to `sample`. Make sure to move the data over or to put a symlink in place.
+- The default `operatorData` was replaced. Make sure to update with valid information for public deployments.
+- The config `uri` has been refactored. Pairs of `uri` and `secured` have been replaced with just `uri` which now requires a `http://` or `https://` prefix.
 
 ### Postgres Evolutions:
 - [049-annotation-listed-teams.sql](conf/evolutions/049-annotation-listed-teams.sql)

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,7 +5,7 @@ This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.md).
 
 ## Unreleased
-- The initial organization was renamed to `sample`. Make sure to move the data over or to put a symlink in place.
+- The initial organization was renamed to `sample_organization`. Make sure to move the data over or to put a symlink in place.
 - The default `operatorData` was replaced. Make sure to update with valid information for public deployments.
 - The config `uri` has been refactored. Pairs of `uri` and `secured` have been replaced with just `uri` which now requires a `http://` or `https://` prefix.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Open your local webknossos instance on [localhost:9000](http://localhost:9000).
 
 See the [wiki](https://github.com/scalableminds/webknossos/wiki/Try-setup) for instructions on updating this try setup.
 
+For non-localhost deployments, make sure to set the `datastore.publicUri` and `tracingstore.publicUri` entries in the config.
+
 
 ### Dependencies
 

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -61,10 +61,10 @@ Samplecountry
 """
   val organizationTeamId = ObjectId.generate
   val defaultOrganization = Organization(ObjectId.generate,
-                                         "sample_orga",
+                                         "sample",
                                          additionalInformation,
-                                         "/assets/images/sample-orga-logo.svg",
-                                         "MPI for Brain Research")
+                                         "/assets/images/oxalis.svg",
+                                         "Sample Organization")
   val organizationTeam = Team(organizationTeamId, defaultOrganization._id, defaultOrganization.name, true)
   val defaultUser = User(
     ObjectId.generate,

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -61,7 +61,7 @@ Samplecountry
 """
   val organizationTeamId = ObjectId.generate
   val defaultOrganization =
-    Organization(ObjectId.generate, "sample", additionalInformation, "/assets/images/oxalis.svg", "Sample Organization")
+    Organization(ObjectId.generate, "sample_organization", additionalInformation, "/assets/images/oxalis.svg", "Sample Organization")
   val organizationTeam = Team(organizationTeamId, defaultOrganization._id, defaultOrganization.name, true)
   val defaultUser = User(
     ObjectId.generate,

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -61,7 +61,11 @@ Samplecountry
 """
   val organizationTeamId = ObjectId.generate
   val defaultOrganization =
-    Organization(ObjectId.generate, "sample_organization", additionalInformation, "/assets/images/oxalis.svg", "Sample Organization")
+    Organization(ObjectId.generate,
+                 "sample_organization",
+                 additionalInformation,
+                 "/assets/images/oxalis.svg",
+                 "Sample Organization")
   val organizationTeam = Team(organizationTeamId, defaultOrganization._id, defaultOrganization.name, true)
   val defaultUser = User(
     ObjectId.generate,

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -61,9 +61,9 @@ Samplecountry
 """
   val organizationTeamId = ObjectId.generate
   val defaultOrganization = Organization(ObjectId.generate,
-                                         "Connectomics_Department",
+                                         "sample_orga",
                                          additionalInformation,
-                                         "/assets/images/mpi-logos.svg",
+                                         "/assets/images/sample-orga-logo.svg",
                                          "MPI for Brain Research")
   val organizationTeam = Team(organizationTeamId, defaultOrganization._id, defaultOrganization.name, true)
   val defaultUser = User(
@@ -207,7 +207,7 @@ Samplecountry
       dataStoreDAO.findOneByName("localhost").futureBox.map { maybeStore =>
         if (maybeStore.isEmpty) {
           logger.info("inserting local datastore")
-          dataStoreDAO.insertOne(DataStore("localhost", conf.Http.uri, conf.Http.uri, conf.Datastore.key))
+          dataStoreDAO.insertOne(DataStore("localhost", conf.Http.uri, conf.Datastore.publicUri.getOrElse(conf.Http.uri), conf.Datastore.key))
         }
       }
     } else Fox.successful(())
@@ -228,7 +228,7 @@ Samplecountry
       tracingStoreDAO.findOneByName("localhost").futureBox.map { maybeStore =>
         if (maybeStore.isEmpty) {
           logger.info("inserting local tracingstore")
-          tracingStoreDAO.insertOne(TracingStore("localhost", conf.Http.uri, conf.Http.uri, conf.Tracingstore.key))
+          tracingStoreDAO.insertOne(TracingStore("localhost", conf.Http.uri, conf.Datastore.publicUri.getOrElse(conf.Http.uri), conf.Tracingstore.key))
         }
       }
     } else Fox.successful(())

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -60,11 +60,8 @@ Sampletown
 Samplecountry
 """
   val organizationTeamId = ObjectId.generate
-  val defaultOrganization = Organization(ObjectId.generate,
-                                         "sample",
-                                         additionalInformation,
-                                         "/assets/images/oxalis.svg",
-                                         "Sample Organization")
+  val defaultOrganization =
+    Organization(ObjectId.generate, "sample", additionalInformation, "/assets/images/oxalis.svg", "Sample Organization")
   val organizationTeam = Team(organizationTeamId, defaultOrganization._id, defaultOrganization.name, true)
   val defaultUser = User(
     ObjectId.generate,
@@ -207,7 +204,11 @@ Samplecountry
       dataStoreDAO.findOneByName("localhost").futureBox.map { maybeStore =>
         if (maybeStore.isEmpty) {
           logger.info("inserting local datastore")
-          dataStoreDAO.insertOne(DataStore("localhost", conf.Http.uri, conf.Datastore.publicUri.getOrElse(conf.Http.uri), conf.Datastore.key))
+          dataStoreDAO.insertOne(
+            DataStore("localhost",
+                      conf.Http.uri,
+                      conf.Datastore.publicUri.getOrElse(conf.Http.uri),
+                      conf.Datastore.key))
         }
       }
     } else Fox.successful(())
@@ -228,7 +229,11 @@ Samplecountry
       tracingStoreDAO.findOneByName("localhost").futureBox.map { maybeStore =>
         if (maybeStore.isEmpty) {
           logger.info("inserting local tracingstore")
-          tracingStoreDAO.insertOne(TracingStore("localhost", conf.Http.uri, conf.Datastore.publicUri.getOrElse(conf.Http.uri), conf.Tracingstore.key))
+          tracingStoreDAO.insertOne(
+            TracingStore("localhost",
+                         conf.Http.uri,
+                         conf.Datastore.publicUri.getOrElse(conf.Http.uri),
+                         conf.Tracingstore.key))
         }
       }
     } else Fox.successful(())

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -66,11 +66,13 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader {
   object Datastore {
     val enabled = get[Boolean]("datastore.enabled")
     val key = get[String]("datastore.key")
+    val publicUri = getOptional[String]("datastore.publicUri")
   }
 
   object Tracingstore {
     val enabled = get[Boolean]("tracingstore.enabled")
     val key = get[String]("tracingstore.key")
+    val publicUri = getOptional[String]("tracingstore.publicUri")
   }
 
   object User {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -13,10 +13,10 @@ datastore {
   enabled = true
   key = "something-secure"
   name = "localhost"
+  publicUri = "http://localhost:9000"
   debugMode = true
   webKnossos {
-    uri = "localhost:9000"
-    secured = false
+    uri = "http://localhost:9000"
     pingIntervalMinutes = 10
   }
   fossildb {
@@ -29,9 +29,9 @@ tracingstore {
   enabled = true
   key = "something-secure"
   name = "localhost"
+  publicUri = "http://localhost:9000"
   webKnossos {
-    uri = "localhost:9000"
-    secured = false
+    uri = "http://localhost:9000"
     pingIntervalMinutes = 10
   }
   fossildb {
@@ -217,16 +217,7 @@ play.server.akka.requestTimeout = 1000s
 pidfile.path = "/dev/null"
 
 operatorData = """
-  **scalable minds GmbH**
+  **This is a dev deployment**
 
-  Großbeerenstraße 15
-  14482 Potsdam
-  Germany
-
-  District Court Potsdam, HRB 25763
-  Managing Directors: Tom Bocklisch, Tom Herold, Norman Rzepka
-  USt-Id. DE283513495
-
-  [hello@scalableminds.com](mailto:hello@scalableminds.com)
-  [https://scalableminds.com](https://scalableminds.com)
+  Please add the information of the operator to comply with GDPR.
 """

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '2.2'
+version: "2.2"
 
 services:
-
   # Production
   webknossos:
     build: .
@@ -131,8 +130,6 @@ services:
         condition: service_healthy
       fossildb-dev:
         condition: service_healthy
-      webknossos-connect:
-        condition: service_healthy
     environment:
       - POSTGRES_URL=jdbc:postgresql://postgres/webknossos
     command:
@@ -161,8 +158,8 @@ services:
     extends:
       service: base
     ports:
-    - "5005:5005"
-    - "9000:9000"
+      - "5005:5005"
+      - "9000:9000"
     command: sbt ";scapegoat; scalafmtCheck; util/scalafmtCheck; webknossosTracingstore/scalafmtCheck; webknossosDatastore/scalafmtCheck"
 
   e2e-tests:
@@ -232,7 +229,7 @@ services:
     extends:
       service: postgres
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - "./pg/dev-db:/var/lib/postgresql/data/"
 
@@ -259,7 +256,6 @@ services:
         condition: service_healthy
     environment:
       PGPASSWORD: postgres
-
 
   # FossilDB
   fossildb:
@@ -298,4 +294,3 @@ services:
       timeout: 1s
       interval: 5s
       retries: 10
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       # - -Dplay.modules.enabled-="com.scalableminds.webknossos.datastore.DataStoreModule"
       # - -Ddatastore.enabled=false
       # - -Dplay.http.router="noDS.Routes"
+      # the following lines need to be adapted for non-localhost deployments
+      # - -Dtracingstore.publicUrl=http://example.org:9000
+      # - -Ddatastore.publicUrl=http://example.org:9000
     volumes:
       - ./binaryData:/srv/webknossos/binaryData
     environment:

--- a/util/src/main/scala/com/scalableminds/util/tools/ConfigReader.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/ConfigReader.scala
@@ -7,4 +7,7 @@ trait ConfigReader {
 
   def get[A](path: String)(implicit loader: ConfigLoader[A]): A =
     raw.get[A](path)
+
+  def getOptional[A](path: String)(implicit loader: ConfigLoader[A]): Option[A] =
+    raw.getOptional[A](path)
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -37,7 +37,6 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
     val name = get[String]("datastore.name")
     object WebKnossos {
       val uri = get[String]("datastore.webKnossos.uri")
-      val secured = get[Boolean]("datastore.webKnossos.secured")
       val pingIntervalMinutes = get[Int]("datastore.webKnossos.pingIntervalMinutes") minutes
     }
     val children = List(WebKnossos)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataStoreWkRpcClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataStoreWkRpcClient.scala
@@ -39,13 +39,7 @@ class DataStoreWkRpcClient @Inject()(
   private val dataStoreName: String = config.Datastore.name
   private val dataStoreUrl: String = config.Http.uri
 
-  private val webKnossosUrl = {
-    val url = config.Datastore.WebKnossos.uri
-    if (config.Datastore.WebKnossos.secured)
-      s"https://$url"
-    else
-      s"http://$url"
-  }
+  private val webKnossosUrl: String = config.Datastore.WebKnossos.uri
 
   protected lazy val tickerInterval: FiniteDuration = config.Datastore.WebKnossos.pingIntervalMinutes
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
@@ -18,7 +18,6 @@ class TracingStoreConfig @Inject()(configuration: Configuration) extends ConfigR
     val name = get[String]("tracingstore.name")
     object WebKnossos {
       val uri = get[String]("tracingstore.webKnossos.uri")
-      val secured = get[Boolean]("tracingstore.webKnossos.secured")
     }
     object Fossildb {
       val address = get[String]("tracingstore.fossildb.address")

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreWkRpcClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreWkRpcClient.scala
@@ -25,13 +25,7 @@ class TracingStoreWkRpcClient @Inject()(
   private val tracingStoreName: String = config.Tracingstore.name
   private val tracingStoreUrl: String = config.Http.uri
 
-  private val webKnossosUrl = {
-    val url = config.Tracingstore.WebKnossos.uri
-    if (config.Tracingstore.WebKnossos.secured)
-      s"https://$url"
-    else
-      s"http://$url"
-  }
+  private val webKnossosUrl: String = config.Tracingstore.WebKnossos.uri
 
   def reportTracingUpdates(tracingId: String,
                            timestamps: List[Long],


### PR DESCRIPTION
- Renames initial organization to `sample`
- Refactors `uri` specification in config
- Replaces default `operatorData`

### Steps to test:
- Clone webknossos on a remote server
- Set the `*.publicUri` fields in the docker-compose.yml
- Start webKnossos and see if it works

### Issues:
- fixes #4221 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
~- [ ] Updated [documentation](../blob/master/docs) if applicable~
~- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [x] Needs datastore update after deployment
- [x] Ready for review
