### PR TITLE
Force to have atleast one tree in set tracing action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Fixed that for uint16 data layer the default value range of [0, 255] was used, causing most of the data to look white without manual adjustments. Now the correct range of [0, 65535] is used as default. [#4381](https://github.com/scalableminds/webknossos/pull/4381)
--
+- Fixed a bug that allowed to remove the initial tree in a skeleton or hybrid tracing using `Ctrl+Z`. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.js
@@ -67,8 +67,9 @@ export function* collectUndoStates(): Saga<void> {
     });
     const curTracing = yield* select(state => enforceSkeletonTracing(state.tracing));
     if (userAction) {
-      if (curTracing !== prevTracing) {
-        // Clear the redo stack when a new action is executed
+      const previousTracingHasTrees = Object.entries(prevTracing.trees).length < 0;
+      if (curTracing !== prevTracing && previousTracingHasTrees) {
+        // Clear the redo stack when a new action is executed.
         redoStack.splice(0);
         undoStack.push(prevTracing);
         if (undoStack.length > UNDO_HISTORY_SIZE) undoStack.shift();
@@ -90,7 +91,7 @@ export function* collectUndoStates(): Saga<void> {
         Toast.info(messages["undo.no_redo"]);
       }
     }
-    // We need the updated tracing here
+    // We need the updated tracing here.
     prevTracing = yield* select(state => enforceSkeletonTracing(state.tracing));
   }
 }


### PR DESCRIPTION
This PR creates one tree in the set tracing action when the new tracing does not have any tree. Additionally, with this PR we do not push tracing states to the undo stack where no trees exist.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a new skeleton tracing, wait for it to load and use "ctrl+z". This should not delete the initial tree.

### Issues:
- fixes #4385

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
