### PR TITLE
When requesting data from fallback layer, skip version field

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 
--
+- Fixed a bug where requesting volume tracing fallback layer data from webknossos-connect failed. [#4644](https://github.com/scalableminds/webknossos/pull/4644)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
@@ -120,7 +120,7 @@ export async function requestFromStore(
   dataUrl: string,
   layerInfo: DataLayerType,
   batch: Array<Vector4>,
-  isVolumeFallback: bool = false,
+  isVolumeFallback: boolean = false,
 ): Promise<Array<?Uint8Array>> {
   const state = Store.getState();
   const isSegmentation = isSegmentationLayer(state.dataset, layerInfo.name);
@@ -137,7 +137,9 @@ export async function requestFromStore(
 
   const resolutions = getResolutions(state.dataset);
   const version =
-    !isVolumeFallback && isSegmentation && state.tracing.volume != null ? state.tracing.volume.version : null;
+    !isVolumeFallback && isSegmentation && state.tracing.volume != null
+      ? state.tracing.volume.version
+      : null;
 
   const bucketInfo = batch.map(zoomedAddress =>
     createRequestBucketInfo(zoomedAddress, resolutions, fourBit, applyAgglomerates, version),

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
@@ -103,6 +103,7 @@ export async function requestWithFallback(
     getDataStoreUrl(enforceVolumeTracing(state.tracing).fallbackLayer),
     layerInfo,
     fallbackBatch,
+    true,
   );
 
   return bucketBuffers.map((bucket, idx) => {
@@ -119,6 +120,7 @@ export async function requestFromStore(
   dataUrl: string,
   layerInfo: DataLayerType,
   batch: Array<Vector4>,
+  isVolumeFallback: bool = false,
 ): Promise<Array<?Uint8Array>> {
   const state = Store.getState();
   const isSegmentation = isSegmentationLayer(state.dataset, layerInfo.name);
@@ -135,7 +137,7 @@ export async function requestFromStore(
 
   const resolutions = getResolutions(state.dataset);
   const version =
-    isSegmentation && state.tracing.volume != null ? state.tracing.volume.version : null;
+    !isVolumeFallback && isSegmentation && state.tracing.volume != null ? state.tracing.volume.version : null;
 
   const bucketInfo = batch.map(zoomedAddress =>
     createRequestBucketInfo(zoomedAddress, resolutions, fourBit, applyAgglomerates, version),


### PR DESCRIPTION
webknkossos-connect is strict about request formats and fails on unexpected fields. When requesting fallback layer data for volume tracings, the version field was sent to the datastore, but datastores don’t know what to do with this field. This PR removes it in this case.
This fixes https://github.com/scalableminds/webknossos-connect/issues/90 (except for the still-wrong largest segment ID, but that is tracked in separate issue https://github.com/scalableminds/webknossos-connect/issues/92)

The scala tracingstores and datastores ignore superfluous fields rather than fail. Do you think we should adapt this behavior for wkconnect also? @philippotto @jstriebel 

### Steps to test:
- start a volume tracing with fallback layer on neuroglancer dataset (e.g. harris2015 which is preconfigured in webknossos-connect). should work as expected (except for segment ID overflow)

### Issues:
- fixes https://github.com/scalableminds/webknossos-connect/issues/90

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
