### PR TITLE
Use back-end upload if NML is dragged into a read-only view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Added
 - Added the possibility to reopen finished tasks as non-admin for a configurable time. [#4415](https://github.com/scalableminds/webknossos/pull/4415)
+- Added support for drag-and-drop import of NML files even if the current view is read-only (e.g., because a dataset was opened in "view" mode). In this case, a new tracing is directly created into which the NML file is imported. [#4459](https://github.com/scalableminds/webknossos/pull/4459)
 
 ### Changed
 -

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -40,7 +40,8 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits {
   val DEFAULT_TIMESTAMP = 0L
 
   @SuppressWarnings(Array("TraversableHead")) //We check if volumes are empty before accessing the head
-  def parse(name: String, nmlInputStream: InputStream)(implicit m: MessagesProvider)
+  def parse(name: String, nmlInputStream: InputStream, overwritingDataSetName: Option[String])(
+      implicit m: MessagesProvider)
     : Box[(Option[SkeletonTracing], Option[(VolumeTracing, String)], String, Option[String])] =
     try {
       val data = XML.load(nmlInputStream)
@@ -58,9 +59,10 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits {
         _ <- TreeValidator.checkAllNodesUsedInBranchPointsExist(trees, branchPoints)
         _ <- TreeValidator.checkAllNodesUsedInCommentsExist(trees, comments)
       } yield {
-        val dataSetName = parseDataSetName(parameters \ "experiment")
+        val dataSetName = overwritingDataSetName.getOrElse(parseDataSetName(parameters \ "experiment"))
         val description = parseDescription(parameters \ "experiment")
-        val organizationName = parseOrganizationName(parameters \ "experiment")
+        val organizationName =
+          if (overwritingDataSetName.isDefined) None else parseOrganizationName(parameters \ "experiment")
         val activeNodeId = parseActiveNode(parameters \ "activeNode")
         val editPosition =
           parseEditPosition(parameters \ "editPosition").getOrElse(SkeletonTracingDefaults.editPosition)

--- a/frontend/javascripts/dashboard/dashboard_view.js
+++ b/frontend/javascripts/dashboard/dashboard_view.js
@@ -154,7 +154,7 @@ class DashboardView extends React.PureComponent<PropsWithRouter, State> {
     ) : null;
 
     return (
-      <NmlUploadZoneContainer onImport={this.uploadNmls} isAllowed>
+      <NmlUploadZoneContainer onImport={this.uploadNmls} isUpdateAllowed>
         <div className="container">
           {userHeader}
           <Tabs activeKey={this.state.activeTabKey} onChange={onTabChange}>

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -56,6 +56,7 @@ type StateProps = {|
   storedLayouts: Object,
   isDatasetOnScratchVolume: boolean,
   autoSaveLayouts: boolean,
+  datasetName: string,
 |};
 type DispatchProps = {|
   setAutoSaveLayouts: boolean => void,
@@ -175,7 +176,7 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
       createGroupForEachFile: boolean,
     ): Promise<void> => {
       const response = await Request.sendMultipartFormReceiveJSON("/api/annotations/upload", {
-        data: { nmlFile: files, createGroupForEachFile },
+        data: { nmlFile: files, createGroupForEachFile, datasetName: this.props.datasetName },
       });
       this.props.history.push(`/annotations/${response.annotation.typ}/${response.annotation.id}`);
     };
@@ -183,7 +184,7 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
     return (
       <NmlUploadZoneContainer
         onImport={isUpdateTracingAllowed ? importTracingFiles : createNewTracing}
-        isAllowed={isUpdateTracingAllowed}
+        isUpdateAllowed={isUpdateTracingAllowed}
       >
         <OxalisController
           initialAnnotationType={this.props.initialAnnotationType}
@@ -333,6 +334,7 @@ function mapStateToProps(state: OxalisState): StateProps {
     showVersionRestore: state.uiInformation.showVersionRestore,
     storedLayouts: state.uiInformation.storedLayouts,
     isDatasetOnScratchVolume: state.dataset.dataStore.isScratch,
+    datasetName: state.dataset.name,
   };
 }
 

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -7,8 +7,10 @@ import { Alert, Icon, Layout, Tooltip } from "antd";
 import type { Dispatch } from "redux";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
+import type { RouterHistory } from "react-router-dom";
 import * as React from "react";
 
+import Request from "libs/request";
 import { ArbitraryViewport, type ViewMode, OrthoViews } from "oxalis/constants";
 import type { OxalisState, AnnotationType, TraceOrViewCommand } from "oxalis/store";
 import { RenderToPortal } from "oxalis/view/layouting/portal_utils";
@@ -59,6 +61,7 @@ type DispatchProps = {|
   setAutoSaveLayouts: boolean => void,
 |};
 type Props = {| ...OwnProps, ...StateProps, ...DispatchProps |};
+type PropsWithRouter = {| ...OwnProps, ...StateProps, ...DispatchProps, history: RouterHistory |};
 
 type State = {
   isSettingsCollapsed: boolean,
@@ -76,7 +79,7 @@ const GOLDEN_LAYOUT_ADAPTER_STYLE = {
   overflow: "hidden",
 };
 
-class TracingLayoutView extends React.PureComponent<Props, State> {
+class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
   currentLayoutConfig: Object;
   currentLayoutName: string;
 
@@ -86,7 +89,7 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
     return { hasError: true };
   }
 
-  constructor(props: Props) {
+  constructor(props: PropsWithRouter) {
     super(props);
     const layoutType = determineLayout(this.props.initialCommandType.type, this.props.viewMode);
     let lastActiveLayout;
@@ -167,8 +170,21 @@ class TracingLayoutView extends React.PureComponent<Props, State> {
     const currentLayoutNames = this.getLayoutNamesFromCurrentView(layoutType);
     const { displayScalebars, isDatasetOnScratchVolume, isUpdateTracingAllowed } = this.props;
 
+    const createNewTracing = async (
+      files: Array<File>,
+      createGroupForEachFile: boolean,
+    ): Promise<void> => {
+      const response = await Request.sendMultipartFormReceiveJSON("/api/annotations/upload", {
+        data: { nmlFile: files, createGroupForEachFile },
+      });
+      this.props.history.push(`/annotations/${response.annotation.typ}/${response.annotation.id}`);
+    };
+
     return (
-      <NmlUploadZoneContainer onImport={importTracingFiles} isAllowed={isUpdateTracingAllowed}>
+      <NmlUploadZoneContainer
+        onImport={isUpdateTracingAllowed ? importTracingFiles : createNewTracing}
+        isAllowed={isUpdateTracingAllowed}
+      >
         <OxalisController
           initialAnnotationType={this.props.initialAnnotationType}
           initialCommandType={this.props.initialCommandType}

--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
@@ -20,7 +20,7 @@ type State = {
 
 type OwnProps = {|
   children: React.Node,
-  isAllowed: boolean,
+  isUpdateAllowed: boolean,
   onImport: (files: Array<File>, createGroupForEachFile: boolean) => Promise<void>,
 |};
 type StateProps = {|
@@ -59,13 +59,13 @@ function OverlayDropZone({ children }) {
   );
 }
 
-function NmlDropArea({ showClickHint, isAllowed }) {
+function NmlDropArea({ showClickHint, isUpdateAllowed }) {
   return (
     <React.Fragment>
       <div>
         <Icon type="inbox" style={{ fontSize: 180, color: "rgb(58, 144, 255)" }} />
       </div>
-      {isAllowed ? (
+      {isUpdateAllowed ? (
         <h5>Drop NML files here{showClickHint ? " or click to select files" : null}...</h5>
       ) : (
         <h5>
@@ -151,7 +151,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
   renderDropzoneModal() {
     return (
       <Modal visible footer={null} onCancel={this.props.hideDropzoneModal}>
-        {this.props.isAllowed ? (
+        {this.props.isUpdateAllowed ? (
           <Alert
             message="Did you know that you do can just drag-and-drop NML files directly into this view? You don't have to explicitly open this dialog first."
             style={{ marginBottom: 12 }}
@@ -169,7 +169,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
           }}
           onDrop={this.onDrop}
         >
-          <NmlDropArea showClickHint isAllowed={this.props.isAllowed} />
+          <NmlDropArea showClickHint isUpdateAllowed={this.props.isUpdateAllowed} />
         </Dropzone>
       </Modal>
     );
@@ -194,7 +194,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
           <React.Fragment>
             {this.state.files.length > 1 ? createGroupsCheckbox : null}
             <Button key="submit" type="primary" onClick={this.importTracingFiles}>
-              {this.props.isAllowed ? "Import" : "Create New Tracing"}
+              {this.props.isUpdateAllowed ? "Import" : "Create New Tracing"}
             </Button>
           </React.Fragment>
         }
@@ -224,7 +224,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
         }
         {this.state.dropzoneActive && !this.props.showDropzoneModal ? (
           <OverlayDropZone>
-            <NmlDropArea showClickHint={false} isAllowed={this.props.isAllowed} />
+            <NmlDropArea showClickHint={false} isUpdateAllowed={this.props.isUpdateAllowed} />
           </OverlayDropZone>
         ) : null}
         {

--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
@@ -68,8 +68,8 @@ function NmlDropArea({ showClickHint, isAllowed }) {
       {isAllowed ? (
         <h5>Drop NML files here{showClickHint ? " or click to select files" : null}...</h5>
       ) : (
-        <h5 style={{ color: "rgb(247,80,61)" }}>
-          You cannot upload NML files into a read-only tracing.
+        <h5>
+          Drop NML files here to <b>create a new tracing</b>.
         </h5>
       )}
     </React.Fragment>
@@ -98,14 +98,11 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
   };
 
   onDrop = (files: Array<File>) => {
-    if (this.props.isAllowed) {
-      this.setState({
-        files,
-        dropzoneActive: false,
-      });
-    } else {
-      this.setState({ dropzoneActive: false });
-    }
+    this.setState({
+      files,
+      dropzoneActive: false,
+    });
+
     trackAction("NML drag and drop");
     this.props.hideDropzoneModal();
   };
@@ -197,7 +194,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
           <React.Fragment>
             {this.state.files.length > 1 ? createGroupsCheckbox : null}
             <Button key="submit" type="primary" onClick={this.importTracingFiles}>
-              Import
+              {this.props.isAllowed ? "Import" : "Create New Tracing"}
             </Button>
           </React.Fragment>
         }

--- a/test/backend/NMLUnitTestSuite.scala
+++ b/test/backend/NMLUnitTestSuite.scala
@@ -31,7 +31,7 @@ class NMLUnitTestSuite extends FlatSpec {
     val nmlEnumarator = new NmlWriter().toNmlStream(Some(skeletonTracing), None, None, None, None, "testOrganization", None, None)
     val arrayFuture = Iteratee.flatten(nmlEnumarator |>> Iteratee.consume[Array[Byte]]()).run
     val array = Await.result(arrayFuture, Duration.Inf)
-    NmlParser.parse("", new ByteArrayInputStream(array))
+    NmlParser.parse("", new ByteArrayInputStream(array), None)
   }
 
   def isParseSuccessful(parsedTracing: Box[(Option[SkeletonTracing], Option[(VolumeTracing, String)], String, Option[String])]): Boolean = {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://importinview.webknossos.xyz

### Steps to test:
- Open a dataset in view mode (or a tracing of another use)
- drag an NML file into the tracing view
- click "create new tracing" in the imprt modal
- webKnossos should reload and show a new tracing with the imported NML

### Issues:
- fixes #4417 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] ~Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- [ ] ~Updated [documentation](../blob/master/docs) if applicable~
- [ ] ~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [ ] ~Needs datastore update after deployment~
- [X] Ready for review
