### PR TITLE
Drop overlaps when saving timespans

### DIFF
--- a/CHANGELOG.released.md
+++ b/CHANGELOG.released.md
@@ -35,6 +35,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Speed up NML import in existing tracings for NMLs with many trees (20,000+). [#4742](https://github.com/scalableminds/webknossos/pull/4742)
 - Fixed tree groups when uploading NMLs with multi-component trees. [#4735](https://github.com/scalableminds/webknossos/pull/4735)
 - Fixed that invalid number values in slider settings could crash webKnossos. [#4758](https://github.com/scalableminds/webknossos/pull/4758)
+- Improved resilience in time tracking, preventing overlapping timespans. [#4830](https://github.com/scalableminds/webknossos/pull/4830)
 
 ## [20.08.0](https://github.com/scalableminds/webknossos/releases/tag/20.08.0) - 2020-07-20
 [Commits](https://github.com/scalableminds/webknossos/compare/20.07.0...20.08.0)
@@ -127,13 +128,13 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added support for ID mapping of segmentation layer based on HDF5 agglomerate files. [#4469](https://github.com/scalableminds/webknossos/pull/4469)
 - Added option to hide all unmapped segments to segmentation tab. [#4510](https://github.com/scalableminds/webknossos/pull/4510)
 - It is now possible to upload volume tracings as a base for tasks. The upload format is similar to the project / task type download format. [#4565](https://github.com/scalableminds/webknossos/pull/4565)
-- Added the possibility to share the dataset which is currently viewed (using a private token if the dataset is not public).  The option can be found in the dropdown of the navigation bar. [#4543](https://github.com/scalableminds/webknossos/pull/4543) 
+- Added the possibility to share the dataset which is currently viewed (using a private token if the dataset is not public).  The option can be found in the dropdown of the navigation bar. [#4543](https://github.com/scalableminds/webknossos/pull/4543)
 
 ### Added
 - Users can undo finishing a task when the task was finished via the API, e.g. by a user script. [#4495](https://github.com/scalableminds/webknossos/pull/4495)
 - Added the magnification used for determining the segment ids in the segmentation tab to the table of the tab. [#4480](https://github.com/scalableminds/webknossos/pull/4480)
 - Added support for ID mapping of segmentation layer based on HDF5 agglomerate files. [#4469](https://github.com/scalableminds/webknossos/pull/4469)
-- Added the possibility to share the dataset which is currently viewed (using a private token if the dataset is not public).  The option can be found in the dropdown of the navigation bar. [#4543](https://github.com/scalableminds/webknossos/pull/4543) 
+- Added the possibility to share the dataset which is currently viewed (using a private token if the dataset is not public).  The option can be found in the dropdown of the navigation bar. [#4543](https://github.com/scalableminds/webknossos/pull/4543)
 - Added option to hide all unmapped segments to segmentation tab. [#4510](https://github.com/scalableminds/webknossos/pull/4510)
 - When wK changes datasource-properties.json files of datasets, now it creates a backup log of previous versions. [#4534](https://github.com/scalableminds/webknossos/pull/4534)
 - Added a warning to the position input in tracings if the current position is out of bounds. The warning colors the position input orange. [#4544](https://github.com/scalableminds/webknossos/pull/4544)

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -122,7 +122,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
         timeSpansToUpdate = (timeSpan, timestamp) :: timeSpansToUpdate
         timeSpan.addTime(duration, timestamp)
       } else {
-        logger.info(
+        logger.warn(
           s"Not updating previous timespan due to negative duration ${duration} for user ${timeSpan._id}, last timespan id ${timeSpan._id}, this=${this}")
         timeSpan
       }


### PR DESCRIPTION
There have been new reports of overlapping timespans. I have two vaguely unlikely theories how this could have happened:
(1) the singleton creation of the timespan service fails, there is more than one timespan service, so the merging fails
(2) there are negative durations in reported timespans due to weird request ordering or some unknown bug in the front-end

This PR deals with (2). Before, negative durations were considered interrupted, so new timespans were created in the db, with overlaps. Now, the overlap is detected and the timestamps that overlap into an existing timespan are dropped. Also, a warning is logged in this case (also including the service hash/id, hopefully giving us insights into both theories).

With the insights gained we should also be able to debug where the negative timespans, if any, come from.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- modify the frontend to randomize timestamps of update actions and/or info/finish requests
- backend logging should warn about negative durations
- the time tracking/db should not show overlaps

### Issues:
- may help fixing #4806 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
