### PR TITLE
filter nan values when generating histogram

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed an issue where in some cases the tree list was only visible after the window was resized. [#4816](https://github.com/scalableminds/webknossos/pull/4816)
 - Fixed a bug where some volume annotations that had been reverted to a previous version became un-downloadable. [#4805](https://github.com/scalableminds/webknossos/pull/4805)
 - Fixed a UI bug where some tooltip wouldn't close after editing a label. [#4815](https://github.com/scalableminds/webknossos/pull/4815)
+- Fixed failing histogram requests for float layers with NaN values. [#4834](https://github.com/scalableminds/webknossos/pull/4834)
 
 ### Removed
 -

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -122,8 +122,8 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
         timeSpansToUpdate = (timeSpan, timestamp) :: timeSpansToUpdate
         timeSpan.addTime(duration, timestamp)
       } else {
-        logger.warn(
-          s"Not updating previous timespan due to negative duration ${duration} for user ${timeSpan._id}, last timespan id ${timeSpan._id}, this=${this}")
+        logger.info(
+          s"Not updating previous timespan due to negative duration ${duration} ms. (user ${timeSpan._user}, last timespan id ${timeSpan._id}, this=${this})")
         timeSpan
       }
     }
@@ -160,7 +160,8 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
   private def isNotInterrupted(current: Long, last: TimeSpan) = {
     val duration = current - last.lastUpdate
     if (duration < 0) {
-      logger.warn(s"Negative timespan duration to previous entry.")
+      logger.info(
+        s"Negative timespan duration ${duration} ms to previous entry. (user ${last._user}, last timespan id ${last._id}, this=${this})")
     }
     duration < MaxTracingPause
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataConverter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataConverter.scala
@@ -44,9 +44,11 @@ trait DataConverter extends FoxImplicits {
           .map(ULong(_))
           .filter(!filterZeroes || _ != ULong(0))
       case ElementClass.float =>
-        convertDataImpl[Float, FloatBuffer](
-          data,
-          DataTypeFunctors[Float, FloatBuffer](_.asFloatBuffer(), _.get(_), _.toFloat)).filter(!filterZeroes || _ != 0f)
+        convertDataImpl[Float, FloatBuffer](data,
+                                            DataTypeFunctors[Float, FloatBuffer](
+                                              _.asFloatBuffer(),
+                                              _.get(_),
+                                              _.toFloat)).filter(!_.isNaN).filter(!filterZeroes || _ != 0f)
     }
 
   private def convertDataImpl[T: ClassTag, B <: Buffer](data: Array[Byte],


### PR DESCRIPTION
float datasets can contain NaN values, the histogram should ignore them. Before this PR, the histogram request failed.
(also slipped in some minor fix in time tracking logging)

### Issues:
- fixes #4817 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
