### PR TITLE
Save Compressed Volume Tracing Buckets 

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 
--
+- Volume tracing data is now saved with lz4 compression, reducing I/O load and required disk space. [#4602](https://github.com/scalableminds/webknossos/pull/4602)
 
 ### Changed
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,6 +41,7 @@ object Dependencies {
   val woodstoxXml = "org.codehaus.woodstox" % "wstx-asl" % "3.2.3"
   val redis = "net.debasishg" %% "redisclient" % "3.9"
   val spire = "org.typelevel" %% "spire" % "0.14.1"
+  val lz4compression = "org.lz4" % "lz4-java" % "1.7.1"
 
   val sql = Seq(
     "com.typesafe.slick" %% "slick" % "3.2.3",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,6 @@ object Dependencies {
   val woodstoxXml = "org.codehaus.woodstox" % "wstx-asl" % "3.2.3"
   val redis = "net.debasishg" %% "redisclient" % "3.9"
   val spire = "org.typelevel" %% "spire" % "0.14.1"
-  val lz4compression = "org.lz4" % "lz4-java" % "1.7.1"
 
   val sql = Seq(
     "com.typesafe.slick" %% "slick" % "3.2.3",

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -24,8 +24,6 @@ trait VolumeBucketCompression extends LazyLogging {
 
   def compressVolumeBucket(data: Array[Byte]): Array[Byte] = {
     val compressedData = compressor.compress(data)
-
-    logger.info(s"${data.length} -> ${compressedData.length}")
     if (compressedData.length < data.length) {
       compressedData
     } else data

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -38,8 +38,12 @@ trait VolumeBucketCompression extends LazyLogging {
       decompressor.decompress(data, expectedUncompressedBucketSize)
     }
 
-  def expectedUncompressedBucketSizeFor(dataLayer: DataLayer): Int =
-    ElementClass.bytesPerElement(dataLayer.elementClass) * scala.math.pow(DataLayer.bucketLength, 3).intValue
+  def expectedUncompressedBucketSizeFor(dataLayer: DataLayer): Int = {
+    // frontend treats 8-byte segmentations as 4-byte segmentations,
+    // truncating high IDs. Volume buckets will have at most 4-byte voxels
+    val bytesPerVoxel = scala.math.min(ElementClass.bytesPerElement(dataLayer.elementClass), 4)
+    bytesPerVoxel * scala.math.pow(DataLayer.bucketLength, 3).intValue
+  }
 }
 
 trait VolumeTracingBucketHelper

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -77,17 +77,6 @@ trait VolumeTracingBucketHelper
       .flatten
   }
 
-  def toList[a](array: Array[a]): List[a] =
-    if (array == null || array.length == 0) Nil
-    else if (array.length == 1) List(array(0))
-    else array(0) :: toList(array.slice(1, array.length))
-
-  def bytes2hex(bytes: List[Byte], sep: Option[String] = None): String =
-    sep match {
-      case None => bytes.map("%02x".format(_)).mkString
-      case _    => bytes.map("%02x".format(_)).mkString(sep.get)
-    }
-
   def saveBucket(dataLayer: VolumeTracingLayer, bucket: BucketPosition, data: Array[Byte], version: Long): Fox[Unit] = {
     val key = buildBucketKey(dataLayer.name, bucket)
     volumeDataStore.put(key, version, compressVolumeBucket(data))


### PR DESCRIPTION
- Compress volume tracing buckets with lz4 before writing them into fossildb.
- When loading buckets, only buckets that are shorter than their expected uncompressed bucket length are assumed to be compressed, for backwards compatibility
- When writing buckets, only buckets that actually get shorter by compressing them are written compressed
- Compression factor for my test tracings was about 100x for sparse annotation (single cell) and 6x–12x for dense annotation (based on L4 oversegmentation)



### Questions
 - [x] Is the perf impact noticable? (speed up due to less db load, slowdown due to compression/decompression routines) → compression and decompression incl detection each took about 200–300 µs per bucket in my tests, which I’d consider acceptable. speedup due to less I/O difficult to measure in small setting, large variance in put times, but I assume we can expect some.
 - [x] Do 64 bit tracings need special handling? → 64 bit tracings are not allowed in wk, added limit to avoid overestimating expected bucket size
 - [x] How to mark which buckets in the db are compressed. There are several competing design ideas (This PR implements B (size), and there is a draft for D (key suffix) here https://github.com/scalableminds/webknossos/pull/4610)
  - A: Prefix in the data. Prefix the bytes with a fixed string, check for that string when loading.
     - ⁺ No changes to db loading abstraction levels
     - ⁻ Prefix could have collisions with existing data
     - ⁻ Introducing an optional header feels somewhat hacky
     - ⁻ Every bucket grows by a few bytes
  - B: Size. Calculate expected bucket size from data type and bucket dimensions. If the returned byte array is shorter, decompress it. (when saving, only save compressed version if it is actually shorter than that number)
     - ⁺ No additional I/O, no additional bytes
     - ⁺ Implemented in a few easily readable lines
     - ⁻ Stored information is very implicit, feels somewhat hacky
  - C: Additional boolean column family in fossildb, always fetch both, if the boolean is set, decompress
     - ⁺ Explicit marking of compressed buckets
     - ⁻ Need to fetch second column family key for every bucket request
  - D: Make use of alphabetical key sorting in rocksdb and use suffix for compressed bucket keys. When fetching, check for duplicates and discard the older version.
     - ⁺ Explicit marking of compressed buckets
     - ⁻ Need to use range queries for every bucket request
     - ⁻ Requests for tracings where old (uncompressed) buckets were overwritten by new (compressed) buckets will return both the newest compressed and the newest uncompressed version, superfluous I/O (Also for volume range queries e.g. for download). It may be argued that those tracings will become rare over time.
  - E: Create fossildb migration, compressing all existing buckets, so no distinction needs to be made
    - ⁺ Clean state of db, no distinction code
    - ⁻ Requires downtime, for duration of the migration requests can’t distinguish buckets.
    - ⁻ Writing fossildb migrations is somewhat tedious

### Follow-Ups:
 - [ ] Change Front-end/Back-end communication, should the frontend compress before sending? how about get requests? (future issue)
 - [ ] Change format of zip downloads, should we write lz4 buckets to zip? (future issue)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open old volume tracing, should still load fine
- edit it, reload, should still load fine (new buckets using compression, the old ones not)
- upload/download/copy-to-my-account of volume tracings should still work

### Issues:
- fixes #4592 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracing update after deployment
- [x] Ready for review
