### PR TITLE
Disable brush autofill when erasing

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Changed
-- 
+- Disabled the autofill feature of the brush when using this tool to erase data. [#4729](https://github.com/scalableminds/webknossos/pull/4729)
 
 ### Fixed
 - 

--- a/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -85,6 +85,9 @@ export function* editVolumeLayerAsync(): Generator<any, any, any> {
     const contourTracingMode = yield* select(
       state => enforceVolumeTracing(state.tracing).contourTracingMode,
     );
+    const isDrawing =
+      contourTracingMode === ContourModeEnum.DRAW_OVERWRITE ||
+      contourTracingMode === ContourModeEnum.DRAW;
 
     // Volume tracing for higher zoomsteps is currently not allowed
     if (yield* select(state => isVolumeTracingDisallowed(state))) {
@@ -118,7 +121,10 @@ export function* editVolumeLayerAsync(): Generator<any, any, any> {
         // if the current viewport does not match the initial viewport -> dont draw
         continue;
       }
-      if (activeTool === VolumeToolEnum.TRACE || activeTool === VolumeToolEnum.BRUSH) {
+      if (
+        activeTool === VolumeToolEnum.TRACE ||
+        (activeTool === VolumeToolEnum.BRUSH && isDrawing)
+      ) {
         currentLayer.addContour(addToLayerAction.position);
       }
       if (activeTool === VolumeToolEnum.BRUSH) {


### PR DESCRIPTION
This PR disables the autofill feature of the brush when using it to erase annotated data.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a volume tracing
- Draw a big circle or so with the brush. The area within the brush should be automatically filled.
- Use the brush to erase a bit of the outer border. Only the outer border should be erased and not the whole circle. 

### Issues:
- fixes #4624

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
