### PR TITLE
When exploring dataset layer, use previous category if available

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that merger mode didn't work with undo and redo. Also fixed that the mapping was not disabled when disabling merger mode. [#4669](https://github.com/scalableminds/webknossos/pull/4669)
 - Fixed a bug where webKnossos relied upon but did not enforce organization names to be unique. [#4685](https://github.com/scalableminds/webknossos/pull/4685)
 - Fixed that being outside of a bounding box could be rendered as if one was inside the bounding box in some cases. [#4690](https://github.com/scalableminds/webknossos/pull/4690)
+- Fixed a bug where webKnossos ignored existing layer category information from datasource-properties.json when exploring layers on disk. [#4694](https://github.com/scalableminds/webknossos/pull/4694)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataFormat.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataFormat.scala
@@ -25,7 +25,7 @@ object WKWDataFormat extends DataSourceImporter with WKWDataFormatHelper {
       ((voxelType, voxelSize), wkwResolutions) <- extractHeaderParameters(resolutions)
       elementClass <- voxelTypeToElementClass(voxelType, voxelSize)
     } yield {
-      val category = guessLayerCategory(name, elementClass)
+      val category = previous.map(_.category).getOrElse(guessLayerCategory(name, elementClass))
       val boundingBox = previous
         .map(_.boundingBox)
         .orElse(guessBoundingBox(baseDir, wkwResolutions.headOption))


### PR DESCRIPTION
If an existing datasource-properties.json contains information about layer category, use it.
This occurred because there are now users with 16-bit color layers (not named “color”). There the guessed category was wrong, mixing up the datasource properties, even though correct information had been supplied on disk.

### Steps to test:
- Have a dataset with a 16-bit color layer not named color, write correct datasource-properties.json to disk
- in the (advanced) “edit” view in wk for this dataset there should not be the wrongly inferred category “segmentation” but it should keep “color”.

### Issues:
- fixes #4673

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
