### PR TITLE
Ensure that accessed data is always non-negative in shader

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that `segmentationOpacity` could not be set anymore as part of the recommended settings for a task type. [#4545](https://github.com/scalableminds/webknossos/pull/4545)
 - Fixed registration for setups with one organization and not configured defaultOrganization. [#4559](https://github.com/scalableminds/webknossos/pull/4559)
 - Fixed a rendering error which could make some layers disappear in certain circumstances. [#4556](https://github.com/scalableminds/webknossos/pull/4556)
+- Fixed a rendering error which caused negative float data to be rendered white. [#4556](https://github.com/scalableminds/webknossos/pull/4571)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/shaders/texture_access.glsl.js
+++ b/frontend/javascripts/oxalis/shaders/texture_access.glsl.js
@@ -116,6 +116,10 @@ export const getColorForCoords: ShaderModule = {
       float packingDegree,
       vec3 worldPositionUVW
     ) {
+      // This method looks up the color data at the given position.
+      // The data will be clamped to be non-negative, since negative data
+      // is reserved for missing buckets.
+
       vec3 coords = floor(getRelativeCoords(worldPositionUVW, zoomStep));
       vec3 relativeBucketPosition = div(coords, bucketWidth);
       vec3 offsetInBucket = mod(coords, bucketWidth);
@@ -216,7 +220,7 @@ export const getColorForCoords: ShaderModule = {
       );
 
       if (packingDegree == 1.0) {
-        return bucketColor;
+        return max(bucketColor, 0.0);
       }
 
       float rgbaIndex = linearizeVec3ToIndexWithMod(offsetInBucket, bucketWidth, packingDegree);
@@ -226,21 +230,31 @@ export const getColorForCoords: ShaderModule = {
         // The caller needs to unpack this vec4 according to the packingDegree, see getSegmentationId for an example.
         // The same goes for the following code where the packingDegree is 4 and we only have 1 byte of information.
         if (rgbaIndex == 0.0) {
-          return vec4(bucketColor.r, bucketColor.g, bucketColor.r, bucketColor.g);
+          return vec4(
+            max(bucketColor.r, 0.0),
+            max(bucketColor.g, 0.0),
+            max(bucketColor.r, 0.0),
+            max(bucketColor.g, 0.0)
+          );
         } else if (rgbaIndex == 1.0) {
-          return vec4(bucketColor.b, bucketColor.a, bucketColor.b, bucketColor.a);
+          return vec4(
+            max(bucketColor.b, 0.0),
+            max(bucketColor.a, 0.0),
+            max(bucketColor.b, 0.0),
+            max(bucketColor.a, 0.0)
+          );
         }
       }
 
       // The following code deals with packingDegree == 4.0
       if (rgbaIndex == 0.0) {
-        return vec4(bucketColor.r);
+        return vec4(max(bucketColor.r, 0.0));
       } else if (rgbaIndex == 1.0) {
-        return vec4(bucketColor.g);
+        return vec4(max(bucketColor.g, 0.0));
       } else if (rgbaIndex == 2.0) {
-        return vec4(bucketColor.b);
+        return vec4(max(bucketColor.b, 0.0));
       } else if (rgbaIndex == 3.0) {
-        return vec4(bucketColor.a);
+        return vec4(max(bucketColor.a, 0.0));
       }
 
       return vec4(0.0);


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- [X] I'll run a screenshot test

### Issues:
- fixes #4570

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
