### PR TITLE
Make number slider more robust against weird input values

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Speed up NML import in existing tracings for NMLs with many trees (20,000+). [#4742](https://github.com/scalableminds/webknossos/pull/4742)
 - Fixed tree groups when uploading NMLs with multi-component trees. [#4735](https://github.com/scalableminds/webknossos/pull/4735)
+- Fixed that invalid number values in slider settings could crash webKnossos. [#4758](https://github.com/scalableminds/webknossos/pull/4758)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/settings/setting_input_views.js
+++ b/frontend/javascripts/oxalis/view/settings/setting_input_views.js
@@ -24,17 +24,22 @@ export class NumberSliderSetting extends React.PureComponent<NumberSliderSetting
   };
 
   _onChange = (_value: number) => {
-    if (this.props.min <= _value && _value <= this.props.max) {
+    if (this.isValueValid(_value)) {
       this.props.onChange(_value);
     }
   };
+
+  isValueValid = (_value: number) => {
+    return _.isNumber(_value) && _value >= this.props.min && _value <= this.props.max;
+  }
 
   render() {
     const { value: originalValue, label, max, min, step, onChange, disabled } = this.props;
 
     // Validate the provided value. If it's not valid, fallback to the midpoint between min and max.
-    const isValueValid = _.isNumber(originalValue) && originalValue >= min && originalValue <= max;
-    const value = isValueValid ? originalValue : Math.floor((min + max) / 2);
+    // This check guards against broken settings which could be introduced before this component
+    // checked more thoroughly against invalid values.
+    const value = this.isValueValid(originalValue) ? originalValue : Math.floor((min + max) / 2);
 
     return (
       <Row type="flex" align="middle">

--- a/frontend/javascripts/oxalis/view/settings/setting_input_views.js
+++ b/frontend/javascripts/oxalis/view/settings/setting_input_views.js
@@ -29,9 +29,8 @@ export class NumberSliderSetting extends React.PureComponent<NumberSliderSetting
     }
   };
 
-  isValueValid = (_value: number) => {
-    return _.isNumber(_value) && _value >= this.props.min && _value <= this.props.max;
-  }
+  isValueValid = (_value: number) =>
+    _.isNumber(_value) && _value >= this.props.min && _value <= this.props.max;
 
   render() {
     const { value: originalValue, label, max, min, step, onChange, disabled } = this.props;

--- a/frontend/javascripts/oxalis/view/settings/setting_input_views.js
+++ b/frontend/javascripts/oxalis/view/settings/setting_input_views.js
@@ -1,6 +1,7 @@
 // @flow
 import { Row, Col, Slider, InputNumber, Switch, Tooltip, Input, Icon, Select } from "antd";
 import * as React from "react";
+import _ from "lodash";
 
 import type { Vector3, Vector6 } from "oxalis/constants";
 import * as Utils from "libs/utils";
@@ -29,7 +30,11 @@ export class NumberSliderSetting extends React.PureComponent<NumberSliderSetting
   };
 
   render() {
-    const { value, label, max, min, step, onChange, disabled } = this.props;
+    const { value: originalValue, label, max, min, step, onChange, disabled } = this.props;
+
+    // Validate the provided value. If it's not valid, fallback to the midpoint between min and max.
+    const isValueValid = _.isNumber(originalValue) && originalValue >= min && originalValue <= max;
+    const value = isValueValid ? originalValue : Math.floor((min + max) / 2);
 
     return (
       <Row type="flex" align="middle">


### PR DESCRIPTION
This is a workaround for layer opacity values which become undefined in some circumstances. The actual cause for this is unknown to me, but making the number slider more robust should be an okay way to tackle this.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I patched the code locally so that undefined is passed to the number slider and it worked as expected. One can also test it by using the front-end api to set an undefined opacity, but I think it's not crucial to reproduce this. A review should be sufficient.

### Issues:
- workaround for #4751

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
