### PR TITLE
Replace Create Explorative buttons by Links

### DIFF
--- a/frontend/javascripts/admin/api_flow_types.js
+++ b/frontend/javascripts/admin/api_flow_types.js
@@ -247,7 +247,13 @@ export type APIAnnotationType = $Keys<typeof APIAnnotationTypeEnum>;
 
 export type APIAnnotationVisibility = "Private" | "Internal" | "Public";
 
-export type TracingType = "skeleton" | "volume" | "hybrid";
+export const TracingTypeEnum = Enum.make({
+  skeleton: "skeleton",
+  volume: "volume",
+  hybrid: "hybrid",
+});
+
+export type TracingType = $Keys<typeof TracingTypeEnum>;
 
 export type APITaskType = {
   +id: string,

--- a/frontend/javascripts/admin/auth/login_view.js
+++ b/frontend/javascripts/admin/auth/login_view.js
@@ -22,9 +22,14 @@ function LoginView({ history, redirect }: Props) {
         history.push("/dashboard");
       }
     } else {
-      // Use "redirectPage" URL parameter to cause a full page reload and redirecting to external sites
-      // e.g. Discuss
-      window.location.replace(Utils.getUrlParamValue("redirectPage"));
+      const redirectPage = Utils.getUrlParamValue("redirectPage");
+      if (redirectPage.startsWith("/")) {
+        history.push(redirectPage);
+      } else {
+        // Use "redirectPage" URL parameter to cause a full page reload and redirecting to external sites
+        // e.g. Discuss
+        window.location.replace(redirectPage);
+      }
     }
   };
 

--- a/frontend/javascripts/components/redirect.js
+++ b/frontend/javascripts/components/redirect.js
@@ -5,16 +5,25 @@ import React from "react";
 type Props = {
   redirectTo: () => Promise<string>,
   history: RouterHistory,
+  pushToHistory: boolean,
 };
 
 class AsyncRedirect extends React.PureComponent<Props> {
+  static defaultProps = {
+    pushToHistory: true,
+  };
+
   componentDidMount() {
     this.redirect();
   }
 
   async redirect() {
     const newPath = await this.props.redirectTo();
-    this.props.history.push(newPath);
+    if (this.props.pushToHistory) {
+      this.props.history.push(newPath);
+    } else {
+      this.props.history.replace(newPath);
+    }
   }
 
   render() {

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
@@ -9,23 +9,29 @@ import Toast from "libs/toast";
 import messages from "messages";
 import { trackAction } from "oxalis/model/helpers/analytics";
 
-export const createTracingOverlayMenu = (
-  dataset: APIMaybeUnimportedDataset,
-  type: TracingType,
-  onClick: (APIMaybeUnimportedDataset, TracingType, boolean) => Promise<void>,
-) => {
+export const createTracingOverlayMenu = (dataset: APIMaybeUnimportedDataset, type: TracingType) => {
   const typeCapitalized = type.charAt(0).toUpperCase() + type.slice(1);
   return (
     <Menu>
-      <Menu.Item key="existing" onClick={() => onClick(dataset, type, true)}>
-        <a href="#" title={`Create ${typeCapitalized} Tracing`}>
+      <Menu.Item key="existing">
+        <Link
+          to={`/datasets/${dataset.owningOrganization}/${
+            dataset.name
+          }/createExplorative/${type}/true`}
+          title={`Create ${typeCapitalized} Tracing`}
+        >
           Use Existing Segmentation Layer
-        </a>
+        </Link>
       </Menu.Item>
-      <Menu.Item key="new" onClick={() => onClick(dataset, type, false)}>
-        <a href="#" title={`Create ${typeCapitalized} Tracing`}>
+      <Menu.Item key="new">
+        <Link
+          to={`/datasets/${dataset.owningOrganization}/${
+            dataset.name
+          }/createExplorative/${type}/false`}
+          title={`Create ${typeCapitalized} Tracing`}
+        >
           Use a New Segmentation Layer
-        </a>
+        </Link>
       </Menu.Item>
     </Menu>
   );
@@ -63,7 +69,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
 
     const volumeTracingMenu = (
       <Dropdown
-        overlay={createTracingOverlayMenu(dataset, "volume", this.createTracing)}
+        overlay={createTracingOverlayMenu(dataset, "volume")}
         trigger={["click"]}
       >
         <a href="#" title="Create Volume Tracing">
@@ -79,7 +85,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
 
     const hybridTracingMenu = (
       <Dropdown
-        overlay={createTracingOverlayMenu(dataset, "hybrid", this.createTracing)}
+        overlay={createTracingOverlayMenu(dataset, "hybrid")}
         trigger={["click"]}
       >
         <a href="#" title="Create Hybrid (Skeleton + Volume) Tracing">
@@ -132,9 +138,10 @@ class DatasetActionView extends React.PureComponent<Props, State> {
             </Link>
             {!dataset.isForeign ? (
               <React.Fragment>
-                <a
-                  href="#"
-                  onClick={() => this.createTracing(dataset, "skeleton", false)}
+                <Link
+                  to={`/datasets/${dataset.owningOrganization}/${
+                    dataset.name
+                  }/createExplorative/skeleton/false`}
                   title="Create Skeleton Tracing"
                 >
                   <img
@@ -143,7 +150,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
                     style={centerBackgroundImageStyle}
                   />{" "}
                   Start Skeleton Tracing
-                </a>
+                </Link>
                 {volumeTracingMenu}
                 {hybridTracingMenu}
               </React.Fragment>

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
@@ -58,10 +58,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
     };
 
     const volumeTracingMenu = (
-      <Dropdown
-        overlay={createTracingOverlayMenu(dataset, "volume")}
-        trigger={["click"]}
-      >
+      <Dropdown overlay={createTracingOverlayMenu(dataset, "volume")} trigger={["click"]}>
         <a href="#" title="Create Volume Tracing">
           <img
             src="/assets/images/volume.svg"
@@ -74,10 +71,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
     );
 
     const hybridTracingMenu = (
-      <Dropdown
-        overlay={createTracingOverlayMenu(dataset, "hybrid")}
-        trigger={["click"]}
-      >
+      <Dropdown overlay={createTracingOverlayMenu(dataset, "hybrid")} trigger={["click"]}>
         <a href="#" title="Create Hybrid (Skeleton + Volume) Tracing">
           <Icon type="swap" />
           Start Hybrid Tracing

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
@@ -46,16 +46,6 @@ type Props = {
 type State = {};
 
 class DatasetActionView extends React.PureComponent<Props, State> {
-  createTracing = async (
-    dataset: APIMaybeUnimportedDataset,
-    type: TracingType,
-    withFallback: boolean,
-  ) => {
-    const annotation = await createExplorational(dataset, type, withFallback);
-    trackAction(`Create ${type} tracing`);
-    this.props.history.push(`/annotations/${annotation.typ}/${annotation.id}`);
-  };
-
   clearCache = async (dataset: APIMaybeUnimportedDataset) => {
     await clearCache(dataset);
     Toast.success(messages["dataset.clear_cache_success"]);

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
@@ -1,13 +1,12 @@
 // @flow
 import { Dropdown, Menu, Icon, Tooltip } from "antd";
-import { Link, type RouterHistory, withRouter } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 import * as React from "react";
 
 import type { APIMaybeUnimportedDataset, TracingType } from "admin/api_flow_types";
-import { createExplorational, clearCache } from "admin/admin_rest_api";
+import { clearCache } from "admin/admin_rest_api";
 import Toast from "libs/toast";
 import messages from "messages";
-import { trackAction } from "oxalis/model/helpers/analytics";
 
 export const createTracingOverlayMenu = (dataset: APIMaybeUnimportedDataset, type: TracingType) => {
   const typeCapitalized = type.charAt(0).toUpperCase() + type.slice(1);
@@ -40,7 +39,6 @@ export const createTracingOverlayMenu = (dataset: APIMaybeUnimportedDataset, typ
 type Props = {
   dataset: APIMaybeUnimportedDataset,
   isUserAdmin: boolean,
-  history: RouterHistory,
 };
 
 type State = {};

--- a/frontend/javascripts/oxalis/view/action_bar_view.js
+++ b/frontend/javascripts/oxalis/view/action_bar_view.js
@@ -16,6 +16,7 @@ import {
   getLayoutConfig,
   addNewLayout,
 } from "oxalis/view/layouting/layout_persistence";
+import { Link } from "react-router-dom";
 import { trackAction } from "oxalis/model/helpers/analytics";
 import { updateUserSettingAction } from "oxalis/model/actions/settings_actions";
 import AddNewLayoutModal from "oxalis/view/action-bar/add_new_layout_modal";
@@ -101,31 +102,32 @@ class ActionBarView extends React.PureComponent<Props, State> {
   };
 
   renderStartTracingButton(): React.Node {
-    const { activeUser, dataset } = this.props;
-    const needsAuthentication = activeUser == null;
-
-    const handleCreateTracing = async (
-      _dataset: APIMaybeUnimportedDataset,
-      _type: TracingType,
-      useExistingSegmentation: boolean,
-    ) => {
-      if (needsAuthentication) {
-        this.setState({ isAuthenticationModalVisible: true, useExistingSegmentation });
-      } else {
-        this.createTracing(dataset, useExistingSegmentation);
-      }
-    };
-
-    return (
-      <Dropdown
-        overlay={createTracingOverlayMenu(dataset, "hybrid", handleCreateTracing)}
-        trigger={["click"]}
-      >
-        <ButtonComponent style={{ marginLeft: 12 }} type="primary">
-          Create Tracing
-        </ButtonComponent>
-      </Dropdown>
+    const { dataset } = this.props;
+    const hasSegmentationLayer = dataset.dataSource.dataLayers.some(
+      layer => layer.category == "segmentation",
     );
+    if (hasSegmentationLayer) {
+      return (
+        <Dropdown overlay={createTracingOverlayMenu(dataset, "hybrid")} trigger={["click"]}>
+          <ButtonComponent style={{ marginLeft: 12 }} type="primary">
+            Create Tracing
+          </ButtonComponent>
+        </Dropdown>
+      );
+    } else {
+      return (
+        <ButtonComponent style={{ marginLeft: 12 }} type="primary">
+          <Link
+            to={`/datasets/${dataset.owningOrganization}/${
+              dataset.name
+            }/createExplorative/hybrid/false`}
+            title={`Create Tracing`}
+          >
+            Create Tracing
+          </Link>
+        </ButtonComponent>
+      );
+    }
   }
 
   render() {

--- a/frontend/javascripts/oxalis/view/action_bar_view.js
+++ b/frontend/javascripts/oxalis/view/action_bar_view.js
@@ -90,7 +90,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
       return (
         <Dropdown overlay={createTracingOverlayMenu(dataset, "hybrid")} trigger={["click"]}>
           <ButtonComponent style={{ marginLeft: 12 }} type="primary">
-            Create Tracing
+            Create Annotation
           </ButtonComponent>
         </Dropdown>
       );
@@ -101,9 +101,9 @@ class ActionBarView extends React.PureComponent<Props, State> {
             to={`/datasets/${dataset.owningOrganization}/${
               dataset.name
             }/createExplorative/hybrid/false`}
-            title="Create Tracing"
+            title="Create Annotation"
           >
-            Create Tracing
+            Create Annotation
           </Link>
         </ButtonComponent>
       );

--- a/frontend/javascripts/oxalis/view/action_bar_view.js
+++ b/frontend/javascripts/oxalis/view/action_bar_view.js
@@ -3,12 +3,7 @@ import { Alert, Dropdown, Icon, Menu } from "antd";
 import { connect } from "react-redux";
 import * as React from "react";
 
-import type {
-  APIDataset,
-  APIUser,
-  APIMaybeUnimportedDataset,
-  TracingType,
-} from "admin/api_flow_types";
+import type { APIDataset, APIUser, APIMaybeUnimportedDataset } from "admin/api_flow_types";
 import { createExplorational } from "admin/admin_rest_api";
 import {
   layoutEmitter,
@@ -58,14 +53,12 @@ type Props = {| ...OwnProps, ...StateProps |};
 
 type State = {
   isNewLayoutModalVisible: boolean,
-  isAuthenticationModalVisible: boolean,
   useExistingSegmentation: boolean,
 };
 
 class ActionBarView extends React.PureComponent<Props, State> {
   state = {
     isNewLayoutModalVisible: false,
-    isAuthenticationModalVisible: false,
     useExistingSegmentation: true,
   };
 
@@ -104,7 +97,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
   renderStartTracingButton(): React.Node {
     const { dataset } = this.props;
     const hasSegmentationLayer = dataset.dataSource.dataLayers.some(
-      layer => layer.category == "segmentation",
+      layer => layer.category === "segmentation",
     );
     if (hasSegmentationLayer) {
       return (
@@ -121,7 +114,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
             to={`/datasets/${dataset.owningOrganization}/${
               dataset.name
             }/createExplorative/hybrid/false`}
-            title={`Create Tracing`}
+            title="Create Tracing"
           >
             Create Tracing
           </Link>
@@ -184,14 +177,6 @@ class ActionBarView extends React.PureComponent<Props, State> {
           addLayout={this.addNewLayout}
           visible={this.state.isNewLayoutModalVisible}
           onCancel={() => this.setState({ isNewLayoutModalVisible: false })}
-        />
-        <AuthenticationModal
-          onLoggedIn={() => {
-            this.setState({ isAuthenticationModalVisible: false });
-            this.createTracing(dataset, this.state.useExistingSegmentation);
-          }}
-          onCancel={() => this.setState({ isAuthenticationModalVisible: false })}
-          visible={this.state.isAuthenticationModalVisible}
         />
       </React.Fragment>
     );

--- a/frontend/javascripts/oxalis/view/action_bar_view.js
+++ b/frontend/javascripts/oxalis/view/action_bar_view.js
@@ -3,8 +3,7 @@ import { Alert, Dropdown, Icon, Menu } from "antd";
 import { connect } from "react-redux";
 import * as React from "react";
 
-import type { APIDataset, APIUser, APIMaybeUnimportedDataset } from "admin/api_flow_types";
-import { createExplorational } from "admin/admin_rest_api";
+import type { APIDataset, APIUser } from "admin/api_flow_types";
 import {
   layoutEmitter,
   deleteLayout,
@@ -12,7 +11,6 @@ import {
   addNewLayout,
 } from "oxalis/view/layouting/layout_persistence";
 import { Link } from "react-router-dom";
-import { trackAction } from "oxalis/model/helpers/analytics";
 import { updateUserSettingAction } from "oxalis/model/actions/settings_actions";
 import AddNewLayoutModal from "oxalis/view/action-bar/add_new_layout_modal";
 import ButtonComponent from "oxalis/view/components/button_component";
@@ -25,7 +23,6 @@ import TracingActionsView, {
 } from "oxalis/view/action-bar/tracing_actions_view";
 import ViewModesView from "oxalis/view/action-bar/view_modes_view";
 import VolumeActionsView from "oxalis/view/action-bar/volume_actions_view";
-import AuthenticationModal from "admin/auth/authentication_modal";
 import { createTracingOverlayMenu } from "dashboard/advanced_dataset/dataset_action_view";
 
 const VersionRestoreWarning = (
@@ -53,13 +50,11 @@ type Props = {| ...OwnProps, ...StateProps |};
 
 type State = {
   isNewLayoutModalVisible: boolean,
-  useExistingSegmentation: boolean,
 };
 
 class ActionBarView extends React.PureComponent<Props, State> {
   state = {
     isNewLayoutModalVisible: false,
-    useExistingSegmentation: true,
   };
 
   handleResetLayout = () => {
@@ -84,14 +79,6 @@ class ActionBarView extends React.PureComponent<Props, State> {
     if (addNewLayout(this.props.layoutProps.layoutKey, layoutName, configForLayout)) {
       this.props.layoutProps.setCurrentLayout(layoutName);
     }
-  };
-
-  createTracing = async (dataset: APIMaybeUnimportedDataset, useExistingSegmentation: boolean) => {
-    const annotation = await createExplorational(dataset, "hybrid", useExistingSegmentation);
-    trackAction("Create hybrid tracing (from view mode)");
-    location.href = `${location.origin}/annotations/${annotation.typ}/${annotation.id}${
-      location.hash
-    }`;
   };
 
   renderStartTracingButton(): React.Node {
@@ -127,7 +114,6 @@ class ActionBarView extends React.PureComponent<Props, State> {
     const {
       hasVolume,
       isReadOnly,
-      dataset,
       showVersionRestore,
       controlMode,
       viewMode,

--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -10,7 +10,11 @@ import { APIAnnotationTypeEnum, type APIUser } from "admin/api_flow_types";
 import { ControlModeEnum } from "oxalis/constants";
 import { Imprint, Privacy } from "components/legal";
 import type { OxalisState } from "oxalis/store";
-import { getAnnotationInformation, getOrganizationForDataset } from "admin/admin_rest_api";
+import {
+  getAnnotationInformation,
+  getOrganizationForDataset,
+  createExplorational,
+} from "admin/admin_rest_api";
 import AdaptViewportMetatag from "components/adapt_viewport_metatag";
 import AsyncRedirect from "components/redirect";
 import AuthTokenView from "admin/auth/auth_token_view";
@@ -49,6 +53,7 @@ import UserListView from "admin/user/user_list_view";
 import * as Utils from "libs/utils";
 import features from "features";
 import window from "libs/window";
+import { trackAction } from "oxalis/model/helpers/analytics";
 
 const { Content } = Layout;
 
@@ -424,6 +429,24 @@ class ReactRouter extends React.Component<Props> {
                       return `/datasets/${organizationName}/${datasetName}/view${location.search}${
                         location.hash
                       }`;
+                    }}
+                  />
+                )}
+              />
+              <Route
+                path="/datasets/:organizationName/:dataSetName/createExplorative/:type/:withFallback"
+                render={({ match, location }: ContextRouter) => (
+                  <AsyncRedirect
+                    redirectTo={async () => {
+                      const dataset = {
+                        owningOrganization: match.params.organizationName,
+                        name: match.params.dataSetName,
+                      };
+                      const type = match.params.type;
+                      const withFallback = match.params.withFallback == "true";
+                      const annotation = await createExplorational(dataset, type, withFallback);
+                      trackAction(`Create ${type} tracing`);
+                      return `/annotations/${annotation.typ}/${annotation.id}`;
                     }}
                   />
                 )}

--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -462,7 +462,7 @@ class ReactRouter extends React.Component<Props> {
                       const type =
                         Enum.coalesce(TracingTypeEnum, match.params.type) ||
                         TracingTypeEnum.skeleton;
-                      const withFallback = match.params.withFallback == "true";
+                      const withFallback = match.params.withFallback === "true";
                       const annotation = await createExplorational(dataset, type, withFallback);
                       trackAction(`Create ${type} tracing`);
                       return `/annotations/${annotation.typ}/${annotation.id}`;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://createexplorativelinks.webknossos.xyz

### Steps to test:
- in dashboard, the create tracing links should actually be links now (should work with “open in new tab”
- in view mode, the blue button should behave like that too. (Also, it should not show the fallback-layer dropdown if there is no segmentation layer in the first place)

### Issues:
- fixes #4351 

------
- [x] Ready for review
