### PR TITLE
Clearer error message if histogram call fails

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -7,6 +7,9 @@ notAllowed=You are not authorized to view or edit this resource
 
 binary.payload.invalid=Couldn’t parse payload
 
+histogram.layerMissing=Could not generate histogram data: missing layer {0}
+histogram.failed=Could not generate histogram data for layer {0}
+
 email=Email
 team=Team
 name=Name

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -408,8 +408,12 @@ class BinaryDataController @Inject()(
         .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
           AllowRemoteOrigin {
             for {
-              (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName)
-              listOfHistograms <- findDataService.createHistogram(dataSource, dataLayer)
+              (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName) ?~> Messages(
+                "histogram.layerMissing",
+                dataLayerName)
+              listOfHistograms <- findDataService.createHistogram(dataSource, dataLayer) ?~> Messages(
+                "histogram.failed",
+                dataLayerName)
             } yield Ok(Json.toJson(listOfHistograms))
           }
         }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
@@ -277,7 +277,7 @@ class FindDataService @Inject()(dataServicesHolder: BinaryDataServiceHolder)(imp
 
     def histogramForPositions(positions: List[Point3D], resolution: Point3D) =
       for {
-        dataConcatenated <- getConcatenatedDataFor(dataSource, dataLayer, positions, resolution) ?~> "getting data failed"
+        dataConcatenated <- getConcatenatedDataFor(dataSource, dataLayer, positions, resolution) ?~> "Could not get data at sampled positions"
         isUint24 = dataLayer.elementClass == ElementClass.uint24
         convertedData = convertData(dataConcatenated, dataLayer.elementClass, filterZeroes = !isUint24)
       } yield calculateHistogramValues(convertedData, dataLayer.bytesPerElement, isUint24)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- cause histogram call to fail (e.g. by specifying a huge bbox for a dataset with a tiny real one in the datasource-properties.json. then the data sampling should fail)
- error message should be histogram-specific

### Issues:
- fixes #4452

------
- [x] Needs datastore update after deployment
- [x] Ready for review
