### PR TITLE
Updated Docs for Permission System

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,16 +49,16 @@ You can also change the size of the viewports to see more details in your data a
 
 
 ## Your First Annotation
-Click the `Create Tracing` button from the view mode of a dataset to create your first annotation.
+Click the `Create Annotation` button from the view mode of a dataset to create your first annotation.
 webKnossos will launch the main annotation screen allowing you to navigate your dataset and place markers to reconstruct skeletons.
 
 Drag the mouse while pressing the left mouse button to navigate the dataset.
 Right-click in the data to place markers, called nodes.
 Basic movement in the dataset is done with the mouse wheel or by pressing the spacebar keyboard shortcut.
 
-Learn more about the skeleton, volume, and hybrid annotations as well as the interface in the [Tracing UI guide](./tracing_ui.md).
+Learn more about the skeleton, volume, and hybrid annotations as well as the interface in the [Annotation UI guide](./tracing_ui.md).
 
-![Editing skeleton and volume annotations in the Tracing UI](./images/tracing_ui.png)
+![Editing skeleton and volume annotations in the Annotation UI](./images/tracing_ui.png)
 
 
 ## Learn More

--- a/docs/hello.md
+++ b/docs/hello.md
@@ -20,8 +20,8 @@ Try webKnossos on a large selection of published datasets: [https://webknossos.o
 * Exploration of large 3D image datasets
 * Fully browser-based user experience with efficient data streaming
 * Creation/editing of skeleton and volume annotations
-* [Innovative flight mode for fast skeleton tracing](https://www.nature.com/articles/nmeth.4331)
-* Optimized performance for large tracings
+* [Innovative flight mode for fast skeleton annotation](https://www.nature.com/articles/nmeth.4331)
+* Optimized performance for large annotations
 * User and task management for high-throughput crowdsourcing
 * Sharing and collaboration features
 * [Standalone datastore component](https://github.com/scalableminds/webknossos/tree/master/webknossos-datastore) for flexible deployments

--- a/docs/images/raw/tracing_ui_overview.svg
+++ b/docs/images/raw/tracing_ui_overview.svg
@@ -29965,7 +29965,7 @@ cedc+juTNtrV+f8Kwp3xMA55GwAAAABJRU5ErkJggg==
          id="tspan4279"
          x="-302.90179"
          y="990.37457"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:37.5px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none">3. Tracing Interface</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:37.5px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none">3. Annotation Interface</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:37.5px;line-height:125%;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#6699ff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 * [Understanding the User Interface](./tracing_ui.md)
 * [Mesh Visualization](./mesh_visualization.md)
 * [Managing Datasets](./datasets.md)
-* [Managing Users and Access Rights](./users.md)
+* [Managing Users and Access Permissions](./users.md)
 * [Managing Tasks and Projects](./tasks.md)
 * [Sharing](./sharing.md)
 * [Installation on your own Server](./installation.md)

--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -19,7 +19,7 @@ Find all available keyboard & mouse shortcuts for webKnossos listed below.
 | Q                             | Download Screenshot(s) of Viewport(s)       |
 | .                             | Toggle Viewport Maximization                |
 
-## Skeleton Tracings
+## Skeleton Annotation Mode
 
 | Key Binding                   | Operation                                   |
 | ----------------------------- | ------------------------------------------- |

--- a/docs/mesh_visualization.md
+++ b/docs/mesh_visualization.md
@@ -8,7 +8,7 @@ These two approaches are explained in the following.
 
 When **viewing a dataset** (using the ["View" action](./dashboard.md#datasets) when opening a dataset) with a segmentation layer, the experimental "Render Isosurfaces" setting can be enabled within the [dataset settings](./mesh_visualization.md#tracing-ui-settings).
 Once the setting is enabled, webKnossos will generate isosurface meshes of the active cell and render these in the 3D viewport.
-To activate a cell, use shift+click on a segment in the tracing view.
+To activate a cell, use shift+click on a segment in the annotation view.
 The isosurface is computed in chunks, which is why the isosurface is likely to appear bit by bit.
 When hovering over an isosurface in the 3D viewport, the cell will also be highlighted in the other viewports.
 Shift + Click on an isosurface in the 3D viewport will change the active position to where you clicked.
@@ -16,7 +16,7 @@ CTRL + Click on an isosurface will remove that isosurface again.
 
 ![Generating isosurfaces for specific cell ids via shift+click](./images/isosurface-demo.gif)
 
-Note that the generated isosurface is not persisted for the tracing.
+Note that the generated isosurface is not persisted for the annotation.
 Consequently, refreshing the page, will "forget" all previously generated isosurfaces.
 To persist generated isosurfaces, you can use the "Download" button within the "Meshes" pane.
 That "Download" button will persist the isosurface of the active cell as an STL file to your disk.
@@ -30,8 +30,8 @@ Apart from importing STLs which were created by webKnossos, you can also use the
 Such files can be created from volume data with the help of external tools, such as [Amira](https://www.fei.com/software/amira-avizo/).
 After the import, meshes are rendered alongside the actual data in the 3D viewport.
 For each mesh, the name, position and visibility can be adapted via the "Meshes" tab.
-In contrast to generated isosurfaces, uploaded STLs will be persisted within the tracing.
-For that reason, the import only works when opening a tracing (as opposed to just viewing a dataset).
+In contrast to generated isosurfaces, uploaded STLs will be persisted within the annotation.
+For that reason, the import only works when opening an annotation (as opposed to just viewing a dataset).
 
 ![A 3D Mesh visualized in webKnossos](./images/stl_mesh.png)
 ![The Meshes Tab can be used to add and edit meshes.](./images/Meshes-Tab.png)
@@ -41,7 +41,7 @@ For that reason, the import only works when opening a tracing (as opposed to jus
 Note that the mesh and isosurface support in webKnossos is an ongoing development effort.
 The functionality is currently limited by the following:
 
-- Isosurface generation only works for segmentation layers (as opposed to volume tracings). As a result, the dataset has to be opened in view mode to enable isosurfaces.
+- Isosurface generation only works for segmentation layers (as opposed to volume annotations). As a result, the dataset has to be opened in view mode to enable isosurfaces.
 - Isosurfaces are not persisted automatically. If you want to manually persist an isosurface, you can use the "Download" button in the meshes tab.
 - Importing an STL which was not generated with webKnossos only works when having an annotation opened (since that mesh will be persisted).
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -323,9 +323,9 @@ Download an annotation as NML/ZIP
 
 #### Returns
  - As chunked file stream:
-   - In case of an explorative annotation with a volume tracing:
+   - In case of a volume annotation:
      - A ZIP file containing both an NML file and a data.zip file with the volume data
-   - In case of a single explorative or task annotation with no volume tracing:
+   - In case of a single explorative or task annotation with no volume annotation:
      - A single NML file
    - In case of compound downloads (CompoundTask/CompoundProject/CompoundTaskType):
      - A ZIP file containing individual NML files for all associated annotations

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -75,7 +75,7 @@ Both are featured next to a preview of the dataset in the gallery of promoted pu
 
 ## Annotation Sharing
 Besides sharing just the data layers for viewing, webKnossos can also share complete annotations, e.g. a large skeleton reconstruction.
-Annotation sharing works for both skeletons and volume tracings.
+Sharing works for both skeletons and volume annotations.
 
 ### Annotation Permissions
 There are three options to control, who can see an annotation if they know the annotation url. To learn how to get the url, look at the following paragraph about [Link Sharing](#link-sharing).
@@ -88,27 +88,27 @@ The default option is `Internal`.
 
 To change the visibility of an annotation, follow these steps:
 
-1. Open your annotation in the regular tracing view. 
+1. Open your annotation
 2. From the [toolbar](./tracing_ui.md/#the-toolbar) select `Share` from the overflow menu next to the `Save` button.
 3. Select the desired option from the three available options.
 
 ![Configure the Annotation Permissions](images/sharing_modal_visibility.png)
 
 ### Link Sharing
-Annotations can be shared via a link. People, who obtain the link, must have access to the annotation according to the permissions above to view the tracing.
+Annotations can be shared via a link. People, who obtain the link, must have access to the annotation according to the permissions above to view the annotation.
 
-`Public` tracings do not require any user authentication and are a great option for sharing a link to your annotation from social media or your website.
+`Public` annotations do not require any user authentication and are a great option for sharing a link to your annotation from social media or your website.
 Unlike with datasets, publicly shared annotations are not featured in a gallery.
 For public annotations to work properly, the underlying dataset must also be shared publicly or privately (via token URL).
 Otherwise, the annotation and data cannot be loaded by webKnossos and an error will occur.
 [Learn how to share datasets publicly above.](#public-sharing)
 
-`Internal` tracings require the recipient of a link to log in with his webKnossos account.
+`Internal` annotations require the recipient of a link to log in with his webKnossos account.
 This is primarily used for sharing annotations with your co-workers, e.g. for highlighting interesting positions in your work.
 Since your position, rotation, zoom etc. is encoded in the URL, it is a great way for working collaboratively.
 Just send an URL to your co-workers in an email or blog post and they may jump right into the annotation at your location.
 
-`Private` tracings don't allow sharing. However, your direct supervisor and admins can still view the annotation.
+`Private` annotations don't allow sharing. However, your direct supervisor and admins can still view the annotation.
 
 Since every annotation is tied to an individual webKnossos user, co-workers cannot modify your annotation if you share it with them.
 Instead, the shared annotation will be read-only.
@@ -118,7 +118,7 @@ Think of this feature like GitHub forks. Changes made to the copy are not automa
 
 To get the sharing link of an annotation, follow the same steps as for changing the viewing permissions:
 
-1. Open your annotation in the regular tracing view. 
+1. Open your annotation
 2. From the [toolbar](./tracing_ui.md/#the-toolbar) select `Share` from the overflow menu next to the `Save` button.
 3. Copy the sharing URL.
 
@@ -129,7 +129,7 @@ In addition to sharing your annotation via a link, you can also share your annot
 This is the simplest way to share an annotation with a whole team.
 
 To share an annotation with a certain team, follow these steps:
-1. Open your annotation in the regular tracing view. 
+1. Open your annotation
 2. From the [toolbar](./tracing_ui.md/#the-toolbar) select `Share` from the overflow menu next to the `Save` button.
 3. Select the teams from the dropdown menu.
 

--- a/docs/skeleton_annotation.md
+++ b/docs/skeleton_annotation.md
@@ -1,6 +1,6 @@
 ## Skeleton Annotations
-The goal of tracing skeletons is to reconstruct structures in a dataset that span across many data slices as a graph of connected nodes.
-A typical example of a skeleton annotation is to follow a nerve cell for a few nanometers, placing a node every few slices. (See image below)
+The typical goal of skeleton annotations is the reconstruction of long-running structures in a dataset that span across many data slices as a graph of connected nodes.
+A typical example of creating skeleton annotations is the analysis of nerve cells placing a node every few slices to reconstruct their path through a dataset. (See image below)
 
 A typical skeleton annotation contains the reconstruction of one or more structures, often with many thousand nodes.
 All connected nodes form a tree or more generally speaking a graph.
@@ -13,7 +13,7 @@ This article outlines commonly used features and operations for viewing, editing
 
 {% embed url="https://www.youtube.com/watch?v=9cqLuJIDDFg "%}
 
-### Tracing Modes
+### Annotation Modes
 webKnossos supports several modes for displaying your dataset & interacting with skeleton annotations.
 
 #### Orthogonal Mode
@@ -23,9 +23,9 @@ All camera movements happen along the respective main axis.
 This view is especially useful for viewing your data in the highest possible quality alongside its main imaging axis, typically XY.
 Every single slice of the raw data can be viewed.
 
-Most skeleton tracing operations and keyboard shortcuts are tailored for the Orthogonal Mode.
+Most skeleton annotation operations and keyboard shortcuts are tailored for the Orthogonal Mode.
 
-![Switch between different tracing modes using the buttons in the toolbar](images/tracing_ui_modes.png)
+![Switch between different annotation modes using the buttons in the toolbar](images/tracing_ui_modes.png)
 
 #### Oblique Mode
 
@@ -36,7 +36,7 @@ In contrast to Orthogonal mode, any arbitrary slice through the dataset at any r
 Flight mode also allows a resliced view through the data.
 In contrast to Oblique mode, the data is projected on the inside of a sphere with the camera located at the center of the sphere.
 
-![Tracing neurons efficiently in Flight mode](./images/tracing_ui_flightmode.jpg)
+![Annotate neurons efficiently in Flight mode](./images/tracing_ui_flightmode.jpg)
 
 Spherical projection is especially useful when rotating the camera, as pixels close to the center of the screen move in a predictable manner.
 Interactions and movements in Flight mode feel similar to First-Person-View (FPV) games.
@@ -137,9 +137,9 @@ There are two ways for downloading your annotations:
 
 1. There is a `Download` button in the overflow menu next to the prominent `Save` button in the toolbar at the top of the screen.
 
-2. If you need more fine-grained control over which trees to download use the `Download Selected Trees` option. From the `Trees Tab` click on `More` and select `Download Selected Trees` from the menu. All visible trees (checkmark in front of the name) will be downloaded as an NML file. This is especially useful if you need to only download a single tree of an otherwise much larger tracing.
+2. If you need more fine-grained control over which trees to download use the `Download Selected Trees` option. From the `Trees Tab` click on `More` and select `Download Selected Trees` from the menu. All visible trees (checkmark in front of the name) will be downloaded as an NML file. This is especially useful if you need to only download a single tree of an otherwise much larger annotation.
 
-![Skeletons can be exported and downloaded as NML files from the tracing view. Either download all or only selected trees.](images/tracing_ui_download.png)
+![Skeletons can be exported and downloaded as NML files from the annotation view. Either download all or only selected trees.](images/tracing_ui_download.png)
 
 Importing a skeleton annotation can be achieved using two approaches as well:
 
@@ -147,12 +147,12 @@ Importing a skeleton annotation can be achieved using two approaches as well:
 
 2. To import a skeleton annotation as a completely new webKnossos annotation, just drag and drop the NML file anywhere on your user dashboard. Alternately, navigate to your user dashboard and use the `Upload Annotation` button within the "Explorative Annotations" section.
 
-![Skeletons can be imported by drag and drop in the tracing view or from the dashboard](images/tracing_ui_import.png)
+![Skeletons can be imported by drag and drop in the annotation view or from the dashboard](images/tracing_ui_import.png)
 
 ### Merging Skeleton Annotations
 There are two ways for merging annotations:
 
-1. While in the tracing UI, **drag and drop** an NML file onto your browser window to import a skeleton. The imported skeleton will be merged with currently open annotation.
+1. While in the annotation UI, **drag and drop** an NML file onto your browser window to import a skeleton. The imported skeleton will be merged with currently open annotation.
 
 2. If you would like to merge your current annotation with another existing annotation, select the `Merge` operation from the overflow menu next to the `Save` button. (see image) Either enter the ID of an existing explorative annotation or select a whole project and proceed to merge the selection with your currently open annotation. The resulting annotation can either be created as a new explorative annotation. Otherwise, the merge will happen in your current annotation.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -6,9 +6,9 @@ webKnossos has a task system that is useful for efficiently managing large annot
 
 - `Task`: Is an assignment for a small piece of work. A Team Manager or Admin creates Tasks with information about the Task Type, the referenced dataset, starting positions and advanced options. These tasks will be distributed to eligible users. 
 - `Task Instance`: Some Tasks need to be completed redundantly by multiple users in order to assure quality. The single assignments of the tasks are called Instances.
-- `Task Type`: Contains a blue print for Tasks. Includes information such as a description with instructions, allowed tracing modes, and advanced options.
+- `Task Type`: Contains a blue print for Tasks. Includes information such as a description with instructions, allowed annotation modes, and advanced options.
 - `Project`: A group of many related Tasks is called a Project. Projects have a priority assigned to them which affects the order of assignment to users. Projects may be paused and resumed in order to manage the user workloads.
-- `Experience`: Admins and Team Managers can assign experience levels to users. Experiences are defined by a domain and a value, such as `flight-tracing` and `100`. Tasks specify the required experience level of a user.
+- `Experience`: Admins and Team Managers can assign experience levels to users. Experiences are defined by a domain and a value, such as `flight-annotation` and `100`. Tasks specify the required experience level of a user.
 
 It is possible to download all annotations that belong to either a Project or a Task Type for further processing.
 

--- a/docs/tracing_ui.md
+++ b/docs/tracing_ui.md
@@ -4,45 +4,45 @@ The main webKnossos user interface for viewing and annotating datasets is divide
 
 1. [A toolbar](#the-toolbar) for general purposes features such as Saving your work and displaying the current position within the dataset. It spans along the full width of the top of your screen.
 2. On the left-hand side, a [settings menu](#tracing-ui-settings) gives you control of several parameters of webKosssos. For instance, you can fine-tune a dataset's contrast & segmentation opacity, as well as adjust movement speed of the mouse and keyboard.
-3. The center of the screen is occupied by [the tracing interface](#skeleton-annotations). Your dataset is displayed here and users can add annotations or add/edit the segmentation. Most interactions will take place here.
+3. The center of the screen is occupied by [the annotation interface](#skeleton-annotations). Your dataset is displayed here and users can add annotations or add/edit the segmentation. Most interactions will take place here.
 4. The right-hand side of the screen is occupied by several tabs providing more information on your current dataset or annotation. Depending on your editing mode these tabs might adapt.
 
-![An overview of the webKnossos tracing UI highlighting the 4 main sections of the interface](images/tracing_ui_overview.png)
+![An overview of the webKnossos annotation UI highlighting the 4 main sections of the interface](images/tracing_ui_overview.png)
 
 [Read More About Skeleton Annotation](./skeleton_annotation.md)
 [Read More About Volume Annotation](./volume_annotation.md)
 
 ## The Toolbar
-The toolbar contains frequently used commands, your current position within the dataset and the ability to switch between various modes for viewing and interaction with the dataset or tools depending on your tracing mode.
+The toolbar contains frequently used commands, your current position within the dataset and the ability to switch between various modes for viewing and interaction with the dataset or tools depending on your annotation mode.
 
 The most common buttons are:
 - `Settings`: Toggles the visibility of the setting menu on the left-hand side to provide more space for your data.
-- `Undo` / `Redo`: Undoes the last operation or redoes it if no new changes have been made in the meantime. Undo can only revert changes made in this session (since the moment the tracing view was opened). To revert to older versions use the "Restore Older Version" functionality, described later in this list.
+- `Undo` / `Redo`: Undoes the last operation or redoes it if no new changes have been made in the meantime. Undo can only revert changes made in this session (since the moment the annotation view was opened). To revert to older versions use the "Restore Older Version" functionality, described later in this list.
 - `Save`: Saves your annotation work. webKnossos automatically saves every 30 seconds.
 - `Archive`: Only available for Explorative Annotations. Closes the annotation and archives it, removing it from a user's dashboard. Archived annotations can be found on a user's dashboard under "Explorative Annotations" and by clicking on "Show Archived Annotations". Use this to declutter your dashboard. 
 - `Download`: Starts the download of the current annotation. Skeleton annotations are downloaded as [NML](./data_formats.md#nml) files. Volume annotation downloads contain the raw segmentation data as [WKW](./data_formats.md#wkw) files.
 - `Share`: Create a shareable link to your dataset containing the current position, rotation, zoom level etc. Use this to collaboratively work with colleagues. Read more about this feature in the [Sharing guide](./sharing.md).  
 - `Add Script`: Using the [webKnossos frontend API](https://webknossos.org/assets/docs/frontend-api/index.html) users can interact with webKnossos programmatically. User scripts can be executed from here. Admins can add often used scripts to webKnossos to make them available to all users for easy access.
-- `Restore Older Version`: Opens a view that shows all previous versions of a tracing. From this view, any older version can be selected, previewed, and restored.
+- `Restore Older Version`: Opens a view that shows all previous versions of an annotation. From this view, any older version can be selected, previewed, and restored.
 
 A user can directly jump to positions within their datasets by entering them in the position input field.
-The same is true for the rotation in some tracing modes.
+The same is true for the rotation in some annotation modes.
 Clicking on the position or rotation labels copies the values to the clipboard.
 
 ![The webKnossos toolbar contains many useful features for quick access such as Saving und Undo/Redo](images/tracing_ui_toolbar.png)
 
 
-## Tracing UI Settings
+## Annotation UI Settings
 The settings menu allows users to fine-tune some parameters of webKnossos.
 All settings are automatically saved as part of a user's profile.
-The `Tracing` settings include options related to interacting with a dataset while annotating, e.g. mouse movement speed.
-Tracing settings only affect the currently open annotation and will be restored when reopening the respective annotation in the future.
+The `Annotation` settings include options related to interacting with a dataset while annotating, e.g. mouse movement speed.
+`Annotation` settings only affect the currently open annotation and will be restored when reopening the respective annotation in the future.
 The `Dataset` settings include options to adjust the rendering of the dataset, e.g. brightness & contrast.
-Dataset settings affect all of the user's annotations referencing this particular dataset so that tracings can be created using the same conditions.
+Dataset settings affect all of the user's annotations referencing this particular dataset so that annotations can be created using the same conditions.
 
-Not all settings are available in every tracing mode.
+Not all settings are available in every annotation mode.
 
-### Tracing Settings
+### Annotation Settings
 #### Controls
 - `Keyboard delay (ms)`: The initial delay before an operation will be executed when pressing a keyboard shortcut. A low value will immediately execute a keyboard's associated operation, whereas a high value will delay the execution of an operation. This is useful for preventing an operation being called multiple times when rapidly pressing a key in short succession, e.g. for movement.
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -45,26 +45,27 @@ Only *Admins* and *Team Managers* can see/access the `Admin` menu options in the
 
 By default, each newly uploaded dataset can only be accessed by `Admins`, `Dataset Managers`, and members of the organization team. Add or remove more teams to a dataset for fine-grained access controls. For more information dataset and access rights, [see the dataset guide](./sharing.md#general)
 
+
 | Action                                           	| Admin 	| Dataset Manager 	| Team Manager 	| Team Member 	|
 |--------------------------------------------------	|-------	|-----------------	|--------------	|-------------	|
-| Access datasets of own teams                        	| Yes   	| Yes             	| Yes          	| Yes         	|
-| Access datasets of other teams                      	| Yes   	| Yes             	| No           	| No          	|
-| Edit datasets of own teams                       	| Yes   	| Yes             	| Yes          	| No          	|
-| Edit datasets of other teams                     	| Yes   	| Yes             	| No           	| No          	|
-| Access all users of own teams                       	| Yes   	| Yes             	| Yes          	| Yes         	|
-| Access all users of other teams                     	| Yes   	| Yes             	| Yes          	| No          	|
-| Assign/remove team membership to own teams       	| Yes   	| No              	| Yes          	| No          	|
-| Make other users team manager of own teams   	| Yes   	| No              	| Yes          	| No          	|
-| Make other users team manager of other teams   	| Yes   	| No              	| No           	| No          	|
-| Grant *Dataset Manager* role to others        	| Yes   	| No              	| No           	| No          	|
-| Grant *Admin* role to others                           	| Yes   	| No              	| No           	| No          	|
-| Access time tracking for oneself                       	| Yes   	| Yes             	| Yes          	| Yes         	|
-| Access time tracking for users of managed teams          	| Yes   	| No              	| Yes          	| No          	|
-| Create scripts (visible to everyone)            	| Yes   	| No              	| Yes          	| No          	|
-| Upload Datasets via UI                           	| Yes   	| Yes             	| Yes          	| No          	|
-| Set *Allowed Teams* upon dataset upload    	| Yes   	| No              	| Yes          	| No          	|
-| Get tasks again after cancelling an instance     	| Yes   	| No              	| Yes          	| No          	|
-| Access to wK Statistics Menu  	| Yes   	| No              	| Yes          	| No          	|
+| Access datasets of own teams                        	| ☑   	| ☑             	| ☑          	| ☑         	|
+| Access datasets of other teams                      	| ☑   	| ☑             	| ☐           	| ☐          	|
+| Edit datasets of own teams                       	| ☑   	| ☑             	| ☑          	| ☐          	|
+| Edit datasets of other teams                     	| ☑   	| ☑             	| ☐           	| ☐          	|
+| Access all users of own teams                       	| ☑   	| ☑             	| ☑          	| ☑         	|
+| Access all users of other teams                     	| ☑   	| ☑             	| ☑          	| ☐          	|
+| Assign/remove team membership to own teams       	| ☑   	| ☐              	| ☑          	| ☐          	|
+| Make other users team manager of own teams   	| ☑   	| ☐              	| ☑          	| ☐          	|
+| Make other users team manager of other teams   	| ☑   	| ☐              	| ☐           	| ☐          	|
+| Grant *Dataset Manager* role to others        	| ☑   	| ☐              	| ☐           	| ☐          	|
+| Grant *Admin* role to others                           	| ☑   	| ☐              	| ☐           	| ☐          	|
+| Access time tracking for oneself                       	| ☑   	| ☑             	| ☑          	| ☑         	|
+| Access time tracking for users of managed teams          	| ☑   	| ☐              	| ☑          	| ☐          	|
+| Create scripts (visible to everyone)            	| ☑   	| ☐              	| ☑          	| ☐          	|
+| Upload Datasets via UI                           	| ☑   	| ☑             	| ☑          	| ☐          	|
+| Set *Allowed Teams* upon dataset upload    	| ☑   	| ☐              	| ☑          	| ☐          	|
+| Get tasks again after cancelling an instance     	| ☑   	| ☐              	| ☑          	| ☐          	|
+| Access to wK Statistics Menu  	| ☑   	| ☐              	| ☑          	| ☐          	|
 
 
 ## Registering New Users

--- a/docs/users.md
+++ b/docs/users.md
@@ -43,7 +43,7 @@ There are four different roles for webKnossos users divided into global, organiz
 
 Only *Admins* and *Team Managers* can see/access the `Admin` menu options in the navigation bar.
 
-By default, each newly uploaded dataset can only be accessed by `Admins`, `Dataset Managers`, and members of the organization team. Add or remove more teams to a dataset for fine-grained access controls. For more information dataset and access rights, [see the dataset guide](./sharing.md#general)
+By default, each newly uploaded dataset can only be accessed by `Admins` and `Dataset Managers`. Add or remove more teams to a dataset for fine-grained access controls. `Team Managers` can also upload datasets via the UI and assign teams during this step. For more information regarding dataset and access rights, [see the dataset guide](./sharing.md#general)
 
 
 | Action                                           	| Admin 	| Dataset Manager 	| Team Manager 	| Team Member 	|

--- a/docs/users.md
+++ b/docs/users.md
@@ -29,7 +29,7 @@ There are four different roles for webKnossos users divided into global, organiz
 
 **On a per team basis:**
 
-  - __Member:__ A regular wK user account. Members are only able to access datasets of their respective teams and can create annotations for those. Further, the can work on tasks created by their `Team Manager` or an `Admin`. They are only able to access their annotations.
+  - __Member:__ A regular wK user account. Members are only able to access datasets of their respective teams and can create annotations for those. Further, the can work on tasks created by their `Team Manager` or an `Admin`. They are only able to access their own annotations or [annotations shared with them](./sharing.md).
 
   - __Team Manager:__ Manage a specific team. Team Managers can administrate and create [Tasks, Task Types, and Projects](./tasks.md) belonging to their respective teams. They also can activate newly registered users and assign/remove new users to theirs teams. Team managers can access all annotations belonging to users of their respective teams. Similarly to regular `Members`, they are only able to access datasets of their respective teams and can create annotations for those. 
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,13 +1,13 @@
-# Managing Users & Access Rights
+# Managing Users & Permissions
 
-webKnossos offers a built-in user management system in order to administer different user roles and permissions.
+webKnossos offers a built-in user management system to administer different user roles and permissions.
 
 
 ## Organizations
 
 The root entity in webKnossos is an **organization**.
 You will create one when setting up webKnossos.
-This organization will contain all your users, datasets, annotations and other data.
+This organization will contain all your users, datasets, annotations, and other data.
 Organizations are isolated.
 You are not allowed to see data from organizations other than your own and members from other organizations will not be able to see data from your organization.
 
@@ -23,23 +23,32 @@ Teams are useful for managing dataset access permissions or simply to organize u
 
 ## Access Rights / Roles
 
-Users are allowed to access and do different things, depending on their specific role.
-There are three different roles for webKnossos users:
+The webKnossos permissions system is designed to 1) control read/write access to datasets and 2) limit access to certain administration functionalities.
 
-  - __User:__ A regular wK user account. Users are able to work on tasks that are assigned to them and create explorational tracings. They are able to access their own annotations.
+There are four different roles for webKnossos users divided into global, organization-wide roles and team-based permissions:
 
-  - __Team Manager:__ Manages a specific team. Team Managers are able to administrate [Tasks, Task Types and Projects](./tasks.md) belonging to that specific team. They are also allowed to activate newly registered users. Team managers are able to access all tracings that belong to users of their team.
+**On a per team basis:**
 
-  - __Admin:__ Manages the whole organization with all teams. Admins are able to do the same things as team managers but across all teams. They can also give admin permissions to other users by using the `Grant Admin Rights` button at the top of the user list. Admins are able to access all tracings that belong to their organization.
+  - __User:__ A regular wK user account. Users are only able to access datasets of their respective teams and can create annotations for those. Further, the can work on tasks created by their `Team Manager` or an `Admin`. They are only able to access their annotations.
 
-Only *Admins* and *Team managers* are able to see/access the `Admin` menu options in the navigation bar.
+  - __Team Manager:__ Manage a specific team. Team Managers can administrate and create [Tasks, Task Types, and Projects](./tasks.md) belonging to their respective teams. They also can activate newly registered users. Team managers can access all annotations belonging to users of their respective teams. Similarly to regular `Users`, they are only able to access datasets of their respective teams and can create annotations for those. 
 
-By default, each new dataset can only be accessed by the members of the organization team. Add or remove more teams to a dataset for fine-grained access controls. For more information dataset and access rights, [see the dataset guide](./sharing.md#general)
+**On an organizational level:** 
+
+  - __Admin:__ Manage a whole organization including full access to all datasets, teams, and projects. Admins can access all administrative settings - similiar to `Team Managers` but for all teams - and have full control over all dataset - similar to `Dataset Managers`. They can award admin permissions to other users by using the `Grant Admin Rights` button at the top of the user list. Admins can access all annotations, datasets, projects, tasks, etc belonging to their respective organization.
+
+  - __Dataset Manager:__ Manage all datasets of an organization. Dataset Managers have full read/wrote access to all datasets within their respective organizations regardless of if a dataset is only been made available to a certain team. Use this role for power users who regularly upload datasets or who need access to all datasets regardless of who created them.
+  Unlike `Admins`, Dataset Managers do NOT have access to any of the administration interfaces for users, tasks, and projects.
+  
+
+Only *Admins* and *Team Managers* can see/access the `Admin` menu options in the navigation bar.
+
+By default, each newly uploaded dataset can only be accessed by `Admins`, `Dataset Managers`, and members of the organization team. Add or remove more teams to a dataset for fine-grained access controls. For more information dataset and access rights, [see the dataset guide](./sharing.md#general)
 
 ## Registering New Users
 
 New users can signup for webKnossos by clicking on the `Register Now` button in the navigation bar.
-In the registration form, they need to select an organization, specify some basic information and confirm acceptance of the privacy agreement.
+In the registration form, they need to select an organization, specify some basic information, and confirm acceptance of the privacy agreement.
 
 {% hint style='info' %}
 You can invite users to your specific organization, by clicking the `Invite Users` button at the top of the user list. This will open a popup containing a customized link that you can share to invite new users to your organization.
@@ -53,7 +62,7 @@ Users that click on this link, don't need to select an organization during regis
 
 Newly registered users are deactivated at first and need to be activated by an admin or a team manager.
 By default, the user list only shows active users, so make sure to deactivate the `Show Active Users Only` filter at the top of the user list to activate new users.
-However, deactivated users that registered in the last 14 days, will be shown above the user list regardlessly and can be activated quickly from there.
+However, deactivated users that registered in the last 14 days, will be shown above the user list regardless and can be activated quickly from there.
 
 When activating new users, a popup opens for
   - team assignment
@@ -68,4 +77,4 @@ Users can _change_ their password by themselves if they are logged in. Password 
 
 Logged-out users can _reset_ their password by clicking on `Forgot Password` in the navigation bar in the top-right corner of the screen. They will have to provide their registered email address and will be sent an email containing a token and instructions to reset the password.
 
-Admins can modify the email address of each user from the user administration list. Select the `Edit` icon next to a user's email address, enter the new email address and confirm the change. Remember to inform the user about the successful change of the email address, since the new email address will be used for the login credentials.
+Admins can modify the email address of each user from the user administration list. Select the `Edit` icon next to a user's email address, enter the new email address, and confirm the change. Remember to inform the user about the successful change of the email address, since the new email address will be used for the login credentials.

--- a/docs/users.md
+++ b/docs/users.md
@@ -48,24 +48,24 @@ By default, each newly uploaded dataset can only be accessed by `Admins`, `Datas
 
 | Action                                           	| Admin 	| Dataset Manager 	| Team Manager 	| Team Member 	|
 |--------------------------------------------------	|-------	|-----------------	|--------------	|-------------	|
-| Access datasets of own teams                        	| ☑   	| ☑             	| ☑          	| ☑         	|
-| Access datasets of other teams                      	| ☑   	| ☑             	| ☐           	| ☐          	|
-| Edit datasets of own teams                       	| ☑   	| ☑             	| ☑          	| ☐          	|
-| Edit datasets of other teams                     	| ☑   	| ☑             	| ☐           	| ☐          	|
-| Access all users of own teams                       	| ☑   	| ☑             	| ☑          	| ☑         	|
-| Access all users of other teams                     	| ☑   	| ☑             	| ☑          	| ☐          	|
-| Assign/remove team membership to own teams       	| ☑   	| ☐              	| ☑          	| ☐          	|
-| Make other users team manager of own teams   	| ☑   	| ☐              	| ☑          	| ☐          	|
-| Make other users team manager of other teams   	| ☑   	| ☐              	| ☐           	| ☐          	|
-| Grant *Dataset Manager* role to others        	| ☑   	| ☐              	| ☐           	| ☐          	|
-| Grant *Admin* role to others                           	| ☑   	| ☐              	| ☐           	| ☐          	|
-| Access time tracking for oneself                       	| ☑   	| ☑             	| ☑          	| ☑         	|
-| Access time tracking for users of managed teams          	| ☑   	| ☐              	| ☑          	| ☐          	|
-| Create scripts (visible to everyone)            	| ☑   	| ☐              	| ☑          	| ☐          	|
-| Upload Datasets via UI                           	| ☑   	| ☑             	| ☑          	| ☐          	|
-| Set *Allowed Teams* upon dataset upload    	| ☑   	| ☐              	| ☑          	| ☐          	|
-| Get tasks again after cancelling an instance     	| ☑   	| ☐              	| ☑          	| ☐          	|
-| Access to wK Statistics Menu  	| ☑   	| ☐              	| ☑          	| ☐          	|
+| Access datasets of own teams                        	| Yes   	| Yes             	| Yes          	| Yes         	|
+| Access datasets of other teams                      	| Yes   	| Yes             	| No           	| No          	|
+| Edit datasets of own teams                       	| Yes   	| Yes             	| Yes          	| No          	|
+| Edit datasets of other teams                     	| Yes   	| Yes             	| No           	| No          	|
+| Access all users of own teams                       	| Yes   	| Yes             	| Yes          	| Yes         	|
+| Access all users of other teams                     	| Yes   	| Yes             	| Yes          	| No          	|
+| Assign/remove team membership to own teams       	| Yes   	| No              	| Yes          	| No          	|
+| Make other users team manager of own teams   	| Yes   	| No              	| Yes          	| No          	|
+| Make other users team manager of other teams   	| Yes   	| No              	| No           	| No          	|
+| Grant *Dataset Manager* role to others        	| Yes   	| No              	| No           	| No          	|
+| Grant *Admin* role to others                           	| Yes   	| No              	| No           	| No          	|
+| Access time tracking for oneself                       	| Yes   	| Yes             	| Yes          	| Yes         	|
+| Access time tracking for users of managed teams          	| Yes   	| No              	| Yes          	| No          	|
+| Create scripts (visible to everyone)            	| Yes   	| No              	| Yes          	| No          	|
+| Upload Datasets via UI                           	| Yes   	| Yes             	| Yes          	| No          	|
+| Set *Allowed Teams* upon dataset upload    	| Yes   	| No              	| Yes          	| No          	|
+| Get tasks again after cancelling an instance     	| Yes   	| No              	| Yes          	| No          	|
+| Access to wK Statistics Menu  	| Yes   	| No              	| Yes          	| No          	|
 
 
 ## Registering New Users

--- a/docs/users.md
+++ b/docs/users.md
@@ -35,7 +35,7 @@ There are four different roles for webKnossos users divided into global, organiz
 
 **On an organizational level:** 
 
-  - __Admin:__ Manage a whole organization including full access to all datasets, teams, and projects. Admins can access all administrative settings - similiar to `Team Managers` but for all teams - and have full control over all dataset - similar to `Dataset Managers`. They can award admin permissions to other users by using the `Grant Admin Rights` button at the top of the user list. Admins can access all annotations, datasets, projects, tasks, etc belonging to their respective organization.
+  - __Admin:__ Manage a whole organization including full access to all datasets, teams, and projects. Admins can access all administrative settings - similiar to `Team Managers` but for all teams - and have full control over all dataset - similar to `Dataset Managers`. They can promote other users to admin or to `Dataset Manager` by using the `Edit Teams and Permissions` modal at the top of the user list. Admins can access all annotations, datasets, projects, tasks, etc belonging to their respective organization.
 
   - __Dataset Manager:__ Manage all datasets of an organization. Dataset Managers have full read/wrote access to all datasets within their respective organizations regardless of if a dataset is only been made available to a certain team. Use this role for power users who regularly upload datasets or who need access to all datasets regardless of who created them.
   Unlike `Admins`, Dataset Managers do NOT have access to any of the administration interfaces for users, tasks, and projects.

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,4 +1,4 @@
-# Managing Users & Permissions
+# Managing Users & Access Permissions
 
 webKnossos offers a built-in user management system to administer different user roles and permissions.
 
@@ -29,9 +29,9 @@ There are four different roles for webKnossos users divided into global, organiz
 
 **On a per team basis:**
 
-  - __User:__ A regular wK user account. Users are only able to access datasets of their respective teams and can create annotations for those. Further, the can work on tasks created by their `Team Manager` or an `Admin`. They are only able to access their annotations.
+  - __Member:__ A regular wK user account. Members are only able to access datasets of their respective teams and can create annotations for those. Further, the can work on tasks created by their `Team Manager` or an `Admin`. They are only able to access their annotations.
 
-  - __Team Manager:__ Manage a specific team. Team Managers can administrate and create [Tasks, Task Types, and Projects](./tasks.md) belonging to their respective teams. They also can activate newly registered users. Team managers can access all annotations belonging to users of their respective teams. Similarly to regular `Users`, they are only able to access datasets of their respective teams and can create annotations for those. 
+  - __Team Manager:__ Manage a specific team. Team Managers can administrate and create [Tasks, Task Types, and Projects](./tasks.md) belonging to their respective teams. They also can activate newly registered users and assign/remove new users to theirs teams. Team managers can access all annotations belonging to users of their respective teams. Similarly to regular `Members`, they are only able to access datasets of their respective teams and can create annotations for those. 
 
 **On an organizational level:** 
 
@@ -44,6 +44,28 @@ There are four different roles for webKnossos users divided into global, organiz
 Only *Admins* and *Team Managers* can see/access the `Admin` menu options in the navigation bar.
 
 By default, each newly uploaded dataset can only be accessed by `Admins`, `Dataset Managers`, and members of the organization team. Add or remove more teams to a dataset for fine-grained access controls. For more information dataset and access rights, [see the dataset guide](./sharing.md#general)
+
+| Action                                           	| Admin 	| Dataset Manager 	| Team Manager 	| Team Member 	|
+|--------------------------------------------------	|-------	|-----------------	|--------------	|-------------	|
+| Access datasets of own teams                        	| Yes   	| Yes             	| Yes          	| Yes         	|
+| Access datasets of other teams                      	| Yes   	| Yes             	| No           	| No          	|
+| Edit datasets of own teams                       	| Yes   	| Yes             	| Yes          	| No          	|
+| Edit datasets of other teams                     	| Yes   	| Yes             	| No           	| No          	|
+| Access all users of own teams                       	| Yes   	| Yes             	| Yes          	| Yes         	|
+| Access all users of other teams                     	| Yes   	| Yes             	| Yes          	| No          	|
+| Assign/remove team membership to own teams       	| Yes   	| No              	| Yes          	| No          	|
+| Make other users team manager of own teams   	| Yes   	| No              	| Yes          	| No          	|
+| Make other users team manager of other teams   	| Yes   	| No              	| No           	| No          	|
+| Grant *Dataset Manager* role to others        	| Yes   	| No              	| No           	| No          	|
+| Grant *Admin* role to others                           	| Yes   	| No              	| No           	| No          	|
+| Access time tracking for oneself                       	| Yes   	| Yes             	| Yes          	| Yes         	|
+| Access time tracking for users of managed teams          	| Yes   	| No              	| Yes          	| No          	|
+| Create scripts (visible to everyone)            	| Yes   	| No              	| Yes          	| No          	|
+| Upload Datasets via UI                           	| Yes   	| Yes             	| Yes          	| No          	|
+| Set *Allowed Teams* upon dataset upload    	| Yes   	| No              	| Yes          	| No          	|
+| Get tasks again after cancelling an instance     	| Yes   	| No              	| Yes          	| No          	|
+| Access to wK Statistics Menu  	| Yes   	| No              	| Yes          	| No          	|
+
 
 ## Registering New Users
 

--- a/docs/volume_annotation.md
+++ b/docs/volume_annotation.md
@@ -27,7 +27,7 @@ In the `Segmentation` tab on the right-hand side, you can see the cell IDs which
 
 webKnossos support proof-reading of segments from automatic segmentations. With "Merger Mode" individual segments (e.g. from over-segmentation) can be combined to refine the segmentation. 
 
-The "merger mode" is available in skeleton and hybrid tracing mode. Mark connected segments by right clicking and placing nodes in the corresponding segments to merge them together. Several segments can be combined by making sure that all "correcting nodes" are part of the same tree.
+The "merger mode" is available in skeleton and hybrid annotation mode. Mark connected segments by right clicking and placing nodes in the corresponding segments to merge them together. Several segments can be combined by making sure that all "correcting nodes" are part of the same tree.
 
 "Merger mode" can be enabled in the settings under "Nodes & Trees" with the option "Enable Merger Mode". As soon as you enable it, all already existing trees will be used to form merged segments.
 
@@ -82,9 +82,9 @@ Mapping files are in JSON and need to follow this schema. All segment IDs belong
 <!-- ![An example of applying a mapping file to agglomerate individal segments from an automated over-segmentation. webKnossos applies the agglomeration on-demand and allows for quick reviews of different agglomeration strategies.](videos/11_mapping.mp4) -->
 
 ### Download File Format
-Volume tracings can be downloaded and imported using ZIP files that contain [WKW](./data_formats.md#wkw-datasets) datasets.
+Volume annotations can be downloaded and imported using ZIP files that contain [WKW](./data_formats.md#wkw-datasets) datasets.
 The ZIP archive contains one NML file that holds meta information including the dataset name and the user's position.
-Additionally, there is another embedded ZIP file that contains the volume tracings in WKW file format.
+Additionally, there is another embedded ZIP file that contains the volume annotations in WKW file format.
 
 {% hint style='info' %}
 In contrast to on-disk WKW datasets, the WKW files in downloaded volume annotations only contain a single 32^3 bucket in each file.
@@ -101,7 +101,7 @@ volumetracing.zip # A ZIP file containing the volume annotation
 │   │ └─ y5445/...
 │   ├─ z49/...
 │   └─ header.wkw # Information about the WKW files
-└─ volumetracing.nml # Tracing metadata NML file
+└─ volumetracing.nml # Annotation metadata NML file
 ```
 
 After unzipping the archives, the WKW files can be read or modified with the WKW libraries that are available for [Python, MATLAB and other languages](https://github.com/scalableminds/webknossos-wrap/). 


### PR DESCRIPTION
I updated the docs for new changes with regards to the permission systems. 

* Updated `Managing Users and Access Permissions` page
* spell-checked `Managing Users and Access Permissions` with grammarly
* replaced all mentions of the word `tracing` with `annotation`

### URL of deployed dev instance (used for testing):
- https://docs.webknossos.org/v/docs_permissions/guides/users

### Steps to test:
- RTFM

### Issues:
- part of #4652

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
