### PR TITLE
Avoid gt and lt signs in dummy descriptions

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -232,7 +232,7 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
     let annotationTypeLabel;
 
     const { annotationType, name } = this.props.tracing;
-    const tracingName = name || "<untitled>";
+    const tracingName = name || "[untitled]";
 
     if (this.props.task != null) {
       // In case we have a task display its id
@@ -257,7 +257,7 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
         </span>
       );
     }
-    const tracingDescription = this.props.tracing.description || "<no description>";
+    const tracingDescription = this.props.tracing.description || "[no description]";
 
     let descriptionEditField;
     if (this.props.tracing.restrictions.allowUpdate) {


### PR DESCRIPTION
If the user clicks edit on the dummy descriptions, but makes no changes, the default strings `<untitled>` and `<no description>` are used as actual values. Those values cause bug #4605 to trigger due to the < and > signs in xml attributes. A quickfix for avoiding that is to use [ and ] instead in the default values.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create annotation, default name should be displayed as [untitled], description should be [no description]

### Issues:
- workaround to dampen the impact of #4605

------
- [x] Ready for review
