### PR TITLE
Fix shared teams error for read only tracings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Fixed
 - Fixed the deactivation of datasets if no datasets are present. [#4388](https://github.com/scalableminds/webknossos/pull/4388)
 - Fixed the team sharing settings for private annotations. [#4409](https://github.com/scalableminds/webknossos/pull/4409)
+- Fixed the team sharing loading for read only tracings. [#4411](https://github.com/scalableminds/webknossos/pull/4411)
 
 ### Removed
 -

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -490,8 +490,12 @@ export function getSharedAnnotations(): Promise<Array<APIAnnotationCompact>> {
   return Request.receiveJSON("/api/annotations/shared");
 }
 
-export function getTeamsForSharedAnnotation(typ: string, id: string): Promise<Array<APITeam>> {
-  return Request.receiveJSON(`/api/annotations/${typ}/${id}/sharedTeams`);
+export function getTeamsForSharedAnnotation(
+  typ: string,
+  id: string,
+  options?: RequestOptions,
+): Promise<Array<APITeam>> {
+  return Request.receiveJSON(`/api/annotations/${typ}/${id}/sharedTeams`, options);
 }
 
 export function updateTeamsForSharedAnnotation(

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.js
@@ -93,6 +93,7 @@ class ShareModalView extends PureComponent<Props, State> {
       const sharedTeams = await getTeamsForSharedAnnotation(
         this.props.annotationType,
         this.props.annotationId,
+        { showErrorToast: false },
       );
       this.setState({ sharingToken, sharedTeams });
     } catch (error) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixsharedteamsreadonlytracings.webknossos.xyz

### Steps to test:
- open read-only tracing
- no error show toast should be shown

### Issues:
- fixes #4384 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
