### PR TITLE
Don't render ActionBarView during loading

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Disabled the backend-side apply agglomerate feature for downsampled magnifications (still allowed for 1 to 8) to save server capacity. [#4578](https://github.com/scalableminds/webknossos/pull/4578)
 - REST API endpoints finish and info now expect additional GET parameter `timestamp=[INT]` timestamp in milliseconds (time the request is sent). [#4580](https://github.com/scalableminds/webknossos/pull/4580)
 - It is now possible to upload volume tracings as a base for tasks. The upload format is similar to the project / task type download format. [#4565](https://github.com/scalableminds/webknossos/pull/4565)
+- Improved the UI in navigation bar during loading of tracings and datasets. [#4612](https://github.com/scalableminds/webknossos/pull/4612)
 
 ### Fixed
 - Users only get tasks of datasets that they can access. [#4488](https://github.com/scalableminds/webknossos/pull/4488)

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -25,6 +25,7 @@ import MappingInfoView from "oxalis/view/right-menu/mapping_info_view";
 import MeshesView from "oxalis/view/right-menu/meshes_view";
 import NmlUploadZoneContainer from "oxalis/view/nml_upload_zone_container";
 import OxalisController from "oxalis/controller";
+import type { ControllerStatus } from "oxalis/controller";
 import RecordingSwitch from "oxalis/view/recording_switch";
 import SettingsView from "oxalis/view/settings/settings_view";
 import MergerModeController from "oxalis/controller/merger_mode_controller";
@@ -68,6 +69,7 @@ type State = {
   isSettingsCollapsed: boolean,
   activeLayout: string,
   hasError: boolean,
+  status: ControllerStatus,
 };
 
 const canvasAndLayoutContainerID = "canvasAndLayoutContainer";
@@ -108,6 +110,7 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
       isSettingsCollapsed: true,
       activeLayout: lastActiveLayout,
       hasError: false,
+      status: "loading",
     };
   }
 
@@ -190,57 +193,61 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
         <OxalisController
           initialAnnotationType={this.props.initialAnnotationType}
           initialCommandType={this.props.initialCommandType}
+          controllerStatus={this.state.status}
+          setControllerStatus={(status: ControllerStatus) => this.setState({ status })}
         />
         <CrossOriginApi />
         <Layout className="tracing-layout">
           <RenderToPortal portalId="navbarTracingSlot">
-            <div style={{ flex: "0 1 auto", zIndex: 210, display: "flex" }}>
-              <ButtonComponent
-                className={this.state.isSettingsCollapsed ? "" : "highlight-togglable-button"}
-                onClick={this.handleSettingsCollapse}
-                shape="circle"
-              >
-                <Icon
-                  type="setting"
-                  className="withoutMargin"
-                  style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
-                />
-              </ButtonComponent>
-              <ActionBarView
-                layoutProps={{
-                  storedLayoutNamesForView: currentLayoutNames,
-                  activeLayout: this.state.activeLayout,
-                  layoutKey: layoutType,
-                  setCurrentLayout: layoutName => {
-                    this.setState({ activeLayout: layoutName });
-                    setActiveLayout(layoutType, layoutName);
-                  },
-                  saveCurrentLayout: this.saveCurrentLayout,
-                  setAutoSaveLayouts: this.props.setAutoSaveLayouts,
-                  autoSaveLayouts: this.props.autoSaveLayouts,
-                }}
-              />
-              {isDatasetOnScratchVolume ? (
-                <Tooltip title={messages["dataset.is_scratch"]}>
-                  <Alert
-                    className="hide-on-small-screen"
-                    style={{
-                      height: 30,
-                      paddingTop: 4,
-                      backgroundColor: "#f17a27",
-                      color: "white",
-                    }}
-                    message={
-                      <span>
-                        Dataset is on tmpscratch!{" "}
-                        <Icon type="warning" theme="filled" style={{ margin: "0 0 0 6px" }} />
-                      </span>
-                    }
-                    type="error"
+            {this.state.status !== "loading" ? (
+              <div style={{ flex: "0 1 auto", zIndex: 210, display: "flex" }}>
+                <ButtonComponent
+                  className={this.state.isSettingsCollapsed ? "" : "highlight-togglable-button"}
+                  onClick={this.handleSettingsCollapse}
+                  shape="circle"
+                >
+                  <Icon
+                    type="setting"
+                    className="withoutMargin"
+                    style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
                   />
-                </Tooltip>
-              ) : null}
-            </div>
+                </ButtonComponent>
+                <ActionBarView
+                  layoutProps={{
+                    storedLayoutNamesForView: currentLayoutNames,
+                    activeLayout: this.state.activeLayout,
+                    layoutKey: layoutType,
+                    setCurrentLayout: layoutName => {
+                      this.setState({ activeLayout: layoutName });
+                      setActiveLayout(layoutType, layoutName);
+                    },
+                    saveCurrentLayout: this.saveCurrentLayout,
+                    setAutoSaveLayouts: this.props.setAutoSaveLayouts,
+                    autoSaveLayouts: this.props.autoSaveLayouts,
+                  }}
+                />
+                {isDatasetOnScratchVolume ? (
+                  <Tooltip title={messages["dataset.is_scratch"]}>
+                    <Alert
+                      className="hide-on-small-screen"
+                      style={{
+                        height: 30,
+                        paddingTop: 4,
+                        backgroundColor: "#f17a27",
+                        color: "white",
+                      }}
+                      message={
+                        <span>
+                          Dataset is on tmpscratch!{" "}
+                          <Icon type="warning" theme="filled" style={{ margin: "0 0 0 6px" }} />
+                        </span>
+                      }
+                      type="error"
+                    />
+                  </Tooltip>
+                ) : null}
+              </div>
+            ) : null}
           </RenderToPortal>
           <Layout style={{ display: "flex" }}>
             <Sider

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -199,7 +199,7 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
         <CrossOriginApi />
         <Layout className="tracing-layout">
           <RenderToPortal portalId="navbarTracingSlot">
-            {this.state.status !== "loading" ? (
+            {this.state.status === "loaded" ? (
               <div style={{ flex: "0 1 auto", zIndex: 210, display: "flex" }}>
                 <ButtonComponent
                   className={this.state.isSettingsCollapsed ? "" : "highlight-togglable-button"}

--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -287,8 +287,8 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
 
     return (
       <div className="flex-overflow">
-        <p>{annotationTypeLabel}</p>
-        <p>{descriptionEditField}</p>
+        <div>{annotationTypeLabel}</div>
+        <div>{descriptionEditField}</div>
       </div>
     );
   }


### PR DESCRIPTION
This kills two birds with one stone: The action bar view doesn't show incorrect data during loading anymore (e.g., invalid position). Additionally, the sharing modals are not instantiated before loading which avoids trying to load sharing tokens for the dummy dataset which the store holds initially (which always fails).

### URL of deployed dev instance (used for testing):
- https://avoidtokenerrors.webknossos.xyz

### Steps to test:
- load a dataset or tracing
- ensure that the action bar is there after loading
- check the network tab that no bogus sharing token requests were performed

### Issues:
- fixes #4597
- contributes to #4572

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
