### PR TITLE
remove onboarding route from demo

### DIFF
--- a/frontend/javascripts/dashboard/dashboard_view.js
+++ b/frontend/javascripts/dashboard/dashboard_view.js
@@ -103,7 +103,7 @@ class DashboardView extends PureComponent<PropsWithRouter, State> {
     const { isAdminView } = this.props;
 
     return {
-      publications: features().isDemoInstance,
+      publications: !isAdminView && features().isDemoInstance,
       datasets: !isAdminView,
       tasks: true,
       explorativeAnnotations: true,
@@ -126,10 +126,10 @@ class DashboardView extends PureComponent<PropsWithRouter, State> {
             <DatasetView user={user} />
           </TabPane>
         ) : null,
-        <TabPane tab="My Tasks" key="tasks">
+        <TabPane tab={isAdminView ? "Tasks" : "My Tasks"} key="tasks">
           <DashboardTaskListView isAdminView={this.props.isAdminView} userId={this.props.userId} />
         </TabPane>,
-        <TabPane tab="My Annotations" key="explorativeAnnotations">
+        <TabPane tab={isAdminView ? "Annotations" : "My Annotations"} key="explorativeAnnotations">
           <ExplorativeAnnotationsView
             isAdminView={this.props.isAdminView}
             userId={this.props.userId}

--- a/frontend/javascripts/dashboard/dashboard_view.js
+++ b/frontend/javascripts/dashboard/dashboard_view.js
@@ -103,7 +103,7 @@ class DashboardView extends PureComponent<PropsWithRouter, State> {
     const { isAdminView } = this.props;
 
     return {
-      publications: !isAdminView && features().isDemoInstance,
+      publications: features().isDemoInstance,
       datasets: !isAdminView,
       tasks: true,
       explorativeAnnotations: true,
@@ -126,10 +126,10 @@ class DashboardView extends PureComponent<PropsWithRouter, State> {
             <DatasetView user={user} />
           </TabPane>
         ) : null,
-        <TabPane tab={isAdminView ? "Tasks" : "My Tasks"} key="tasks">
+        <TabPane tab="My Tasks" key="tasks">
           <DashboardTaskListView isAdminView={this.props.isAdminView} userId={this.props.userId} />
         </TabPane>,
-        <TabPane tab={isAdminView ? "Annotations" : "My Annotations"} key="explorativeAnnotations">
+        <TabPane tab="My Annotations" key="explorativeAnnotations">
           <ExplorativeAnnotationsView
             isAdminView={this.props.isAdminView}
             userId={this.props.userId}

--- a/frontend/javascripts/dashboard/spotlight_view.js
+++ b/frontend/javascripts/dashboard/spotlight_view.js
@@ -258,7 +258,7 @@ class SpotlightView extends React.PureComponent<PropsWithRouter, State> {
                 <React.Fragment>
                   <p style={{ textAlign: "center" }}>There are no publications yet.</p>
                   <p style={{ textAlign: "center" }}>
-                    <Link to={useOnboardingFlow ? "/onboarding" : "/dashboard"}>
+                    <Link to={useOnboardingFlow ? "/" : "/dashboard"}>
                       Start importing your data
                     </Link>{" "}
                     or check out <a href="https://webknossos.org/">webknossos.org</a> for some

--- a/frontend/javascripts/pages/frontpage/features_view.js
+++ b/frontend/javascripts/pages/frontpage/features_view.js
@@ -172,7 +172,7 @@ const FeaturesView = ({ history }: { history: RouterHistory }) => (
             type="primary"
             size="large"
             style={{ marginTop: 40, marginRight: 50, marginBottom: 20 }}
-            onClick={() => history.push("/onboarding")}
+            onClick={() => history.push("/")}
           >
             Create a Free Account
           </Button>

--- a/frontend/javascripts/pages/frontpage/pricing_view.js
+++ b/frontend/javascripts/pages/frontpage/pricing_view.js
@@ -151,7 +151,7 @@ const PricingView = () => (
             "Suggest new datasets for publication",
             "Community Support",
             "All webKnossos features",
-            <Link to="/onboarding" key="link-to-onboarding">
+            <Link to="/" key="link-to-onboarding">
               <Button
                 size="large"
                 style={{ marginTop: 20 }}
@@ -280,7 +280,7 @@ const PricingView = () => (
         <FAQItem title="How do I get started?">
           <p>
             You can try webKnossos for free with any of public dataset here on webknossos.org.{" "}
-            <Link to="/onboarding" onClick={() => trackAction("[Pricing] CreateFreeAccount")}>
+            <Link to="/" onClick={() => trackAction("[Pricing] CreateFreeAccount")}>
               Create a free account today.
             </Link>
           </p>

--- a/frontend/javascripts/router.js
+++ b/frontend/javascripts/router.js
@@ -483,7 +483,7 @@ class ReactRouter extends React.Component<Props> {
               />
               <Route path="/imprint" component={Imprint} />
               <Route path="/privacy" component={Privacy} />
-              <Route path="/onboarding" component={Onboarding} />
+              {!features().isDemoInstance && <Route path="/onboarding" component={Onboarding} />}
               <Route path="/features" component={FeaturesView} />
               <Route path="/pricing" component={PricingView} />
               <Route component={PageNotFoundView} />


### PR DESCRIPTION
Removes `/onboarding` from the demo instance. Currently, it is still possible to create organizations and user accounts through that route. However, we want all registrations to go through the frontpage or organization invites.

------
- [x] Ready for review
