### PR TITLE
include creation info in task csv

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The position input of tracings now accepts decimal input. When losing focus the values are cut off at the comma. [#4803](https://github.com/scalableminds/webknossos/pull/4803)
 - webknossos.org only: Accounts associated with new organizations can now be created even when a datastore is unreachable. The necessary folders are created lazily when needed. [#4846](https://github.com/scalableminds/webknossos/pull/4846)
 - When downloading a volume tracing, buckets containing a single 0 byte, that were created to restore older versions, are now skipped. [#4851](https://github.com/scalableminds/webknossos/pull/4851)
+- Task information CSV now contains additional column `creationInfo`, containing the original NML filename for tasks based on existing NMLs. [#4866](https://github.com/scalableminds/webknossos/pull/4866)
 
 ### Fixed
 - Fixed failing histogram requests for float layers with NaN values. [#4834](https://github.com/scalableminds/webknossos/pull/4834)

--- a/frontend/javascripts/admin/task/task_create_form_view.js
+++ b/frontend/javascripts/admin/task/task_create_form_view.js
@@ -53,7 +53,7 @@ const fullWidth = { width: "100%" };
 const maxDisplayedTasksCount = 50;
 
 const TASK_CSV_HEADER =
-  "taskId,dataSet,taskTypeId,experienceDomain,minExperience,x,y,z,rotX,rotY,rotZ,instances,minX,minY,minZ,width,height,depth,project,scriptId";
+  "taskId,dataSet,taskTypeId,experienceDomain,minExperience,x,y,z,rotX,rotY,rotZ,instances,minX,minY,minZ,width,height,depth,project,scriptId,creationInfo";
 
 type Props = {
   form: Object,
@@ -92,6 +92,7 @@ export function taskToText(task: APITask) {
     editPosition,
     editRotation,
     status,
+    creationInfo,
     boundingBoxVec6,
     projectName,
     script,
@@ -103,10 +104,11 @@ export function taskToText(task: APITask) {
   const totalNumberOfInstances = status.open + status.active + status.finished;
   const boundingBoxAsString = boundingBoxVec6 ? boundingBoxVec6.join(",") : "0,0,0,0,0,0";
   const scriptId = script ? `${script.id}` : "";
+  const creationInfoOrEmpty = creationInfo || "";
 
   const taskAsString =
     `${id},${dataSet},${type.id},${neededExperienceAsString},${editPositionAsString},` +
-    `${editRotationAsString},${totalNumberOfInstances},${boundingBoxAsString},${projectName},${scriptId}`;
+    `${editRotationAsString},${totalNumberOfInstances},${boundingBoxAsString},${projectName},${scriptId},${creationInfoOrEmpty}`;
   return taskAsString;
 }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create task(s) from existing nml
- „download tasks as csv“ button should include `creationInfo` column
- csv downloaded later (from task search view) should contain the same info
- create task(s) *without* existing nml
- csv download should contain empty fields in creationInfo (should not crash)

### Issues:
- fixes #4865 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
