### PR TITLE
Avoid volume mode in hybrid tracings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Fixed opening view only dataset links with arbitrary modes being initially displayed in plane mode. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
+- Fixed that converting a volume tracing into a hybrid tracing opens the hybrid tracing in "volume" mode. [#4467](https://github.com/scalableminds/webknossos/pull/4467)
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Added
 - Added the possibility to reopen finished tasks as non-admin for a configurable time. [#4415](https://github.com/scalableminds/webknossos/pull/4415)
 - Added indication for reloading a dataset in the dataset actions in the dashboard. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
+- Added refreshing of the tracing page when the user logs in to access the dataset as the newly logged in user. [#4467](https://github.com/scalableminds/webknossos/pull/4467)
 
 ### Changed
 - Changed NML import in tracings to try parsing files as NMLs and protobuf regardless of the file extension. [#4421](https://github.com/scalableminds/webknossos/pull/4421)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Added the possibility to reopen finished tasks as non-admin for a configurable time. [#4415](https://github.com/scalableminds/webknossos/pull/4415)
 - Added support for drag-and-drop import of NML files even if the current view is read-only (e.g., because a dataset was opened in "view" mode). In this case, a new tracing is directly created into which the NML file is imported. [#4459](https://github.com/scalableminds/webknossos/pull/4459)
 - Added indication for reloading a dataset in the dataset actions in the dashboard. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
-- Added refreshing of the tracing page when the user logs in to access the dataset as the newly logged-in user. [#4467](https://github.com/scalableminds/webknossos/pull/4467)
+- Added login prompt to the tracing page when fetching the dataset fails. Upon successful login, the dataset gets fetched with the rights of the newly logged-in user. [#4467](https://github.com/scalableminds/webknossos/pull/4467)
 
 ### Changed
 - Changed NML import in tracings to try parsing files as NMLs and protobuf regardless of the file extension. [#4421](https://github.com/scalableminds/webknossos/pull/4421)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Added
 - Added the possibility to reopen finished tasks as non-admin for a configurable time. [#4415](https://github.com/scalableminds/webknossos/pull/4415)
 - Added indication for reloading a dataset in the dataset actions in the dashboard. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
-- Added refreshing of the tracing page when the user logs in to access the dataset as the newly logged in user. [#4467](https://github.com/scalableminds/webknossos/pull/4467)
+- Added refreshing of the tracing page when the user logs in to access the dataset as the newly logged-in user. [#4467](https://github.com/scalableminds/webknossos/pull/4467)
 
 ### Changed
 - Changed NML import in tracings to try parsing files as NMLs and protobuf regardless of the file extension. [#4421](https://github.com/scalableminds/webknossos/pull/4421)

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -31,7 +31,9 @@ function LoginForm({ layout, form, onLoggedIn, hideFooter, style }: Props) {
       if (!err) {
         const user = await loginUser(formValues);
         Store.dispatch(setActiveUserAction(user));
-        if (onLoggedIn) onLoggedIn();
+        if (onLoggedIn) {
+          onLoggedIn();
+        }
       }
     });
   };

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -15,7 +15,7 @@ const { Password } = Input;
 type Props = {
   layout: "horizontal" | "vertical" | "inline",
   form: Object,
-  onLoggedIn?: () => void | Promise<void>,
+  onLoggedIn?: () => void,
   hideFooter?: boolean,
   style?: Object,
 };

--- a/frontend/javascripts/admin/auth/login_form.js
+++ b/frontend/javascripts/admin/auth/login_form.js
@@ -15,7 +15,7 @@ const { Password } = Input;
 type Props = {
   layout: "horizontal" | "vertical" | "inline",
   form: Object,
-  onLoggedIn?: () => void,
+  onLoggedIn?: () => void | Promise<void>,
   hideFooter?: boolean,
   style?: Object,
 };

--- a/frontend/javascripts/components/brain_spinner.js
+++ b/frontend/javascripts/components/brain_spinner.js
@@ -1,7 +1,12 @@
 // @flow
 import * as React from "react";
 
-export default function BrainSpinner() {
+type Props = {
+  message: ?string,
+  isLoading: boolean,
+};
+
+export default function BrainSpinner({ message, isLoading = true }: Props) {
   return (
     <div className="cover-whole-screen">
       <div className="Aligner" style={{ height: "80%" }}>
@@ -18,10 +23,17 @@ export default function BrainSpinner() {
                 marginTop: "10%",
               }}
             />
-            <div
-              className="loader"
-              style={{ width: "80%", marginLeft: "auto", marginRight: "auto", marginTop: 30 }}
-            />
+            {isLoading ? (
+              <div
+                className="loader"
+                style={{ width: "80%", marginLeft: "auto", marginRight: "auto", marginTop: 30 }}
+              />
+            ) : null}
+            {message ? (
+              <div style={{ marginLeft: "auto", marginRight: "auto", marginTop: 30 }}>
+                {message}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/frontend/javascripts/components/brain_spinner.js
+++ b/frontend/javascripts/components/brain_spinner.js
@@ -2,8 +2,8 @@
 import * as React from "react";
 
 type Props = {
-  message: ?string,
-  isLoading: boolean,
+  message?: string,
+  isLoading?: boolean,
 };
 
 export default function BrainSpinner({ message, isLoading = true }: Props) {

--- a/frontend/javascripts/components/brain_spinner.js
+++ b/frontend/javascripts/components/brain_spinner.js
@@ -3,17 +3,7 @@ import * as React from "react";
 
 export default function BrainSpinner() {
   return (
-    <div
-      style={{
-        position: "absolute",
-        top: 0,
-        left: 0,
-        width: "100%",
-        height: "100%",
-        background: "rgb(252, 252, 252)",
-        zIndex: 300,
-      }}
-    >
+    <div className="cover-whole-screen">
       <div className="Aligner" style={{ height: "80%" }}>
         <div className="Aligner-item Aligner-item--fixed">
           <div style={{ width: 375 }}>

--- a/frontend/javascripts/components/brain_spinner.js
+++ b/frontend/javascripts/components/brain_spinner.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 type Props = {
-  message?: string,
+  message?: React.Node,
   isLoading?: boolean,
 };
 
@@ -29,7 +29,7 @@ export default function BrainSpinner({ message, isLoading = true }: Props) {
                 style={{ width: "80%", marginLeft: "auto", marginRight: "auto", marginTop: 30 }}
               />
             ) : null}
-            {message ? (
+            {message != null ? (
               <div style={{ marginLeft: "auto", marginRight: "auto", marginTop: 30 }}>
                 {message}
               </div>

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -270,17 +270,7 @@ function AnonymousAvatar() {
   return (
     <Popover
       placement="bottomRight"
-      content={
-        <LoginForm
-          layout="horizontal"
-          style={{ maxWidth: 500 }}
-          onLoggedIn={async () => {
-            // We reload the tracing upon successful login to access the dataset with the newly logged in user.
-            await Model.ensureSavedState();
-            location.reload();
-          }}
-        />
-      }
+      content={<LoginForm layout="horizontal" style={{ maxWidth: 500 }} />}
       trigger="click"
       style={{ position: "fixed" }}
     >

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -15,8 +15,6 @@ import Request from "libs/request";
 import Store, { type OxalisState } from "oxalis/store";
 import * as Utils from "libs/utils";
 import features from "features";
-import Model from "oxalis/model";
-import { location } from "libs/window";
 
 const { SubMenu } = Menu;
 const { Header } = Layout;

--- a/frontend/javascripts/navbar.js
+++ b/frontend/javascripts/navbar.js
@@ -15,6 +15,8 @@ import Request from "libs/request";
 import Store, { type OxalisState } from "oxalis/store";
 import * as Utils from "libs/utils";
 import features from "features";
+import Model from "oxalis/model";
+import { location } from "libs/window";
 
 const { SubMenu } = Menu;
 const { Header } = Layout;
@@ -268,7 +270,17 @@ function AnonymousAvatar() {
   return (
     <Popover
       placement="bottomRight"
-      content={<LoginForm layout="horizontal" style={{ maxWidth: 500 }} />}
+      content={
+        <LoginForm
+          layout="horizontal"
+          style={{ maxWidth: 500 }}
+          onLoggedIn={async () => {
+            // We reload the tracing upon successful login to access the dataset with the newly logged in user.
+            await Model.ensureSavedState();
+            location.reload();
+          }}
+        />
+      }
       trigger="click"
       style={{ position: "fixed" }}
     >

--- a/frontend/javascripts/oxalis/controller.js
+++ b/frontend/javascripts/oxalis/controller.js
@@ -8,6 +8,7 @@ import { connect } from "react-redux";
 import BackboneEvents from "backbone-events-standalone";
 import * as React from "react";
 import _ from "lodash";
+import { Col, Row } from "antd";
 
 import { HANDLED_ERROR } from "oxalis/model_initialization";
 import { InputKeyboardNoLoop, InputKeyboard } from "libs/input";
@@ -21,6 +22,7 @@ import {
   updateDatasetSettingAction,
 } from "oxalis/model/actions/settings_actions";
 import { wkReadyAction } from "oxalis/model/actions/actions";
+import LoginForm from "admin/auth/login_form";
 import ApiLoader from "oxalis/api/api_loader";
 import ArbitraryController from "oxalis/controller/viewmodes/arbitrary_controller";
 import BrainSpinner from "components/brain_spinner";
@@ -34,24 +36,27 @@ import Store, {
 import Toast from "libs/toast";
 import UrlManager from "oxalis/controller/url_manager";
 import * as Utils from "libs/utils";
+import type { APIUser } from "admin/api_flow_types";
 
 import app from "app";
 import constants, { ControlModeEnum, type ViewMode } from "oxalis/constants";
 import messages from "messages";
 import window, { document } from "libs/window";
 
+type ControllerStatus = "loading" | "loaded" | "failedLoading";
 type OwnProps = {|
   initialAnnotationType: AnnotationType,
   initialCommandType: TraceOrViewCommand,
 |};
 type StateProps = {|
   viewMode: ViewMode,
+  user: APIUser,
 |};
 type Props = {| ...OwnProps, ...StateProps |};
 type PropsWithRouter = {| ...Props, history: RouterHistory |};
 
 type State = {
-  ready: boolean,
+  status: ControllerStatus,
 };
 
 class Controller extends React.PureComponent<PropsWithRouter, State> {
@@ -60,7 +65,7 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
   isMounted: boolean;
 
   state = {
-    ready: false,
+    status: "loading",
   };
 
   // Main controller, responsible for setting modes and everything
@@ -90,22 +95,27 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
       Toast.error(messages["webgl.disabled"]);
     }
 
+    this.tryFetchingModel();
+  }
+
+  componentWillUnmount() {
+    this.isMounted = false;
+    Store.dispatch(setIsInAnnotationViewAction(false));
+  }
+
+  tryFetchingModel() {
     // Preview a working tracing version if the showVersionRestore URL parameter is supplied
     const versions = Utils.hasUrlParam("showVersionRestore") ? { skeleton: 1 } : undefined;
 
     Model.fetch(this.props.initialAnnotationType, this.props.initialCommandType, true, versions)
       .then(() => this.modelFetchDone())
       .catch(error => {
+        this.setState({ status: "failedLoading" });
         // Don't throw errors for errors already handled by the model.
         if (error !== HANDLED_ERROR) {
           throw error;
         }
       });
-  }
-
-  componentWillUnmount() {
-    this.isMounted = false;
-    Store.dispatch(setIsInAnnotationViewAction(false));
   }
 
   modelFetchDone() {
@@ -148,7 +158,7 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
       // Give wk (sagas and bucket loading) a bit time to catch air before
       // showing the UI as "ready". The goal here is to avoid that the
       // UI is still freezing after the loading indicator is gone.
-      this.setState({ ready: true });
+      this.setState({ status: "loaded" });
     }, 200);
   }
 
@@ -262,24 +272,36 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
   }
 
   render() {
-    if (!this.state.ready) {
+    const { status } = this.state;
+    const { user, viewMode } = this.props;
+    if (status === "loading" || (status === "failedLoading" && user != null)) {
       return <BrainSpinner />;
+    } else if (status === "failedLoading") {
+      return (
+        <div className="cover-whole-screen">
+          <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
+            <Col span={8}>
+              <h3>Try logging in to view the dataset.</h3>
+              <LoginForm layout="horizontal" onLoggedIn={() => this.tryFetchingModel()} />
+            </Col>
+          </Row>
+        </div>
+      );
     }
     const { allowedModes } = Store.getState().tracing.restrictions;
-    const mode = this.props.viewMode;
 
-    if (!allowedModes.includes(mode)) {
+    if (!allowedModes.includes(viewMode)) {
       // Since this mode is not allowed, render nothing. A warning about this will be
       // triggered in the model. Don't throw an error since the store might change so that
       // the render function can succeed.
       return null;
     }
 
-    const isArbitrary = constants.MODES_ARBITRARY.includes(mode);
-    const isPlane = constants.MODES_PLANE.includes(mode);
+    const isArbitrary = constants.MODES_ARBITRARY.includes(viewMode);
+    const isPlane = constants.MODES_PLANE.includes(viewMode);
 
     if (isArbitrary) {
-      return <ArbitraryController viewMode={mode} />;
+      return <ArbitraryController viewMode={viewMode} />;
     } else if (isPlane) {
       return <PlaneController />;
     } else {
@@ -293,6 +315,7 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
 function mapStateToProps(state: OxalisState): StateProps {
   return {
     viewMode: state.temporaryConfiguration.viewMode,
+    user: state.activeUser,
   };
 }
 

--- a/frontend/javascripts/oxalis/controller.js
+++ b/frontend/javascripts/oxalis/controller.js
@@ -3,12 +3,12 @@
  * @flow
  */
 
-import { type RouterHistory, withRouter } from "react-router-dom";
+import { type RouterHistory, withRouter, Link } from "react-router-dom";
 import { connect } from "react-redux";
 import BackboneEvents from "backbone-events-standalone";
 import * as React from "react";
 import _ from "lodash";
-import { Col, Row } from "antd";
+import { Button, Col, Row } from "antd";
 
 import { HANDLED_ERROR } from "oxalis/model_initialization";
 import { InputKeyboardNoLoop, InputKeyboard } from "libs/input";
@@ -104,6 +104,7 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
   }
 
   tryFetchingModel() {
+    this.setState({ status: "loading" });
     // Preview a working tracing version if the showVersionRestore URL parameter is supplied
     const versions = Utils.hasUrlParam("showVersionRestore") ? { skeleton: 1 } : undefined;
 
@@ -279,7 +280,15 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
     } else if (status === "failedLoading" && user != null) {
       return (
         <BrainSpinner
-          message="Either the dataset does not exist or you do not have the necessary access rights."
+          message={
+            <div style={{ textAlign: "center" }}>
+              Either the dataset does not exist or you do not have the necessary access rights.
+              <br />
+              <Link to="/" style={{ marginTop: 16, display: "inline-block" }}>
+                <Button type="primary">Return to dashboard</Button>
+              </Link>
+            </div>
+          }
           isLoading={false}
         />
       );
@@ -289,13 +298,7 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
           <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
             <Col span={8}>
               <h3>Try logging in to view the dataset.</h3>
-              <LoginForm
-                layout="horizontal"
-                onLoggedIn={() => {
-                  this.setState({ status: "loading" });
-                  this.tryFetchingModel();
-                }}
-              />
+              <LoginForm layout="horizontal" onLoggedIn={() => this.tryFetchingModel()} />
             </Col>
           </Row>
         </div>

--- a/frontend/javascripts/oxalis/controller.js
+++ b/frontend/javascripts/oxalis/controller.js
@@ -274,15 +274,28 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
   render() {
     const { status } = this.state;
     const { user, viewMode } = this.props;
-    if (status === "loading" || (status === "failedLoading" && user != null)) {
+    if (status === "loading") {
       return <BrainSpinner />;
+    } else if (status === "failedLoading" && user != null) {
+      return (
+        <BrainSpinner
+          message="Either the dataset does not exist or you do not have the necessary access rights."
+          isLoading={false}
+        />
+      );
     } else if (status === "failedLoading") {
       return (
         <div className="cover-whole-screen">
           <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
             <Col span={8}>
               <h3>Try logging in to view the dataset.</h3>
-              <LoginForm layout="horizontal" onLoggedIn={() => this.tryFetchingModel()} />
+              <LoginForm
+                layout="horizontal"
+                onLoggedIn={() => {
+                  this.setState({ status: "loading" });
+                  this.tryFetchingModel();
+                }}
+              />
             </Col>
           </Row>
         </div>

--- a/frontend/javascripts/oxalis/controller.js
+++ b/frontend/javascripts/oxalis/controller.js
@@ -50,7 +50,7 @@ type OwnProps = {|
 |};
 type StateProps = {|
   viewMode: ViewMode,
-  user: APIUser,
+  user: ?APIUser,
 |};
 type Props = {| ...OwnProps, ...StateProps |};
 type PropsWithRouter = {| ...Props, history: RouterHistory |};

--- a/frontend/javascripts/oxalis/model_initialization.js
+++ b/frontend/javascripts/oxalis/model_initialization.js
@@ -255,7 +255,13 @@ function initializeTracing(_annotation: APIAnnotation, tracing: HybridServerTrac
   if (allowedModes.length === 0) {
     Toast.error(messages["tracing.no_allowed_mode"]);
   } else {
-    const mode = preferredMode || UrlManager.initialState.mode || allowedModes[0];
+    const isHybridTracing = tracing.skeleton != null && tracing.volume != null;
+    let maybeUrlViewMode = UrlManager.initialState.mode;
+    if (isHybridTracing && UrlManager.initialState.mode === constants.MODE_VOLUME) {
+      // Here we avoid going into volume mode in hybrid tracings.
+      maybeUrlViewMode = constants.MODE_PLANE_TRACING;
+    }
+    const mode = preferredMode || maybeUrlViewMode || allowedModes[0];
     Store.dispatch(setViewModeAction(mode));
   }
 }

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -340,6 +340,16 @@ img.img-50 {
   top: 500px !important;
 }
 
+.cover-whole-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgb(252, 252, 252);
+  z-index: 300;
+}
+
 // Flex helper
 
 .Aligner {


### PR DESCRIPTION
This PR defaults to orthogonal mode when the active tracing is hybrid and the URL says to go into volume mode.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a volume tracing and convert it into a hybrid tracing (Dataset info tab).
- The opened tracing should be a hybrid tracing in orthogonal mode.

### Issues:
- fixes  #4460

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
