### PR TITLE
Update react-debounce-render to fix warning and clean up some logging

### DIFF
--- a/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -232,11 +232,7 @@ export function* finishLayer(
   }
 
   if (activeTool === VolumeToolEnum.TRACE || activeTool === VolumeToolEnum.BRUSH) {
-    const start = Date.now();
-
     yield* call(labelWithIterator, layer.getVoxelIterator(activeTool), contourTracingMode);
-
-    console.log("Labeling time:", Date.now() - start);
   }
 
   yield* put(updateDirectionAction(layer.getCentroid()));

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "pretty-bytes": "^5.1.0",
     "protobufjs": "^6.8.6",
     "react": "^16.8.0",
-    "react-debounce-render": "^4.0.1",
+    "react-debounce-render": "^6.0.0",
     "react-dom": "^16.8.0",
     "react-dropzone": "^4.2.13",
     "react-google-charts": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5928,6 +5928,13 @@ hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   dependencies:
     react-is "^16.7.0"
 
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
@@ -10189,12 +10196,12 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-debounce-render@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/react-debounce-render/-/react-debounce-render-4.0.3.tgz#ce58026578d73b81f1f990d7c4bfd3fa038b5620"
-  integrity sha512-bjbpWHE0gRhkZoH0F+G3Azc7Zceb/Et1fwMJuKYagRnd0LqwcaC/JuECyPlFKK36HiRhzMO9kQplGLF/nlt7Lg==
+react-debounce-render@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-debounce-render/-/react-debounce-render-6.0.0.tgz#5865d727479126edc9d14b71cfcbfd47d852846e"
+  integrity sha512-JlseqWoAvvAZWtqK0ZMraRT1e4LyYanx3LP0Hc6ejuO9OPtEPx1aCMyZLLoB2XOL+b4a1BHFiKLQ2VOhMCBe4A==
   dependencies:
-    lodash "^4.17.10"
+    hoist-non-react-statics "^3.3.2"
     lodash.debounce "^4.0.8"
 
 react-display-name@^0.2.0:


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://cleanuplogging.webknossos.xyz

### Steps to test:
- open a tracing and ensure that the logging is not too verbose. I'm open to suggestions to improve it further.

### Issues:
- fixes #4572

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
