### PR TITLE
Avoid the word »hybrid« in task type creation view

### DIFF
--- a/frontend/javascripts/admin/tasktype/task_type_create_view.js
+++ b/frontend/javascripts/admin/tasktype/task_type_create_view.js
@@ -236,7 +236,7 @@ class TaskTypeCreateView extends React.PureComponent<Props, State> {
                     Volume
                   </Radio>
                   <Radio value="hybrid" disabled={isEditingMode}>
-                    Hybrid
+                    Skeleton and Volume
                   </Radio>
                 </RadioGroup>,
               )}


### PR DESCRIPTION
Renaming »hybrid« to »skeleton and volume« in task type creation view, as discussed in #4747. This is in preparation for #3433 .

### Issues:
- fixes #4747

------
- [x] Ready for review
