### PR TITLE
no modal for empty tree-group deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
  ### Changed
 - Reported datasets can now overwrite existing ones that are reported as missing, this ignores the isScratch precedence. [#4465](https://github.com/scalableminds/webknossos/pull/4465)
+- Deleting an empty tree group in the `Trees` tab no longer prompts for user confirmation. [#4506](https://github.com/scalableminds/webknossos/pull/4506)
 
  ### Fixed
 - Users only get tasks of datasets that they can access. [#4488](https://github.com/scalableminds/webknossos/pull/4488)

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -328,11 +328,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
     const treeGroupToDelete = treeGroups.find(el => el.groupId === id);
     const groupToTreesMap = createGroupToTreesMap(trees);
 
-    if (
-      treeGroupToDelete &&
-      treeGroupToDelete.children.length === 0 &&
-      !groupToTreesMap[id]
-    )
+    if (treeGroupToDelete && treeGroupToDelete.children.length === 0 && !groupToTreesMap[id])
       this.deleteGroup(id);
     else this.setState({ groupToDelete: id });
   };

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -322,7 +322,19 @@ class TreesTabView extends React.PureComponent<Props, State> {
   };
 
   showDeleteGroupModal = (id: number) => {
-    this.setState({ groupToDelete: id });
+    if (!this.props.skeletonTracing) return;
+
+    const { trees, treeGroups } = this.props.skeletonTracing;
+    const treeGroupToDelete = treeGroups.find(el => el.groupId === id);
+    const groupToTreesMap = createGroupToTreesMap(trees);
+
+    if (
+      treeGroupToDelete &&
+      treeGroupToDelete.children.length === 0 &&
+      !groupToTreesMap[id]
+    )
+      this.deleteGroup(id);
+    else this.setState({ groupToDelete: id });
   };
 
   handleDelete = () => {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- delete empty tree group => should just work
- delete non-empty tree group => should still ask for confirmation

### Issues:
- fixes #4499 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
