### PR TITLE
Also support dataset route without /view suffix

### DIFF
--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -411,6 +411,10 @@ class ReactRouter extends React.Component<Props> {
               />
               <Route path="/spotlight" component={SpotlightView} />
               <Route
+                path="/datasets/:organizationName/:datasetName"
+                render={this.tracingViewMode}
+              />
+              <Route
                 path="/datasets/:organizationName/:datasetName/view"
                 render={this.tracingViewMode}
               />


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://altviewroute.webknossos.xyz/datasets/sample_organization/2017-05-31_mSEM_scMS109_bk_100um_v01-aniso#4608,4608,512,0,1.000

### Steps to test:
- open a dataset in view mode without the `/view` suffix

### Issues:
- fixes #4523

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
