### PR TITLE
Remove wkconnect from default docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,14 @@ Open your local webknossos instance on [localhost:9000](http://localhost:9000).
 
 See the [wiki](https://github.com/scalableminds/webknossos/wiki/Try-setup) for instructions on updating this try setup.
 
-For non-localhost deployments, make sure to set the `datastore.publicUri` and `tracingstore.publicUri` entries in the config.
+For non-localhost deployments, make sure to use the `webknossos-public` docker-compose service and set the `PUBLIC_URI` environment variable:
 
+```bash
+git clone -b master --depth=1 git@github.com:scalableminds/webknossos.git
+cd webknossos
+docker-compose pull webknossos
+PUBLIC_URI=http://example.org:9000 docker-compose up webknossos-public
+```
 
 ### Dependencies
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,39 @@ services:
       - POSTGRES_URL=jdbc:postgresql://postgres/webknossos
     user: ${USER_UID:-1000}:${USER_GID:-1000}
 
+  webknossos-public:
+    build: .
+    image: scalableminds/webknossos:${DOCKER_TAG:-master}
+    ports:
+      - "9000:9000"
+    links:
+      - "fossildb-persisted:fossildb"
+      - "postgres-persisted:postgres"
+    depends_on:
+      postgres-persisted:
+        condition: service_healthy
+      fossildb-persisted:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command:
+      - -Dconfig.file=conf/application.conf
+      - -Djava.net.preferIPv4Stack=true
+      - -Dhttp.address=0.0.0.0
+      - -Dtracingstore.fossildb.address=fossildb
+      - -Dtracingstore.redis.address=redis
+      - -Dslick.db.url=jdbc:postgresql://postgres/webknossos
+      - -Dapplication.insertInitialData=false
+      - -Dapplication.authentication.enableDevAutoLogin=false
+      - -Dhttp.uri=${PUBLIC_URI}
+      - -Dtracingstore.publicUrl=${PUBLIC_URI}
+      - -Ddatastore.publicUrl=${PUBLIC_URI}
+    volumes:
+      - ./binaryData:/srv/webknossos/binaryData
+    environment:
+      - POSTGRES_URL=jdbc:postgresql://postgres/webknossos
+    user: ${USER_UID:-1000}:${USER_GID:-1000}
+
   webknossos-datastore:
     build: webknossos-datastore
     image: scalableminds/webknossos-datastore:${DOCKER_TAG:-master}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     image: scalableminds/webknossos:${DOCKER_TAG:-master}
     ports:
       - "9000:9000"
-      - "8000:8000" # from webknossos-connect
     links:
       - "fossildb-persisted:fossildb"
       - "postgres-persisted:postgres"
@@ -26,15 +25,15 @@ services:
       - -Dtracingstore.redis.address=redis
       - -Dslick.db.url=jdbc:postgresql://postgres/webknossos
       - -Dapplication.insertInitialData=false
-      - -Dapplication.insertLocalConnectDatastore=true
       - -Dapplication.authentication.enableDevAutoLogin=false
+      # the following lines need to be adapted for non-localhost deployments
+      # - -Dhttp.uri=http://example.org:9000
+      # - -Dtracingstore.publicUrl=http://example.org:9000
+      # - -Ddatastore.publicUrl=http://example.org:9000
       # the following lines disable the integrated datastore:
       # - -Dplay.modules.enabled-="com.scalableminds.webknossos.datastore.DataStoreModule"
       # - -Ddatastore.enabled=false
       # - -Dplay.http.router="noDS.Routes"
-      # the following lines need to be adapted for non-localhost deployments
-      # - -Dtracingstore.publicUrl=http://example.org:9000
-      # - -Ddatastore.publicUrl=http://example.org:9000
     volumes:
       - ./binaryData:/srv/webknossos/binaryData
     environment:
@@ -204,8 +203,6 @@ services:
     image: scalableminds/webknossos-connect:master__205
     volumes:
       - "./conf/connect:/app/data"
-    # Publish webknossos-connect ports in webknossos container
-    network_mode: service:webknossos
 
   # Postgres
   postgres:

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -3,4 +3,4 @@ set -Eeuo pipefail
 
 mkdir -p binaryData
 
-USER_UID=$(id -u) USER_GID=$(id -g) docker-compose up webknossos webknossos-connect
+USER_UID=$(id -u) USER_GID=$(id -g) docker-compose up webknossos


### PR DESCRIPTION
Removes wkconnect from the default docker-compose setup. Most of the time, connect is not required for the users. The network bridging is a bit wonky, so I think it is better to not have it as a default. 

### Steps to test:
Run webknossos on a non-localhost URI (e.g. a real hostname or the local machine's network IP):
- `DOCKER_TAG=19.12.0 docker-compose pull webknossos`
- `DOCKER_TAG=19.12.0 PUBLIC_URI=http://xx.xx.xx.xx:9000 docker-compose up webknossos-public`
- Check that webknossos works in the browser

------
- [x] Ready for review
