### PR TITLE
Revert "Check if task team is allowed for dataset"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed a bug where users were wrongly allowed to edit the description of an annotation they were allowed to see but not update [#4466](https://github.com/scalableminds/webknossos/pull/4466)
 - Fixed the creation of histograms for float datasets that only have one value besides 0. [#4468](https://github.com/scalableminds/webknossos/pull/4468)
 - Fixed the creation of histograms for float datasets that have values close to the minimum. [#4475](https://github.com/scalableminds/webknossos/pull/4475)
-- Users only get tasks of datasets that they can access. [#4437](https://github.com/scalableminds/webknossos/pull/4437)
 
 ### Removed
 -

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -182,6 +182,10 @@ class AnnotationDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContex
   def findAllByTaskIdAndType(taskId: ObjectId, typ: AnnotationType)(
       implicit ctx: DBAccessContext): Fox[List[Annotation]] =
     for {
+      r <- run(Annotations
+        .filter(r =>
+          notdel(r) && r._Task === taskId.id && r.typ === typ.toString && r.state =!= AnnotationState.Cancelled.toString)
+        .result)
       accessQuery <- readAccessQuery
       r <- run(
         sql"""select #${columns} from #${existingCollectionName}

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -183,9 +183,6 @@ class TaskDAO @Inject()(sqlClient: SQLClient, projectDAO: ProjectDAO)(implicit e
                as user_experiences on webknossos.tasks_.neededExperience_domain = user_experiences.domain and webknossos.tasks_.neededExperience_value <= user_experiences.value
              join webknossos.projects_ on webknossos.tasks_._project = webknossos.projects_._id
              left join (select _task from webknossos.annotations_ where _user = '${userId.id}' and typ = '${AnnotationType.Task}' and not ($isTeamManagerOrAdmin and state = '${AnnotationState.Cancelled}')) as userAnnotations ON webknossos.tasks_._id = userAnnotations._task
-             ${if (isTeamManagerOrAdmin) ""
-    else
-      s"join webknossos.dataSet_allowedTeams as allowedTeams on allowedTeams._team = webknossos.projects_._team and allowedTeams._dataset = (select _dataset from webknossos.annotations_ where _task = webknossos.tasks_._id and typ = '${AnnotationType.TracingBase}' and state != '${AnnotationState.Cancelled}')"}
            where webknossos.tasks_.openInstances > 0
                  and webknossos.projects_._team in ${writeStructTupleWithQuotes(teamIds.map(t => sanitize(t.id)))}
                  and userAnnotations._task is null


### PR DESCRIPTION
Reverts scalableminds/webknossos#4437

Hiwis were running out of tasks, which is why I had to unroll that change.