### PR TITLE
Fix user dataset configuration

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -9,6 +9,7 @@ User-facing changes are documented in the [changelog](CHANGELOG.md).
 
 ### Postgres Evolutions:
 - [051-add-source-view-configuration.sql](conf/evolutions/051-add-source-view-configuration.sql)
+- [052-replace-segmentation-opacity.sql](conf/evolutions/052-replace-segmentation-opacity.sql)
 
 ## [20.03.0](https://github.com/scalableminds/webknossos/releases/tag/20.03.0) - 2020-02-27
 No migrations necessary.

--- a/conf/evolutions/052-replace-segmentation-opacity.sql
+++ b/conf/evolutions/052-replace-segmentation-opacity.sql
@@ -1,0 +1,24 @@
+-- https://github.com/scalableminds/webknossos/pull/4357
+
+START TRANSACTION;
+
+-- Update alpha value of segmentation layer based on segmentationOpacity
+UPDATE webknossos.user_dataSetConfigurations
+SET configuration = jsonb_set(
+        configuration,
+        array['configuration','layers'],
+        (configuration->'configuration'->'layers')::jsonb || jsonb_build_object(dl.name, jsonb_build_object('alpha', configuration->'configuration'->'segmentationOpacity')))
+FROM webknossos.dataSet_layers dl
+WHERE _dataSet = dl._dataset and dl.category = 'segmentation' and configuration->'configuration' ? 'segmentationOpacity';
+
+-- Remove segmentationOpacityField
+UPDATE webknossos.user_dataSetConfigurations
+SET configuration = jsonb_set(
+        configuration,
+        array['configuration'],
+        (configuration->'configuration')::jsonb - 'segmentationOpacity')
+WHERE configuration->'configuration' ? 'segmentationOpacity';
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 52;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/052-replace-segmentation-opacity.sql
+++ b/conf/evolutions/052-replace-segmentation-opacity.sql
@@ -6,18 +6,15 @@ START TRANSACTION;
 UPDATE webknossos.user_dataSetConfigurations
 SET configuration = jsonb_set(
         configuration,
-        array['configuration','layers'],
-        (configuration->'configuration'->'layers')::jsonb || jsonb_build_object(dl.name, jsonb_build_object('alpha', configuration->'configuration'->'segmentationOpacity')))
+        array['layers'],
+        (configuration->'layers')::jsonb || jsonb_build_object(dl.name, jsonb_build_object('alpha', configuration->'segmentationOpacity')))
 FROM webknossos.dataSet_layers dl
-WHERE _dataSet = dl._dataset and dl.category = 'segmentation' and configuration->'configuration' ? 'segmentationOpacity';
+WHERE webknossos.user_dataSetConfigurations._dataSet = dl._dataset and dl.category = 'segmentation' and configuration ? 'segmentationOpacity';
 
 -- Remove segmentationOpacityField
 UPDATE webknossos.user_dataSetConfigurations
-SET configuration = jsonb_set(
-        configuration,
-        array['configuration'],
-        (configuration->'configuration')::jsonb - 'segmentationOpacity')
-WHERE configuration->'configuration' ? 'segmentationOpacity';
+SET configuration = configuration - 'segmentationOpacity'
+WHERE configuration ? 'segmentationOpacity';
 
 UPDATE webknossos.releaseInformation SET schemaVersion = 52;
 

--- a/conf/evolutions/052-replace-segmentation-opacity.sql
+++ b/conf/evolutions/052-replace-segmentation-opacity.sql
@@ -1,4 +1,4 @@
--- https://github.com/scalableminds/webknossos/pull/4357
+-- https://github.com/scalableminds/webknossos/pull/4484
 
 START TRANSACTION;
 

--- a/conf/evolutions/reversions/052-replace-segmentation-opacity.sql
+++ b/conf/evolutions/reversions/052-replace-segmentation-opacity.sql
@@ -2,21 +2,18 @@ START TRANSACTION;
 
 -- set segmentationOpacity based on layer alpha value
 UPDATE webknossos.user_dataSetConfigurations
-SET configuration = jsonb_set(
-        configuration,
-        array['configuration'],
-        (configuration->'configuration')::jsonb || jsonb_build_object('segmentationOpacity', configuration->'configuration'->'layers'->dl.name->'alpha'))
-from webknossos.dataSet_layers dl
-WHERE _dataSet = dl._dataset and dl.category = 'segmentation';
+SET configuration = configuration || jsonb_build_object('segmentationOpacity', configuration->'layers'->dl.name->'alpha')
+FROM webknossos.dataSet_layers dl
+WHERE webknossos.user_dataSetConfigurations._dataSet = dl._dataset and dl.category = 'segmentation' and configuration->'layers'->dl.name ? 'alpha';
 
 -- remove segmentationLayer configuration
 UPDATE webknossos.user_dataSetConfigurations
 SET configuration = jsonb_set(
         configuration,
-        array['configuration','layers'],
-        (configuration->'configuration'->'layers')::jsonb - dl.name)
+        array['layers'],
+        (configuration->'layers')::jsonb - dl.name)
 from webknossos.dataSet_layers dl
-WHERE _dataSet = dl._dataset and dl.category = 'segmentation' and configuration->'configuration' ? 'segmentationOpacity';
+WHERE webknossos.user_dataSetConfigurations._dataSet = dl._dataset and dl.category = 'segmentation' and configuration ? 'segmentationOpacity';
 
 UPDATE webknossos.releaseInformation SET schemaVersion = 51;
 

--- a/conf/evolutions/reversions/052-replace-segmentation-opacity.sql
+++ b/conf/evolutions/reversions/052-replace-segmentation-opacity.sql
@@ -1,0 +1,23 @@
+START TRANSACTION;
+
+-- set segmentationOpacity based on layer alpha value
+UPDATE webknossos.user_dataSetConfigurations
+SET configuration = jsonb_set(
+        configuration,
+        array['configuration'],
+        (configuration->'configuration')::jsonb || jsonb_build_object('segmentationOpacity', configuration->'configuration'->'layers'->dl.name->'alpha'))
+from webknossos.dataSet_layers dl
+WHERE _dataSet = dl._dataset and dl.category = 'segmentation';
+
+-- remove segmentationLayer configuration
+UPDATE webknossos.user_dataSetConfigurations
+SET configuration = jsonb_set(
+        configuration,
+        array['configuration','layers'],
+        (configuration->'configuration'->'layers')::jsonb - dl.name)
+from webknossos.dataSet_layers dl
+WHERE _dataSet = dl._dataset and dl.category = 'segmentation' and configuration->'configuration' ? 'segmentationOpacity';
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 51;
+
+COMMIT TRANSACTION;

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ START TRANSACTION;
 CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(51);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(52);
 COMMIT TRANSACTION;
 
 CREATE TABLE webknossos.analytics(


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- apply evolution to user_dataset_configurations
- old `segmentationOpacity` values should now be the `alpha` values of the respective segmentation layer

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
