### PR TITLE
Use scala-style external process runner for Buildinfo

### DIFF
--- a/project/BuildInfoSettings.scala
+++ b/project/BuildInfoSettings.scala
@@ -42,7 +42,8 @@ object BuildInfoSettings {
       "ciBuild" -> ciBuild,
       "ciTag" -> ciTag,
       "gitTag" -> gitTag,
-      "version" -> webKnossosVersion
+      "version" -> webKnossosVersion,
+      "datastoreApiVersion" -> "1.0"
     ),
     buildInfoPackage := "webknossosDatastore",
     buildInfoOptions := Seq(BuildInfoOption.ToJson)


### PR DESCRIPTION
The old java-sytle execution of git to retrieve buildinfo data returned null in case of exit code 1 (which caused compilation errors). This now throws an exception, which triggers our error handling.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- buildinfo should contain expected values
- if one of the commands fails (exits with 1) the buildinfo should show the respective error message. to test this, e.g. change `git rev-parse HEAD` to `git nonexistingcommand` in BuildInfoSettings.scala:18

### Issues:
- fixes dev setups where git tags are not available

---

- [x] Ready for review
