### PR TITLE
Make navbar scrollable and add info that fallback layer is excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 [Commits](https://github.com/scalableminds/webknossos/compare/20.02.0...HEAD)
 
 ### Added
--
+- Added a notification when downloading nml including volume that informs that the fallback data is excluded in the download. [#4413](https://github.com/scalableminds/webknossos/pull/4413)
+
 
 ### Changed
--
+- Made the navbar scrollable on small screens. [#4413](https://github.com/scalableminds/webknossos/pull/4413)
 
 ### Fixed
 -

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -668,12 +668,16 @@ export function convertToHybridTracing(annotationId: string): Promise<void> {
 export async function downloadNml(
   annotationId: string,
   annotationType: APIAnnotationType,
+  showVolumeDownloadWarning?: boolean = false,
   versions?: Versions = {},
 ) {
   const possibleVersionString = Object.entries(versions)
     // $FlowFixMe Flow returns val as mixed here due to the use of Object.entries
     .map(([key, val]) => `${key}Version=${val}`)
     .join("&");
+  if (showVolumeDownloadWarning) {
+    Toast.info(messages["annotation.no_fallback_data_included"], { timeout: 12000 });
+  }
   const downloadUrl = `/api/annotations/${annotationType}/${annotationId}/download?${possibleVersionString}`;
   const { buffer, headers } = await Request.receiveArraybuffer(downloadUrl, {
     extractHeaders: true,

--- a/frontend/javascripts/admin/project/project_list_view.js
+++ b/frontend/javascripts/admin/project/project_list_view.js
@@ -18,7 +18,9 @@ import {
   pauseProject,
   resumeProject,
   downloadNml,
+  getTasks,
 } from "admin/admin_rest_api";
+import Toast from "libs/toast";
 import { handleGenericError } from "libs/error_handling";
 import Persistence from "libs/persistence";
 import TransferAllTasksModal from "admin/project/transfer_all_tasks_modal";
@@ -313,7 +315,17 @@ class ProjectListView extends React.PureComponent<PropsWithRouter, State> {
                     <br />
                     <AsyncLink
                       href="#"
-                      onClick={() => downloadNml(project.id, "CompoundProject")}
+                      onClick={async () => {
+                        downloadNml(project.id, "CompoundProject");
+                        const tasks = await getTasks({
+                          project: project.name,
+                        });
+                        if (tasks.some(task => task.type.tracingType !== "skeleton")) {
+                          Toast.info(messages["project.no_fallback_data_included"], {
+                            timeout: 12000,
+                          });
+                        }
+                      }}
                       title="Download all Finished Tracings"
                     >
                       <Icon type="download" />

--- a/frontend/javascripts/admin/task/task_annotation_view.js
+++ b/frontend/javascripts/admin/task/task_annotation_view.js
@@ -130,8 +130,8 @@ class TaskAnnotationView extends React.PureComponent<Props, State> {
           <AsyncLink
             href="#"
             onClick={() => {
-              const isVolumeIncluded = annotation.task.type.tracingType !== "skeleton";
-              downloadNml(annotation.id, "Task", isVolumeIncluded);
+              const isVolumeIncluded = annotation.tracing.volume != null;
+              return downloadNml(annotation.id, "Task", isVolumeIncluded);
             }}
           >
             <Icon type="download" />

--- a/frontend/javascripts/admin/task/task_annotation_view.js
+++ b/frontend/javascripts/admin/task/task_annotation_view.js
@@ -127,7 +127,13 @@ class TaskAnnotationView extends React.PureComponent<Props, State> {
           Transfer
         </Item>
         <Item key={`${annotation.id}-download`}>
-          <AsyncLink href="#" onClick={() => downloadNml(annotation.id, "Task")}>
+          <AsyncLink
+            href="#"
+            onClick={() => {
+              const isVolumeIncluded = annotation.task.type.tracingType !== "skeleton";
+              downloadNml(annotation.id, "Task", isVolumeIncluded);
+            }}
+          >
             <Icon type="download" />
             Download
           </AsyncLink>

--- a/frontend/javascripts/admin/task/task_list_view.js
+++ b/frontend/javascripts/admin/task/task_list_view.js
@@ -305,7 +305,7 @@ class TaskListView extends React.PureComponent<Props, State> {
                       href="#"
                       onClick={() => {
                         const includesVolumeData = task.type.tracingType !== "skeleton";
-                        downloadNml(task.id, "CompoundTask", includesVolumeData);
+                        return downloadNml(task.id, "CompoundTask", includesVolumeData);
                       }}
                       title="Download all Finished Tracings"
                     >

--- a/frontend/javascripts/admin/task/task_list_view.js
+++ b/frontend/javascripts/admin/task/task_list_view.js
@@ -303,7 +303,10 @@ class TaskListView extends React.PureComponent<Props, State> {
                   {task.status.finished > 0 ? (
                     <AsyncLink
                       href="#"
-                      onClick={() => downloadNml(task.id, "CompoundTask")}
+                      onClick={() => {
+                        const includesVolumeData = task.type.tracingType !== "skeleton";
+                        downloadNml(task.id, "CompoundTask", includesVolumeData);
+                      }}
                       title="Download all Finished Tracings"
                     >
                       <Icon type="download" />

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.js
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.js
@@ -251,7 +251,10 @@ class TaskTypeListView extends React.PureComponent<Props, State> {
                     <br />
                     <AsyncLink
                       href="#"
-                      onClick={() => downloadNml(taskType.id, "CompoundTaskType")}
+                      onClick={() => {
+                        const includesVolumeData = taskType.tracingType !== "skeleton";
+                        downloadNml(taskType.id, "CompoundTaskType", includesVolumeData);
+                      }}
                       title="Download all Finished Tracings"
                     >
                       <Icon type="download" />

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.js
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.js
@@ -253,7 +253,7 @@ class TaskTypeListView extends React.PureComponent<Props, State> {
                       href="#"
                       onClick={() => {
                         const includesVolumeData = taskType.tracingType !== "skeleton";
-                        downloadNml(taskType.id, "CompoundTaskType", includesVolumeData);
+                        return downloadNml(taskType.id, "CompoundTaskType", includesVolumeData);
                       }}
                       title="Download all Finished Tracings"
                     >

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.js
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.js
@@ -257,8 +257,8 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
             <AsyncLink
               href="#"
               onClick={() => {
-                const isVolumeIncluded = annotation.task.type.tracingType !== "skeleton";
-                downloadNml(annotation.id, "Task", isVolumeIncluded);
+                const isVolumeIncluded = annotation.tracing.volume != null;
+                return downloadNml(annotation.id, "Task", isVolumeIncluded);
               }}
             >
               <Icon type="download" />

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.js
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.js
@@ -254,7 +254,13 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
         ) : null}
         {isAdmin ? (
           <div>
-            <AsyncLink href="#" onClick={() => downloadNml(annotation.id, "Task")}>
+            <AsyncLink
+              href="#"
+              onClick={() => {
+                const isVolumeIncluded = annotation.task.type.tracingType !== "skeleton";
+                downloadNml(annotation.id, "Task", isVolumeIncluded);
+              }}
+            >
               <Icon type="download" />
               Download
             </AsyncLink>

--- a/frontend/javascripts/dashboard/explorative_annotations_view.js
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.js
@@ -209,7 +209,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
     if (tracing.typ !== "Explorational") {
       return null;
     }
-
+    const hasVolumeTracing = tracing.tracing.volume != null;
     const { typ, id } = tracing;
     if (!this.state.shouldShowArchivedTracings) {
       return (
@@ -219,7 +219,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
             Trace
           </Link>
           <br />
-          <AsyncLink href="#" onClick={() => downloadNml(id, typ)}>
+          <AsyncLink href="#" onClick={() => downloadNml(id, typ, hasVolumeTracing)}>
             <Icon type="download" />
             Download
           </AsyncLink>

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -168,6 +168,8 @@ In order to restore the current window, a reload is necessary.`,
     "This dataset contains multiple layers which differ in their resolution. Please convert the layers to make their resolutions match. Otherwise, rendering errors cannot be avoided.",
   "annotation.finish": "Are you sure you want to permanently finish this tracing?",
   "annotation.was_finished": "Annotation was archived",
+  "annotation.no_fallback_data_included":
+    "This download does only include the volume data annotated in this annotation. The fallback volume data is excluded.",
   "annotation.was_re_opened": "Annotation was reopened",
   "annotation.delete": "Do you really want to reset and cancel this annotation?",
   "annotation.was_edited": "Successfully updated annotation",
@@ -180,6 +182,8 @@ In order to restore the current window, a reload is necessary.`,
     "All active tasks were transferred to the selected user",
   "project.unsuccessful_active_tasks_transfer":
     "An error occurred while trying to transfer the tasks. Please check your permissions and the server logs",
+  "project.no_fallback_data_included":
+    "This download does only include the volume data annotated in the tasks of this project. The fallback volume data is excluded.",
   "script.delete": "Do you really want to delete this script?",
   "team.delete": "Do you really want to delete this team?",
   "taskType.delete": "Do you really want to delete this task type and all its associated tasks?",

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -303,6 +303,7 @@ function Navbar({ activeUser, isAuthenticated, history, isInAnnotationView, hasO
     alignItems: "center",
     color: "rgba(255, 255, 255, 0.67)",
     background: "#001529",
+    whiteSpace: "nowrap",
   };
 
   const _isAuthenticated = isAuthenticated && activeUser != null;

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -294,6 +294,7 @@ function Navbar({ activeUser, isAuthenticated, history, isInAnnotationView, hasO
 
   const navbarStyle: Object = {
     padding: 0,
+    overflowX: "auto",
     position: "fixed",
     width: "100%",
     zIndex: 1000,

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -28,6 +28,7 @@ import { downloadScreenshot } from "oxalis/view/rendering_utils";
 
 type OwnProps = {|
   layoutMenu: React.Node,
+  hasVolume: boolean,
 |};
 type StateProps = {|
   annotationType: APIAnnotationType,
@@ -237,7 +238,8 @@ class TracingActionsView extends React.PureComponent<Props, State> {
 
   handleDownload = async () => {
     await Model.ensureSavedState();
-    downloadNml(this.props.annotationId, this.props.annotationType);
+    const { annotationId, annotationType, hasVolume } = this.props;
+    downloadNml(annotationId, annotationType, hasVolume);
   };
 
   handleFinishAndGetNextTask = async () => {

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -266,6 +266,22 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     const archiveButtonText = this.props.task ? "Finish and go to Dashboard" : "Archive";
     const { restrictions } = this.props;
 
+    let saveButtonMinWidth = 0;
+    if (restrictions.allowUpdate) {
+      if (isSkeletonMode) {
+        // We do not need to add the redo button, as it is hidden on small screens.
+        saveButtonMinWidth += 34;
+      }
+      if (restrictions.allowSave) {
+        // We only need to add the width of the icon, as the text "Sandbox" is hidden on small screens.
+        saveButtonMinWidth += 46;
+      } else {
+        saveButtonMinWidth += 46;
+      }
+    } else {
+      saveButtonMinWidth += 96 + 182;
+    }
+
     const saveButton = restrictions.allowUpdate
       ? [
           isSkeletonMode
@@ -311,6 +327,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
           </AsyncButton>,
         ];
 
+    const finishAndNextTaskButtonWidth = restrictions.allowFinish && this.props.task ? 196 : 0;
     const finishAndNextTaskButton =
       restrictions.allowFinish && this.props.task ? (
         <ButtonComponent
@@ -411,9 +428,11 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     }
 
     const menu = <Menu>{elements}</Menu>;
-
+    const dropdownMenuWidth = 34;
+    const totalTracingActionButtonsWidth =
+      saveButtonMinWidth + finishAndNextTaskButtonWidth + dropdownMenuWidth;
     return (
-      <div>
+      <div style={{ minWidth: totalTracingActionButtonsWidth }}>
         <Button.Group>
           {saveButton}
           {finishAndNextTaskButton}

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -313,7 +313,6 @@ class TracingActionsView extends React.PureComponent<Props, State> {
           </AsyncButton>,
         ];
 
-    const finishAndNextTaskButtonWidth = restrictions.allowFinish && this.props.task ? 196 : 0;
     const finishAndNextTaskButton =
       restrictions.allowFinish && this.props.task ? (
         <ButtonComponent

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.js
@@ -268,22 +268,6 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     const archiveButtonText = this.props.task ? "Finish and go to Dashboard" : "Archive";
     const { restrictions } = this.props;
 
-    let saveButtonMinWidth = 0;
-    if (restrictions.allowUpdate) {
-      if (isSkeletonMode) {
-        // We do not need to add the redo button, as it is hidden on small screens.
-        saveButtonMinWidth += 34;
-      }
-      if (restrictions.allowSave) {
-        // We only need to add the width of the icon, as the text "Sandbox" is hidden on small screens.
-        saveButtonMinWidth += 46;
-      } else {
-        saveButtonMinWidth += 46;
-      }
-    } else {
-      saveButtonMinWidth += 96 + 182;
-    }
-
     const saveButton = restrictions.allowUpdate
       ? [
           isSkeletonMode
@@ -430,11 +414,8 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     }
 
     const menu = <Menu>{elements}</Menu>;
-    const dropdownMenuWidth = 34;
-    const totalTracingActionButtonsWidth =
-      saveButtonMinWidth + finishAndNextTaskButtonWidth + dropdownMenuWidth;
     return (
-      <div style={{ minWidth: totalTracingActionButtonsWidth }}>
+      <div>
         <Button.Group>
           {saveButton}
           {finishAndNextTaskButton}

--- a/frontend/javascripts/oxalis/view/action_bar_view.js
+++ b/frontend/javascripts/oxalis/view/action_bar_view.js
@@ -129,18 +129,27 @@ class ActionBarView extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const isTraceMode = this.props.controlMode === ControlModeEnum.TRACE;
-    const isVolumeSupported = !Constants.MODES_ARBITRARY.includes(this.props.viewMode);
-    const isArbitrarySupported =
-      this.props.hasSkeleton || this.props.controlMode === ControlModeEnum.VIEW;
+    const {
+      hasVolume,
+      isReadOnly,
+      dataset,
+      showVersionRestore,
+      controlMode,
+      viewMode,
+      hasSkeleton,
+      layoutProps,
+    } = this.props;
+    const isTraceMode = controlMode === ControlModeEnum.TRACE;
+    const isVolumeSupported = !Constants.MODES_ARBITRARY.includes(viewMode);
+    const isArbitrarySupported = hasSkeleton || controlMode === ControlModeEnum.VIEW;
     const layoutMenu = (
       <LayoutMenu
-        {...this.props.layoutProps}
+        {...layoutProps}
         addNewLayout={() => {
           this.setState({ isNewLayoutModalVisible: true });
         }}
         onResetLayout={this.handleResetLayout}
-        onSelectLayout={this.props.layoutProps.setCurrentLayout}
+        onSelectLayout={layoutProps.setCurrentLayout}
         onDeleteLayout={this.handleLayoutDeleted}
       />
     );
@@ -158,16 +167,14 @@ class ActionBarView extends React.PureComponent<Props, State> {
     return (
       <React.Fragment>
         <div className="action-bar">
-          {isTraceMode && !this.props.showVersionRestore ? (
-            <TracingActionsView layoutMenu={layoutMenu} />
+          {isTraceMode && !showVersionRestore ? (
+            <TracingActionsView layoutMenu={layoutMenu} hasVolume={hasVolume} />
           ) : (
             viewDropdown
           )}
-          {this.props.showVersionRestore ? VersionRestoreWarning : null}
+          {showVersionRestore ? VersionRestoreWarning : null}
           <DatasetPositionView />
-          {!this.props.isReadOnly && this.props.hasVolume && isVolumeSupported ? (
-            <VolumeActionsView />
-          ) : null}
+          {!isReadOnly && hasVolume && isVolumeSupported ? <VolumeActionsView /> : null}
           {isArbitrarySupported ? <ViewModesView /> : null}
           {isTraceMode ? null : this.renderStartTracingButton()}
         </div>
@@ -179,7 +186,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
         <AuthenticationModal
           onLoggedIn={() => {
             this.setState({ isAuthenticationModalVisible: false });
-            this.createTracing(this.props.dataset, this.state.useExistingSegmentation);
+            this.createTracing(dataset, this.state.useExistingSegmentation);
           }}
           onCancel={() => this.setState({ isAuthenticationModalVisible: false })}
           visible={this.state.isAuthenticationModalVisible}

--- a/frontend/javascripts/oxalis/view/version_list.js
+++ b/frontend/javascripts/oxalis/view/version_list.js
@@ -107,8 +107,11 @@ class VersionList extends React.Component<Props, State> {
       Store.dispatch(setVersionRestoreVisibilityAction(false));
       Store.dispatch(setAnnotationAllowUpdateAction(true));
     } else {
-      const { annotationType, annotationId } = Store.getState().tracing;
-      downloadNml(annotationId, annotationType, { [this.props.tracingType]: version });
+      const { annotationType, annotationId, volume } = Store.getState().tracing;
+      const includesVolumeData = volume != null;
+      downloadNml(annotationId, annotationType, includesVolumeData, {
+        [this.props.tracingType]: version,
+      });
     }
   };
 


### PR DESCRIPTION
This PR makes the navbar scrollable for smalls screens as otherwise button group form weird multiline looking constructs.
As the items and their size in the navbar itself are variable, I chose to give the button groups a `min-width` depending on their size, forcing them to stay inline.

## TODO
 - [x] Check the navbar while not in a tracing: Does it look fine on small screens? -> Should be fine


### URL of deployed dev instance (used for testing):
- https://makenavbarscrollable.webknossos.xyz

### Steps to test:
- Open the dashboard and resize the window
- Open a tracing and resize the window
- In both cases, the responsiveness should have improved

### Issues:
- fixes #4342, #4394

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
