### PR TITLE
Allow component updates when tab is in background

### DIFF
--- a/frontend/javascripts/libs/utils.js
+++ b/frontend/javascripts/libs/utils.js
@@ -344,10 +344,15 @@ export function busyWaitDevHelper(time: number) {
   }
 }
 
-export function animationFrame(): Promise<void> {
-  return new Promise(resolve => {
+export function animationFrame(maxTimeout?: number): Promise<void> {
+  const rafPromise = new Promise(resolve => {
     window.requestAnimationFrame(resolve);
   });
+  if (maxTimeout == null) {
+    return rafPromise;
+  }
+  const timeoutPromise = sleep(maxTimeout);
+  return Promise.race([rafPromise, timeoutPromise]);
 }
 
 export function diffArrays<T>(

--- a/frontend/javascripts/oxalis/throttled_store.js
+++ b/frontend/javascripts/oxalis/throttled_store.js
@@ -4,6 +4,7 @@ import Deferred from "libs/deferred";
 import Store from "oxalis/store";
 import * as Utils from "libs/utils";
 
+const MAXIMUM_STORE_UPDATE_DELAY = 10000;
 const listeners = [];
 let waitForUpdate = new Deferred();
 let prevState;
@@ -21,7 +22,7 @@ Store.subscribe(() => {
 async function go() {
   while (true) {
     await waitForUpdate.promise();
-    await Utils.animationFrame();
+    await Utils.animationFrame(MAXIMUM_STORE_UPDATE_DELAY);
     for (const listener of listeners) {
       listener();
     }

--- a/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.js
@@ -167,8 +167,9 @@ class MergeModalView extends PureComponent<Props, MergeModalViewState> {
     }
     const { trees, treeGroups } = tracing;
     this.setState({ isUploading: true });
-    // Wait for an animation frame so that the loading animation is kicked off
-    await Utils.animationFrame();
+    // Wait for an animation frame (but not longer than a second) so that the loading
+    // animation is kicked off
+    await Utils.animationFrame(1000);
     this.props.addTreesAndGroupsAction(createMutableTreeMapFromTreeArray(trees), treeGroups);
     this.setState({ isUploading: false });
     Toast.success(messages["tracing.merged"]);


### PR DESCRIPTION
Due to requestAnimationFrame some updates "starved" when the tab was in background. All react components are hooked to the throttled store, which is why this affected all components. Most of the time this is not a big issue. However, recent changes introduced component-side warnings when unsaved changes become too old. Due to the starvation, false-positive warnings were emitted.
This PR introduces a max timeout parameter to the `animationFrame` method which is used in the component root as well as in the NML import code. I also checked all other usages of animation frames to check that there are no other problems.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I added some logging to the code and ensured that the unsaved warning is not emitted anymore when putting a wk tab with unsaved changes in the background
- the logging showed that the changes were saved and that no warning was emitted

### Issues:
- follow-up for https://github.com/scalableminds/webknossos/pull/4593

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
