### PR TITLE
fix shader compilation error and invisible color layers in certain circumstances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - The datastore checks if a organization folder can be created before creating a new organization. [#4501](https://github.com/scalableminds/webknossos/pull/4501)
 - Fixed a bug where under certain circumstances groups in the tree tab were not sorted by name. [#4542](https://github.com/scalableminds/webknossos/pull/4542)
 - Fixed that `segmentationOpacity` could not be set anymore as part of the recommended settings for a task type. [#4545](https://github.com/scalableminds/webknossos/pull/4545)
+- Fixed a rendering error which could make some layers disappear in certain circumstances. [#4556](https://github.com/scalableminds/webknossos/pull/4556)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.js
+++ b/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.js
@@ -624,7 +624,7 @@ class PlaneMaterialFactory {
     return names.map(sanitizeName);
   }
 
-  onDisableColorLayer = (layerName, isSegmentationLayer) => {
+  onDisableColorLayer = layerName => {
     this.leastRecentlyVisibleColorLayers = _.without(
       this.leastRecentlyVisibleColorLayers,
       layerName,
@@ -634,7 +634,7 @@ class PlaneMaterialFactory {
     this.recomputeFragmentShader();
   };
 
-  onEnableColorLayer = (layerName, isSegmentationLayer) => {
+  onEnableColorLayer = layerName => {
     this.leastRecentlyVisibleColorLayers = _.without(
       this.leastRecentlyVisibleColorLayers,
       layerName,

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
@@ -327,7 +327,7 @@ export function getEnabledLayers(
     if (settings == null) {
       return false;
     }
-    return settings.isDisabled === options.invert;
+    return settings.isDisabled === Boolean(options.invert);
   });
 }
 

--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -224,7 +224,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps> {
           <span style={{ fontWeight: 700 }}>
             {!isColorLayer && isVolumeTracing ? "Volume Layer" : layerName}
           </span>
-          <Tag style={{ cursor: "default", marginLeft: 8 }}>{elementClass} Layer</Tag>
+          <Tag style={{ cursor: "default", marginLeft: 8 }}>{elementClass}</Tag>
           {this.getFindDataButton(layerName, isDisabled, isColorLayer)}
           {this.getReloadDataButton(layerName)}
         </Col>


### PR DESCRIPTION
This PR fixes two bugs (both mentioned in #4553).

One issue was a `===` comparison between a boolean and undefined (I thought, the flow linter would warn about this, but unfortunately it doesn't. we disabled sketchy-bool checks because it also warns about a lot of other stuff, which is usually fine for is).

The other issue was that the segmentation layer name could slip into the `colorLayerNames` variable. The reason for this was that the LRU layer could contain the segmentation layer. I made the naming clearer and excluded the segmentation layer from the LRU system (since the shader s always compiled for thesegmentation layer; one could re-think this, but that's outside the scope of this PR imo).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I created a dataset which contains too many layers to render all at once and a segmentation layer
- I also ensured that toggling the segmentation layer doesn't throw an error anymore and that the color layer can now be rendered.
I think the case in question doesn't need to be tested again.

### Issues:
- fixes #4553

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- [X] Ready for review
