### PR TITLE
Disable apply agglomerate for mags lower than 8

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,8 +26,9 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Toggling the "Render missing data black" option now automatically reloads all layers making it unnecessary to reload the whole page. [#4516](https://github.com/scalableminds/webknossos/pull/4516)
 - The "mappings" attribute of segmentation layers in datasource jsons can now be omitted. [#4532](https://github.com/scalableminds/webknossos/pull/4532)
 - Uploading a single nml, allows to wrap the tracing in a new tree group. [#4563](https://github.com/scalableminds/webknossos/pull/4563)
-- Unconnected trees no longer cause an error during NML import in the tracing view. Instead, unconnected trees are split into their components. The split components are wrapped in a tree group with the original tree's name. [#4541](https://github.com/scalableminds/webknossos/pull/4541)            
+- Unconnected trees no longer cause an error during NML import in the tracing view. Instead, unconnected trees are split into their components. The split components are wrapped in a tree group with the original tree's name. [#4541](https://github.com/scalableminds/webknossos/pull/4541)
 - Made the NML importer in the tracing view less strict. Incorrect timestamps, missing tree names or missing node radii no longer cause an error. [#4541](https://github.com/scalableminds/webknossos/pull/4541)
+- Disabled the backend-side apply agglomerate feature for downsampled magnifications (still allowed for 1 to 8) to save server capacity. [#4578](https://github.com/scalableminds/webknossos/pull/4578)
 
 ### Fixed
 - Users only get tasks of datasets that they can access. [#4488](https://github.com/scalableminds/webknossos/pull/4488)

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -87,6 +87,8 @@ instead. Only enable this option if you understand its effect. All layers will n
     "You didn't add a node after jumping to this branchpoint, do you really want to jump again?",
   "tracing.segmentation_zoom_warning":
     "Segmentation data and volume annotation is only fully supported at a smaller zoom level.",
+  "tracing.segmentation_zoom_warning_agglomerate":
+    "Segmentation data which is mapped using an agglomerate file cannot be rendered in this magnification. Please zoom in further.",
   "tracing.no_access": "You are not allowed to access this annotation.",
   "tracing.no_allowed_mode": "There was no valid allowed annotation mode specified.",
   "tracing.volume_missing_segmentation": "Volume is allowed, but segmentation does not exist.",

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/Cuboid.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/Cuboid.scala
@@ -1,5 +1,6 @@
 package com.scalableminds.webknossos.datastore.models.requests
 
+import com.scalableminds.util.geometry.Point3D
 import com.scalableminds.webknossos.datastore.models.{BucketPosition, VoxelPosition}
 
 /**
@@ -41,4 +42,6 @@ case class Cuboid(topLeft: VoxelPosition, width: Int, height: Int, depth: Int) {
     }
     bucketList
   }
+
+  def resolution: Point3D = topLeft.resolution
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -67,7 +67,7 @@ class BinaryDataService(dataBaseDir: Path,
         for {
           data <- handleDataRequest(request)
           mappedData <- convertIfNecessary(
-            request.settings.appliedAgglomerate.isDefined && request.dataLayer.category == Category.segmentation,
+            request.settings.appliedAgglomerate.isDefined && request.dataLayer.category == Category.segmentation && request.cuboid.resolution.maxDim <= 8,
             data,
             agglomerateService.applyAgglomerate(request),
             Fox.successful(_)


### PR DESCRIPTION
If you have downsampled segmentations you tend to request buckets with a lot of different segments. this makes looking up the IDs in the agglomerate file extremely slow, even overloading the server. As a quickfix, this PR disables the feature for any magnifications lower (higher? still unclear about the terminology) than 8.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz


### Steps to test:
- open dataset with downsampled segmentation + agglomerate view file
- upon zooming out, agglomerates should no longer be applied

### Issues:
- workaround for #4577

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
