### PR TITLE
Prevent false version mismatches when saving annotations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Users can undo finishing a task when the task was finished via the API, e.g. by a user script. [#4495](https://github.com/scalableminds/webknossos/pull/4495)
 - Added the magnification used for determining the segment ids in the segmentation tab to the table of the tab. [#4480](https://github.com/scalableminds/webknossos/pull/4480)
 - Added support for ID mapping of segmentation layer based on HDF5 agglomerate files. [#4469](https://github.com/scalableminds/webknossos/pull/4469)
-- Added the possibility to share the dataset which is currently viewed (using a private token if the dataset is not public).  The option can be found in the dropdown of the navigation bar. [#4543](https://github.com/scalableminds/webknossos/pull/4543) 
+- Added the possibility to share the dataset which is currently viewed (using a private token if the dataset is not public).  The option can be found in the dropdown of the navigation bar. [#4543](https://github.com/scalableminds/webknossos/pull/4543)
 - Added option to hide all unmapped segments to segmentation tab. [#4510](https://github.com/scalableminds/webknossos/pull/4510)
 - When wK changes datasource-properties.json files of datasets, now it creates a backup log of previous versions. [#4534](https://github.com/scalableminds/webknossos/pull/4534)
 - Added a warning to the position input in tracings if the current position is out of bounds. The warning colors the position input orange. [#4544](https://github.com/scalableminds/webknossos/pull/4544)
@@ -47,6 +47,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a rendering error which could make some layers disappear in certain circumstances. [#4556](https://github.com/scalableminds/webknossos/pull/4556)
 - Fixed a rendering error which caused negative float data to be rendered white. [#4556](https://github.com/scalableminds/webknossos/pull/4571)
 - Fixed the histogram creation if some sampled positions don't contain data. [#4584](https://github.com/scalableminds/webknossos/pull/4584)
+- Fixed retrying of failed save requests sent during tracingstore restart. [#4591](https://github.com/scalableminds/webknossos/pull/4591)
 
 ### Removed
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -80,11 +80,17 @@ class FossilDBClient(collection: String, config: TracingStoreConfig) extends Fox
       case e: Exception => Fox.failure("Could not get from FossilDB: " + e.getMessage)
     }
 
-  def getVersion(key: String, version: Option[Long] = None, mayBeEmpty: Option[Boolean] = None): Fox[Long] =
+  def getVersion(key: String, version: Option[Long] = None, mayBeEmpty: Option[Boolean], emptyFallback: Option[Long] = None): Fox[Long] =
     try {
       val reply = blockingStub.get(GetRequest(collection, key, version, mayBeEmpty))
-      if (!reply.success) throw new Exception(reply.errorMessage.getOrElse(""))
-      Fox.successful(reply.actualVersion)
+      if (reply.success) Fox.successful(reply.actualVersion)
+      else {
+        if (mayBeEmpty.contains(true) && emptyFallback.isDefined && reply.errorMessage.contains("No such element")) {
+          emptyFallback.toFox
+        } else {
+          throw new Exception(reply.errorMessage.getOrElse(""))
+        }
+      }
     } catch {
       case e: Exception => Fox.failure("Could not get from FossilDB: " + e.getMessage)
     }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -80,7 +80,10 @@ class FossilDBClient(collection: String, config: TracingStoreConfig) extends Fox
       case e: Exception => Fox.failure("Could not get from FossilDB: " + e.getMessage)
     }
 
-  def getVersion(key: String, version: Option[Long] = None, mayBeEmpty: Option[Boolean], emptyFallback: Option[Long] = None): Fox[Long] =
+  def getVersion(key: String,
+                 version: Option[Long] = None,
+                 mayBeEmpty: Option[Boolean],
+                 emptyFallback: Option[Long] = None): Fox[Long] =
     try {
       val reply = blockingStub.get(GetRequest(collection, key, version, mayBeEmpty))
       if (reply.success) Fox.successful(reply.actualVersion)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -33,7 +33,7 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
   implicit val updateActionJsonFormat = SkeletonUpdateAction.skeletonUpdateActionFormat
 
   def currentVersion(tracingId: String): Fox[Long] =
-    tracingDataStore.skeletonUpdates.getVersion(tracingId, mayBeEmpty = Some(true)).getOrElse(0L)
+    tracingDataStore.skeletonUpdates.getVersion(tracingId, mayBeEmpty = Some(true), emptyFallback = Some(0L))
 
   def handleUpdateGroup(tracingId: String,
                         updateActionGroup: UpdateActionGroup[SkeletonTracing],

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -70,14 +70,21 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
   private def findDesiredOrNewestPossibleVersion(tracing: SkeletonTracing,
                                                  tracingId: String,
                                                  desiredVersion: Option[Long]): Fox[Long] =
-    (for {
-      newestUpdateVersion <- tracingDataStore.skeletonUpdates.getVersion(tracingId, mayBeEmpty = Some(true))
+    /*
+     * Determines the newest saved version from the updates column.
+     * if there are no updates at all, assume tracing is brand new (possibly created from NML,
+     * hence the emptyFallbck tracing.version)
+     */
+    for {
+      newestUpdateVersion <- tracingDataStore.skeletonUpdates.getVersion(tracingId,
+                                                                         mayBeEmpty = Some(true),
+                                                                         emptyFallback = Some(tracing.version))
     } yield {
       desiredVersion match {
         case None              => newestUpdateVersion
         case Some(desiredSome) => math.min(desiredSome, newestUpdateVersion)
       }
-    }).getOrElse(tracing.version) //if there are no updates at all, assume tracing is brand new (possibly created from NML)
+    }
 
   private def findPendingUpdates(tracingId: String,
                                  existingVersion: Long,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -63,7 +63,7 @@ class VolumeTracingService @Inject()(
   val binaryDataService = new BinaryDataService(Paths.get(""), 10 seconds, 100, null)
 
   override def currentVersion(tracingId: String): Fox[Long] =
-    tracingDataStore.volumes.getVersion(tracingId).getOrElse(0L)
+    tracingDataStore.volumes.getVersion(tracingId, mayBeEmpty = Some(true), emptyFallback = Some(0L))
 
   def handleUpdateGroup(tracingId: String,
                         updateGroup: UpdateActionGroup[VolumeTracing],


### PR DESCRIPTION
During fossildb restart some save requests were wrongly answered with 409 CONFLICT (version mismatch, expected 1 got 313), when they should have been answered with 400 (or 500, or anything that doesn’t prevent the frontend from retrying). This was caused by falling back to 0 not only if the error cause was no-such-element (in which case 0 is correct), but always. This PR adds this distinction.

### URL of deployed dev instance (used for testing):
- dev instance testing is difficult since we can’t kill the fossildb there.

### Steps to test:
- create tracing, save some versions (should work with old and new tracings)
- kill fossildb (or restart server without fossildb, e.g. comment it out in tools/proxy/proxy.js), but keep tracing tab open. saving should now fail, but not with error 409, frontend should say “retrying”

### Issues:
- fixes #4590 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
