### PR TITLE
Show Warning When Creating Inaccessible Tasks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added a warning to the segmentation tab when viewing `uint64` bit segmentation data. [#4598](https://github.com/scalableminds/webknossos/pull/4598)
 - Added the possibility to have multiple user-defined bounding boxes in an annotation. Task bounding boxes are automatically converted to such user bounding boxes upon “copy to my account” / reupload as explorational annotation. [#4536](https://github.com/scalableminds/webknossos/pull/4536)
 - Added additional information to each task in CSV download. [#4647](https://github.com/scalableminds/webknossos/pull/4647)
+- Added a warning during task creation if task dataset cannot be accessed by project team members. [#4695](https://github.com/scalableminds/webknossos/pull/4695)
 
 ### Changed
 - Separated the permissions of Team Managers (now actually team-scoped) and Dataset Managers (who can see all datasets). The database evolution makes all Team Managers also Dataset Managers, so no workflows should be interrupted. New users may have to be made Dataset Managers, though. For more information, refer to the updated documentation. [#4663](https://github.com/scalableminds/webknossos/pull/4663)
@@ -27,4 +28,4 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Removed
 
--
+- Removed the “are you sure” warning when editing datasets with no allowed teams. Instead, a warning during task creation is shown in this case. [#4695](https://github.com/scalableminds/webknossos/pull/4695)

--- a/app/controllers/Controller.scala
+++ b/app/controllers/Controller.scala
@@ -31,7 +31,7 @@ trait Controller
       })
     )
 
-  def bulk2StatusJson(results: List[Box[JsObject]]) =
+  def bulk2StatusJson(results: List[Box[JsObject]]): Seq[JsObject] =
     results.map {
       case Full(s) =>
         Json.obj("status" -> OK, jsonSuccess -> s)

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -438,7 +438,7 @@ class TaskController @Inject()(annotationDAO: AnnotationDAO,
     for {
       projects: List[Project] <- Fox.serialCombined(projectNames)(projectDAO.findOneByName(_))
       dataSetTeams <- teamDAO.findAllForDataSet(dataSet._id)
-      noAccessTeamIds = projects.map(_._team).filter(projectTeam => !dataSetTeams.map(_._id).contains(projectTeam))
+      noAccessTeamIds = projects.map(_._team).diff(dataSetTeams.map(_._id))
       noAccessTeams: List[Team] <- Fox.serialCombined(noAccessTeamIds)(id => teamDAO.findOne(id))
       warnings = noAccessTeams.map(team =>
         s"Project team “${team.name}” has no read permission to dataset “${dataSet.name}”.")

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -50,7 +50,7 @@ import {
   type WkConnectDatasetConfig,
 } from "admin/api_flow_types";
 import type { DatasetConfiguration } from "oxalis/store";
-import type { NewTask, TaskCreationResponse } from "admin/task/task_create_bulk_view";
+import type { NewTask, TaskCreationResponseContainer } from "admin/task/task_create_bulk_view";
 import type { QueryObject } from "admin/task/task_search_form";
 import { V3 } from "libs/mjs";
 import type { Vector3 } from "oxalis/constants";
@@ -408,14 +408,14 @@ export async function getTasks(queryObject: QueryObject): Promise<Array<APITask>
 }
 
 // TODO fix return types
-export function createTasks(tasks: Array<NewTask>): Promise<Array<TaskCreationResponse>> {
+export function createTasks(tasks: Array<NewTask>): Promise<TaskCreationResponseContainer> {
   return Request.sendJSONReceiveJSON("/api/tasks", {
     data: tasks,
   });
 }
 
 // TODO fix return types
-export function createTaskFromNML(task: NewTask): Promise<Array<TaskCreationResponse>> {
+export function createTaskFromNML(task: NewTask): Promise<TaskCreationResponseContainer> {
   return Request.sendMultipartFormReceiveJSON("/api/tasks/createFromFiles", {
     data: {
       nmlFiles: task.nmlFiles,

--- a/frontend/javascripts/admin/task/task_create_bulk_view.js
+++ b/frontend/javascripts/admin/task/task_create_bulk_view.js
@@ -52,6 +52,11 @@ export type TaskCreationResponse = {
   error?: string,
 };
 
+export type TaskCreationResponseContainer = {
+  tasks: Array<TaskCreationResponse>,
+  warnings: Array<string>,
+};
+
 class TaskCreateBulkView extends React.PureComponent<Props, State> {
   state = {
     isUploading: false,
@@ -226,19 +231,21 @@ class TaskCreateBulkView extends React.PureComponent<Props, State> {
     });
 
     try {
-      let responses = [];
+      let taskResponses = [];
+      let warnings = [];
 
       for (let i = 0; i < tasks.length; i += NUM_TASKS_PER_BATCH) {
         const subArray = tasks.slice(i, i + NUM_TASKS_PER_BATCH);
         // eslint-disable-next-line no-await-in-loop
         const response = await createTasks(subArray);
-        responses = responses.concat(response);
+        taskResponses = taskResponses.concat(response.tasks);
+        warnings = warnings.concat(response.warnings);
         this.setState({
           tasksProcessed: i + NUM_TASKS_PER_BATCH,
         });
       }
 
-      handleTaskCreationResponse(responses);
+      handleTaskCreationResponse({ tasks: taskResponses, warnings: _.uniq(warnings) });
     } finally {
       this.setState({
         isUploading: false,

--- a/frontend/javascripts/dashboard/dataset/dataset_import_view.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_import_view.js
@@ -25,7 +25,7 @@ import Toast from "libs/toast";
 import messages from "messages";
 import { getDefaultIntensityRangeOfLayer } from "oxalis/model/accessors/dataset_accessor";
 
-import { Hideable, confirmAsync, hasFormError, jsonEditStyle } from "./helper_components";
+import { Hideable, hasFormError, jsonEditStyle } from "./helper_components";
 import DefaultConfigComponent from "./default_config_component";
 import ImportGeneralComponent from "./import_general_component";
 import ImportSharingComponent from "./import_sharing_component";
@@ -285,23 +285,6 @@ class DatasetImportView extends React.PureComponent<Props, State> {
     }
   }
 
-  async doesUserWantToChangeAllowedTeams(teamIds: Array<string>): Promise<boolean> {
-    if (teamIds.length > 0) {
-      return false;
-    }
-    return !(await confirmAsync({
-      title: "Are you sure?",
-      content: (
-        <p>
-          You did not specify any teams, for which this dataset should be visible. This means that
-          only administrators and dataset managers will be able to view this dataset.
-          <br /> Please hit &ldquo;Cancel&rdquo; if you would like to review the team permissions in
-          the &ldquo;General&rdquo; tab.
-        </p>
-      ),
-    }));
-  }
-
   handleSubmit = (e: SyntheticEvent<>) => {
     e.preventDefault();
     // Ensure that all form fields are in sync
@@ -318,9 +301,6 @@ class DatasetImportView extends React.PureComponent<Props, State> {
         datasetChangeValues.sortingKey = datasetChangeValues.sortingKey.valueOf();
       }
       const teamIds = formValues.dataset.allowedTeams.map(t => t.id);
-      if (await this.doesUserWantToChangeAllowedTeams(teamIds)) {
-        return;
-      }
 
       await updateDataset(this.props.datasetId, Object.assign({}, dataset, datasetChangeValues));
 

--- a/frontend/javascripts/test/backend-snapshot-tests/tasks.e2e.js
+++ b/frontend/javascripts/test/backend-snapshot-tests/tasks.e2e.js
@@ -99,7 +99,8 @@ const newTask = {
 };
 
 test.serial("createTasks() and deleteTask()", async t => {
-  const createdTaskWrappers = await api.createTasks([newTask]);
+  const createTaskResponse = await api.createTasks([newTask]);
+  const createdTaskWrappers = createTaskResponse.tasks;
   t.is(createdTaskWrappers.length, 1);
   const createdTaskWrapper = createdTaskWrappers[0];
 
@@ -117,7 +118,8 @@ test.serial("createTasks() and deleteTask()", async t => {
 });
 
 test.serial("requestTask()", async t => {
-  const createdTaskWrappers = await api.createTasks([newTask]);
+  const createTaskResponse = await api.createTasks([newTask]);
+  const createdTaskWrappers = createTaskResponse.tasks;
   t.is(createdTaskWrappers.length, 1);
   const createdTaskWrapper = createdTaskWrappers[0];
   const newTaskAnnotation = await api.requestTask();


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create tasks for dataset with no allowed teams (bulk + individual) → warning should be shown
- create tasks for dataset with allowed team matching the project team (bulk + individual) → no warning should be shown
- edit dataset: no annoying “are you sure?” popup anymore

### Issues:
- fixes #4502 
- fixes #3597

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
