### PR TITLE
Easier docker-based server installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Added
 - Added support for datasets with more layers than the hardware can render simultaneously. The user can disable layers temporarily to control for which layers the GPU resources should be used. [#4424](https://github.com/scalableminds/webknossos/pull/4424)
 - Added a notification when downloading nml including volume that informs that the fallback data is excluded in the download. [#4413](https://github.com/scalableminds/webknossos/pull/4413)
+- Added a simpler method to install webKnossos on an own server. [#4446](https://github.com/scalableminds/webknossos/pull/4446)
 
 ### Changed
 - Made the navbar scrollable on small screens. [#4413](https://github.com/scalableminds/webknossos/pull/4413)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ webKnossos is an open-source tool for annotating and exploring large 3D image da
 * Scale data reconstruction projects with crowdsourcing workflows
 * Share datasets and annotations with collaborating scientists
 
-[Start using webKnossos](https://webknossos.org) - [User Documentation](https://docs.webknossos.org) - [Contact us](mailto:hello@scalableminds.com)
+[Start using webKnossos](https://webknossos.org) - [On your own server](https://docs.webknossos.org/) - [User Documentation](https://docs.webknossos.org) - [Contact us](mailto:hello@scalableminds.com)
 
 [![](	https://img.shields.io/circleci/project/github/scalableminds/webknossos/master.svg?logo=circleci)](https://circleci.com/gh/scalableminds/webknossos)
 [![](https://img.shields.io/github/release/scalableminds/webknossos.svg)](https://github.com/scalableminds/webknossos/releases/latest)
@@ -42,60 +42,11 @@ webKnossos is an open-source tool for annotating and exploring large 3D image da
 [Read more about the original publication.](https://publication.webknossos.org)
 
 ## Installation
-### Docker
-Docker 17+ and Docker Compose 1.18+ are required.
+webKnossos is open-source, so you can install it on your own server.
 
-This tutorial shows how to install webKnossos on a fresh VM which is available over the public internet and has a domain name (or a subdomain) already configured.
-webKnossos will then be available with over a secured connection (HTTPS) with automatic certificate management.
-
-```bash
-# Create a new folder for webknossos
-mkdir -p /opt/webknossos
-cd /opt/webknossos
-
-# Download the docker-compose.yml for hosting
-wget https://github.com/scalableminds/webknossos/raw/master/tools/hosting/docker-compose.yml
-
-# Create the data folder which will contain all your datasets
-mkdir data
-
-# The data folder needs to be readable/writable by user id=1000,gid=1000
-chown -R 1000:1000 data
-
-# Start webKnossos and supply the PUBLIC_HOST and LETSENCRYPT_EMAIL variables
-# In addition to webKnossos, we also start an nginx proxy with automatic 
-# SSL certificate management via letsencrypt
-PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
-docker-compose up webknossos nginx nginx-letsencrypt
-
-# Wait a couple of minutes for webKnossos to become available under your domain
-# e.g. https://webknossos.example.com
-# Set up your organization using the installation process in the browser
-
-# Start webKnossos in the background
-PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
-docker-compose up -d webknossos nginx nginx-letsencrypt
-
-# Stop everything
-docker-compose down
-```
-
-This setup does not support regular backups or monitoring. For production deployments, please refer to [our paid service plans](https://webknossos.org/pricing).
-
-When using symbolic links in your data directory, you need to adapt the `docker-compose.yml` to also mount the link targets. For example, you could have a link from `/opt/webknossos/data/sample_organization/awesome_dataset` to `/cluster/path/to/awesome_dataset`. In this case you would also need to mount the target (or a parent directory) in the webknossos container, e.g.,
-```yaml
-...
-services:
-  webknossos:
-    ...
-    volumes:
-      - ./data:/srv/webknossos/binaryData
-      - /cluster:/cluser
-...
-```
+[Check out the documentation](https://docs.webknossos.org/guides/installation) for a tutorial on how to install webKnossos on your own server.
 
 For installations on localhost, please see below.
-
 
 ## Development installation
 ### Docker

--- a/README.md
+++ b/README.md
@@ -41,13 +41,66 @@ webKnossos is an open-source tool for annotating and exploring large 3D image da
 
 [Read more about the original publication.](https://publication.webknossos.org)
 
+## Installation
+### Docker
+Docker 17+ and Docker Compose 1.18+ are required.
+
+This tutorial assumes that you wish to install webKnossos on a fresh VM which available over the public internet and has a domain name (or a subdomain) configured.
+
+```bash
+# Create a new folder for webknossos
+mkdir -p /opt/webknossos
+cd /opt/webknossos
+
+# Download the docker-compose.yml for hosting
+wget https://github.com/scalableminds/webknossos/raw/master/tools/hosting/docker-compose.yml
+
+# Create the data folder which will contain all your datasets
+mkdir data
+
+# The data folder needs to be readable/writable by user id=1000,gid=1000
+chown -R 1000:1000 data
+
+# Start webKnossos and supply the PUBLIC_HOST and LETSENCRYPT_EMAIL variables
+# In addition to webKnossos, we also start an nginx proxy with automatic 
+# SSL certificate management via letsencrypt
+PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
+docker-compose up webknossos nginx nginx-letsencrypt
+
+# Wait a couple of minutes for webKnossos to become available under your domain
+# e.g. https://webknossos.example.com
+# Set up your organization using the installation process in the browser
+
+# Start webKnossos in the background
+PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
+docker-compose up -d webknossos nginx nginx-letsencrypt
+
+# Stop everything
+docker-compose down
+```
+
+This setup does not support regular backups or monitoring. For production deployments, please refer to [our paid service plans](https://webknossos.org/pricing).
+
+When using symbolic links in your data directory, you need to adapt the `docker-compose.yml` to also mount the link targets. For example, you could have a link from `/opt/webknossos/data/sample_organization/awesome_dataset` to `/cluster/path/to/awesome_dataset`. In this case you would also need to mount the target (or a parent directory) in the webknossos container, e.g.,
+```yaml
+...
+services:
+  webknossos:
+    ...
+    volumes:
+      - ./data:/srv/webknossos/binaryData
+      - /cluster:/cluser
+...
+```
+
+For installations on localhost, please see below.
+
 
 ## Development installation
 ### Docker
 This is the fastest way to try webKnossos.
-Docker CE 17+ and Docker Compose 1.18+ is required.
-This is only recommended for testing.
-[For production](https://github.com/scalableminds/webknossos/wiki/Production-setup), a more elaborate setup with persistent file mounts and HTTPS reverse proxy is recommended.
+Docker 17+ and Docker Compose 1.18+ are required.
+This is only recommended for local testing.
 
 ```bash
 git clone -b master --depth=1 git@github.com:scalableminds/webknossos.git
@@ -60,7 +113,7 @@ Open your local webknossos instance on [localhost:9000](http://localhost:9000).
 
 See the [wiki](https://github.com/scalableminds/webknossos/wiki/Try-setup) for instructions on updating this try setup.
 
-For non-localhost deployments, make sure to use the `webknossos-public` docker-compose service and set the `PUBLIC_URI` environment variable:
+For non-localhost deployments, make sure to use the `webknossos` docker-compose service and set the `PUBLIC_URI` environment variable:
 
 ```bash
 git clone -b master --depth=1 git@github.com:scalableminds/webknossos.git

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ For installations on localhost, please see below.
 
 ## Development installation
 ### Docker
-This is the fastest way to try webKnossos.
-Docker 17+ and Docker Compose 1.18+ are required.
-This is only recommended for local testing.
+This is only recommended for local testing. Docker 17+ and Docker Compose 1.18+ are required.
 
 ```bash
 git clone -b master --depth=1 git@github.com:scalableminds/webknossos.git
@@ -61,18 +59,12 @@ docker-compose pull webknossos
 ./start-docker.sh
 ```
 
-Open your local webknossos instance on [localhost:9000](http://localhost:9000).
+Open your local webknossos instance on [localhost:9000](http://localhost:9000) and complete the onboarding steps in the browser.
+Now, you are ready to use your local webKnossos instance.
 
-See the [wiki](https://github.com/scalableminds/webknossos/wiki/Try-setup) for instructions on updating this try setup.
+See the wiki for [instructions on updating](https://github.com/scalableminds/webknossos/wiki/Development-setup) this development setup.
 
-For non-localhost deployments, make sure to use the `webknossos` docker-compose service and set the `PUBLIC_URI` environment variable:
-
-```bash
-git clone -b master --depth=1 git@github.com:scalableminds/webknossos.git
-cd webknossos
-docker-compose pull webknossos
-PUBLIC_URI=http://example.org:9000 docker-compose up webknossos-public
-```
+For non-localhost deployments, check out the [installation guide in the documentation](https://docs.webknossos.org/guides/installation).
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ webKnossos is an open-source tool for annotating and exploring large 3D image da
 ### Docker
 Docker 17+ and Docker Compose 1.18+ are required.
 
-This tutorial assumes that you wish to install webKnossos on a fresh VM which available over the public internet and has a domain name (or a subdomain) configured.
+This tutorial shows how to install webKnossos on a fresh VM which is available over the public internet and has a domain name (or a subdomain) already configured.
+webKnossos will then be available with over a secured connection (HTTPS) with automatic certificate management.
 
 ```bash
 # Create a new folder for webknossos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,9 +64,8 @@ services:
       - -Dslick.db.url=jdbc:postgresql://postgres/webknossos
       - -Dapplication.insertInitialData=false
       - -Dapplication.authentication.enableDevAutoLogin=false
-      - -Dhttp.uri=${PUBLIC_URI}
-      - -Dtracingstore.publicUrl=${PUBLIC_URI}
-      - -Ddatastore.publicUrl=${PUBLIC_URI}
+      - -Dtracingstore.publicUri=${PUBLIC_URI}
+      - -Ddatastore.publicUri=${PUBLIC_URI}
     volumes:
       - ./binaryData:/srv/webknossos/binaryData
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,44 +28,12 @@ services:
       - -Dapplication.authentication.enableDevAutoLogin=false
       # the following lines need to be adapted for non-localhost deployments
       # - -Dhttp.uri=http://example.org:9000
-      # - -Dtracingstore.publicUrl=http://example.org:9000
-      # - -Ddatastore.publicUrl=http://example.org:9000
+      # - -Dtracingstore.publicUri=http://example.org:9000
+      # - -Ddatastore.publicUri=http://example.org:9000
       # the following lines disable the integrated datastore:
       # - -Dplay.modules.enabled-="com.scalableminds.webknossos.datastore.DataStoreModule"
       # - -Ddatastore.enabled=false
       # - -Dplay.http.router="noDS.Routes"
-    volumes:
-      - ./binaryData:/srv/webknossos/binaryData
-    environment:
-      - POSTGRES_URL=jdbc:postgresql://postgres/webknossos
-    user: ${USER_UID:-1000}:${USER_GID:-1000}
-
-  webknossos-public:
-    build: .
-    image: scalableminds/webknossos:${DOCKER_TAG:-master}
-    ports:
-      - "9000:9000"
-    links:
-      - "fossildb-persisted:fossildb"
-      - "postgres-persisted:postgres"
-    depends_on:
-      postgres-persisted:
-        condition: service_healthy
-      fossildb-persisted:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    command:
-      - -Dconfig.file=conf/application.conf
-      - -Djava.net.preferIPv4Stack=true
-      - -Dhttp.address=0.0.0.0
-      - -Dtracingstore.fossildb.address=fossildb
-      - -Dtracingstore.redis.address=redis
-      - -Dslick.db.url=jdbc:postgresql://postgres/webknossos
-      - -Dapplication.insertInitialData=false
-      - -Dapplication.authentication.enableDevAutoLogin=false
-      - -Dtracingstore.publicUri=${PUBLIC_URI}
-      - -Ddatastore.publicUri=${PUBLIC_URI}
     volumes:
       - ./binaryData:/srv/webknossos/binaryData
     environment:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,66 +80,7 @@ Feel free to explore more features of webKnossos in this documentation.
 * [Task and Project Management](./tasks.md)
 * [FAQ](./faq.md)
 
-If you need help with webKnossos, there is a [Community Support forum](https://support.webknososs.org) where members of the community and scalable minds are happy to answer your questions.
+If you need help with webKnossos, feel free to send contact us at [hello@scalableminds.com]((mailto:hello@scalableminds.com).
 [scalable minds](https://scalableminds.com) also offers commercial support, managed hosting and feature development services.
-[Please contact us](mailto:hello@scalableminds.com) if you want to learn more.
 
-
-## webKnossos on Your Own Server
-webKnossos is open-source, so you can install it on your own server.
-We recommend a server with at least 4 CPU cores, 16 GB RAM, and as much disk space as you require for your datasets.
-As prerequisites, you need to install [Git](https://git-scm.com/), [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) on your server.
-
-### Installation
-To get started, simply clone the Git repository and start the docker containers:
-
-```bash
-git clone https://github.com/scalableminds/webknossos.git
-cd webknossos
-
-docker-compose pull webknossos
-./start-docker.sh
-```
-
-This will start an instance of webKnossos on http://localhost:9000/.
-Open the URL in your browser and configure your organization (see below).
-This will create a folder for your data at `webknossos/binaryData/<organization name>`.
-
-{% hint style='info' %}
-For production setups, we recommend more elaborate configurations with a public domain name and HTTPS support.
-[Please contact us](mailto:hello@scalableminds.com) if you require any assistance with your production setup.
-{% endhint %}
-
-You may also install webKnossos without Docker.
-This may be useful if you intend to develop features for webKnossos.
-Please refer to the [Code Readme](../README.md) for details.
-
-### Onboarding
-When starting with webKnossos you first need to create an organization.
-An organization represents your lab in webKnossos and handles permissions for users and datasets.
-Choose a descriptive name for your organization, e.g. "The University of Springfield", "Simpsons Lab" or "Neuroscience Department".
-
-![Create your organization](./images/onboarding_organization.png)
-
-In the onboarding flow, you are asked to create a user account for yourself.
-This will be the first user of your organization which will automatically be activated and granted admin rights.
-Make sure to enter a correct email address.
-
-![Create your first user](./images/onboarding_user.png)
-
-
-### Your First Dataset
-Now that you've completed the onboarding, you need to import a dataset.
-Without any data, webKnossos is not fun.
-
-For small datasets (max. 1GB), you can use the upload functionality provide in the web interface.
-For larger datasets, we recommend the file system upload.
-Read more about the import functionality in the [Datasets guide](./datasets.md).
-
-If you do not have a compatible dataset available, you can use one of the [sample datasets](./datasets.md#sample-datasets) for testing purposes.
-
-By default, datasets are visible to all users in your organization.
-However, webKnossos includes fine-grained permissions to assign datasets to groups of users.
-
-![Upload your first dataset](./images/onboarding_data1.png)
-![Confirm the dataset properties](./images/onboarding_data2.png)
+[Read the installation tutorial](./installation.md), if you wish to install webKnossos on your own server.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,7 +80,7 @@ Feel free to explore more features of webKnossos in this documentation.
 * [Task and Project Management](./tasks.md)
 * [FAQ](./faq.md)
 
-If you need help with webKnossos, feel free to send contact us at [hello@scalableminds.com](mailto:hello@scalableminds.com).
-[scalable minds](https://scalableminds.com) also offers commercial support, managed hosting and feature development services.
+If you need help with webKnossos, feel free to contact us at [hello@scalableminds.com](mailto:hello@scalableminds.com).
+scalable minds also offers [commercial support, managed hosting and feature development services](https://webknossos.org/pricing).
 
 [Read the installation tutorial](./installation.md), if you wish to install webKnossos on your own server.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 Welcome to the webKnossos documentation.
-webKnossos is a tool for [exploring large-scale 3D image datasets](./tracing_ui.md), [creating versatile skeleton annotations](./skeleton_annotation.md) and [generating 3D training data for automated segmentations](./volume_annotation.md).
+webKnossos is a tool for [exploring large-scale 3D image datasets](./tracing_ui.md), [creating skeleton annotations](./skeleton_annotation.md) and [3D volume segmentations](./volume_annotation.md).
 Since it is a web-based tool, [collaboration](./sharing.md), [crowdsourcing](./tasks.md) and [publication](https://webknossos.org) is very easy.
 
 Feel free to [drop us a line](mailto:hello@scalableminds.com) or [create a Pull Request](https://github.com/scalableminds/webknossos/pulls) if you have any suggestions for improving the documentation.
@@ -80,7 +80,7 @@ Feel free to explore more features of webKnossos in this documentation.
 * [Task and Project Management](./tasks.md)
 * [FAQ](./faq.md)
 
-If you need help with webKnossos, feel free to send contact us at [hello@scalableminds.com]((mailto:hello@scalableminds.com).
+If you need help with webKnossos, feel free to send contact us at [hello@scalableminds.com](mailto:hello@scalableminds.com).
 [scalable minds](https://scalableminds.com) also offers commercial support, managed hosting and feature development services.
 
 [Read the installation tutorial](./installation.md), if you wish to install webKnossos on your own server.

--- a/docs/hello.md
+++ b/docs/hello.md
@@ -45,9 +45,8 @@ Try webKnossos on a large selection of published datasets: [https://webknossos.o
 
 webKnossos was developed by [scalable minds](https://scalableminds.com) in collaboration with the [Max Planck Institute for Brain Research](https://brain.mpg.de/connectomics).
 
-If you need help with webKnossos, there is a [Community Support forum](https://support.webknososs.org) where members of the community and scalable minds are happy to answer your questions.
-[scalable minds](https://scalableminds.com) also offers commercial support, managed hosting and feature development services.
-[Please contact us](mailto:hello@scalableminds.com) if you want to learn more.
+If you need help with webKnossos, feel free to contact us at [hello@scalableminds.com](mailto:hello@scalableminds.com).
+scalable minds also offers [commercial support, managed hosting and feature development services](https://webknossos.org/pricing).
 
 <!--
 ## Labs that use webKnossos

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@
 * [Managing Users and Access Rights](./users.md)
 * [Managing Tasks and Projects](./tasks.md)
 * [Sharing](./sharing.md)
-* [Installation on own Server](./installation.md)
+* [Installation on your own Server](./installation.md)
 
 ## Reference
 * [Supported Data Formats](./data_formats.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,11 +13,11 @@
 * [Managing Users and Access Rights](./users.md)
 * [Managing Tasks and Projects](./tasks.md)
 * [Sharing](./sharing.md)
+* [Installation on own Server](./installation.md)
 
 ## Reference
 * [Supported Data Formats](./data_formats.md)
 * [Keyboard Shortcuts](./keyboard_shortcuts.md)
-* [FAQ](./faq.md)
 * [Backend REST API](./rest_api.md)
 * [Code Readme](../README.md)
 * [Changelog](../CHANGELOG.md)
@@ -26,5 +26,6 @@
 * [Tooling](./tooling.md) 
 
 ## Getting Help
-* [Community Support](https://support.webknossos.org)
+* [FAQ](./faq.md)
+* [Email Support](mailto:hello@scalableminds.com)
 * [Commercial Support](https://scalableminds.com)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,6 +25,7 @@ chown -R 1000:1000 binaryData
 # Start webKnossos and supply the PUBLIC_HOST and LETSENCRYPT_EMAIL variables
 # In addition to webKnossos, we also start an nginx proxy with automatic 
 # SSL certificate management via letsencrypt
+# Note that PUBLIC_HOST does not include http:// or https:// prefixes
 PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
 docker-compose up webknossos nginx nginx-letsencrypt
 
@@ -32,7 +33,7 @@ docker-compose up webknossos nginx nginx-letsencrypt
 # e.g. https://webknossos.example.com
 # Set up your organization and admin account using the onboarding screens (see below)
 
-# Start webKnossos in the background
+# After the initial run, you can start webKnossos in the background
 PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
 docker-compose up -d webknossos nginx nginx-letsencrypt
 
@@ -72,7 +73,7 @@ For small datasets (max. 1GB), you can use the upload functionality provide in t
 For larger datasets, we recommend the file system upload.
 Read more about the import functionality in the [Datasets guide](./datasets.md).
 
-If you do not have a compatible dataset available, you can use one of the [sample datasets](./datasets.md#sample-datasets) for testing purposes.
+If you do not have a compatible dataset available, you can convert your own data using [the webKnossos cuber tool](./tooling.md#webknossos-cuber) or use one of the [sample datasets](./datasets.md#sample-datasets) for testing purposes.
 
 By default, datasets are visible to all users in your organization.
 However, webKnossos includes fine-grained permissions to assign datasets to groups of users.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,81 @@
+# Installation on your own Server
+
+webKnossos is open-source, so you can install it on your own server.
+We recommend a server with at least 4 CPU cores, 16 GB RAM, and as much disk space as you require for your datasets.
+
+As prerequisites, you need to install [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) on your server. Docker 17+ and Docker Compose 1.18+ are required.
+
+This tutorial shows how to install webKnossos on a fresh VM which is available over the public internet and has a domain name (or a subdomain) already configured.
+webKnossos will then be available with over a secured connection (HTTPS) with automatic certificate management.
+
+```bash
+# Create a new folder for webknossos
+mkdir -p /opt/webknossos
+cd /opt/webknossos
+
+# Download the docker-compose.yml for hosting
+wget https://github.com/scalableminds/webknossos/raw/master/tools/hosting/docker-compose.yml
+
+# Create the binaryData folder which will contain all your datasets
+mkdir binaryData
+
+# The binaryData folder needs to be readable/writable by user id=1000,gid=1000
+chown -R 1000:1000 binaryData
+
+# Start webKnossos and supply the PUBLIC_HOST and LETSENCRYPT_EMAIL variables
+# In addition to webKnossos, we also start an nginx proxy with automatic 
+# SSL certificate management via letsencrypt
+PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
+docker-compose up webknossos nginx nginx-letsencrypt
+
+# Wait a couple of minutes for webKnossos to become available under your domain
+# e.g. https://webknossos.example.com
+# Set up your organization and admin account using the onboarding screens (see below)
+
+# Start webKnossos in the background
+PUBLIC_HOST=webknossos.example.com LETSENCRYPT_EMAIL=admin@example.com \
+docker-compose up -d webknossos nginx nginx-letsencrypt
+
+# Congratulations! Your webKnossos is now up and running.
+
+# Stop everything
+docker-compose down
+```
+
+{% hint style='info' %}
+This setup does not support regular backups or monitoring.
+Please check out [our paid service plans](https://webknossos.org/pricing) if you require any assistance with your production setup.
+{% endhint %}
+
+For installations on localhost, please refer to the [Code Readme](../README.md#docker).
+
+### Onboarding
+When starting with webKnossos you first need to create an organization.
+An organization represents your lab in webKnossos and handles permissions for users and datasets.
+Choose a descriptive name for your organization, e.g. "The University of Springfield", "Simpsons Lab" or "Neuroscience Department".
+
+![Create your organization](./images/onboarding_organization.png)
+
+In the onboarding flow, you are asked to create a user account for yourself.
+This will be the first user of your organization which will automatically be activated and granted admin rights.
+Make sure to enter a correct email address.
+
+![Create your first user](./images/onboarding_user.png)
+
+
+### Your First Dataset
+Without any data, webKnossos is not fun.
+Luckily, there are some sample datasets that you can download directly from the onboarding screens.
+Once you've completed the onboarding, you can also import your own datasets.
+
+For small datasets (max. 1GB), you can use the upload functionality provide in the web interface.
+For larger datasets, we recommend the file system upload.
+Read more about the import functionality in the [Datasets guide](./datasets.md).
+
+If you do not have a compatible dataset available, you can use one of the [sample datasets](./datasets.md#sample-datasets) for testing purposes.
+
+By default, datasets are visible to all users in your organization.
+However, webKnossos includes fine-grained permissions to assign datasets to groups of users.
+
+![Upload your first dataset](./images/onboarding_data1.png)
+![Confirm the dataset properties](./images/onboarding_data2.png)

--- a/tools/hosting/docker-compose.yml
+++ b/tools/hosting/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   webknossos:
-    image: scalableminds/webknossos:${DOCKER_TAG:-master}
+    image: scalableminds/webknossos:${DOCKER_TAG:-20.02.0}
     ports:
       - "127.0.0.1:9000:9000"
     depends_on:
@@ -86,7 +86,7 @@ services:
 
   # Nginx
   nginx:
-    image: scalableminds/nginx-proxy:master
+    image: scalableminds/nginx-proxy:master__117
     ports:
       - "80:80"
       - "443:443"

--- a/tools/hosting/docker-compose.yml
+++ b/tools/hosting/docker-compose.yml
@@ -1,0 +1,111 @@
+version: "2.2"
+
+services:
+  webknossos:
+    image: scalableminds/webknossos:${DOCKER_TAG:-master}
+    ports:
+      - "127.0.0.1:9000:9000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      fossildb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command:
+      - -Dconfig.file=conf/application.conf
+      - -Djava.net.preferIPv4Stack=true
+      - -Dhttp.address=0.0.0.0
+      - -Dtracingstore.fossildb.address=fossildb
+      - -Dtracingstore.redis.address=redis
+      - -Dslick.db.url=jdbc:postgresql://postgres/webknossos
+      - -Dapplication.insertInitialData=false
+      - -Dapplication.authentication.enableDevAutoLogin=false
+      - -Dtracingstore.publicUri=https://${PUBLIC_HOST}
+      - -Ddatastore.publicUri=https://${PUBLIC_HOST}
+    volumes:
+      - ./data:/srv/webknossos/binaryData
+    environment:
+      - POSTGRES_URL=jdbc:postgresql://postgres/webknossos
+      - VIRTUAL_HOST=${PUBLIC_HOST}
+      - LETSENCRYPT_HOST=${PUBLIC_HOST}
+    user: ${USER_UID:-1000}:${USER_GID:-1000}
+
+  # Postgres
+  postgres:
+    image: postgres:10-alpine
+    environment:
+      POSTGRES_DB: webknossos
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -h 127.0.0.1 -p 5432"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - "./persistent/postgres:/var/lib/postgresql/data/"
+
+  psql:
+    extends: postgres
+    command: psql -h postgres -U postgres webknossos
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: postgres
+
+  # FossilDB
+  fossildb:
+    image: scalableminds/fossildb:master__410
+    command:
+      - fossildb
+      - -c
+      - skeletons,skeletonUpdates,volumes,volumeData,volumeUpdates
+    user: 0:0
+    volumes:
+      - "./persistent/fossildb/data:/fossildb/data"
+      - "./persistent/fossildb/backup:/fossildb/backup"
+
+  # Redis
+  redis:
+    image: redis:5.0
+    command:
+      - redis-server
+    healthcheck:
+      test:
+        - CMD
+        - bash
+        - -c
+        - "exec 3<> /dev/tcp/127.0.0.1/6379 && echo PING >&3 && head -1 <&3 | grep PONG"
+      timeout: 1s
+      interval: 5s
+      retries: 10
+
+  # Nginx
+  nginx:
+    image: scalableminds/nginx-proxy:master
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./persistent/nginx/certs:/etc/nginx/certs
+      - ./persistent/nginx/vhost.d:/etc/nginx/vhost.d
+      - ./persistent/nginx/html:/usr/share/nginx/html
+    labels:
+      - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
+
+  nginx-letsencrypt:
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    environment:
+      - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
+    depends_on:
+      - nginx
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./persistent/nginx/certs:/etc/nginx/certs
+      - ./persistent/nginx/vhost.d:/etc/nginx/vhost.d
+      - ./persistent/nginx/html:/usr/share/nginx/html


### PR DESCRIPTION
This PR makes the installation on a custom server much easier. Users only have to download 1 docker-compose file and follow a few steps in order to get an HTTPS-secured public installation of webKnossos.

Regular backups and monitoring is not included and available via [paid service plans](https://webknossos.org/pricing).

### Steps to test:
- Follow the steps on https://docs.webknossos.org/v/docs-hosting-docker/guides/installation

### Issues:
- fixes #4423

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
~- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [x] Updated [documentation](../blob/master/docs) if applicable
~- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
~- [ ] Needs datastore update after deployment~
- [x] Ready for review
