### PR TITLE
Cleaner logging for datasource list updates

### DIFF
--- a/app/controllers/WKDataStoreController.scala
+++ b/app/controllers/WKDataStoreController.scala
@@ -55,6 +55,9 @@ class WKDataStoreController @Inject()(dataSetService: DataSetService,
       request.body.validate[List[InboxDataSource]] match {
         case JsSuccess(dataSources, _) =>
           for {
+            _ <- Fox.successful(
+              logger.info(s"Received dataset list from datastore '${dataStore.name}': " +
+                s"${dataSources.count(_.isUsable)} active, ${dataSources.count(!_.isUsable)} inactive datasets"))
             existingIds <- dataSetService.updateDataSources(dataStore, dataSources)(GlobalAccessContext)
             _ <- dataSetService.deactivateUnreportedDataSources(existingIds, dataStore)(GlobalAccessContext)
           } yield {

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -118,9 +118,6 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
 
   def updateDataSources(dataStore: DataStore, dataSources: List[InboxDataSource])(
       implicit ctx: DBAccessContext): Fox[List[ObjectId]] = {
-    logger.info(
-      s"[${dataStore.name}] Available datasets: " +
-        s"${dataSources.count(_.isUsable)} (usable), ${dataSources.count(!_.isUsable)} (unusable)")
 
     val groupedByOrga = dataSources.groupBy(_.id.team).toList
     Fox

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -64,7 +64,7 @@ class DataSourceController @Inject()(
   def triggerInboxCheck() = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(UserAccessRequest.administrateDataSources) {
       AllowRemoteOrigin {
-        dataSourceService.checkInbox()
+        dataSourceService.checkInbox(verbose = true)
         Ok
       }
     }
@@ -74,7 +74,7 @@ class DataSourceController @Inject()(
     accessTokenService.validateAccess(UserAccessRequest.administrateDataSources) {
       AllowRemoteOrigin {
         for {
-          _ <- dataSourceService.checkInbox()
+          _ <- dataSourceService.checkInbox(verbose = true)
         } yield Ok
       }
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataStoreWkRpcClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataStoreWkRpcClient.scala
@@ -58,6 +58,7 @@ class DataStoreWkRpcClient @Inject()(
   def reportDataSources(dataSources: List[InboxDataSourceLike]): Fox[_] =
     rpc(s"$webKnossosUrl/api/datastores/$dataStoreName/datasources")
       .addQueryString("key" -> dataStoreKey)
+      .silent
       .put(dataSources)
 
   def validateDataSourceUpload(id: DataSourceId): Fox[_] =


### PR DESCRIPTION
Since the interval for datasource list reports has been lowered to 1 minute, a lot of spam gets added to the logfiles. This PR cleans the logging for this (verbose version only every 10 times and on explicit refresh requests)

### Steps to test:
- run wK, console output should be somewhat cleaner

- [x] Needs datastore update after deployment
- [x] Ready for review
