### PR TITLE
Ensure that the interpretation of bounding boxes is always half-open

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed the message formatting for standalone datastores and tracingstores. [#4656](https://github.com/scalableminds/webknossos/pull/4656)
 - Fixed that merger mode didn't work with undo and redo. Also fixed that the mapping was not disabled when disabling merger mode. [#4669](https://github.com/scalableminds/webknossos/pull/4669)
 - Fixed a bug where webKnossos relied upon but did not enforce organization names to be unique. [#4685](https://github.com/scalableminds/webknossos/pull/4685)
+- Fixed that being outside of a bounding box could be rendered as if one was inside the bounding box in some cases. [#4690](https://github.com/scalableminds/webknossos/pull/4690)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/api/api_v2.js
+++ b/frontend/javascripts/oxalis/api/api_v2.js
@@ -563,7 +563,9 @@ class DataApi {
   }
 
   /**
-   * Returns the bounding box for a given layer name.
+   * Returns the bounding box for a given layer name. Note that the described interval
+     is half-open, meaning that the lowerBoundary is included and the upperBoundary is not
+     included in the bounding box.
    */
   getBoundingBox(layerName: string): [Vector3, Vector3] {
     const { lowerBoundary, upperBoundary } = getLayerBoundaries(

--- a/frontend/javascripts/oxalis/geometries/cube.js
+++ b/frontend/javascripts/oxalis/geometries/cube.js
@@ -40,6 +40,7 @@ class Cube {
   listenTo: Function;
 
   constructor(properties: Properties) {
+    // min/max should denote a half-open interval.
     this.min = properties.min || [0, 0, 0];
     this.max = properties.max;
     const lineWidth = properties.lineWidth != null ? properties.lineWidth : 1;
@@ -72,10 +73,13 @@ class Cube {
     });
   }
 
-  setCorners(min1: Vector3, max1: Vector3) {
-    this.min = min1;
-    this.max = max1;
-    const { min, max } = this;
+  setCorners(min: Vector3, max: Vector3) {
+    this.min = min;
+    this.max = max;
+
+    // Since `max` itself should not be included in the rendered
+    // box, we subtract Number.EPSILON.
+    max = [max[0] - Number.EPSILON, max[1] - Number.EPSILON, max[2] - Number.EPSILON];
 
     const vec = (x, y, z) => new THREE.Vector3(x, y, z);
 
@@ -163,7 +167,7 @@ class Cube {
     for (const planeId of OrthoViewValuesWithoutTDView) {
       const thirdDim = dimensions.thirdDimensionForPlane(planeId);
       const position = getPosition(Store.getState().flycam);
-      if (position[thirdDim] >= this.min[thirdDim] && position[thirdDim] <= this.max[thirdDim]) {
+      if (position[thirdDim] >= this.min[thirdDim] && position[thirdDim] < this.max[thirdDim]) {
         this.crossSections[planeId].visible =
           this.visible && planeId === id && this.showCrossSections;
       } else {

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
@@ -134,6 +134,10 @@ export function getDefaultIntensityRangeOfLayer(
 
 export type Boundary = { lowerBoundary: Vector3, upperBoundary: Vector3 };
 
+/*
+   The returned Boundary denotes a half-open interval. This means that the lowerBoundary
+   is included in the bounding box and the upper boundary is *not* included.
+*/
 export function getLayerBoundaries(dataset: APIDataset, layerName: string): Boundary {
   const { topLeft, width, height, depth } = getLayerByName(dataset, layerName).boundingBox;
   const lowerBoundary = topLeft;

--- a/frontend/javascripts/oxalis/shaders/coords.glsl.js
+++ b/frontend/javascripts/oxalis/shaders/coords.glsl.js
@@ -94,7 +94,7 @@ export const isOutsideOfBoundingBox: ShaderModule = {
       vec3 worldCoord = transDim(worldCoordUVW);
       return (
         worldCoord.x < bboxMin.x || worldCoord.y < bboxMin.y || worldCoord.z < bboxMin.z ||
-        worldCoord.x > bboxMax.x || worldCoord.y > bboxMax.y || worldCoord.z > bboxMax.z
+        worldCoord.x >= bboxMax.x || worldCoord.y >= bboxMax.y || worldCoord.z >= bboxMax.z
       );
     }
   `,

--- a/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
@@ -52,9 +52,9 @@ class DatasetPositionView extends PureComponent<Props> {
       position[0] < min[0] ||
       position[1] < min[1] ||
       position[2] < min[2] ||
-      position[0] > max[0] ||
-      position[1] > max[1] ||
-      position[2] > max[2];
+      position[0] >= max[0] ||
+      position[1] >= max[1] ||
+      position[2] >= max[2];
     const isOutOfDatasetBounds = isPositionOutOfBounds(datasetMin, datasetMax);
     let isOutOfTaskBounds = false;
     if (task && task.boundingBox) {


### PR DESCRIPTION
When a bounding box is defined with [0, 0, 0, 10, 10, 10], the position [10, 10, 10] should be outside of the bounding box. This interpretation was not consistent within the code base which I cleaned up with this PR. I tried to go through all the relevant code and double-check / fix it where necessary. Predominantly, the following two cases needed fixing:

- the dataset position view 
- the rendered cube mesh (since threeJS renders the mesh always inclusively, I subtracted an epsilon there)

### URL of deployed dev instance (used for testing):
- https://makebboxconsistent.webknossos.xyz

### Steps to test:
- I did the following:
  - open a task with a bounding box (e.g., 0, 0, 0, 10, 10, 10)
  - initialize the api with `window.webknossos.apiReady(3).then(api => window.api = api)`
  - test the rendering with `api.tracing.centerPositionAnimated([8, 5, z])` where z can be something like 9, 9.9, 10, 10.01 etc.
  - before this PR, being at z=10 and z=10.1 behaved differently (one showed the box, the other did not). with this pr, both positions act correctly (i.e., behave like one is outside of the bounding box)

### Issues:
- fixes #4684 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
