### PR TITLE
Improve airbrake reporting for unhandled rejections

### DIFF
--- a/frontend/javascripts/libs/error_handling.js
+++ b/frontend/javascripts/libs/error_handling.js
@@ -117,7 +117,7 @@ class ErrorHandling {
       const originalError = event.reason instanceof Error ? event.reason.toString() : event.reason;
       // Put the actual error into the main string so that not all unhandled errors are grouped
       // together in airbrake
-      this.notify(Error(`Unhandled Rejection: ${originalError.toString().slice(0, 80)}`), {
+      this.notify(Error(`Unhandled Rejection: ${JSON.stringify(originalError).slice(0, 80)}`), {
         originalError,
       });
     });

--- a/frontend/javascripts/libs/error_handling.js
+++ b/frontend/javascripts/libs/error_handling.js
@@ -114,8 +114,11 @@ class ErrorHandling {
     window.removeEventListener("unhandledrejection", this.airbrake.onUnhandledrejection);
     window.addEventListener("unhandledrejection", event => {
       // Create our own error for unhandled rejections here to get additional information for [Object object] errors in airbrake
-      this.notify(Error("Unhandled Rejection"), {
-        originalError: event.reason instanceof Error ? event.reason.toString() : event.reason,
+      const originalError = event.reason instanceof Error ? event.reason.toString() : event.reason;
+      // Put the actual error into the main string so that not all unhandled errors are grouped
+      // together in airbrake
+      this.notify(Error(`Unhandled Rejection: ${originalError.toString().slice(0, 80)}`), {
+        originalError,
       });
     });
 


### PR DESCRIPTION
Right now, all unhandled rejections are grouped together in airbrake, but they actually can be divided up further by using the actual error message (e.g., failed to fetch xyz). This should give a better overview in airbrake.

### URL of deployed dev instance (used for testing):
- https://betterunhandledrejection.webknossos.xyz/

### Steps to test:
- open a tracing
- a failing request to `/api/datasets/Connectomics department/Test Dataset/sharingToken` should be sent
- check that this arrives in airbrake (e.g, https://scm.airbrake.io/projects/95438/groups/2737134562249075798?tab=notice-detail)


------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
