### PR TITLE
Speed up nml import for nmls with many trees

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Disabled the autofill feature of the brush when using this tool to erase data. [#4729](https://github.com/scalableminds/webknossos/pull/4729)
 
 ### Fixed
-- 
+- Speed up NML import in existing tracings for NMLs with many trees (20,000+). [#4742](https://github.com/scalableminds/webknossos/pull/4742)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -794,15 +794,17 @@ export function parseNml(
       .on("end", () => {
         // Split potentially unconnected trees
         const originalTreeIds = Object.keys(trees);
+        let maxTreeId = getMaximumTreeId(trees);
         for (const treeId of originalTreeIds) {
           const tree = trees[Number(treeId)];
-          const maxTreeId = getMaximumTreeId(trees);
           const newTrees = splitTreeIntoComponents(tree, treeGroups, maxTreeId);
-          if (_.size(newTrees) > 1) {
+          const newTreesSize = _.size(newTrees);
+          if (newTreesSize > 1) {
             delete trees[tree.treeId];
             for (const newTree of newTrees) {
               trees[newTree.treeId] = newTree;
             }
+            maxTreeId += newTreesSize;
           }
         }
         resolve({ trees, treeGroups, datasetName, userBoundingBoxes });

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
@@ -72,8 +72,10 @@ function getMaximumNodeId(trees: TreeMap | MutableTreeMap): number {
 }
 
 export function getMaximumTreeId(trees: TreeMap | MutableTreeMap): number {
-  const maxTreeId = _.max(_.map(trees, "treeId"));
-  return maxTreeId != null ? maxTreeId : Constants.MIN_TREE_ID - 1;
+  return Object.values(trees).reduce(
+    (maxId, tree) => (tree.treeId > maxId ? tree.treeId : maxId),
+    Constants.MIN_TREE_ID - 1,
+  );
 }
 
 function getNearestTreeId(treeId: number, trees: TreeMap): number {

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
@@ -72,10 +72,8 @@ function getMaximumNodeId(trees: TreeMap | MutableTreeMap): number {
 }
 
 export function getMaximumTreeId(trees: TreeMap | MutableTreeMap): number {
-  return Object.values(trees).reduce(
-    (maxId, tree) => (tree.treeId > maxId ? tree.treeId : maxId),
-    Constants.MIN_TREE_ID - 1,
-  );
+  const maxTreeId = _.max(_.map(trees, "treeId"));
+  return maxTreeId != null ? maxTreeId : Constants.MIN_TREE_ID - 1;
 }
 
 function getNearestTreeId(treeId: number, trees: TreeMap): number {


### PR DESCRIPTION
I noticed that the NML import for NMLs with many trees (20,000+) was very slow and had a look. Turns out I introduced this regression in https://github.com/scalableminds/webknossos/pull/4541 by repeatedly calling the `getMaximumTreeId` function when importing trees. ~~The `getMaximumTreeId` function was also rather slow as it created a potentially large array everytime it was called.~~ I ~~replaced that with a simple reduce (10x speedup for tracings with >20,000 trees) and also~~ made sure to only call the `getMaximumTreeId` function when it is necessary (~100x speedup during nml import).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Unzip and import [synapses_0.80.zip](https://github.com/scalableminds/webknossos/files/4995799/synapses_0.80.zip) in an existing tracing. The import should be fast and not take multiple minutes.


------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [ ] Ready for review
