### PR TITLE
fix exit-codes for postgres-scripts

### DIFF
--- a/tools/postgres/ensure_db.sh
+++ b/tools/postgres/ensure_db.sh
@@ -6,8 +6,8 @@ scriptdir="$(dirname "$0")"
 dbName="$("$scriptdir"/db_name.sh)"
 dbHost="$("$scriptdir"/db_host.sh)"
 
-DATABASE_EXISTENCE="$(PGPASSWORD=postgres psql -U postgres -h $dbHost -tAc "SELECT 1 FROM pg_database WHERE datname='$dbName'" )"
-if [ "$DATABASE_EXISTENCE" = '1' ]
+dbExistence="$(PGPASSWORD=postgres psql -U postgres -h $dbHost -tAc "SELECT 1 FROM pg_database WHERE datname='$dbName'" )"
+if [ "$dbExistence" = '1' ]
 then
     echo "Database already exists"
 else

--- a/tools/postgres/ensure_db.sh
+++ b/tools/postgres/ensure_db.sh
@@ -6,7 +6,8 @@ scriptdir="$(dirname "$0")"
 dbName="$("$scriptdir"/db_name.sh)"
 dbHost="$("$scriptdir"/db_host.sh)"
 
-if [ "$(PGPASSWORD=postgres psql -U postgres -h $dbHost -tAc "SELECT 1 FROM pg_database WHERE datname='$dbName'" )" = '1' ]
+DATABASE_EXISTENCE="$(PGPASSWORD=postgres psql -U postgres -h $dbHost -tAc "SELECT 1 FROM pg_database WHERE datname='$dbName'" )"
+if [ "$DATABASE_EXISTENCE" = '1' ]
 then
     echo "Database already exists"
 else

--- a/tools/postgres/ensure_schema.sh
+++ b/tools/postgres/ensure_schema.sh
@@ -8,8 +8,8 @@ dbHost="$("$scriptdir"/db_host.sh)"
 
 schemaPath="$scriptdir/schema.sql"
 
-SCHEMA_EXISTENCE="$(PGPASSWORD=postgres psql -U postgres -h  $dbHost --dbname=$dbName -tAc "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'webknossos';")"
-if [ "$SCHEMA_EXISTENCE" = 'webknossos' ]
+schemaName="$(PGPASSWORD=postgres psql -U postgres -h  $dbHost --dbname=$dbName -tAc "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'webknossos';")"
+if [ "$schemaName" = 'webknossos' ]
 then
     echo "Schema already exists"
     exit

--- a/tools/postgres/ensure_schema.sh
+++ b/tools/postgres/ensure_schema.sh
@@ -8,7 +8,8 @@ dbHost="$("$scriptdir"/db_host.sh)"
 
 schemaPath="$scriptdir/schema.sql"
 
-if [ "$(PGPASSWORD=postgres psql -U postgres -h  $dbHost --dbname=$dbName -tAc "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'webknossos';")" = 'webknossos' ]
+SCHEMA_EXISTENCE="$(PGPASSWORD=postgres psql -U postgres -h  $dbHost --dbname=$dbName -tAc "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'webknossos';")"
+if [ "$SCHEMA_EXISTENCE" = 'webknossos' ]
 then
     echo "Schema already exists"
     exit


### PR DESCRIPTION
This fixes the early exit of `ensure_db.sh` & `ensure_schema.sh`. Before, the exit code of the command in the if-clause was hidden. A failure of the command did not cause the early exit of the script as usual through `set -e`. Using an assignment fixes this, this triggers the early exit as expected.

- fixes #4392 
- [x] Ready for review
