### PR TITLE
Remove invariant that a tree is always needed

### DIFF
--- a/flow-typed/npm/antd_vx.x.x.js
+++ b/flow-typed/npm/antd_vx.x.x.js
@@ -22,6 +22,9 @@ declare module "antd" {
   }
   declare export class Divider<P> extends React$Component<P> {}
   declare export class Dropdown<P> extends React$Component<P> {}
+  declare export class Empty<P> extends React$Component<P> {
+    static PRESENTED_IMAGE_SIMPLE: string;
+  }
   declare export class Icon<P> extends React$Component<P> {}
   declare class InputGroup<P> extends React$Component<P> {}
   declare class InputPassword<P> extends React$Component<P> {}

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -107,8 +107,7 @@ In order to restore the current window, a reload is necessary.`,
   "tracing.no_viewport_scaling_setting":
     "Scaling the viewports via k/l is not supported anymore. Instead you can increase the viewport size by dragging the borders between the panes. You can also rearrange the panes by dragging the tabs.",
   "tracing.natural_sorting": "Correctly sort numbers in text (word2 < word10). This may be slow!",
-  "tracing.cant_create_node_due_to_active_group":
-    "You cannot create nodes, since no tree is active.",
+  "tracing.cant_create_node": "You cannot create nodes, since no tree is active.",
   "tracing.invalid_state":
     "A corruption in the current skeleton tracing was detected. Please contact your supervisor and/or the maintainers of webKnossos to get help for restoring a working version. Please include as much details as possible about your past user interactions. This will be very helpful to investigate the source of this bug.",
   "layouting.missing_custom_layout_info":

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.js
@@ -78,7 +78,7 @@ type AddTreesAndGroupsAction = {
   trees: TreeMap,
   treeGroups: Array<TreeGroup>,
 };
-type DeleteTreeAction = { type: "DELETE_TREE", treeId?: number, timestamp: number };
+type DeleteTreeAction = { type: "DELETE_TREE", treeId?: number };
 type ResetSkeletonTracingAction = { type: "RESET_SKELETON_TRACING" };
 type SetActiveTreeAction = { type: "SET_ACTIVE_TREE", treeId: number };
 type SetActiveTreeByNameAction = { type: "SET_ACTIVE_TREE_BY_NAME", treeName: string };
@@ -282,13 +282,9 @@ export const addTreesAndGroupsAction = (
   treeGroups: treeGroups || [],
 });
 
-export const deleteTreeAction = (
-  treeId?: number,
-  timestamp: number = Date.now(),
-): DeleteTreeAction => ({
+export const deleteTreeAction = (treeId?: number): DeleteTreeAction => ({
   type: "DELETE_TREE",
   treeId,
-  timestamp,
 });
 
 export const resetSkeletonTracingAction = (): ResetSkeletonTracingAction => ({

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.js
@@ -29,7 +29,6 @@ import {
   select,
 } from "oxalis/model/sagas/effect-generators";
 import {
-  createTreeAction,
   SkeletonTracingSaveRelevantActions,
   setTracingAction,
 } from "oxalis/model/actions/skeletontracing_actions";
@@ -262,11 +261,7 @@ export function* saveTracingTypeAsync(tracingType: "skeleton" | "volume"): Saga<
 
   let prevTracing = yield* select(state => state.tracing);
   let prevFlycam = yield* select(state => state.flycam);
-  if (tracingType === "skeleton") {
-    if (yield* select(state => enforceSkeletonTracing(state.tracing).activeTreeId == null)) {
-      yield* put(createTreeAction());
-    }
-  }
+
   yield* take("WK_READY");
   const initialAllowUpdate = yield* select(
     state =>

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.js
@@ -114,11 +114,9 @@ function* watchBranchPointDeletion(): Saga<void> {
 function* watchFailedNodeCreations(): Saga<void> {
   while (true) {
     yield* take("CREATE_NODE");
-    const activeGroupId = yield* select(
-      state => enforceSkeletonTracing(state.tracing).activeGroupId,
-    );
-    if (activeGroupId != null) {
-      Toast.warning(messages["tracing.cant_create_node_due_to_active_group"]);
+    const activeTreeId = yield* select(state => enforceSkeletonTracing(state.tracing).activeTreeId);
+    if (activeTreeId == null) {
+      Toast.warning(messages["tracing.cant_create_node"]);
     }
   }
 }

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -554,7 +554,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
       .map(activeGroup => activeGroup.name)
       .getOrElse("");
     const { trees, treeGroups } = skeletonTracing;
-    const noTrees = _.size(trees) == 0;
+    const noTrees = _.size(trees) === 0;
     const orderAttribute = this.props.userConfiguration.sortTreesByName ? "name" : "timestamp";
 
     // Avoid that the title switches to the other title during the fadeout of the Modal

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -554,7 +554,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
       .map(activeGroup => activeGroup.name)
       .getOrElse("");
     const { trees, treeGroups } = skeletonTracing;
-    const noTrees = _.size(trees) === 0;
+    const noTreesAndGroups = _.size(trees) === 0 && _.size(treeGroups) === 0;
     const orderAttribute = this.props.userConfiguration.sortTreesByName ? "name" : "timestamp";
 
     // Avoid that the title switches to the other title during the fadeout of the Modal
@@ -621,7 +621,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
           <InputComponent
             onChange={this.handleChangeTreeName}
             value={activeTreeName || activeGroupName}
-            disabled={noTrees}
+            disabled={noTreesAndGroups}
             style={{ width: "60%" }}
           />
           <ButtonComponent onClick={this.props.onSelectNextTreeForward}>
@@ -633,7 +633,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
             </ButtonComponent>
           </Dropdown>
         </InputGroup>
-        {noTrees ? (
+        {noTreesAndGroups ? (
           <Empty
             image={Empty.PRESENTED_IMAGE_SIMPLE}
             description={

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -1,5 +1,5 @@
 // @flow
-import { Alert, Button, Dropdown, Input, Menu, Icon, Spin, Modal, Tooltip } from "antd";
+import { Alert, Button, Dropdown, Empty, Input, Menu, Icon, Spin, Modal, Tooltip } from "antd";
 import type { Dispatch } from "redux";
 import { connect } from "react-redux";
 import { batchActions } from "redux-batched-actions";
@@ -554,6 +554,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
       .map(activeGroup => activeGroup.name)
       .getOrElse("");
     const { trees, treeGroups } = skeletonTracing;
+    const noTrees = _.size(trees) == 0;
     const orderAttribute = this.props.userConfiguration.sortTreesByName ? "name" : "timestamp";
 
     // Avoid that the title switches to the other title during the fadeout of the Modal
@@ -620,6 +621,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
           <InputComponent
             onChange={this.handleChangeTreeName}
             value={activeTreeName || activeGroupName}
+            disabled={noTrees}
             style={{ width: "60%" }}
           />
           <ButtonComponent onClick={this.props.onSelectNextTreeForward}>
@@ -631,10 +633,22 @@ class TreesTabView extends React.PureComponent<Props, State> {
             </ButtonComponent>
           </Dropdown>
         </InputGroup>
-        <ul style={{ flex: "1 1 auto", overflow: "auto", margin: 0, padding: 0 }}>
-          <div className="tree-hierarchy-header">{this.getSelectedTreesAlert()}</div>
-          {this.getTreesComponents(orderAttribute)}
-        </ul>
+        {noTrees ? (
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={
+              <span>
+                There are no trees in this tracing.
+                <br /> A new tree will be created automatically once a node is set.
+              </span>
+            }
+          />
+        ) : (
+          <ul style={{ flex: "1 1 auto", overflow: "auto", margin: 0, padding: 0 }}>
+            <div className="tree-hierarchy-header">{this.getSelectedTreesAlert()}</div>
+            {this.getTreesComponents(orderAttribute)}
+          </ul>
+        )}
         {groupToDelete !== null ? (
           <DeleteGroupModalView
             onCancel={this.hideDeleteGroupsModal}

--- a/frontend/javascripts/test/geometries/skeleton.spec.js
+++ b/frontend/javascripts/test/geometries/skeleton.spec.js
@@ -38,10 +38,9 @@ test.before(t => {
   Store.dispatch(initializeAnnotationAction(annotation));
   Store.dispatch(initializeSkeletonTracingAction(tracing));
 
-  // create 20 trees with 100 nodes each
+  // Create 20 trees with 100 nodes each
   for (let i = 0; i < 2000; i++) {
-    // The first tree is created automatically
-    if (i % 100 === 0 && i !== 0) {
+    if (i % 100 === 0) {
       Store.dispatch(createTreeAction());
     }
     Store.dispatch(createNodeAction([i, i, i], rotation, viewport, resolution));

--- a/frontend/javascripts/test/reducers/skeletontracing_reducer.spec.js
+++ b/frontend/javascripts/test/reducers/skeletontracing_reducer.spec.js
@@ -786,8 +786,7 @@ test("SkeletonTracing should delete several trees", t => {
   const createTreeAction = SkeletonTracingActions.createTreeAction();
   const deleteTreeAction = SkeletonTracingActions.deleteTreeAction();
 
-  // create a tree and delete it three times
-  // there should always be at least one tree in a tracing
+  // create trees and delete them
   const newState = ChainReducer(initialState)
     .apply(SkeletonTracingReducer, createTreeAction)
     .apply(SkeletonTracingReducer, deleteTreeAction)
@@ -796,9 +795,8 @@ test("SkeletonTracing should delete several trees", t => {
     .unpack();
 
   t.not(newState, initialState);
-  t.deepEqual(_.size(newState.tracing.skeleton.trees), 1);
+  t.deepEqual(_.size(newState.tracing.skeleton.trees), 0);
   t.not(newState.tracing.skeleton.trees, initialState.tracing.skeleton.trees);
-  t.is(Object.keys(newState.tracing.skeleton.trees).length, 1);
 });
 
 test("SkeletonTracing should set a new active tree", t => {

--- a/frontend/javascripts/test/sagas/skeletontracing_saga.spec.js
+++ b/frontend/javascripts/test/sagas/skeletontracing_saga.spec.js
@@ -121,22 +121,12 @@ const createBranchPointAction = SkeletonTracingActions.createBranchPointAction(
   12345678,
 );
 
-test("SkeletonTracingSaga should create a tree if there is none (saga test)", t => {
-  const saga = saveTracingTypeAsync("skeleton");
-  expectValueDeepEqual(t, saga.next(), take("INITIALIZE_SKELETONTRACING"));
-  saga.next();
-  saga.next({ tracing: { trees: {} } });
-  saga.next(initialState.flycam);
-  t.is(saga.next(true).value.payload.action.type, "CREATE_TREE");
-});
-
 test("SkeletonTracingSaga shouldn't do anything if unchanged (saga test)", t => {
   const saga = saveTracingTypeAsync("skeleton");
   expectValueDeepEqual(t, saga.next(), take("INITIALIZE_SKELETONTRACING"));
   saga.next();
   saga.next(initialState.tracing);
   saga.next(initialState.flycam);
-  saga.next(false);
   saga.next();
   saga.next(true);
   saga.next();
@@ -155,7 +145,6 @@ test("SkeletonTracingSaga should do something if changed (saga test)", t => {
   saga.next();
   saga.next(initialState.tracing);
   saga.next(initialState.flycam);
-  saga.next(false);
   saga.next();
   saga.next(true);
   saga.next();


### PR DESCRIPTION
After seeing #4432 (which is a PR to fix #4385) we decided that the invariant _"A skeleton tracing always needs to contain at least one tree"_ is unnecessary and seems to lead to dubious errors from time to time (especially because there actually are short timeframes where there is no tree). Fortunately, the code was already mostly prepared for that (due to the use of Maybe-s) and I only had to make little adaptions. A tree is now automatically created when setting a node in a tracing with no trees. However, there is no tree created if there is no `activeTreeId` because a group is active (as before).

I added a simple placeholder to the trees tab, if there are no trees:

![no-trees](https://user-images.githubusercontent.com/1702075/73867675-630e9780-4847-11ea-9e9c-93ae00aa0978.png)

@MichaelBuessemeyer Hope you agree that this is a cleaner solution and sorry for making you put effort into #4432. I'd vote to merge this PR instead.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Load skeleton tracing and try to do things while there is no tree (NML import, setting nodes, Undo, etc.)

### Issues:
- fixes #4385 

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
