### PR TITLE
word break in upload zone nml filename

### DIFF
--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
@@ -121,7 +121,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
                 <Avatar size="large" icon="file" style={{ backgroundColor: "rgb(58, 144, 255)" }} />
               }
               title={
-                <span>
+                <span style={{ wordBreak: "break-word" }}>
                   {file.name}{" "}
                   <span className="ant-list-item-meta-description">({prettyBytes(file.size)})</span>
                 </span>


### PR DESCRIPTION
CSS again behaving rather weird… `word-wrap: break-word` does not do the trick in this case (it was set already before this pr), but `word-break: break-word` does so in major browsers, even though it is not in the standard. Compare [this SO thread](https://stackoverflow.com/questions/36150458/flex-item-overflows-container-due-to-long-word-even-after-using-word-wrap).

@leowe I hope I interpreted your issue description correctly in assuming that you are referring to the upload zone modal?

### Steps to test:
- drag nml with long filename (no spaces or dashs) into dataset / annotation
- filename in import modal should be readable

### Issues:
- fixes #4250

------
- [x] Ready for review
