### PR TITLE
Add extensive logging for finish calls, allow double finish requests

### DIFF
--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -37,6 +37,8 @@ case class User(
     with Identity
     with FoxImplicits {
 
+  def toStringAnonymous: String = s"user ${_id.toString}"
+
   val name: String = firstName + " " + lastName
 
   val abreviatedName: String =

--- a/app/oxalis/security/URLSharing.scala
+++ b/app/oxalis/security/URLSharing.scala
@@ -10,9 +10,15 @@ import com.scalableminds.util.accesscontext.{
 }
 import models.user.User
 
-case class SharingTokenContainer(sharingToken: String) extends DBAccessContextPayload
+case class SharingTokenContainer(sharingToken: String) extends DBAccessContextPayload {
+  def toStringAnonymous: String =
+    s"sharingToken ${sharingToken.take(4)}***"
+}
 
-case class UserSharingTokenContainer(user: User, sharingToken: Option[String]) extends DBAccessContextPayload
+case class UserSharingTokenContainer(user: User, sharingToken: Option[String]) extends DBAccessContextPayload {
+  def toStringAnonymous: String =
+    s"user ${user._id} with sharingToken ${sharingToken.take(4)}***"
+}
 
 object URLSharing {
 

--- a/util/src/main/scala/com/scalableminds/util/accesscontext/AccessContext.scala
+++ b/util/src/main/scala/com/scalableminds/util/accesscontext/AccessContext.scala
@@ -1,11 +1,19 @@
 package com.scalableminds.util.accesscontext
 
-trait DBAccessContextPayload
+trait DBAccessContextPayload {
+  def toStringAnonymous: String
+}
 
 trait DBAccessContext {
   def data: Option[DBAccessContextPayload] = None
 
   def globalAccess: Boolean = false
+
+  def toStringAnonymous: String =
+    data match {
+      case Some(payload: DBAccessContextPayload) => payload.toStringAnonymous
+      case _                                     => "None"
+    }
 }
 
 case class AuthorizedAccessContext(t: DBAccessContextPayload) extends DBAccessContext {
@@ -16,6 +24,8 @@ case object UnAuthorizedAccessContext extends DBAccessContext
 
 case object GlobalAccessContext extends DBAccessContext {
   override val globalAccess = true
+
+  override def toStringAnonymous: String = "global"
 }
 
 object DBAccessContext {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- finish/archive annotations, reopen, etc, should get useful yet anonymous logging.
- sending double finish requests should not result in failing requests, logging should note that the second finishing is silently omitted.

------
- [x] Ready for review
