### PR TITLE
Include Server Time in Error Replies

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,13 +12,14 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 
-- Added the possibility to adjust the minimum and maximum value of the histogram for a layer. This option can be opened in the top right corner of the histogram. [#4630](https://github.com/scalableminds/webknossos/pull/4630)  
+- Added the possibility to adjust the minimum and maximum value of the histogram for a layer. This option can be opened in the top right corner of the histogram. [#4630](https://github.com/scalableminds/webknossos/pull/4630)
 
 - Added a warning to the segmentation tab when viewing `uint64` bit segmentation data. [#4598](https://github.com/scalableminds/webknossos/pull/4598)
 - Added the possibility to have multiple user-defined bounding boxes in an annotation. Task bounding boxes are automatically converted to such user bounding boxes upon “copy to my account” / reupload as explorational annotation. [#4536](https://github.com/scalableminds/webknossos/pull/4536)
 - Added additional information to each task in CSV download. [#4647](https://github.com/scalableminds/webknossos/pull/4647)
 - Added the possibility to configure the sender address used in emails wk sends (mail.defaultSender in application.conf). [#4701](https://github.com/scalableminds/webknossos/pull/4701)
 - Added a warning during task creation if task dataset cannot be accessed by project team members. [#4695](https://github.com/scalableminds/webknossos/pull/4695)
+- Included the server time in error messages, making debugging misbehavior easier. [#4707](https://github.com/scalableminds/webknossos/pull/4707)
 
 ### Changed
 - Separated the permissions of Team Managers (now actually team-scoped) and Dataset Managers (who can see all datasets). The database evolution makes all Team Managers also Dataset Managers, so no workflows should be interrupted. New users may have to be made Dataset Managers, though. For more information, refer to the updated documentation. [#4663](https://github.com/scalableminds/webknossos/pull/4663)

--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -14,7 +14,7 @@ import play.twirl.api._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait ResultBox extends I18nSupport {
+trait ResultBox extends I18nSupport with Formatter {
 
   def asResult[T <: Result](b: Box[T])(implicit messages: MessagesProvider): Result = b match {
     case Full(result) =>
@@ -34,9 +34,11 @@ trait ResultBox extends I18nSupport {
     case _             => None
   }
 
-  private def formatChain(chain: Box[Failure])(implicit messages: MessagesProvider): String = chain match {
+  private def formatChain(chain: Box[Failure], includeTime: Boolean = true)(
+      implicit messages: MessagesProvider): String = chain match {
     case Full(failure) =>
-      " <~ " + Messages(failure.msg) + formatChain(failure.chain)
+      val serverTimeMsg = if (includeTime) "[Server Time " + formatDate(System.currentTimeMillis()) + "] " else ""
+      serverTimeMsg + " <~ " + Messages(failure.msg) + formatChain(failure.chain, includeTime = false)
     case _ => ""
   }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- trigger request that fails with error chain (e.g. I added `_ <- Fox.failure("nope")` to `DataSet.findOne` and then clicked create skeleton annotation on a dataset
- server time should be included in the toast (behind “show more information”)

### Issues:
- fixes #4620

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
