### PR TITLE
Reduce default dataset reporting interval from 10 to 1 minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Changed
 - Changed NML import in tracings to try parsing files as NMLs and protobuf regardless of the file extension. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
+- Default interval for detecting new/deleted datasets on disk has been reduced from 10 to 1 minute. [#4464](https://github.com/scalableminds/webknossos/pull/4464)
 
 ### Fixed
 - Fixed opening view only dataset links with arbitrary modes being initially displayed in plane mode. [#4421](https://github.com/scalableminds/webknossos/pull/4421)

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,7 +5,7 @@ This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.md).
 
 ## Unreleased
--
+- Default interval for detecting new/deleted datasets on disk (`braingames.binary.changeHandler.tickerInterval` in the config) has been reduced from 10 to 1 minute. If you relied on the value being 10 minutes, you have to set it explicitly now.
 
 ### Postgres Evolutions:
 -

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -113,7 +113,7 @@ braingames.binary {
 
   changeHandler {
     enabled = true
-    tickerInterval = 10 # in minutes
+    tickerInterval = 1 # in minutes
   }
 }
 

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -35,7 +35,7 @@ braingames.binary {
 
   changeHandler {
     enabled = true
-    tickerInterval = 10 # in minutes
+    tickerInterval = 1 # in minutes
   }
 
   useRemote = false


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- check that the dataset detection logging appears once per minute now
- I’m currently checking that this does not lead to performance issues in a production instance

### Issues:
- fixes #4462 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- [x] Needs datastore update after deployment
- [x] Ready for review
