### PR TITLE
Backup old datasource-properties upon change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 ## Unreleased
 [Commits](https://github.com/scalableminds/webknossos/compare/20.04.0...HEAD)
 
- ### Added
+### Added
 - Users can undo finishing a task when the task was finished via the API, e.g. by a user script. [#4495](https://github.com/scalableminds/webknossos/pull/4495)
 - Added the magnification used for determining the segment ids in the segmentation tab to the table of the tab. [#4480](https://github.com/scalableminds/webknossos/pull/4480)
 - Added support for ID mapping of segmentation layer based on HDF5 agglomerate files. [#4469](https://github.com/scalableminds/webknossos/pull/4469)
 - Added option to hide all unmapped segments to segmentation tab. [#4510](https://github.com/scalableminds/webknossos/pull/4510)
+- When wK changes datasource-properties.json files of datasets, now it creates a backup log of previous versions. [#4534](https://github.com/scalableminds/webknossos/pull/4534)
 
- ### Changed
+### Changed
 - Reported datasets can now overwrite existing ones that are reported as missing, this ignores the isScratch precedence. [#4465](https://github.com/scalableminds/webknossos/pull/4465)
 - Improved the performance for large skeleton tracings with lots of comments. [#4473](https://github.com/scalableminds/webknossos/pull/4473)
 - Users can now input floating point numbers into the rotation field in flight and oblique mode. These values will get rounded internally. [#4507](https://github.com/scalableminds/webknossos/pull/4507)
@@ -23,13 +24,13 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Toggling the "Render missing data black" option now automatically reloads all layers making it unnecessary to reload the whole page. [#4516](https://github.com/scalableminds/webknossos/pull/4516)
 - The "mappings" attribute of segmentation layers in datasource jsons can now be omitted. [#4532](https://github.com/scalableminds/webknossos/pull/4532)
 
- ### Fixed
+### Fixed
 - Users only get tasks of datasets that they can access. [#4488](https://github.com/scalableminds/webknossos/pull/4488)
 - Fixed the import of datasets which was temporarily broken. [#4497](https://github.com/scalableminds/webknossos/pull/4497)
 - Fixed the displayed segment ids in segmentation tab when "Render Missing Data Black" is turned off. [#4480](https://github.com/scalableminds/webknossos/pull/4480)
 - The datastore checks if a organization folder can be created before creating a new organization. [#4501](https://github.com/scalableminds/webknossos/pull/4501)
 
- ### Removed
+### Removed
 
 -
 

--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -465,6 +465,10 @@ class ReactRouter extends React.Component<Props> {
                   />
                 )}
               />
+              {
+                // Note that this route has to be beneath all others sharing the same prefix,
+                // to avoid url mismatching
+              }
               <Route
                 path="/datasets/:organizationName/:datasetName"
                 render={this.tracingViewMode}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.datastore.services
 
-import java.io.File
-import java.nio.file.{AccessDeniedException, Path, Paths}
+import java.io.{File, FileWriter}
+import java.nio.file.{AccessDeniedException, Files, Path, Paths}
 
 import akka.actor.ActorSystem
 import com.google.inject.Inject
@@ -18,11 +18,14 @@ import com.scalableminds.webknossos.datastore.models.datasource.inbox.{InboxData
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common._
 import net.liftweb.util.Helpers.tryo
+import org.joda.time.DateTime
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
+import org.joda.time.format.ISODateTimeFormat
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.io.Source
 
 class DataSourceService @Inject()(
     config: DataStoreConfig,
@@ -40,6 +43,7 @@ class DataSourceService @Inject()(
   val dataBaseDir = Paths.get(config.Braingames.Binary.baseFolder)
 
   private val propertiesFileName = Paths.get("datasource-properties.json")
+  private val logFileName = Paths.get("datasource-properties-backups.log")
 
   def tick: Unit = checkInbox()
 
@@ -148,10 +152,37 @@ class DataSourceService @Inject()(
   def updateDataSource(dataSource: DataSource): Fox[Unit] =
     for {
       _ <- validateDataSource(dataSource).toFox
-      propertiesFile = dataBaseDir.resolve(dataSource.id.team).resolve(dataSource.id.name).resolve(propertiesFileName)
+      dataSourcePath = dataBaseDir.resolve(dataSource.id.team).resolve(dataSource.id.name)
+      propertiesFile = dataSourcePath.resolve(propertiesFileName)
+      _ <- backupPreviousProperties(dataSourcePath) ?~> "Could not update datasource-properties.json"
       _ <- JsonHelper.jsonToFile(propertiesFile, dataSource) ?~> "Could not update datasource-properties.json"
       _ <- dataSourceRepository.updateDataSource(dataSource)
     } yield ()
+
+  def backupPreviousProperties(dataSourcePath: Path): Box[Unit] = {
+    val propertiesFile = dataSourcePath.resolve(propertiesFileName)
+    val previousContentOrEmpty = if (Files.exists(propertiesFile)) {
+      val previousContentSource = Source.fromFile(propertiesFile.toString)
+      val previousContent = previousContentSource.getLines.mkString("\n")
+      previousContentSource.close()
+      previousContent
+    } else {
+      "<empty>"
+    }
+    val timestamp = ISODateTimeFormat.dateTime.print(new DateTime())
+    val outputForLogfile =
+      f"Contents of $propertiesFileName were changed by webKnossos at $timestamp. Old content: \n\n$previousContentOrEmpty\n\n"
+    val logfilePath = dataSourcePath.resolve(logFileName)
+    try {
+      val fileWriter = new FileWriter(logfilePath.toString, true)
+      try {
+        fileWriter.write(outputForLogfile)
+        Full(())
+      } finally fileWriter.close()
+    } catch {
+      case e: Exception => Failure(s"Could not back up old contents: ${e.toString}")
+    }
+  }
 
   private def teamAwareInboxSources(path: Path): List[InboxDataSource] = {
     val organization = path.getFileName.toString


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- edit datasource properties via wK (i.e. using the dataset edit page)
- backup log text file should be created

### Issues:
- fixes #4530 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
