### PR TITLE
Move generic view route all the way down to avoid url mismatches

### DIFF
--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -416,10 +416,6 @@ class ReactRouter extends React.Component<Props> {
               />
               <Route path="/spotlight" component={SpotlightView} />
               <Route
-                path="/datasets/:organizationName/:datasetName"
-                render={this.tracingViewMode}
-              />
-              <Route
                 path="/datasets/:organizationName/:datasetName/view"
                 render={this.tracingViewMode}
               />
@@ -468,6 +464,10 @@ class ReactRouter extends React.Component<Props> {
                     }}
                   />
                 )}
+              />
+              <Route
+                path="/datasets/:organizationName/:datasetName"
+                render={this.tracingViewMode}
               />
               <Route
                 path="/publication/:id"


### PR DESCRIPTION
The generic matching of this route leads to it overwriting other routes that have the same prefix. This PR moves it all the way down in the routing priority.

### Steps to test:
- create explorative link in dataset list should work again

------
- [x] Ready for review
