### PR TITLE
show seconds in timeline view tooltip

### DIFF
--- a/frontend/javascripts/admin/time/time_line_view.js
+++ b/frontend/javascripts/admin/time/time_line_view.js
@@ -26,6 +26,7 @@ const { RangePicker } = DatePicker;
 
 const dayFormat = "dd, MMM, YYYY";
 const hourFormat = "HH:mm";
+const hourFormatPrecise = "HH:mm:ss";
 
 type TimeTrackingStats = {
   totalTime: number,
@@ -174,7 +175,7 @@ class TimeLineView extends React.PureComponent<Props, State> {
     const isSameDay = start.getUTCDate() === end.getUTCDate();
     const duration = end - start;
     const durationAsString = formatDurationToMinutesAndSeconds(duration);
-    const dayFormatForMomentJs = "DD, MMM, YYYY";
+    const dayFormatForMomentJs = "DD MMM, YYYY";
     const tooltip = (
       <div>
         <div className="highlighted">
@@ -191,7 +192,7 @@ class TimeLineView extends React.PureComponent<Props, State> {
                   <FormattedDate timestamp={start} format={dayFormatForMomentJs} />
                 ) : (
                   <React.Fragment>
-                    <FormattedDate timestamp={start} format={dayFormatForMomentJs} /> -{" "}
+                    <FormattedDate timestamp={start} format={dayFormatForMomentJs} /> –{" "}
                     <FormattedDate timestamp={end} format={dayFormatForMomentJs} />
                   </React.Fragment>
                 )}
@@ -200,8 +201,8 @@ class TimeLineView extends React.PureComponent<Props, State> {
             <tr>
               <td className="highlighted">Time:</td>
               <td>
-                <FormattedDate timestamp={start} format={hourFormat} /> -{" "}
-                <FormattedDate timestamp={end} format={hourFormat} />
+                <FormattedDate timestamp={start} format={hourFormatPrecise} /> –{" "}
+                <FormattedDate timestamp={end} format={hourFormatPrecise} />
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
To create more transparency for users about tracing pauses, let’s show seconds in the time tracking view tooltips

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- trace some task
- select suitable time in time tracking view, hover over task entry, time should be shown with seconds


------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
