### PR TITLE
Fix float histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
 ### Fixed
 - Fixed opening view only dataset links with arbitrary modes being initially displayed in plane mode. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
+- Fixed the creation of histograms for float datasets that only have one value besides 0. [#4468](https://github.com/scalableminds/webknossos/pull/4468)
 
 ### Removed
 -

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
@@ -263,7 +263,8 @@ class FindDataService @Inject()(dataServicesHolder: BinaryDataServiceHolder)(imp
               case ((currMin, currMax), e) => (math.min(currMin, e), math.max(currMax, e))
             }
             val bucketSize = (max - min) / 255
-            floatData.foreach(el => counts(Math.roundDown((el - min) / bucketSize)) += 1)
+            val finalBucketSize = if (bucketSize == 0f) 1f else bucketSize
+            floatData.foreach(el => counts(Math.roundDown((el - min) / finalBucketSize)) += 1)
             extrema = (min, max)
         }
       }


### PR DESCRIPTION
- prevent dividing by 0

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- have a float layer where all non-zero values are equal
- histogram should work

### Issues:
- might fix #4405 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [x] Needs datastore update after deployment
- [x] Ready for review
