### PR TITLE
Fix project download loading indicator

### DIFF
--- a/frontend/javascripts/admin/project/project_list_view.js
+++ b/frontend/javascripts/admin/project/project_list_view.js
@@ -179,6 +179,17 @@ class ProjectListView extends React.PureComponent<PropsWithRouter, State> {
     });
   };
 
+  maybeShowNoFallbackDataInfo = async (projectName: string) => {
+    const tasks = await getTasks({
+      project: projectName,
+    });
+    if (tasks.some(task => task.type.tracingType !== "skeleton")) {
+      Toast.info(messages["project.no_fallback_data_included"], {
+        timeout: 12000,
+      });
+    }
+  };
+
   onTaskTransferComplete = () => {
     this.setState({ isTransferTasksVisible: false });
     this.fetchData();
@@ -344,15 +355,8 @@ class ProjectListView extends React.PureComponent<PropsWithRouter, State> {
                     <AsyncLink
                       href="#"
                       onClick={async () => {
-                        downloadNml(project.id, "CompoundProject");
-                        const tasks = await getTasks({
-                          project: project.name,
-                        });
-                        if (tasks.some(task => task.type.tracingType !== "skeleton")) {
-                          Toast.info(messages["project.no_fallback_data_included"], {
-                            timeout: 12000,
-                          });
-                        }
+                        this.maybeShowNoFallbackDataInfo(project.name);
+                        await downloadNml(project.id, "CompoundProject");
                       }}
                       title="Download all Finished Annotations"
                     >


### PR DESCRIPTION
This PR fixes the project download loading indication by waiting for the download to complete.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a project and do some tracing for that project (or just use the sample project)
- Then go to the projects tab and download the project. The button should be in the loading state as long as the download takes

Note: Testing this might be difficult as the download for small (mocked) projects is very fast.

### Issues:
- fixes #4131

------
- ~~[ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~~
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
