### PR TITLE
Rotate camera on sphere via quaternions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The rotation buttons of the 3D-viewport no longer change the zoom. [#4750](https://github.com/scalableminds/webknossos/pull/4750)
 - Improved the performance of applying agglomerate files. [#4706](https://github.com/scalableminds/webknossos/pull/4706)
 - In the Edit/Import Dataset form, the "Sharing" tab was renamed to "Sharing & Permissions". Also, existing permission-related settings were moved to that tab.  [#4683](https://github.com/scalableminds/webknossos/pull/4763)
+- Improved rotation of camera in 3D viewport. [#4768](https://github.com/scalableminds/webknossos/pull/4768)
 
 ### Fixed
 - Speed up NML import in existing tracings for NMLs with many trees (20,000+). [#4742](https://github.com/scalableminds/webknossos/pull/4742)

--- a/frontend/javascripts/oxalis/controller/camera_controller.js
+++ b/frontend/javascripts/oxalis/controller/camera_controller.js
@@ -31,12 +31,55 @@ import { setTDCameraAction } from "oxalis/model/actions/view_mode_actions";
 import { voxelToNm, getBaseVoxel } from "oxalis/model/scaleinfo";
 import Store, { type CameraData } from "oxalis/store";
 import api from "oxalis/api/internal_api";
-import getSceneController from "oxalis/controller/scene_controller_provider";
 
 type Props = {
   cameras: OrthoViewMap<THREE.OrthographicCamera>,
   onCameraPositionChanged: () => void,
 };
+
+function getCameraAsQuaternion(_up, position, center) {
+  const up = V3.normalize(_up);
+  const forward = V3.normalize(V3.sub(center, position));
+  const right = V3.normalize(V3.cross(up, forward));
+
+  const rotationMatrix = new THREE.Matrix4();
+  rotationMatrix.set(
+    right[0], up[0], forward[0], 0,
+    right[1], up[1], forward[1], 0,
+    right[2], up[2], forward[2], 0,
+    0, 0, 0, 1,
+  );
+
+  const quat = new THREE.Quaternion();
+  quat.setFromRotationMatrix(rotationMatrix);
+
+  return quat;
+}
+
+function getCameraFromQuaternion(quat) {
+  // Derived from: https://stackoverflow.com/questions/1556260/convert-quaternion-rotation-to-rotation-matrix
+  const {x, y, z, w} = quat;
+
+  const right = [
+    1.0 - 2.0*y*y - 2.0*z*z,
+    2.0*x*y + 2.0*z*w,
+    2.0*x*z - 2.0*y*w,
+  ]
+
+  const up = [
+    2.0*x*y - 2.0*z*w,
+    1.0 - 2.0*x*x - 2.0*z*z,
+    2.0*y*z + 2.0*x*w,
+  ]
+
+  const forward = [
+    2.0*x*z + 2.0*y*w,
+    2.0*y*z - 2.0*x*w,
+    1.0 - 2.0*x*x - 2.0*y*y,
+  ]
+
+  return {right, up, forward}
+}
 
 class CameraController extends React.PureComponent<Props> {
   storePropertyUnsubscribers: Array<Function>;
@@ -172,12 +215,6 @@ class CameraController extends React.PureComponent<Props> {
 }
 
 type TweenState = {
-  upX: number,
-  upY: number,
-  upZ: number,
-  xPos: number,
-  yPos: number,
-  zPos: number,
   left: number,
   right: number,
   top: number,
@@ -253,79 +290,36 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
     getPosition(Store.getState().flycam),
   ) || [0, 0, 0];
 
-
-  // const diff = V3.sub(tdCamera.position, position);
-  // const v1 = V3.normalize(diff);
-  // const v2 = V3.normalize(V3.cross(up, v1));
-  // const center = V3.scale(V3.add(tdCamera.position, position), 1/2);
-  // const radius = V3.length(diff) / 2;
-
-  // const diff = V3.sub(tdCamera.position, position);
-  const v1Unnormalized = V3.sub(currentFlycamPos, position);
-  let v2Unnormalized = V3.sub(currentFlycamPos, tdCamera.position);
-  v2Unnormalized = V3.cross(V3.cross(v1Unnormalized, v2Unnormalized), v1Unnormalized);
-  const v1 = V3.normalize(v1Unnormalized);
-  const v2 = V3.normalize(v2Unnormalized);
-
-  const center = currentFlycamPos;
-  const radius = Math.min(V3.length(v1Unnormalized), V3.length(v2Unnormalized));
-
-  const points = [];
-
-  let multiplier = 1;
-  // const posDiff = V3.length(V3.sub(currentFlycamPos, calculateCirclePoint(0.5)))
-  // const negDiff = V3.length(V3.sub(currentFlycamPos, calculateCirclePoint(-0.5)))
-
-  // const usePositiveCircleHalf = posDiff > negDiff;
-  // multiplier = usePositiveCircleHalf ? 1 : -1;
-  // console.log("usePositiveCircleHalf", usePositiveCircleHalf)
-  function calculateCirclePoint(t) {
-    const a = V3.scale(v1, radius * Math.cos(Math.PI * t * multiplier));
-    const b = V3.scale(v2, radius * Math.sin(Math.PI * t * multiplier));
-    const p = V3.add(V3.add(center, a), b);
-    return p;
-  }
-
-  for (let t = 0; t < 1.0; t += 1 / 25) {
-    points.push(calculateCirclePoint(t));
-  }
-
-  getSceneController().drawPoints(points);
-  console.log("drawPoints", points)
+  // Compute current and target orientation as quaternion. When tweening between
+  // these orientations, we compute the new camera position by keeping the distance
+  // (radius) to currentFlycamPos constant. Consequently, the camera moves on the
+  // surfaces of a sphere with the center at currentFlycamPos.
+  const startQuaternion = getCameraAsQuaternion(tdCamera.up, tdCamera.position, currentFlycamPos)
+  const targetQuaternion = getCameraAsQuaternion(up, position, currentFlycamPos)
+  const centerDistance = V3.length(V3.sub(currentFlycamPos, position));
 
   const to: TweenState = {
-    xPos: position[0],
-    yPos: position[1],
-    zPos: position[2],
-    upX: up[0],
-    upY: up[1],
-    upZ: up[2],
     left: -width / 2,
     right: width / 2,
     top: height / 2,
     bottom: -height / 2,
   };
 
-  const updateCameraTDView = (tweenState: TweenState, t) => {
-    let { xPos, yPos, zPos, upX, upY, upZ, left, right, top, bottom } = tweenState;
+  const updateCameraTDView = (tweenState: TweenState, t: number) => {
+    const { left, right, top, bottom } = tweenState;
 
-    const p = calculateCirclePoint(t)
-    const currentFlycamPos = voxelToNm(
-      Store.getState().dataset.dataSource.scale,
-      getPosition(Store.getState().flycam),
-    );
+    const tweenedQuat = new THREE.Quaternion();
+    THREE.Quaternion.slerp(startQuaternion, targetQuaternion, tweenedQuat, t);
+    const tweened = getCameraFromQuaternion(tweenedQuat);
 
-    if (!isNaN(p[0])) {
-      xPos = p[0];
-      yPos = p[1];
-      zPos = p[2];
-    }
-
+    // Use forward vector and currentFlycamPos (lookAt target) to calculate the current
+    // camera's position which should be on a sphere (center=currentFlycamPos, radius=centerDistance).
+    const newPosition = V3.toArray(V3.sub(currentFlycamPos, V3.scale(tweened.forward, centerDistance)));
 
     Store.dispatch(
       setTDCameraAction({
-        position: [xPos, yPos, zPos],
-        up: [upX, upY, upZ],
+        position: newPosition,
+        up: tweened.up,
         left,
         right,
         top,
@@ -337,12 +331,6 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
 
   if (animate) {
     const from: TweenState = {
-      upX: tdCamera.up[0],
-      upY: tdCamera.up[1],
-      upZ: tdCamera.up[2],
-      xPos: tdCamera.position[0],
-      yPos: tdCamera.position[1],
-      zPos: tdCamera.position[2],
       left: tdCamera.left,
       right: tdCamera.right,
       top: tdCamera.top,
@@ -362,7 +350,7 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
       })
       .start();
   } else {
-    updateCameraTDView(to);
+    updateCameraTDView(to, 1);
   }
 }
 

--- a/frontend/javascripts/oxalis/controller/camera_controller.js
+++ b/frontend/javascripts/oxalis/controller/camera_controller.js
@@ -37,7 +37,7 @@ type Props = {
   onCameraPositionChanged: () => void,
 };
 
-function getCameraAsQuaternion(_up, position, center) {
+function getQuaternionFromCamera(_up, position, center) {
   const up = V3.normalize(_up);
   const forward = V3.normalize(V3.sub(center, position));
   const right = V3.normalize(V3.cross(up, forward));
@@ -300,8 +300,8 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
   // these orientations, we compute the new camera position by keeping the distance
   // (radius) to currentFlycamPos constant. Consequently, the camera moves on the
   // surfaces of a sphere with the center at currentFlycamPos.
-  const startQuaternion = getCameraAsQuaternion(tdCamera.up, tdCamera.position, currentFlycamPos);
-  const targetQuaternion = getCameraAsQuaternion(up, position, currentFlycamPos);
+  const startQuaternion = getQuaternionFromCamera(tdCamera.up, tdCamera.position, currentFlycamPos);
+  const targetQuaternion = getQuaternionFromCamera(up, position, currentFlycamPos);
   const centerDistance = V3.length(V3.sub(currentFlycamPos, position));
 
   const to: TweenState = {

--- a/frontend/javascripts/oxalis/controller/camera_controller.js
+++ b/frontend/javascripts/oxalis/controller/camera_controller.js
@@ -43,6 +43,8 @@ function getCameraAsQuaternion(_up, position, center) {
   const right = V3.normalize(V3.cross(up, forward));
 
   const rotationMatrix = new THREE.Matrix4();
+
+  // prettier-ignore
   rotationMatrix.set(
     right[0], up[0], forward[0], 0,
     right[1], up[1], forward[1], 0,
@@ -58,27 +60,27 @@ function getCameraAsQuaternion(_up, position, center) {
 
 function getCameraFromQuaternion(quat) {
   // Derived from: https://stackoverflow.com/questions/1556260/convert-quaternion-rotation-to-rotation-matrix
-  const {x, y, z, w} = quat;
+  const { x, y, z, w } = quat;
 
   const right = [
-    1.0 - 2.0*y*y - 2.0*z*z,
-    2.0*x*y + 2.0*z*w,
-    2.0*x*z - 2.0*y*w,
-  ]
+    1.0 - 2.0 * y * y - 2.0 * z * z,
+    2.0 * x * y + 2.0 * z * w,
+    2.0 * x * z - 2.0 * y * w,
+  ];
 
   const up = [
-    2.0*x*y - 2.0*z*w,
-    1.0 - 2.0*x*x - 2.0*z*z,
-    2.0*y*z + 2.0*x*w,
-  ]
+    2.0 * x * y - 2.0 * z * w,
+    1.0 - 2.0 * x * x - 2.0 * z * z,
+    2.0 * y * z + 2.0 * x * w,
+  ];
 
   const forward = [
-    2.0*x*z + 2.0*y*w,
-    2.0*y*z - 2.0*x*w,
-    1.0 - 2.0*x*x - 2.0*y*y,
-  ]
+    2.0 * x * z + 2.0 * y * w,
+    2.0 * y * z - 2.0 * x * w,
+    1.0 - 2.0 * x * x - 2.0 * y * y,
+  ];
 
-  return {right, up, forward}
+  return { right, up, forward };
 }
 
 class CameraController extends React.PureComponent<Props> {
@@ -229,7 +231,11 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
   const datasetExtent = getDatasetExtentInLength(dataset);
   // This distance ensures that the 3D camera is so far "in the back" that all elements in the scene
   // are in front of it and thus visible.
-  const clippingOffsetFactor = Math.max(datasetExtent.width, datasetExtent.height, datasetExtent.depth);
+  const clippingOffsetFactor = Math.max(
+    datasetExtent.width,
+    datasetExtent.height,
+    datasetExtent.depth,
+  );
   // Use width and height to keep the same zoom.
   let width = tdCamera.right - tdCamera.left;
   let height = tdCamera.top - tdCamera.bottom;
@@ -294,8 +300,8 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
   // these orientations, we compute the new camera position by keeping the distance
   // (radius) to currentFlycamPos constant. Consequently, the camera moves on the
   // surfaces of a sphere with the center at currentFlycamPos.
-  const startQuaternion = getCameraAsQuaternion(tdCamera.up, tdCamera.position, currentFlycamPos)
-  const targetQuaternion = getCameraAsQuaternion(up, position, currentFlycamPos)
+  const startQuaternion = getCameraAsQuaternion(tdCamera.up, tdCamera.position, currentFlycamPos);
+  const targetQuaternion = getCameraAsQuaternion(up, position, currentFlycamPos);
   const centerDistance = V3.length(V3.sub(currentFlycamPos, position));
 
   const to: TweenState = {
@@ -314,7 +320,9 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
 
     // Use forward vector and currentFlycamPos (lookAt target) to calculate the current
     // camera's position which should be on a sphere (center=currentFlycamPos, radius=centerDistance).
-    const newPosition = V3.toArray(V3.sub(currentFlycamPos, V3.scale(tweened.forward, centerDistance)));
+    const newPosition = V3.toArray(
+      V3.sub(currentFlycamPos, V3.scale(tweened.forward, centerDistance)),
+    );
 
     Store.dispatch(
       setTDCameraAction({

--- a/frontend/javascripts/oxalis/controller/scene_controller.js
+++ b/frontend/javascripts/oxalis/controller/scene_controller.js
@@ -95,12 +95,14 @@ class SceneController {
     this.rootGroup = new THREE.Object3D();
     this.rootGroup.add(this.getRootNode());
     this.isosurfacesRootGroup = new THREE.Group();
+    this.pointsHelperGroup = new THREE.Group();
 
     // The dimension(s) with the highest resolution will not be distorted
     this.rootGroup.scale.copy(new THREE.Vector3(...Store.getState().dataset.dataSource.scale));
     // Add scene to the group, all Geometries are then added to group
     this.scene.add(this.rootGroup);
     this.scene.add(this.isosurfacesRootGroup);
+    this.scene.add(this.pointsHelperGroup);
 
     this.rootGroup.add(new THREE.DirectionalLight());
     this.addLights();
@@ -337,6 +339,27 @@ class SceneController {
       }
     }
   };
+
+  drawPoints = (points) => {
+    this.scene.remove(this.pointsHelperGroup);
+    this.pointsHelperGroup = new THREE.Group();
+
+    for (const point of points) {
+      var dir = new THREE.Vector3( 1, 0, 0 );
+
+      //normalize the direction vector (convert to vector of length 1)
+      dir.normalize();
+
+      var origin = new THREE.Vector3( point[0], point[1], point[2] );
+      var length = 1000;
+      var hex = 0xff1122;
+
+      var arrowHelper = new THREE.ArrowHelper( dir, origin, length, hex );
+
+      this.pointsHelperGroup.add(arrowHelper)
+    }
+    this.scene.add(this.pointsHelperGroup);
+  }
 
   update(optArbitraryPlane?: ArbitraryPlane): void {
     const state = Store.getState();

--- a/frontend/javascripts/oxalis/controller/scene_controller.js
+++ b/frontend/javascripts/oxalis/controller/scene_controller.js
@@ -95,14 +95,12 @@ class SceneController {
     this.rootGroup = new THREE.Object3D();
     this.rootGroup.add(this.getRootNode());
     this.isosurfacesRootGroup = new THREE.Group();
-    this.pointsHelperGroup = new THREE.Group();
 
     // The dimension(s) with the highest resolution will not be distorted
     this.rootGroup.scale.copy(new THREE.Vector3(...Store.getState().dataset.dataSource.scale));
     // Add scene to the group, all Geometries are then added to group
     this.scene.add(this.rootGroup);
     this.scene.add(this.isosurfacesRootGroup);
-    this.scene.add(this.pointsHelperGroup);
 
     this.rootGroup.add(new THREE.DirectionalLight());
     this.addLights();
@@ -339,27 +337,6 @@ class SceneController {
       }
     }
   };
-
-  drawPoints = (points) => {
-    this.scene.remove(this.pointsHelperGroup);
-    this.pointsHelperGroup = new THREE.Group();
-
-    for (const point of points) {
-      var dir = new THREE.Vector3( 1, 0, 0 );
-
-      //normalize the direction vector (convert to vector of length 1)
-      dir.normalize();
-
-      var origin = new THREE.Vector3( point[0], point[1], point[2] );
-      var length = 1000;
-      var hex = 0xff1122;
-
-      var arrowHelper = new THREE.ArrowHelper( dir, origin, length, hex );
-
-      this.pointsHelperGroup.add(arrowHelper)
-    }
-    this.scene.add(this.pointsHelperGroup);
-  }
 
   update(optArbitraryPlane?: ArbitraryPlane): void {
     const state = Store.getState();


### PR DESCRIPTION
This PR changes how the camera is moved and rotated when clicking the orientation buttons in the 3D viewport. Instead of directly tweening between position and rotation, the new code computes start and end rotation as quaternions and tweens the rotation between these. Then, the tweened position is calculated by projecting the camera from the lookAt target onto a sphere (by using the cameras orientation). That way, the camera moves on the sphere surface with an "intuitive" path and rotation.

### URL of deployed dev instance (used for testing):
- https://cameraquaternion.webknossos.xyz

### Steps to test:
- rotate the 3D view in an arbitrary (e.g., invert the XY plane so that it's upside down)
- click an orientation button (e.g., XY) --> the camera should move around the center instead of directly going through)

### Issues:
- fixes #4769

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
