### PR TITLE
Only reload segmentation layer when activating agglomerate file mapping

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 
-- 
+- When activating an agglomerate file-based ID mapping, only the segmentation layer will be reloaded from now on. This will improve mapping activation performance. [#4600](https://github.com/scalableminds/webknossos/pull/4600)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.js
+++ b/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.js
@@ -264,7 +264,11 @@ class PlaneMaterialFactory {
 
     // Add mapping
     const segmentationLayer = Model.getSegmentationLayer();
-    if (segmentationLayer != null && Model.isMappingSupported) {
+    if (
+      segmentationLayer != null &&
+      segmentationLayer.mappings != null &&
+      Model.isMappingSupported
+    ) {
       const [
         mappingTexture,
         mappingLookupTexture,

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/mappings.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/mappings.js
@@ -35,12 +35,12 @@ export function setupGlobalMappingsObject(segmentationLayer: DataLayer) {
       console.warn(
         "Using mappings.getAll() is deprecated. Please use the official front-end API function getMappingNames() instead.",
       );
-      return segmentationLayer.mappings.getMappingNames();
+      return segmentationLayer.mappings != null ? segmentationLayer.mappings.getMappingNames() : [];
     },
     getActive(): ?string {
       trackAction("Deprecated mapping usage (getActive)");
       console.warn(
-        "Using mappings.getAll() is deprecated. Please use the official front-end API function getActiveMapping() instead.",
+        "Using mappings.getActive() is deprecated. Please use the official front-end API function getActiveMapping() instead.",
       );
       return segmentationLayer.activeMapping;
     },
@@ -92,6 +92,7 @@ class Mappings {
         const shouldReload = isAgglomerate(oldMapping) || isAgglomerate(mapping);
         oldMapping = mapping;
         if (shouldReload) {
+          // We cannot use the internal_api here as this will result in a circular dependency
           window.webknossos.apiReady().then(api => {
             api.data.reloadBuckets(this.layerName);
           });

--- a/frontend/javascripts/oxalis/model/data_layer.js
+++ b/frontend/javascripts/oxalis/model/data_layer.js
@@ -19,7 +19,7 @@ class DataLayer {
   connectionInfo: ConnectionInfo;
   pullQueue: PullQueue;
   pushQueue: PushQueue;
-  mappings: Mappings;
+  mappings: ?Mappings;
   activeMapping: ?string;
   activeMappingType: MappingType = "JSON";
   layerRenderingManager: LayerRenderingManager;
@@ -58,7 +58,7 @@ class DataLayer {
     this.pushQueue = new PushQueue(this.cube);
     this.cube.initializeWithQueues(this.pullQueue, this.pushQueue);
     const fallbackLayerName = layerInfo.fallbackLayer != null ? layerInfo.fallbackLayer : null;
-    this.mappings = new Mappings(layerInfo.name, fallbackLayerName);
+    if (isSegmentation) this.mappings = new Mappings(layerInfo.name, fallbackLayerName);
     this.layerRenderingManager = new LayerRenderingManager(
       this.name,
       this.pullQueue,
@@ -73,6 +73,9 @@ class DataLayer {
     mappingType: MappingType,
     progressCallback?: ProgressCallback,
   ): void {
+    if (this.mappings == null) {
+      throw new Error("Mappings can only be activated for segmentation layers.");
+    }
     this.activeMapping = mappingName;
     this.activeMappingType = mappingType;
     this.mappings.activateMapping(mappingName, mappingType, progressCallback);


### PR DESCRIPTION
I noticed that all layers were reloaded when an agglomerate file mapping was activated.
This was because the mappings class was instantiated even for non-segmentation layers. This has led to bugs in the past already (but was kept like this for consistencies' sake I assume) , so I made sure it won't happen again. Only segmentation layers instantiate that class from now on.

As a result, activating agglomerate file mappings should be even faster now :tada: 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Activate an agglomerate file mapping - only the segmentation layer should be reloaded.

### Issues:
- improves agglomerate file activation performance

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
