### PR TITLE
Don't default to 2D layout for empty dummy dataset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
             curl
             -X POST
             -H "X-Auth-Token: $RELEASE_API_TOKEN"
-            https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
+            https://kube.scm.io/hooks/remove/webknossos/dev/consideremptylayerasd?user=CI+%28nightly%29
       - run:
           name: Wait 3min
           command: sleep 180
@@ -259,7 +259,7 @@ jobs:
             curl
             -X POST
             -H "X-Auth-Token: $RELEASE_API_TOKEN"
-            https://kube.scm.io/hooks/install/webknossos/dev/master?user=CI+%28nightly%29
+            https://kube.scm.io/hooks/install/webknossos/dev/consideremptylayerasd?user=CI+%28nightly%29
       - run:
           name: Install dependencies and sleep at least 3min
           command: |
@@ -268,11 +268,11 @@ jobs:
             wait
       - run:
           name: Refresh datasets
-          command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
+          command: curl https://consideremptylayerasd.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
       - run:
           name: Run screenshot-tests
           command: |
-            URL=https://master.webknossos.xyz/ \
+            URL=https://consideremptylayerasd.webknossos.xyz/ \
             yarn test-screenshot
 
       - store_artifacts:
@@ -283,6 +283,10 @@ workflows:
   circleci_build:
     jobs:
       - build_test_deploy:
+          filters:
+            tags:
+              only: /.*/
+      - nightly:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
             curl
             -X POST
             -H "X-Auth-Token: $RELEASE_API_TOKEN"
-            https://kube.scm.io/hooks/remove/webknossos/dev/consideremptylayerasd?user=CI+%28nightly%29
+            https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
       - run:
           name: Wait 3min
           command: sleep 180
@@ -259,7 +259,7 @@ jobs:
             curl
             -X POST
             -H "X-Auth-Token: $RELEASE_API_TOKEN"
-            https://kube.scm.io/hooks/install/webknossos/dev/consideremptylayerasd?user=CI+%28nightly%29
+            https://kube.scm.io/hooks/install/webknossos/dev/master?user=CI+%28nightly%29
       - run:
           name: Install dependencies and sleep at least 3min
           command: |
@@ -268,11 +268,11 @@ jobs:
             wait
       - run:
           name: Refresh datasets
-          command: curl https://consideremptylayerasd.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
+          command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
       - run:
           name: Run screenshot-tests
           command: |
-            URL=https://consideremptylayerasd.webknossos.xyz/ \
+            URL=https://master.webknossos.xyz/ \
             yarn test-screenshot
 
       - store_artifacts:
@@ -283,10 +283,6 @@ workflows:
   circleci_build:
     jobs:
       - build_test_deploy:
-          filters:
-            tags:
-              only: /.*/
-      - nightly:
           filters:
             tags:
               only: /.*/

--- a/frontend/javascripts/libs/utils.js
+++ b/frontend/javascripts/libs/utils.js
@@ -190,6 +190,13 @@ export function computeArrayFromBoundingBox(bb: BoundingBoxType): Vector6 {
 }
 
 export function aggregateBoundingBox(boundingBoxes: Array<BoundingBoxObject>): BoundingBoxType {
+  if (boundingBoxes.length === 0) {
+    return {
+      min: [0, 0, 0],
+      max: [0, 0, 0],
+    };
+  }
+
   const allCoordinates = [0, 1, 2].map(index =>
     boundingBoxes
       .map(box => box.topLeft[index])

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
@@ -398,7 +398,11 @@ export function isLayerVisible(
 }
 
 export function is2dDataset(dataset: APIDataset): boolean {
-  return getDatasetExtentInVoxel(dataset).depth < 2;
+  // An empty dataset (e.g., depth == 0), should not be considered as 2D.
+  // This avoids that the empty dummy dataset is rendered with a 2D layout
+  // which is usually switched to the 3D layout after the proper dataset has
+  // been loaded.
+  return getDatasetExtentInVoxel(dataset).depth === 1;
 }
 
 export default {};


### PR DESCRIPTION
The new 2D layout was also used for the empty dummy dataset with which the store is initialized. This PR ensures that the 2D layout is only used if the depth of the dataset is exactly 1 (and not 0, for example). I've yet to test whether this really fixes the nightly test, but I also noticed that the layout can switch between the two modes quickly when a dataset is opened.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- execute screenshot tests

### Issues:
- fixes nightly CI

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
