### PR TITLE
Update Public URIs on Startup from Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ### Changed
 - Changed NML import in tracings to try parsing files as NMLs and protobuf regardless of the file extension. [#4421](https://github.com/scalableminds/webknossos/pull/4421)
 - Default interval for detecting new/deleted datasets on disk has been reduced from 10 to 1 minute. [#4464](https://github.com/scalableminds/webknossos/pull/4464)
+- The config values datastore.publicUri, tracingstore.publicUri and http.uri are now reapplied from the config at every startup if your instance has localhost-stores [#4482](https://github.com/scalableminds/webknossos/pull/4482)
 
 ### Fixed
 - Fixed that a node was created when using right click while brushing mode is active in hybrid tracings. [#4433](https://github.com/scalableminds/webknossos/pull/4433)

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -12,7 +12,7 @@ import models.project.{Project, ProjectDAO}
 import models.task.{TaskType, TaskTypeDAO}
 import models.team._
 import models.user._
-import net.liftweb.common.Full
+import net.liftweb.common.{Box, Full}
 import org.joda.time.DateTime
 import oxalis.security._
 import play.api.i18n.MessagesApi
@@ -93,6 +93,8 @@ Samplecountry
 
   def insert: Fox[Unit] =
     for {
+      _ <- updateLocalDataStorePublicUri
+      _ <- updateLocalTracingStorePublicUri
       _ <- insertLocalDataStoreIfEnabled
       _ <- insertLocalTracingStoreIfEnabled
       _ <- insertConnectDataStoreIfEnabled
@@ -236,8 +238,36 @@ Samplecountry
           tracingStoreDAO.insertOne(
             TracingStore("localhost",
                          conf.Http.uri,
-                         conf.Datastore.publicUri.getOrElse(conf.Http.uri),
+                         conf.Tracingstore.publicUri.getOrElse(conf.Http.uri),
                          conf.Tracingstore.key))
+        }
+      }
+    } else Fox.successful(())
+
+  def updateLocalDataStorePublicUri: Fox[Any] =
+    if (conf.Datastore.enabled) {
+      dataStoreDAO.findOneByName("localhost").futureBox.map { storeOpt: Box[DataStore] =>
+        storeOpt match {
+          case Full(store) =>
+            val newPublicUri = conf.Datastore.publicUri.getOrElse(conf.Http.uri)
+            if (store.url == conf.Http.uri && store.publicUrl == newPublicUri) {
+              Fox.successful(())
+            } else dataStoreDAO.updateOne(store.copy(url = conf.Http.uri, publicUrl = newPublicUri))
+          case _ => Fox.successful(())
+        }
+      }
+    } else Fox.successful(())
+
+  def updateLocalTracingStorePublicUri: Fox[Any] =
+    if (conf.Tracingstore.enabled) {
+      tracingStoreDAO.findOneByName("localhost").futureBox.map { storeOpt: Box[TracingStore] =>
+        storeOpt match {
+          case Full(store) =>
+            val newPublicUri = conf.Tracingstore.publicUri.getOrElse(conf.Http.uri)
+            if (store.url == conf.Http.uri && store.publicUrl == newPublicUri) {
+              Fox.successful(())
+            } else tracingStoreDAO.updateOne(store.copy(url = conf.Http.uri, publicUrl = newPublicUri))
+          case _ => Fox.successful(())
         }
       }
     } else Fox.successful(())

--- a/app/models/annotation/TracingStore.scala
+++ b/app/models/annotation/TracingStore.scala
@@ -111,7 +111,7 @@ class TracingStoreDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionCont
       _ <- run(sqlu"""update webknossos.tracingStores set isDeleted = true where name = $name""")
     } yield ()
 
-  def updateOne(t: TracingStore) =
+  def updateOne(t: TracingStore): Fox[Unit] =
     for {
       _ <- run(
         sqlu""" update webknossos.tracingStores set url = ${t.url}, publicUrl = ${t.publicUrl} where name = ${t.name}""")

--- a/clean
+++ b/clean
@@ -14,4 +14,4 @@ rm -rf webknossos-tracingstore/project/project/target
 rm -rf node_modules
 mkdir target
 
-echo "[info] Done."
+echo "[info] Done. Don’t forget to run yarn install before the next yarn start."


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- change datastore or tracingstore publicUri or http.uri in application.conf
- change should propagate at next wK restart
- should happen only if datastore.enabled/tracingstore.enabled respectively AND if the stores are still named `localhost`

### Issues:
- fixes #4434 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- ~[ ] Needs datastore update after deployment~
- [x] Ready for review
