### PR TITLE
Do not show toasts for bucket errors but notify airbrake instead

### DIFF
--- a/frontend/javascripts/libs/request.js
+++ b/frontend/javascripts/libs/request.js
@@ -266,13 +266,6 @@ class Request {
       setTimeout(() => resolve("timeout"), timeout);
     });
 
-  handleStatus = (response: Response): Promise<Response> => {
-    if (response.status >= 200 && response.status < 400) {
-      return Promise.resolve(response);
-    }
-    return Promise.reject(response);
-  };
-
   handleError = (
     requestedUrl: string,
     showErrorToast: boolean,

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
@@ -10,6 +10,7 @@ import {
   isSegmentationLayer,
   getByteCountFromLayer,
 } from "oxalis/model/accessors/dataset_accessor";
+import ErrorHandling from "libs/error_handling";
 import { parseAsMaybe } from "libs/utils";
 import { pushSaveQueueTransaction } from "oxalis/model/actions/save_actions";
 import { updateBucket } from "oxalis/model/sagas/update_actions";
@@ -179,14 +180,7 @@ export async function requestFromStore(
     detailedError += `(URL: ${dataUrl})`;
     console.error(`${errorMessage} ${detailedError}`);
     console.error(errorResponse);
-    Toast.warning(
-      errorMessage,
-      {
-        key: errorMessage,
-        sticky: false,
-      },
-      detailedError,
-    );
+    ErrorHandling.notify(new Error(errorMessage), { detailedError, errorResponse });
     return batch.map(_val => null);
   }
 }

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
@@ -18,7 +18,6 @@ import ByteArrayToLz4Base64Worker from "oxalis/workers/byte_array_to_lz4_base64.
 import DecodeFourBitWorker from "oxalis/workers/decode_four_bit.worker";
 import Request from "libs/request";
 import Store, { type DataLayerType } from "oxalis/store";
-import Toast from "libs/toast";
 import constants, { type Vector3, type Vector4 } from "oxalis/constants";
 
 const decodeFourBit = createWorker(DecodeFourBitWorker);

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/wkstore_adapter.js
@@ -171,15 +171,19 @@ export async function requestFromStore(
     const errorMessage = `Requesting data from layer "${
       layerInfo.name
     }" failed. Some rendered areas might remain empty. Retrying...`;
-    let detailedError =
+    const detailedError =
       errorResponse.status != null
-        ? `Status code ${errorResponse.status} - "${errorResponse.statusText}".`
+        ? `Status code ${errorResponse.status} - "${errorResponse.statusText}" - URL: ${
+            errorResponse.url
+          }.`
         : errorResponse.message;
 
-    detailedError += `(URL: ${dataUrl})`;
     console.error(`${errorMessage} ${detailedError}`);
     console.error(errorResponse);
-    ErrorHandling.notify(new Error(errorMessage), { detailedError, errorResponse });
+    ErrorHandling.notify(new Error(errorMessage), {
+      detailedError,
+      isOnline: window.navigator.onLine,
+    });
     return batch.map(_val => null);
   }
 }


### PR DESCRIPTION
For historical context, initially the toasts were enabled as part of https://github.com/scalableminds/webknossos/issues/4725.

Check airbrake and search for `requesting data` to see the error that is logged to airbrake.

### URL of deployed dev instance (used for testing):
- https://donotshowbucketerrors.webknossos.xyz

### Steps to test:
- Open a tracing on the deployed dev branch, open dev tools and choose "Offline" in the network tab. Move, so that buckets are requested. There should be no toast regarding the failed bucket requests. Check airbrake for the errors.

### Issues:
- fixes #4819 

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [ ] Ready for review
