### PR TITLE
Dont warn if team has transitive dataset access

### DIFF
--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -72,6 +72,7 @@ class TaskController @Inject()(annotationDAO: AnnotationDAO,
                                projectDAO: ProjectDAO,
                                taskTypeDAO: TaskTypeDAO,
                                dataSetDAO: DataSetDAO,
+                               userTeamRolesDAO: UserTeamRolesDAO,
                                userService: UserService,
                                dataSetService: DataSetService,
                                tracingStoreService: TracingStoreService,
@@ -439,11 +440,18 @@ class TaskController @Inject()(annotationDAO: AnnotationDAO,
       projects: List[Project] <- Fox.serialCombined(projectNames)(projectDAO.findOneByName(_))
       dataSetTeams <- teamDAO.findAllForDataSet(dataSet._id)
       noAccessTeamIds = projects.map(_._team).diff(dataSetTeams.map(_._id))
-      noAccessTeams: List[Team] <- Fox.serialCombined(noAccessTeamIds)(id => teamDAO.findOne(id))
+      noAccessTeamIdsTransitive <- Fox.serialCombined(noAccessTeamIds)(id =>
+        filterOutTransitiveSubteam(id, dataSetTeams.map(_._id)))
+      noAccessTeams: List[Team] <- Fox.serialCombined(noAccessTeamIdsTransitive.flatten)(id => teamDAO.findOne(id))
       warnings = noAccessTeams.map(team =>
         s"Project team “${team.name}” has no read permission to dataset “${dataSet.name}”.")
     } yield warnings
   }
+
+  private def filterOutTransitiveSubteam(subteamId: ObjectId, dataSetTeams: List[ObjectId]): Fox[Option[ObjectId]] =
+    for {
+      memberDifference <- userTeamRolesDAO.findMemberDifference(subteamId, dataSetTeams)
+    } yield if (memberDifference.isEmpty) None else Some(subteamId)
 
   private def validateScript(scriptIdOpt: Option[String])(implicit request: SecuredRequest[WkEnv, _]): Fox[Unit] =
     scriptIdOpt match {

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -266,7 +266,7 @@ class UserTeamRolesDAO @Inject()(userDAO: UserDAO, sqlClient: SQLClient)(implici
 
   def findMemberDifference(potentialSubteam: ObjectId, superteams: List[ObjectId]): Fox[List[User]] =
     for {
-      r <- run(sql"""select #${userDAO.columnsWithPrefix("u.")} from webknossos.users_
+      r <- run(sql"""select #${userDAO.columnsWithPrefix("u.")} from webknossos.users_ u
                      join webknossos.user_team_roles tr on u._id = tr._user
                      where not u.isAdmin
                      and not u.isDeactivated

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -269,8 +269,8 @@ class UserTeamRolesDAO @Inject()(userDAO: UserDAO, sqlClient: SQLClient)(implici
       r <- run(sql"""select #${userDAO.columnsWithPrefix("u.")} from webknossos.users_
                      join webknossos.user_team_roles tr on u._id = tr._user
                      where not u.isAdmin
-                     and tr._team = $potentialSubteam)
-                     and _id not in
+                     and tr._team = $potentialSubteam
+                     and u._id not in
                      (select _user from webknossos.user_team_roles
                      where _team in #${writeStructTupleWithQuotes(superteams.map(_.id))})
                      """.as[UsersRow])

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -267,9 +267,9 @@ class UserTeamRolesDAO @Inject()(userDAO: UserDAO, sqlClient: SQLClient)(implici
   def findMemberDifference(potentialSubteam: ObjectId, superteams: List[ObjectId]): Fox[List[User]] =
     for {
       r <- run(sql"""select #${userDAO.columnsWithPrefix("u.")} from webknossos.users_
-                     where not u.isAdmin
                      join webknossos.user_team_roles tr on u._id = tr._user
-                     where tr._team = $potentialSubteam)
+                     where not u.isAdmin
+                     and tr._team = $potentialSubteam)
                      and _id not in
                      (select _user from webknossos.user_team_roles
                      where _team in #${writeStructTupleWithQuotes(superteams.map(_.id))})

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -269,6 +269,7 @@ class UserTeamRolesDAO @Inject()(userDAO: UserDAO, sqlClient: SQLClient)(implici
       r <- run(sql"""select #${userDAO.columnsWithPrefix("u.")} from webknossos.users_
                      join webknossos.user_team_roles tr on u._id = tr._user
                      where not u.isAdmin
+                     and not u.isDeactivated
                      and tr._team = $potentialSubteam
                      and u._id not in
                      (select _user from webknossos.user_team_roles


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create two users + teams so that
- team A is a subteam of organization team (meaning all its members are also members of the orga team)
- team B is not a subteam of organization team (meaning there is a user in team B but not in the orga team)
- give only the orga team access to a dataset
- create task for team A → access warning should not be shown
- create tsk for team B → access warning should be shown

### Issues:
- fixes #4710

------
- [x] Ready for review
