### PR TITLE
Support smaller brushsizes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 - The redundant “team” column was removed from the bulk task creation format. [#4629](https://github.com/scalableminds/webknossos/pull/4629)
+- The brush size minimum was changed from 5 to 1. [#4648](https://github.com/scalableminds/webknossos/pull/4648)
 
 ### Fixed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 - The redundant “team” column was removed from the bulk task creation format. [#4629](https://github.com/scalableminds/webknossos/pull/4629)
-- The brush size minimum was changed from 5 to 1. [#4648](https://github.com/scalableminds/webknossos/pull/4648)
+- The brush size minimum was changed from 5 voxels to 1. [#4648](https://github.com/scalableminds/webknossos/pull/4648)
 
 ### Fixed
 
@@ -26,4 +26,3 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Removed
 
 -
-

--- a/frontend/javascripts/libs/user_settings.schema.js
+++ b/frontend/javascripts/libs/user_settings.schema.js
@@ -32,7 +32,7 @@ export const userSettings = {
   highlightHoveredCellId: { type: "boolean" },
   zoom: { type: "number", minimum: 0.005 },
   renderMissingDataBlack: { type: "boolean" },
-  brushSize: { type: "number", minimum: 5, maximum: 5000 },
+  brushSize: { type: "number", minimum: 1, maximum: 5000 },
   layoutScaleValue: { type: "number", minimum: 1, maximum: 5 },
   autoSaveLayouts: { type: "boolean" },
   gpuMemoryFactor: { type: "number" },


### PR DESCRIPTION
This PR changes the minimum brush size from 5 to 1.

### URL of deployed dev instance (used for testing):
- https://supportsmallerbrushsizes.webknossos.xyz

### Steps to test:
- open a volume tracing
- adjust the brush size to something smaller 5 via settings
- adjust the brush size to something smaller 5 via the shift+scroll shortcut

### Issues:
- fixes #4645

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] ~~Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- [ ] ~~Updated [documentation](../blob/master/docs) if applicable~~
- [ ] ~~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [ ] ~~Needs datastore update after deployment~~
- [x] Ready for review
