### PR TITLE
fix tree ids in multicomponent tree splitter

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/MultiComponentTreeSplitter.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/MultiComponentTreeSplitter.scala
@@ -42,9 +42,9 @@ object MultiComponentTreeSplitter {
               connectedNodeSet.contains(edge.source) && connectedNodeSet.contains(edge.target))
             val branchPoints = tree.branchPoints.filter(bp => connectedNodeSet.contains(bp.nodeId))
             val comments = tree.comments.filter(comment => connectedNodeSet.contains(comment.nodeId))
+            largestTreeId += 1
             val treeId = largestTreeId
             val name = tree.name + "_" + index
-            largestTreeId += 1
             Tree(treeId,
                  nodes,
                  edges,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- upload nml with multi-component trees (where the tree with the largest id is not one that needs to be split)
- should not complain about multiple tree ids

- [x] Ready for review
