### PR TITLE
Disallow editing description of someone else’s annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Fixed opening view only dataset links with arbitrary modes being initially displayed in plane mode. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
+- Fixed a bug where users were wrongly allowed to edit the description of an annotation they were allowed to see but not update [#4466](https://github.com/scalableminds/webknossos/pull/4466)
 
 ### Removed
 -

--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -213,6 +213,8 @@ class AnnotationController @Inject()(
   def editAnnotation(typ: String, id: String) = sil.SecuredAction.async(parse.json) { implicit request =>
     for {
       annotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
+      restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
+      _ <- restrictions.allowUpdate(request.identity) ?~> "notAllowed" ~> FORBIDDEN
       name = (request.body \ "name").asOpt[String]
       description = (request.body \ "description").asOpt[String]
       visibility = (request.body \ "visibility").asOpt[String]

--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -210,19 +210,15 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
         </span>
       );
     } else {
-      if (this.props.tracing.description) {
-        descriptionEditField = (
-          <span style={{ verticalAlign: "top" }}>
-            Description:
-            <Markdown
-              source={tracingDescription}
-              options={{ html: false, breaks: true, linkify: true }}
-            />
-          </span>
-        );
-      } else {
-        descriptionEditField = <span>Description: {tracingDescription}</span>;
-      }
+      descriptionEditField = (
+        <span style={{ verticalAlign: "top" }}>
+          Description:
+          <Markdown
+            source={tracingDescription}
+            options={{ html: false, breaks: true, linkify: true }}
+          />
+        </span>
+      );
     }
 
     return (

--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -195,21 +195,40 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
     }
     const tracingDescription = this.props.tracing.description || "<no description>";
 
+    let descriptionEditField;
+    if (this.props.tracing.restrictions.allowUpdate) {
+      descriptionEditField = (
+        <span style={{ verticalAlign: "top" }}>
+          Description:
+          <EditableTextLabel
+            value={tracingDescription}
+            onChange={this.setAnnotationDescription}
+            rows={4}
+            markdown
+            label="Annotation Description"
+          />
+        </span>
+      );
+    } else {
+      if (this.props.tracing.description) {
+        descriptionEditField = (
+          <span style={{ verticalAlign: "top" }}>
+            Description:
+            <Markdown
+              source={tracingDescription}
+              options={{ html: false, breaks: true, linkify: true }}
+            />
+          </span>
+        );
+      } else {
+        descriptionEditField = <span>Description: {tracingDescription}</span>;
+      }
+    }
+
     return (
       <div className="flex-overflow">
         <p>{annotationTypeLabel}</p>
-        <p>
-          <span style={{ verticalAlign: "top" }}>
-            Description:
-            <EditableTextLabel
-              value={tracingDescription}
-              onChange={this.setAnnotationDescription}
-              rows={4}
-              markdown
-              label="Annotation Description"
-            />
-          </span>
-        </p>
+        <p>{descriptionEditField}</p>
       </div>
     );
   }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- set up two users, create a tracing
- open the tracing as owner, also as not the owner
- owner should be allowed to edit description, other user should just see it

### Issues:
- fixes #4449 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- ~[ ] Needs datastore update after deployment~
- [x] Ready for review
