### PR TITLE
Default to dataset pane when opening settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 -
 
 ### Changed
--
+- Opening the settings sidebar when viewing a dataset or tracing defaults to the dataset settings now. [#4425](https://github.com/scalableminds/webknossos/pull/4425)
 
 ### Fixed
 -

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -233,8 +233,7 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
               width={350}
               style={{ zIndex: 100, marginRight: this.state.isSettingsCollapsed ? 0 : 8 }}
             >
-              {/* Don't render SettingsView if it's hidden to improve performance */}
-              {!this.state.isSettingsCollapsed ? <SettingsView /> : null}
+              <SettingsView dontRenderContents={this.state.isSettingsCollapsed} />
             </Sider>
             <MergerModeController />
             <div id={canvasAndLayoutContainerID} style={{ position: "relative" }}>

--- a/frontend/javascripts/oxalis/view/settings/settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/settings_view.js
@@ -11,13 +11,18 @@ import UserSettingsView from "oxalis/view/settings/user_settings_view";
 
 const TabPane = Tabs.TabPane;
 
-const SettingsView = () => (
-  <Tabs destroyInactiveTabPane className="tracing-settings-menu">
+type Props = {
+  dontRenderContents: boolean,
+};
+
+const SettingsView = ({ dontRenderContents }: Props) => (
+  // Don't render contents to improve performance
+  <Tabs destroyInactiveTabPane className="tracing-settings-menu" defaultActiveKey="2">
     <TabPane tab="Tracing" key="1">
-      <UserSettingsView />
+      {!dontRenderContents && <UserSettingsView />}
     </TabPane>
     <TabPane tab="Dataset" key="2">
-      <DatasetSettingsView />
+      {!dontRenderContents && <DatasetSettingsView />}
     </TabPane>
   </Tabs>
 );


### PR DESCRIPTION
Also: remember active settings pane when toggling settings sidebar

### URL of deployed dev instance (used for testing):
- https://defaulttodsview.webknossos.xyz

### Steps to test:
- open settings sidebar (should default to dataset settings)
- verify that the active pane is remembered between toggling the side bar

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [ ] ~Updated [documentation](../blob/master/docs) if applicable~
- [ ] ~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [ ] ~Needs datastore update after deployment~
- [X] Ready for review
