### PR TITLE
Disable brush in merge mode

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,7 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - In the Edit/Import Dataset form, the "Sharing" tab was renamed to "Sharing & Permissions". Also, existing permission-related settings were moved to that tab.  [#4683](https://github.com/scalableminds/webknossos/pull/4763)
 - Improved rotation of camera in 3D viewport. [#4768](https://github.com/scalableminds/webknossos/pull/4768)
 - Improved handling and communication of failures during download of data from datasets. [#4765](https://github.com/scalableminds/webknossos/pull/4765)
-- The annotation tools in hybrid tracings are disabled while in merger mode. [#4757](https://github.com/scalableminds/webknossos/pull/4770)
+- The volume annotation tools in hybrid tracings are disabled while in merger mode. [#4757](https://github.com/scalableminds/webknossos/pull/4770)
 
 ### Fixed
 - Speed up NML import in existing tracings for NMLs with many trees (20,000+). [#4742](https://github.com/scalableminds/webknossos/pull/4742)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Improved the performance of applying agglomerate files. [#4706](https://github.com/scalableminds/webknossos/pull/4706)
 - In the Edit/Import Dataset form, the "Sharing" tab was renamed to "Sharing & Permissions". Also, existing permission-related settings were moved to that tab.  [#4683](https://github.com/scalableminds/webknossos/pull/4763)
 - Improved handling and communication of failures during download of data from datasets. [#4765](https://github.com/scalableminds/webknossos/pull/4765)
+- The annotation tools in hybrid tracings are disabled while in merger mode. [#4757](https://github.com/scalableminds/webknossos/pull/4770)
 
 ### Fixed
 - Speed up NML import in existing tracings for NMLs with many trees (20,000+). [#4742](https://github.com/scalableminds/webknossos/pull/4742)

--- a/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -50,7 +50,9 @@ class VolumeActionsView extends PureComponent<Props> {
           <RadioButton value={VolumeToolEnum.MOVE}>Move</RadioButton>
           <Tooltip
             title={
-              this.props.isInMergerMode ? "Annotation tools are disabled while in merger mode." : ""
+              this.props.isInMergerMode
+                ? "Volume annotation is disabled while the merger mode is active."
+                : ""
             }
           >
             <RadioButton value={VolumeToolEnum.TRACE} disabled={this.props.isInMergerMode}>

--- a/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -21,7 +21,7 @@ type Props = {|
 |};
 
 class VolumeActionsView extends PureComponent<Props> {
-  componentDidUpdate = (preProps: Props) => {
+  componentDidUpdate = (prevProps: Props) => {
     if (!preProps.isInMergerMode && this.props.isInMergerMode) {
       Store.dispatch(setToolAction(VolumeToolEnum.MOVE));
     }

--- a/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -22,7 +22,7 @@ type Props = {|
 
 class VolumeActionsView extends PureComponent<Props> {
   componentDidUpdate = (prevProps: Props) => {
-    if (!preProps.isInMergerMode && this.props.isInMergerMode) {
+    if (!prevProps.isInMergerMode && this.props.isInMergerMode) {
       Store.dispatch(setToolAction(VolumeToolEnum.MOVE));
     }
   };

--- a/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -1,5 +1,5 @@
 // @flow
-import { Button, Radio } from "antd";
+import { Button, Radio, Tooltip } from "antd";
 import { connect } from "react-redux";
 import React, { PureComponent } from "react";
 
@@ -48,10 +48,18 @@ class VolumeActionsView extends PureComponent<Props> {
           style={{ marginRight: 10 }}
         >
           <RadioButton value={VolumeToolEnum.MOVE}>Move</RadioButton>
-          <RadioButton value={VolumeToolEnum.TRACE}>Trace</RadioButton>
-          <RadioButton value={VolumeToolEnum.BRUSH} disabled={this.props.isInMergerMode}>
-            Brush
-          </RadioButton>
+          <Tooltip
+            title={
+              this.props.isInMergerMode ? "Annotation tools are disabled while in merger mode." : ""
+            }
+          >
+            <RadioButton value={VolumeToolEnum.TRACE} disabled={this.props.isInMergerMode}>
+              Trace
+            </RadioButton>
+            <RadioButton value={VolumeToolEnum.BRUSH} disabled={this.props.isInMergerMode}>
+              Brush
+            </RadioButton>
+          </Tooltip>
         </RadioGroup>
         <ButtonGroup>
           <ButtonComponent onClick={this.handleCreateCell}>

--- a/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -17,6 +17,7 @@ const ButtonGroup = Button.Group;
 
 type Props = {|
   activeTool: VolumeTool,
+  isInMergerMode: boolean,
 |};
 
 class VolumeActionsView extends PureComponent<Props> {
@@ -37,12 +38,18 @@ class VolumeActionsView extends PureComponent<Props> {
       >
         <RadioGroup
           onChange={this.handleSetTool}
-          value={this.props.activeTool}
+          value={
+            this.props.isInMergerMode && this.props.activeTool === VolumeToolEnum.BRUSH
+              ? VolumeToolEnum.TRACE
+              : this.props.activeTool
+          }
           style={{ marginRight: 10 }}
         >
           <RadioButton value={VolumeToolEnum.MOVE}>Move</RadioButton>
           <RadioButton value={VolumeToolEnum.TRACE}>Trace</RadioButton>
-          <RadioButton value={VolumeToolEnum.BRUSH}>Brush</RadioButton>
+          <RadioButton value={VolumeToolEnum.BRUSH} disabled={this.props.isInMergerMode}>
+            Brush
+          </RadioButton>
         </RadioGroup>
         <ButtonGroup>
           <ButtonComponent onClick={this.handleCreateCell}>
@@ -58,6 +65,7 @@ class VolumeActionsView extends PureComponent<Props> {
 function mapStateToProps(state: OxalisState): Props {
   return {
     activeTool: enforceVolumeTracing(state.tracing).activeTool,
+    isInMergerMode: state.temporaryConfiguration.isMergerModeEnabled,
   };
 }
 

--- a/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/volume_actions_view.js
@@ -21,6 +21,12 @@ type Props = {|
 |};
 
 class VolumeActionsView extends PureComponent<Props> {
+  componentDidUpdate = (preProps: Props) => {
+    if (!preProps.isInMergerMode && this.props.isInMergerMode) {
+      Store.dispatch(setToolAction(VolumeToolEnum.MOVE));
+    }
+  };
+
   handleSetTool = (event: { target: { value: VolumeTool } }) => {
     Store.dispatch(setToolAction(event.target.value));
   };
@@ -38,11 +44,7 @@ class VolumeActionsView extends PureComponent<Props> {
       >
         <RadioGroup
           onChange={this.handleSetTool}
-          value={
-            this.props.isInMergerMode && this.props.activeTool === VolumeToolEnum.BRUSH
-              ? VolumeToolEnum.TRACE
-              : this.props.activeTool
-          }
+          value={this.props.activeTool}
           style={{ marginRight: 10 }}
         >
           <RadioButton value={VolumeToolEnum.MOVE}>Move</RadioButton>

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -194,6 +194,14 @@
     &:hover {
       border-color: @hover-border;
     }
+
+    &.ant-btn-disabled,
+    &.ant-input-disabled,
+    &.ant-radio-button-wrapper-disabled,
+    &.ant-select-selection-disabled {
+      color: fade(@dark-fg, 50%);
+      border-color: @dark-border;
+    }
   }
 
   .ant-select-arrow {


### PR DESCRIPTION
This PR disables the brush when merger mode is enabled in a hybrid tracing.

### URL of deployed dev instance (used for testing):
- https://disablebrushinmergemode.webknossos.xyz

### Steps to test:
- open a hybrid tracing
- select the brush tool
- enable merger mode
- the tool should change to "move" and the brush button should be disabled
- disable merger mode
- the brush should be available again

### Issues:
- fixes #4757

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] ~~Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- [ ] ~~Updated [documentation](../blob/master/docs) if applicable~~
- [ ] ~~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [ ] ~~Needs datastore update after deployment~~
- [x] Ready for review
