### PR TITLE
do not try to decompress reverted buckets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Fixed
-- 
+- Fixed a bug where volume tracings some that had been reverted to a previous version became un-downloadable. [#4805](https://github.com/scalableminds/webknossos/pull/4805)
 
 ### Removed
 -

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Fixed
-- Fixed a bug where volume tracings some that had been reverted to a previous version became un-downloadable. [#4805](https://github.com/scalableminds/webknossos/pull/4805)
+- Fixed a bug where some volume annotations that had been reverted to a previous version became un-downloadable. [#4805](https://github.com/scalableminds/webknossos/pull/4805)
 
 ### Removed
 -

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -32,8 +32,11 @@ trait VolumeBucketCompression extends LazyLogging {
       data
     }
 
-  def decompressIfNeeded(data: Array[Byte], expectedUncompressedBucketSize: Int, debugInfo: String): Array[Byte] =
-    if (data.length == expectedUncompressedBucketSize) {
+  def decompressIfNeeded(data: Array[Byte], expectedUncompressedBucketSize: Int, debugInfo: String): Array[Byte] = {
+    val isAlreadyDecompressed = data.length == expectedUncompressedBucketSize
+    // revertToVersion overwrites buckets with a single zero to indicate the absence of data without deleting old versions
+    val isRevertedBucket = data.length == 1
+    if (isAlreadyDecompressed || isRevertedBucket) {
       data
     } else {
       try {
@@ -45,6 +48,7 @@ trait VolumeBucketCompression extends LazyLogging {
           throw e
       }
     }
+  }
 
   def expectedUncompressedBucketSizeFor(dataLayer: DataLayer): Int = {
     // frontend treats 8-byte segmentations as 4-byte segmentations,


### PR DESCRIPTION
The revertToVersion update action of volume tracings overwrites buckets that are empty in the old version with a single zero byte to indicate that there is no data there, without actually deleting the old versions.

This special bucket value was assumed to be a compressed bucket by the loading algorithm, which subsequently failed to decompress it. However, this special value is not compressed and should thus just be passed as is. It is then correctly interpreted as an absent bucket (and the fallback layer data is loaded).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create volume tracing, brush some, save.
- revert to previous version (e.g. version 0), reload
- the fallback layer should be rendered again at those areas
- tracing should be downloadable (some zero-sized wkw files are created there, which is not ideal, but this is the old behavior too)

### Issues:
- fixes #4801 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
