### PR TITLE
Allow floats as rotation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 
  ### Changed
 - Reported datasets can now overwrite existing ones that are reported as missing, this ignores the isScratch precedence. [#4465](https://github.com/scalableminds/webknossos/pull/4465)
+- Users can now input floating point numbers into the rotation field in flight and oblique mode. These values will get rounded internally. [#4507](https://github.com/scalableminds/webknossos/pull/4507)
 
  ### Fixed
 - Users only get tasks of datasets that they can access. [#4488](https://github.com/scalableminds/webknossos/pull/4488)

--- a/frontend/javascripts/libs/vector_input.js
+++ b/frontend/javascripts/libs/vector_input.js
@@ -109,11 +109,9 @@ class BaseVector<T: Vector3 | Vector6> extends React.PureComponent<BaseProps<T>,
     const value = Utils.stringToNumberArray(text);
     const isValidFormat = value.length === this.defaultValue.length;
 
-    if (isValidFormat && isValidInput) {
-      if (!this.props.changeOnlyOnBlur) {
-        const vector = ((value: any): T);
-        this.props.onChange(vector);
-      }
+    if (isValidFormat && isValidInput && !this.props.changeOnlyOnBlur) {
+      const vector = ((value: any): T);
+      this.props.onChange(vector);
     }
 
     this.setState({

--- a/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
@@ -80,6 +80,7 @@ class DatasetPositionView extends PureComponent<Props> {
                 value={rotation}
                 onChange={this.handleChangeRotation}
                 style={{ textAlign: "center", width: 120 }}
+                allowDecimals
               />
             </Input.Group>
           </Tooltip>


### PR DESCRIPTION
The values are rounded internally, but only shown after the user clicks into the input again.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- allow decimals as rotation parameters

### Issues:
- fixes #4498 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
