### PR TITLE
Extract Default Mail Sender to application.conf

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added a warning to the segmentation tab when viewing `uint64` bit segmentation data. [#4598](https://github.com/scalableminds/webknossos/pull/4598)
 - Added the possibility to have multiple user-defined bounding boxes in an annotation. Task bounding boxes are automatically converted to such user bounding boxes upon “copy to my account” / reupload as explorational annotation. [#4536](https://github.com/scalableminds/webknossos/pull/4536)
 - Added additional information to each task in CSV download. [#4647](https://github.com/scalableminds/webknossos/pull/4647)
+- Added the possibility to configure the sender address used in emails wk sends (mail.defaultSender in application.conf). [#4701](https://github.com/scalableminds/webknossos/pull/4701)
 
 ### Changed
 - Separated the permissions of Team Managers (now actually team-scoped) and Dataset Managers (who can see all datasets). The database evolution makes all Team Managers also Dataset Managers, so no workflows should be interrupted. New users may have to be made Dataset Managers, though. For more information, refer to the updated documentation. [#4663](https://github.com/scalableminds/webknossos/pull/4663)

--- a/app/controllers/Authentication.scala
+++ b/app/controllers/Authentication.scala
@@ -224,7 +224,7 @@ class Authentication @Inject()(actorSystem: ActorSystem,
                   Mailer ! Send(
                     defaultMails.newUserMail(user.name, user.email, brainDBResult, organization.enableAutoVerify))
                 }
-                Mailer ! Send(defaultMails.registerAdminNotifyerMail(user, user.email, brainDBResult, organization))
+                Mailer ! Send(defaultMails.registerAdminNotifyerMail(user, brainDBResult, organization))
                 Ok
               }
             }

--- a/app/oxalis/mail/DefaultMails.scala
+++ b/app/oxalis/mail/DefaultMails.scala
@@ -10,30 +10,26 @@ import views._
 
 class DefaultMails @Inject()(conf: WkConf) {
 
-  /**
-    * Base url used in emails
-    */
   val uri = conf.Http.uri
 
-  val defaultFrom = "no-reply@webknossos.org"
+  val defaultSender = conf.Mail.defaultSender
 
   val wkOrgSender = conf.Mail.demoSender
 
   val newOrganizationMailingList = conf.WebKnossos.newOrganizationMailingList
 
-  def registerAdminNotifyerMail(user: User, email: String, brainDBResult: Option[String], organization: Organization) =
+  def registerAdminNotifyerMail(user: User, brainDBResult: Option[String], organization: Organization) =
     Mail(
-      from = email,
-      headers = Map("Sender" -> defaultFrom),
+      from = defaultSender,
       subject =
-        s"webKnossos | A new user (${user.name}) registered on $uri for ${organization.displayName} (${organization.name})",
+        s"webKnossos | A new user (${user.name}, ${user.email}) registered on $uri for ${organization.displayName} (${organization.name})",
       bodyHtml = html.mail.notifyAdminNewUser(user, brainDBResult, uri).body,
       recipients = List(organization.newUserMailingList)
     )
 
   def overLimitMail(user: User, projectName: String, taskId: String, annotationId: String, organization: Organization) =
     Mail(
-      from = defaultFrom,
+      from = defaultSender,
       subject = s"webKnossos | Time limit reached. ${user.abreviatedName} in $projectName",
       bodyHtml = html.mail.notifyAdminTimeLimit(user.name, projectName, taskId, annotationId, uri).body,
       recipients = List(organization.overTimeMailingList)
@@ -42,7 +38,7 @@ class DefaultMails @Inject()(conf: WkConf) {
   def newUserMail(name: String, receiver: String, brainDBresult: Option[String], enableAutoVerify: Boolean)(
       implicit messages: Messages) =
     Mail(
-      from = defaultFrom,
+      from = defaultSender,
       subject = "Welcome to webKnossos",
       bodyHtml = html.mail.newUser(name, brainDBresult.map(Messages(_)), enableAutoVerify).body,
       recipients = List(receiver)
@@ -65,20 +61,20 @@ class DefaultMails @Inject()(conf: WkConf) {
     )
 
   def activatedMail(name: String, receiver: String) =
-    Mail(from = defaultFrom,
+    Mail(from = defaultSender,
          subject = "webKnossos | Account activated",
          bodyHtml = html.mail.validateUser(name, uri).body,
          recipients = List(receiver))
 
   def changePasswordMail(name: String, receiver: String) =
-    Mail(from = defaultFrom,
+    Mail(from = defaultSender,
          subject = "webKnossos | Password changed",
          bodyHtml = html.mail.passwordChanged(name, uri).body,
          recipients = List(receiver))
 
   def resetPasswordMail(name: String, receiver: String, token: String) =
     Mail(
-      from = defaultFrom,
+      from = defaultSender,
       subject = "webKnossos | Password Reset",
       bodyHtml = html.mail.resetPassword(name, uri, token).body,
       recipients = List(receiver)
@@ -86,7 +82,7 @@ class DefaultMails @Inject()(conf: WkConf) {
 
   def newOrganizationMail(organizationName: String, creatorEmail: String, domain: String) =
     Mail(
-      from = defaultFrom,
+      from = defaultSender,
       subject = s"webKnossos | New Organization created on ${domain}",
       bodyHtml = html.mail.notifyAdminNewOrganization(organizationName, creatorEmail, domain).body,
       recipients = List(newOrganizationMailingList)

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -44,6 +44,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader {
       val pass = get[String]("mail.smtp.pass")
     }
     val demoSender = get[String]("mail.demoSender")
+    val defaultSender = get[String]("mail.defaultSender")
   }
 
   object WebKnossos {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,6 +137,7 @@ mail {
     user = ""
     pass = ""
   }
+  defaultSender = "no-reply@webknossos.org"
   demoSender = ""
 }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- overwrite mail.defaultSender in application.conf
- should be used in the “from” field
- also, new-user emails (sent to admin) should not use the user email as “from” adress but contain the user email in the email body

### Issues:
- fixes #4657

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
