### PR TITLE
Fix error in statistics page and more

### DIFF
--- a/frontend/javascripts/admin/statistic/statistic_view.js
+++ b/frontend/javascripts/admin/statistic/statistic_view.js
@@ -31,7 +31,7 @@ type State = {
 };
 
 type GoogleCharts = {
-  chart: { getSelection: Function }, // https://developers.google.com/chart/interactive/docs/drawing_charts#chartwrapper
+  chartWrapper: { getChart: () => { getSelection: Function } }, // https://developers.google.com/chart/interactive/docs/drawing_charts#chartwrapper
 };
 
 class StatisticView extends React.PureComponent<{}, State> {
@@ -88,8 +88,9 @@ class StatisticView extends React.PureComponent<{}, State> {
     });
   }
 
-  selectDataPoint = (chart: GoogleCharts) => {
-    const indicies = chart.chart.getSelection()[0];
+  selectDataPoint = ({ chartWrapper }: GoogleCharts) => {
+    const chart = chartWrapper.getChart();
+    const indicies = chart.getSelection().selection[0];
     const startDate = this.state.achievements.tracingTimes[indicies.row].start;
     this.setState(
       {

--- a/frontend/javascripts/oxalis/model/accessors/view_mode_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/view_mode_accessor.js
@@ -56,6 +56,9 @@ export function getViewportExtents(state: OxalisState): OrthoViewExtents {
 
 export function getInputCatcherAspectRatio(state: OxalisState, viewport: Viewport): number {
   const { width, height } = getInputCatcherRect(state, viewport);
+  if (width === 0 || height === 0) {
+    return 1;
+  }
   return width / height;
 }
 

--- a/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
@@ -125,11 +125,7 @@ class DatasetPositionView extends PureComponent<Props> {
         ) : null}
       </div>
     );
-    return maybeErrorMessage ? (
-      <Tooltip title={maybeErrorMessage}>{positionView}</Tooltip>
-    ) : (
-      positionView
-    );
+    return <Tooltip title={maybeErrorMessage || null}>{positionView}</Tooltip>;
   }
 }
 


### PR DESCRIPTION
This PR fixes multiple bugs.
 - No longer losing focus of position input when leaving the dataset bounds
 - No error when clicking on a point of the line chart in the statistics overview
 - Resolved weird 3d viewport bug

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the statistics overview and click on one point on the line chart. Nothing should break and the details in the list below should update.
- Open a tracing and edit the position view freely. When leaving the dataset's bounding box or reentering it, the focus on the position input should not be lost.
- Open the tracing Move the 3d viewport behind another viewport, so it is not visible anymore. Then reload the tracing and open select the 3d viewport so that it is visible. The three lines of the other viewports should be visible and not everything should be white.

### Issues:
- fixes #4691
- fixes #4638
- fixes #4547

------
- ~~[ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~~ -> I think this is unnecessary
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
