### PR TITLE
allow creating tree groups even for single nml upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.md).
 - Deleting an empty tree group in the `Trees` tab no longer prompts for user confirmation. [#4506](https://github.com/scalableminds/webknossos/pull/4506)
 - Toggling the "Render missing data black" option now automatically reloads all layers making it unnecessary to reload the whole page. [#4516](https://github.com/scalableminds/webknossos/pull/4516)
 - The "mappings" attribute of segmentation layers in datasource jsons can now be omitted. [#4532](https://github.com/scalableminds/webknossos/pull/4532)
+- Uploading a single nml, allows to wrap the tracing in a new tree group. [#4563](https://github.com/scalableminds/webknossos/pull/4563)
 
 ### Fixed
 - Users only get tasks of datasets that they can access. [#4488](https://github.com/scalableminds/webknossos/pull/4488)

--- a/app/models/annotation/nml/NmlService.scala
+++ b/app/models/annotation/nml/NmlService.scala
@@ -88,18 +88,14 @@ class NmlService @Inject()(temporaryFileCreator: TemporaryFileCreator)(implicit 
       tracing.copy(trees = newTrees, treeGroups = newTreeGroups)
     }
 
-    if (parseResults.length > 1) {
-      parseResults.map {
-        case NmlParseSuccess(name, Some(skeletonTracing), volumeTracingOpt, description, organizationNameOpt) =>
-          NmlParseSuccess(name,
-                          Some(wrapTreesInGroup(name, skeletonTracing)),
-                          volumeTracingOpt,
-                          description,
-                          organizationNameOpt)
-        case r => r
-      }
-    } else {
-      parseResults
+    parseResults.map {
+      case NmlParseSuccess(name, Some(skeletonTracing), volumeTracingOpt, description, organizationNameOpt) =>
+        NmlParseSuccess(name,
+                        Some(wrapTreesInGroup(name, skeletonTracing)),
+                        volumeTracingOpt,
+                        description,
+                        organizationNameOpt)
+      case r => r
     }
   }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- drop single nml and the resulting tracing should differ based on the checkbox

### Issues:
- fixes #4525 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.md#unreleased)
- ~~[ ] Updated [migration guide](../blob/master/MIGRATIONS.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
