### PR TITLE
redirect / to dashboard when logged-in and on demo

### DIFF
--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -140,14 +140,16 @@ class ReactRouter extends React.Component<Props> {
                 exact
                 path="/"
                 render={() => {
-                  if (!this.props.hasOrganizations) return <Redirect to="/onboarding" />;
-                  if (features().isDemoInstance) return <SpotlightView />;
-
-                  return isAuthenticated ? (
-                    <DashboardView userId={null} isAdminView={false} initialTabKey={null} />
-                  ) : (
-                    <Redirect to="/auth/login" />
-                  );
+                  if (!this.props.hasOrganizations) {
+                    return <Redirect to="/onboarding" />;
+                  }
+                  if (isAuthenticated) {
+                    return <DashboardView userId={null} isAdminView={false} initialTabKey={null} />;
+                  }
+                  if (features().isDemoInstance) {
+                    return <SpotlightView />;
+                  }
+                  return <Redirect to="/auth/login" />;
                 }}
               />
               <SecuredRoute


### PR DESCRIPTION
When a user is logged in on webknossos.org, `/` shows the publications list. But now that we have the publications also in the dashboard, I think we should link to the dashboard directly.

------
- [x] Ready for review
