### PR TITLE
Fix tooltip glitch

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Improved the data loading behavior for flight and oblique mode. [#4800](https://github.com/scalableminds/webknossos/pull/4800)
 - Fixed a bug where some volume annotations that had been reverted to a previous version became un-downloadable. [#4805](https://github.com/scalableminds/webknossos/pull/4805)
+- Fixed a UI bug where some tooltip wouldn't close after editing a label. [#4815](https://github.com/scalableminds/webknossos/pull/4815)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/components/editable_text_label.js
+++ b/frontend/javascripts/oxalis/view/components/editable_text_label.js
@@ -86,7 +86,7 @@ class EditableTextLabel extends React.PureComponent<EditableTextLabelProp, State
           {this.props.rows === 1 ? (
             <React.Fragment>
               <Input {...inputComponentProps} />
-              <Tooltip title={`Save ${this.props.label}`} placement="bottom">
+              <Tooltip key="save" title={`Save ${this.props.label}`} placement="bottom">
                 <Icon
                   type="check"
                   style={iconStyle}
@@ -122,7 +122,7 @@ class EditableTextLabel extends React.PureComponent<EditableTextLabelProp, State
               this.props.value
             )}
           </span>
-          <Tooltip title={`Edit ${this.props.label}`} placement="bottom">
+          <Tooltip key="edit" title={`Edit ${this.props.label}`} placement="bottom">
             <Icon
               type="edit"
               style={iconStyle}


### PR DESCRIPTION
... by providing a key attribute. As far as I can see, React got confused and reused the same tooltip after the Edit button was clicked (to render the Save ... tooltip) which is why the tooltip stayed open, but was moved to the side. Therefore, the mouseleave or whatever other necessary event was not received. Providing a `key` solves this issue.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Click `Edit annotation name` in the annotation list, then click save or press enter -> The tooltip should be gone as expected.

### Issues:
- fixes #4799 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
