### PR TITLE
Remove task column from bulk task creation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 
-- 
+- The redundant “team” column was removed from bulk task creation. [#4629](https://github.com/scalableminds/webknossos/pull/4629)
 
 ### Fixed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 
-- The redundant “team” column was removed from bulk task creation. [#4629](https://github.com/scalableminds/webknossos/pull/4629)
+- The redundant “team” column was removed from the bulk task creation format. [#4629](https://github.com/scalableminds/webknossos/pull/4629)
 
 ### Fixed
 

--- a/frontend/javascripts/admin/task/task_create_bulk_view.js
+++ b/frontend/javascripts/admin/task/task_create_bulk_view.js
@@ -38,7 +38,6 @@ export type NewTask = {|
   +projectName: string,
   +scriptId: ?string,
   +openInstances: number,
-  +teamName: string,
   +taskTypeId: string,
   +csvFile?: File,
   +nmlFiles?: File,
@@ -72,7 +71,6 @@ class TaskCreateBulkView extends React.PureComponent<Props, State> {
       !_.isString(task.neededExperience.domain) ||
       !_.isString(task.dataSet) ||
       !_.isString(task.taskTypeId) ||
-      !_.isString(task.teamName) ||
       !_.isString(task.projectName) ||
       task.editPosition.some(Number.isNaN) ||
       task.editRotation.some(Number.isNaN) ||
@@ -127,21 +125,20 @@ class TaskCreateBulkView extends React.PureComponent<Props, State> {
     const rotY = parseInt(words[8]);
     const rotZ = parseInt(words[9]);
     const openInstances = parseInt(words[10]);
-    const teamName = words[11];
-    const boundingBoxX = parseInt(words[12]);
-    const boundingBoxY = parseInt(words[13]);
-    const boundingBoxZ = parseInt(words[14]);
-    const width = parseInt(words[15]);
-    const height = parseInt(words[16]);
-    const depth = parseInt(words[17]);
-    const projectName = words[18];
+    const boundingBoxX = parseInt(words[11]);
+    const boundingBoxY = parseInt(words[12]);
+    const boundingBoxZ = parseInt(words[13]);
+    const width = parseInt(words[14]);
+    const height = parseInt(words[15]);
+    const depth = parseInt(words[16]);
+    const projectName = words[17];
 
     // mapOptional takes care of treating empty strings as null
     function mapOptional<U>(word, fn: string => U): ?U {
       return word != null && word !== "" ? fn(word) : undefined;
     }
-    const scriptId = mapOptional(words[19], a => a);
-    const baseAnnotation = mapOptional(words[20], word => ({ baseId: word }));
+    const scriptId = mapOptional(words[18], a => a);
+    const baseAnnotation = mapOptional(words[19], word => ({ baseId: word }));
 
     // BoundingBox is optional and can be set to null by using the format [0, 0, 0, 0, 0, 0]
     const boundingBox =
@@ -156,7 +153,6 @@ class TaskCreateBulkView extends React.PureComponent<Props, State> {
 
     return {
       dataSet,
-      teamName,
       taskTypeId,
       scriptId,
       openInstances,
@@ -269,9 +265,9 @@ class TaskCreateBulkView extends React.PureComponent<Props, State> {
               following format:
               <br />
               <a href="/dashboard">dataSet</a>, <a href="/taskTypes">taskTypeId</a>,{" "}
-              experienceDomain, minExperience, x, y, z, rotX, rotY, rotZ, instances,{" "}
-              <a href="/teams">team</a>, minX, minY, minZ, width, height, depth,{" "}
-              <a href="/projects">project</a> [, <a href="/scripts">scriptId</a>, baseAnnotationId]
+              experienceDomain, minExperience, x, y, z, rotX, rotY, rotZ, instances, minX, minY,{" "}
+              minZ, width, height, depth, <a href="/projects">project</a> [,{" "}
+              <a href="/scripts">scriptId</a>, baseAnnotationId]
               <br />
               If you want to define some (but not all) of the optional values, please list all
               optional values and use an empty value for the ones you do not want to set (e.g.,
@@ -300,7 +296,7 @@ class TaskCreateBulkView extends React.PureComponent<Props, State> {
                 })(
                   <TextArea
                     className="input-monospace"
-                    placeholder="dataSet, taskTypeId, experienceDomain, minExperience, x, y, z, rotX, rotY, rotZ, instances, team, minX, minY, minZ, width, height, depth, project[, scriptId, baseAnnotationId]"
+                    placeholder="dataSet, taskTypeId, experienceDomain, minExperience, x, y, z, rotX, rotY, rotZ, instances, minX, minY, minZ, width, height, depth, project[, scriptId, baseAnnotationId]"
                     autosize={{ minRows: 6 }}
                     style={{
                       fontFamily: 'Monaco, Consolas, "Lucida Console", "Courier New", monospace',

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -151,7 +151,7 @@ instead. Only enable this option if you understand its effect. All layers will n
   "annotation.undoFinish.content":
     "If you reopen your old tracing, the current annotation will not be finished or cancelled. Instead, it will remain open and you can find it in the dashboard to continue annotating.",
   "task.bulk_create_invalid":
-    "Can not parse task specification. It includes at least one invalid task.",
+    "Can not parse task specification. It includes at least one invalid task. (Note that the obsolete “team” column was recently removed, are you still using the old format?)",
   "task.recommended_configuration": "The author of this task suggests to use these settings:",
   "dataset.clear_cache_success": _.template(
     "The dataset <%- datasetName %> was reloaded successfully.",

--- a/frontend/javascripts/test/backend-snapshot-tests/tasks.e2e.js
+++ b/frontend/javascripts/test/backend-snapshot-tests/tasks.e2e.js
@@ -95,7 +95,6 @@ const newTask = {
   projectName: "Test_Project4",
   scriptId: null,
   openInstances: 3,
-  teamName: "570b9f4b2a7c0e3b008da6ec",
   taskTypeId: "570b9f4c2a7c0e4c008da6ee",
 };
 


### PR DESCRIPTION
This time we gave some heads-up about this change. Redoing the front-end changes of #2553

### URL of deployed dev instance (used for testing):
- https://removeteamfrombulkcsv.webknossos.xyz

### Steps to test:
- create some tasks via csv or via bulk form

### Issues:
- fixes #2653 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- ~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~
- ~[ ] Updated [documentation](../blob/master/docs) if applicable~
- ~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~
- ~[ ] Needs datastore update after deployment~
- [x] Ready for review
