### PR TITLE
Dataset info tab: break long dataset names

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -208,7 +208,7 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
     if (isDatasetViewMode) {
       return (
         <div>
-          <p>
+          <p style={{ wordWrap: "break-word" }}>
             <strong>{displayName || datasetName}</strong>
           </p>
           {datasetDescription ? (


### PR DESCRIPTION
### Steps to test:
- view dataset with long title but no spaces or hyphens, make info tab small, name should break

### Issues:
- fixes #4554 

------
- [x] Ready for review
