### PR TITLE
Fix float histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed opening view only dataset links with arbitrary modes being initially displayed in plane mode. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
 - Fixed a bug where users were wrongly allowed to edit the description of an annotation they were allowed to see but not update [#4466](https://github.com/scalableminds/webknossos/pull/4466)
 - Fixed the creation of histograms for float datasets that only have one value besides 0. [#4468](https://github.com/scalableminds/webknossos/pull/4468)
+- Fixed the creation of histograms for float datasets that have values close to the minimum. [#4475](https://github.com/scalableminds/webknossos/pull/4475)
 
 ### Removed
 -

--- a/util/src/main/scala/com/scalableminds/util/tools/Math.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Math.scala
@@ -15,22 +15,6 @@ object Math {
 
   def log2(x: Double): Double = scala.math.log(x) / lnOf2
 
-  def roundUp(x: Double) = {
-    val c = x.ceil.toInt
-    if (c != x)
-      c + 1
-    else
-      c
-  }
-
-  def roundDown(x: Double) = {
-    val c = x.floor.toInt
-    if (c != x)
-      c - 1
-    else
-      c
-  }
-
   def clamp[T](x: T, lower: T, upper: T)(implicit num: Numeric[T]): T = {
     import num._
     lower.max(x).min(upper)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
@@ -264,7 +264,7 @@ class FindDataService @Inject()(dataServicesHolder: BinaryDataServiceHolder)(imp
             }
             val bucketSize = (max - min) / 255
             val finalBucketSize = if (bucketSize == 0f) 1f else bucketSize
-            floatData.foreach(el => counts(Math.roundDown((el - min) / finalBucketSize)) += 1)
+            floatData.foreach(el => counts(((el - min) / finalBucketSize).floor.toInt) += 1)
             extrema = (min, max)
         }
       }


### PR DESCRIPTION
- fix rounding of floats and remove wrong implementations

### Steps to test:
- generating a histogram for every float layer should work

### Issues:
- fixes #4405 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [x] Needs datastore update after deployment
- [x] Ready for review
