### PR TITLE
Make CI more robust by skipping chromium when installing puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: tools/postgres/assert_unique_evolution_numbers.sh
       - run:
           name: Install frontend dependencies
-          command: docker-compose run base "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install --frozen-lockfile"
+          command: docker-compose run --env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true base yarn install --frozen-lockfile
       - restore_cache:
           name: Restore webpack-uglifyjs cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Install dependencies and sleep at least 3min
           command: |
-            yarn install --frozen-lockfile &
+            PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install --frozen-lockfile &
             sleep 180 &
             wait
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-
+      - nightly
   circleci_nightly:
     jobs:
       - nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: tools/postgres/assert_unique_evolution_numbers.sh
       - run:
           name: Install frontend dependencies
-          command: docker-compose run base yarn install --frozen-lockfile
+          command: docker-compose run base "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install --frozen-lockfile"
       - restore_cache:
           name: Restore webpack-uglifyjs cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Install dependencies and sleep at least 3min
           command: |
-            PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install --frozen-lockfile &
+            yarn install --frozen-lockfile &
             sleep 180 &
             wait
       - run:
@@ -286,7 +286,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - nightly
   circleci_nightly:
     jobs:
       - nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: tools/postgres/assert_unique_evolution_numbers.sh
       - run:
           name: Install frontend dependencies
-          command: docker-compose run --env PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true base yarn install --frozen-lockfile
+          command: docker-compose run -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true base yarn install --frozen-lockfile
       - restore_cache:
           name: Restore webpack-uglifyjs cache
           keys:


### PR DESCRIPTION
The CI failed quite a lot in the past, since chromium couldn't be downloaded. At least, for the branch builds, this doesn't seem to be necessary, anyway, which is why this can be skipped. The nightlies seem fairly stable which is why I left them as is (they need chromium; so the fix wouldn't work).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- CI 

### Issues:
- fixes #4583

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
