### PR TITLE
Fix group sorting when there are no trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Fixed the import of datasets which was temporarily broken. [#4497](https://github.com/scalableminds/webknossos/pull/4497)
 - Fixed the displayed segment ids in segmentation tab when "Render Missing Data Black" is turned off. [#4480](https://github.com/scalableminds/webknossos/pull/4480)
 - The datastore checks if a organization folder can be created before creating a new organization. [#4501](https://github.com/scalableminds/webknossos/pull/4501)
+- Fixed a bug where under certain circumstances groups in the tree tab were not sorted by name. [#4542](https://github.com/scalableminds/webknossos/pull/4542)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view_helpers.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view_helpers.js
@@ -89,12 +89,11 @@ export function insertTreesAndTransform(
       expanded: expandedGroupIds[groupId] != null ? expandedGroupIds[groupId] : true,
       children: insertTreesAndTransform(group.children, groupToTreesMap, expandedGroupIds, sortBy),
     });
-    if (groupToTreesMap[groupId] != null) {
-      // Groups are always sorted by name and appear before the trees, trees are sorted according to the sortBy prop
-      treeNode.children = _.orderBy(treeNode.children, ["name"], ["asc"]).concat(
-        _.orderBy(groupToTreesMap[groupId], [sortBy], ["asc"]).map(makeTreeNodeFromTree),
-      );
-    }
+    // Groups are always sorted by name and appear before the trees, trees are sorted according to the sortBy prop
+    const trees = _.orderBy(groupToTreesMap[groupId] || [], [sortBy], ["asc"]).map(
+      makeTreeNodeFromTree,
+    );
+    treeNode.children = _.orderBy(treeNode.children, ["name"], ["asc"]).concat(trees);
     treeNode.isChecked = _.every(treeNode.children, groupOrTree => groupOrTree.isChecked);
     return treeNode;
   });


### PR DESCRIPTION
Group sorting by name didn't work when there were no trees in this nesting level.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a tracing and only create groups. The groups should be sorted as expected.

### Issues:
- fixes #4490 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [x] Ready for review
