### PR TITLE
Make explicit datastore refresh more resilient

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 
--
+- Improved resilience when refreshing datasets while a datastore is down. [#4636](https://github.com/scalableminds/webknossos/pull/4636)
 
 ### Removed
 

--- a/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
@@ -68,9 +68,9 @@ export default function DatasetCacheProvider({ children }: { children: Node }) {
         datastores
           .filter(ds => !ds.isForeign)
           .map(datastore =>
-            // Catch potentally failing triggers, since these should not
+            // Catch potentially failing triggers, since these should not
             // block the subsequent fetch of datasets. Otherwise, one offline
-            // datastore will stop the refresh for all datastres.
+            // datastore will stop the refresh for all datastores.
             triggerDatasetCheck(datastore.url).catch(() => {}),
           ),
       );

--- a/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
@@ -65,7 +65,14 @@ export default function DatasetCacheProvider({ children }: { children: Node }) {
       setIsLoading(true);
       const datastores = await getDatastores();
       await Promise.all(
-        datastores.filter(ds => !ds.isForeign).map(datastore => triggerDatasetCheck(datastore.url)),
+        datastores
+          .filter(ds => !ds.isForeign)
+          .map(datastore =>
+            // Catch potentally failing triggers, since these should not
+            // block the consequent fetch of datasets. Otherwise, one offline
+            // datastore will stop the refresh for all datastres.
+            triggerDatasetCheck(datastore.url).catch(() => {}),
+          ),
       );
       await fetchDatasets();
     } catch (error) {

--- a/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
@@ -69,7 +69,7 @@ export default function DatasetCacheProvider({ children }: { children: Node }) {
           .filter(ds => !ds.isForeign)
           .map(datastore =>
             // Catch potentally failing triggers, since these should not
-            // block the consequent fetch of datasets. Otherwise, one offline
+            // block the subsequent fetch of datasets. Otherwise, one offline
             // datastore will stop the refresh for all datastres.
             triggerDatasetCheck(datastore.url).catch(() => {}),
           ),


### PR DESCRIPTION
... by simply ignoring failed dataset-checks (an error toast should still be shown).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I temporarily "broke" the `checkInboxBlocking` route and checked in the network tab that a subsequent datasets GET is performed. also, I ensured that an error toast is shown.

### Issues:
- fixes https://github.com/scalableminds/webknossos/issues/4635

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
