### PR TITLE
Prevent Zero Admins in Organization

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that merger mode didn't work with undo and redo. Also fixed that the mapping was not disabled when disabling merger mode. [#4669](https://github.com/scalableminds/webknossos/pull/4669)
 - Fixed a bug where webKnossos relied upon but did not enforce organization names to be unique. [#4685](https://github.com/scalableminds/webknossos/pull/4685)
 - Fixed that being outside of a bounding box could be rendered as if one was inside the bounding box in some cases. [#4690](https://github.com/scalableminds/webknossos/pull/4690)
+- Fixed a bug where admins could revoke their own admin rights even if they are the only admin in their organization, leading to an invalid state. [#4698](https://github.com/scalableminds/webknossos/pull/4698)
 
 ### Removed
 

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -146,6 +146,14 @@ class UserDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       result <- resultList.headOption
     } yield result
 
+  def countAdminsForOrganization(organizationId: ObjectId): Fox[Int] =
+    for {
+      resultList <- run(
+        sql"select count(_id) from #${existingCollectionName} where _organization = ${organizationId} and isAdmin"
+          .as[Int])
+      result <- resultList.headOption
+    } yield result
+
   def insertOne(u: User)(implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- run(

--- a/conf/messages
+++ b/conf/messages
@@ -53,6 +53,7 @@ user.noAdmin=Access denied. Only admin users can execute this operation.
 user.deactivated=Your account hasn’t been activated yet
 user.deleted={0} has been deleted
 user.bulk.empty=No user has been chosen
+user.lastAdmin=Cannot remove admin privileges from the only admin in the organization
 
 user.resetPassword.failed=Invalid old password
 user.resetPassword.success=Your password was successfully changed


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- promote & depromote second user to/from admin, should still work
- try depromote yourself if you are the only admin in organization, should result in error toast

### Issues:
- fixes #4680 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
