### PR TITLE
Fix an exception in the TextureBucketManager

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -47,6 +47,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a rendering error which could make some layers disappear in certain circumstances. [#4556](https://github.com/scalableminds/webknossos/pull/4556)
 - Fixed a rendering error which caused negative float data to be rendered white. [#4556](https://github.com/scalableminds/webknossos/pull/4571)
 - Fixed the histogram creation if some sampled positions don't contain data. [#4584](https://github.com/scalableminds/webknossos/pull/4584)
+- Fixed a rendering exception which could occur in rare circumstandes. [#4588](https://github.com/scalableminds/webknossos/pull/4588)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
@@ -200,7 +200,7 @@ export default class TextureBucketManager {
       if (bucket.data == null) {
         // The bucket is not available anymore (was collected
         // and not yet removed from the queue). Ignore it.
-        console.warn("Skipping unavailable bucket in TextureBucketManager.")
+        console.warn("Skipping unavailable bucket in TextureBucketManager.");
         continue;
       }
 

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
@@ -197,14 +197,18 @@ export default class TextureBucketManager {
         // This bucket is not needed anymore
         continue;
       }
-
-      const dataTextureIndex = Math.floor(_index / bucketsPerTexture);
-      const indexInDataTexture = _index % bucketsPerTexture;
+      if (bucket.data == null) {
+        // The bucket is not available anymore (was collected
+        // and not yet removed from the queue). Ignore it.
+        continue;
+      }
 
       if (bucketDebuggingFlags.visualizeBucketsOnGPU) {
         bucket.visualize();
       }
 
+      const dataTextureIndex = Math.floor(_index / bucketsPerTexture);
+      const indexInDataTexture = _index % bucketsPerTexture;
       const data = bucket.getData();
       const TypedArrayClass = this.elementClass === "float" ? Float32Array : Uint8Array;
       this.dataTextures[dataTextureIndex].update(

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
@@ -200,6 +200,7 @@ export default class TextureBucketManager {
       if (bucket.data == null) {
         // The bucket is not available anymore (was collected
         // and not yet removed from the queue). Ignore it.
+        console.warn("Skipping unavailable bucket in TextureBucketManager.")
         continue;
       }
 


### PR DESCRIPTION
Sometimes the exception `Bucket.getData() called, but data does not exist (anymore).` is raised. I assume this happens when a bucket was garbage-collected, but wasn't yet removed from the queue in the TextureBucketManager. I added a not-null check to avoid this and a warning. Should be an improvement to before.

In airbrake, I also saw the following log in relation to the error:
```
A bucket was forcefully garbage-collected. This indicates that too many buckets are currently in RAM.
```
This explains the error even better (but I think, the error also occurs without the warning sometimes). Not too sure what to do about it, though. Just putting it out here for now.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Couldn't test it, but the change should be straightforward.


------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
