### PR TITLE
specifies initial selected dataset in publication tile

### DIFF
--- a/frontend/javascripts/dashboard/publication_card.js
+++ b/frontend/javascripts/dashboard/publication_card.js
@@ -143,7 +143,7 @@ const typeHint: Array<APIDataset> = [];
 
 type Props = { datasets: Array<APIDataset>, showDetailedLink: boolean };
 
-function PublicationCard({ datasets, showDetailedLink }: Props){
+function PublicationCard({ datasets, showDetailedLink }: Props) {
   const sortedDatasets = datasets.sort(compareBy(typeHint, dataset => dataset.sortingKey));
   const [activeDataset, setActiveDataset] = useState<APIDataset>(sortedDatasets[0]);
 


### PR DESCRIPTION
Previously the initially selected dataset in the publication tile was somewhat random. However, we have a sorting key that we use in the dataset list. This PR selects the first dataset initially.

------
- [x] Ready for review
