### PR TITLE
Fix that imported invisible trees were visible

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that the dataset list in the dashboard could reorder its items asynchronously which could be very annoying for the user. [#4640](https://github.com/scalableminds/webknossos/pull/4640)
 - Improved resilience when refreshing datasets while a datastore is down. [#4636](https://github.com/scalableminds/webknossos/pull/4636)
 - Fixed a bug where requesting volume tracing fallback layer data from webknossos-connect failed. [#4644](https://github.com/scalableminds/webknossos/pull/4644)
+- Fixed a bug where imported invisible trees were still visible. [#4659](https://github.com/scalableminds/webknossos/issues/4659)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/geometries/skeleton.js
+++ b/frontend/javascripts/oxalis/geometries/skeleton.js
@@ -310,7 +310,7 @@ class Skeleton {
           this.updateNodeRadius(update.value.treeId, update.value.id, update.value.radius);
           break;
         case "createTree":
-          this.updateTreeColor(update.value.id, update.value.color);
+          this.updateTreeColor(update.value.id, update.value.color, update.value.isVisible);
           break;
         case "updateTreeVisibility": {
           const { treeId } = update.value;


### PR DESCRIPTION

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Import an NML with a tree that is invisible (`color.a="0"`).

[invisible_tree.zip](https://github.com/scalableminds/webknossos/files/4764112/invisible_tree.zip)

### Issues:
- fixes #4659 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
