### PR TITLE
Temporarily disable delete of dev-deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,16 +243,16 @@ jobs:
       - image: scalableminds/puppeteer:master
     steps:
       - checkout
-      - run:
-          name: Remove dev-deployment
-          command: >
-            curl
-            -X POST
-            -H "X-Auth-Token: $RELEASE_API_TOKEN"
-            https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
-      - run:
-          name: Wait 3min
-          command: sleep 180
+      #- run:
+      #    name: Remove dev-deployment
+      #    command: >
+      #      curl
+      #      -X POST
+      #      -H "X-Auth-Token: $RELEASE_API_TOKEN"
+      #      https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
+      #- run:
+      #    name: Wait 3min
+      #    command: sleep 180
       - run:
           name: Install dev-deployment
           command: >


### PR DESCRIPTION
Currently deleting dev-deployments leads to an inconsistency in our deployment and fails. Therefore we need to disable this in the nightly test for now, which might lead to failures in it, since the state is not reset between runs.

- [x] Ready for review
