### PR TITLE
Make TimeSpanService EagerSingleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Fixed that for uint16 data layer the default value range of [0, 255] was used, causing most of the data to look white without manual adjustments. Now the correct range of [0, 65535] is used as default. [#4381](https://github.com/scalableminds/webknossos/pull/4381)
--
+- Time tracking precision is improved. [#4445](https://github.com/scalableminds/webknossos/pull/4445)
 
 ### Removed
 -

--- a/app/WebKnossosModule.scala
+++ b/app/WebKnossosModule.scala
@@ -4,6 +4,7 @@ import models.annotation.AnnotationStore
 import models.binary.DataSetService
 import models.task.TaskService
 import models.user._
+import models.user.time.TimeSpanService
 import oxalis.user.UserCache
 import utils.SQLClient
 
@@ -21,5 +22,6 @@ class WebKnossosModule extends AbstractModule {
     bind(classOf[UserCache]).asEagerSingleton()
     bind(classOf[AnnotationStore]).asEagerSingleton()
     bind(classOf[DataSetService]).asEagerSingleton()
+    bind(classOf[TimeSpanService]).asEagerSingleton()
   }
 }


### PR DESCRIPTION
`TimeSpanService` is stateful (`lastUserActivities`), this state needs to be shared for all requests.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- trace a few tasks (with no pauses >30s )
- double check in the db that there are no overlapping timespans. `select _user, _annotation, time, lastupdate - time * INTERVAL '1 ms'as firstupdate, lastupdate from webknossos.timespans where created > '2020-02-17 01:25:29.947+01' order by lastupdate`

### Issues:
- fixes #4441

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- ~[ ] Needs datastore update after deployment~
- [x] Ready for review
