### PR TITLE
Ignore ResizeObserver error

### DIFF
--- a/frontend/javascripts/libs/error_handling.js
+++ b/frontend/javascripts/libs/error_handling.js
@@ -15,6 +15,7 @@ import window, { document, location } from "libs/window";
 const MAX_NUM_ERRORS = 50;
 const BLACKLISTED_ERROR_MESSAGES = [
   "ResizeObserver loop limit exceeded",
+  "ResizeObserver loop completed with undelivered notifications.",
   "Invariant Violation: Cannot call hover while not dragging.",
   // Errors from the sortable-tree when dragging an element onto itself
   "Uncaught Invariant Violation: Expected to find a valid target.",


### PR DESCRIPTION
The error doesn't cause any problems. I checked airbrake for the exact error message, so this should be good to go, no need to test :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Issues:
- fixes #4839 

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [ ] Ready for review
