### PR TITLE
Time-track movements in the 3D viewport

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The find data function now works for volume tracings, too. [#4847](https://github.com/scalableminds/webknossos/pull/4847)
 - Added admins and dataset managers to dataset access list, as they can access all datasets of the organization. [#4862](https://github.com/scalableminds/webknossos/pull/4862)
 - Sped up the NML parsing via dashboard import. [#4872](https://github.com/scalableminds/webknossos/pull/4872)
+- Movements in the 3D viewport are now time-tracked. [#4876](https://github.com/scalableminds/webknossos/pull/4876)
 
 ### Changed
 - Brush circles are now connected with rectangles to provide a continuous stroke even if the brush is moved quickly. [#4785](https://github.com/scalableminds/webknossos/pull/4822)

--- a/frontend/javascripts/libs/trackball_controls.js
+++ b/frontend/javascripts/libs/trackball_controls.js
@@ -269,7 +269,7 @@ function TrackballControls(object, domElement, target, updateCallback) {
     }
   };
 
-  this.update = (externalUpdate = false) => {
+  this.update = (externalUpdate = false, userTriggered = false) => {
     _eye.subVectors(_this.object.position, _this.lastTarget);
 
     if (!_this.noRotate) {
@@ -298,7 +298,7 @@ function TrackballControls(object, domElement, target, updateCallback) {
 
     _this.lastTarget = _this.target.clone();
     if (!externalUpdate) {
-      _this.updateCallback();
+      _this.updateCallback(userTriggered);
     }
   };
 
@@ -383,7 +383,7 @@ function TrackballControls(object, domElement, target, updateCallback) {
     } else if (_state === STATE.PAN && !_this.noPan) {
       _this.getMouseOnScreen(event.pageX, event.pageY, _panEnd);
     }
-    _this.update();
+    _this.update(false, true);
   }
 
   function mouseup(event) {
@@ -490,7 +490,7 @@ function TrackballControls(object, domElement, target, updateCallback) {
       default:
         _state = STATE.NONE;
     }
-    _this.update();
+    _this.update(false, true);
   }
 
   function touchend(event) {

--- a/frontend/javascripts/oxalis/controller/camera_controller.js
+++ b/frontend/javascripts/oxalis/controller/camera_controller.js
@@ -27,7 +27,7 @@ import {
   getPosition,
 } from "oxalis/model/accessors/flycam_accessor";
 import { listenToStoreProperty } from "oxalis/model/helpers/listener_helpers";
-import { setTDCameraAction } from "oxalis/model/actions/view_mode_actions";
+import { setTDCameraWithoutTimeTrackingAction } from "oxalis/model/actions/view_mode_actions";
 import { voxelToNm, getBaseVoxel } from "oxalis/model/scaleinfo";
 import Store, { type CameraData } from "oxalis/store";
 import api from "oxalis/api/internal_api";
@@ -94,7 +94,7 @@ class CameraController extends React.PureComponent<Props> {
     }
 
     Store.dispatch(
-      setTDCameraAction({
+      setTDCameraWithoutTimeTrackingAction({
         near: 0,
         far,
       }),
@@ -325,7 +325,7 @@ export function rotate3DViewTo(id: OrthoView, animate: boolean = true): void {
     );
 
     Store.dispatch(
-      setTDCameraAction({
+      setTDCameraWithoutTimeTrackingAction({
         position: newPosition,
         up: tweened.up,
         left,

--- a/frontend/javascripts/oxalis/model/actions/view_mode_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/view_mode_actions.js
@@ -113,4 +113,13 @@ export type ViewModeAction =
   | SetInputCatcherRect
   | SetInputCatcherRects;
 
+export const ViewModeSaveRelevantActions = [
+  // TODO: This action is executed by the code very often, but also when rotating. Maybe trigger an extra
+  // action for the rotation and add it here, to find out whether the user triggered an action or the code.
+  // "SET_TD_CAMERA",
+  "CENTER_TD_VIEW",
+  "ZOOM_TD_VIEW",
+  "MOVE_TD_VIEW_BY_VECTOR",
+];
+
 export default {};

--- a/frontend/javascripts/oxalis/model/actions/view_mode_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/view_mode_actions.js
@@ -39,6 +39,23 @@ type MoveTDViewByVectorAction = {
   y: number,
 };
 
+// These two actions are used instead of their functionally identical counterparts
+// (without the `_WITHOUT_TIME_TRACKING` suffix)
+// when dispatching these actions should not trigger the save queue diffing.
+// Therefore, the save queue will not become dirty and no time is tracked by the backend.
+// The actions are used by initialization code and by the `setTargetAndFixPosition`
+// workaround in the td_controller.js.
+type SetTDCameraWithoutTimeTrackingAction = {
+  type: "SET_TD_CAMERA_WITHOUT_TIME_TRACKING",
+  cameraData: PartialCameraData,
+};
+
+type MoveTDViewByVectorWithoutTimeTrackingAction = {
+  type: "MOVE_TD_VIEW_BY_VECTOR_WITHOUT_TIME_TRACKING",
+  x: number,
+  y: number,
+};
+
 type SetInputCatcherRect = {
   type: "SET_INPUT_CATCHER_RECT",
   viewport: Viewport,
@@ -57,6 +74,14 @@ export const setViewportAction = (viewport: OrthoView): SetViewportAction => ({
 
 export const setTDCameraAction = (cameraData: PartialCameraData): SetTDCameraAction => ({
   type: "SET_TD_CAMERA",
+  cameraData,
+});
+
+// See the explanation further up for when to use this action instead of the setTDCameraAction
+export const setTDCameraWithoutTimeTrackingAction = (
+  cameraData: PartialCameraData,
+): SetTDCameraWithoutTimeTrackingAction => ({
+  type: "SET_TD_CAMERA_WITHOUT_TIME_TRACKING",
   cameraData,
 });
 
@@ -79,6 +104,16 @@ export const zoomTDViewAction = (
 
 export const moveTDViewByVectorAction = (x: number, y: number): MoveTDViewByVectorAction => ({
   type: "MOVE_TD_VIEW_BY_VECTOR",
+  x,
+  y,
+});
+
+// See the explanation further up for when to use this action instead of the moveTDViewByVectorAction
+export const moveTDViewByVectorWithoutTimeTrackingAction = (
+  x: number,
+  y: number,
+): MoveTDViewByVectorWithoutTimeTrackingAction => ({
+  type: "MOVE_TD_VIEW_BY_VECTOR_WITHOUT_TIME_TRACKING",
   x,
   y,
 });
@@ -107,16 +142,16 @@ export const setInputCatcherRects = (viewportRects: ViewportRects): SetInputCatc
 export type ViewModeAction =
   | SetViewportAction
   | SetTDCameraAction
+  | SetTDCameraWithoutTimeTrackingAction
   | CenterTDViewAction
   | ZoomTDViewAction
   | MoveTDViewByVectorAction
+  | MoveTDViewByVectorWithoutTimeTrackingAction
   | SetInputCatcherRect
   | SetInputCatcherRects;
 
 export const ViewModeSaveRelevantActions = [
-  // TODO: This action is executed by the code very often, but also when rotating. Maybe trigger an extra
-  // action for the rotation and add it here, to find out whether the user triggered an action or the code.
-  // "SET_TD_CAMERA",
+  "SET_TD_CAMERA",
   "CENTER_TD_VIEW",
   "ZOOM_TD_VIEW",
   "MOVE_TD_VIEW_BY_VECTOR",

--- a/frontend/javascripts/oxalis/model/helpers/compaction/compact_save_queue.js
+++ b/frontend/javascripts/oxalis/model/helpers/compaction/compact_save_queue.js
@@ -13,6 +13,15 @@ function removeAllButLastUpdateTracingAction(updateActionsBatches: Array<SaveQue
   return _.without(updateActionsBatches, ...updateTracingOnlyBatches.slice(0, -1));
 }
 
+function removeAllButLastUpdateTdCameraAction(updateActionsBatches: Array<SaveQueueEntry>) {
+  // This part of the code removes all entries from the save queue that consist only of
+  // one updateTdCamera update action, except for the last one
+  const updateTracingOnlyBatches = updateActionsBatches.filter(
+    batch => batch.actions.length === 1 && batch.actions[0].name === "updateTdCamera",
+  );
+  return _.without(updateActionsBatches, ...updateTracingOnlyBatches.slice(0, -1));
+}
+
 function removeSubsequentUpdateTreeActions(updateActionsBatches: Array<SaveQueueEntry>) {
   const obsoleteUpdateActions = [];
   // If two updateTree update actions for the same treeId follow one another, the first one is obsolete
@@ -32,6 +41,25 @@ function removeSubsequentUpdateTreeActions(updateActionsBatches: Array<SaveQueue
   return _.without(updateActionsBatches, ...obsoleteUpdateActions);
 }
 
+function removeSubsequentUpdateNodeActions(updateActionsBatches: Array<SaveQueueEntry>) {
+  const obsoleteUpdateActions = [];
+  // If two updateNode update actions for the same nodeId follow one another, the first one is obsolete
+  for (let i = 0; i < updateActionsBatches.length - 1; i++) {
+    const actions1 = updateActionsBatches[i].actions;
+    const actions2 = updateActionsBatches[i + 1].actions;
+    if (
+      actions1.length === 1 &&
+      actions1[0].name === "updateNode" &&
+      actions2.length === 1 &&
+      actions2[0].name === "updateNode" &&
+      actions1[0].value.id === actions2[0].value.id
+    ) {
+      obsoleteUpdateActions.push(updateActionsBatches[i]);
+    }
+  }
+  return _.without(updateActionsBatches, ...obsoleteUpdateActions);
+}
+
 export default function compactSaveQueue(
   updateActionsBatches: Array<SaveQueueEntry>,
 ): Array<SaveQueueEntry> {
@@ -40,5 +68,9 @@ export default function compactSaveQueue(
     updateActionsBatch => updateActionsBatch.actions.length > 0,
   );
 
-  return removeSubsequentUpdateTreeActions(removeAllButLastUpdateTracingAction(result));
+  return removeSubsequentUpdateTreeActions(
+    removeSubsequentUpdateNodeActions(
+      removeAllButLastUpdateTdCameraAction(removeAllButLastUpdateTracingAction(result)),
+    ),
+  );
 }

--- a/frontend/javascripts/oxalis/model/reducers/view_mode_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/view_mode_reducer.js
@@ -20,6 +20,7 @@ function ViewModeReducer(state: OxalisState, action: Action): OxalisState {
         },
       });
     }
+    case "SET_TD_CAMERA_WITHOUT_TIME_TRACKING":
     case "SET_TD_CAMERA": {
       return setTDCameraReducer(state, action.cameraData);
     }
@@ -35,6 +36,7 @@ function ViewModeReducer(state: OxalisState, action: Action): OxalisState {
         action.curHeight,
       );
     }
+    case "MOVE_TD_VIEW_BY_VECTOR_WITHOUT_TIME_TRACKING":
     case "MOVE_TD_VIEW_BY_VECTOR": {
       return moveTDViewByVectorReducer(state, action.x, action.y);
     }

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.js
@@ -520,9 +520,9 @@ export function* saveTracingTypeAsync(tracingType: "skeleton" | "volume"): Saga<
 
   while (true) {
     if (tracingType === "skeleton") {
-      console.log(yield* take(saveRelevantActionsForSkeleton));
+      yield* take(saveRelevantActionsForSkeleton);
     } else {
-      console.log(yield* take(saveRelevantActionsForVolume));
+      yield* take(saveRelevantActionsForVolume);
     }
     // The allowUpdate setting could have changed in the meantime
     const allowUpdate = yield* select(

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.js
@@ -488,18 +488,6 @@ export function* saveTracingAsync(): Saga<void> {
   yield _all([_call(saveTracingTypeAsync, "skeleton"), _call(saveTracingTypeAsync, "volume")]);
 }
 
-const saveRelevantActionsForSkeleton = [
-  ...SkeletonTracingSaveRelevantActions,
-  ...FlycamActions,
-  ...ViewModeSaveRelevantActions,
-  "SET_TRACING",
-];
-const saveRelevantActionsForVolume = [
-  ...VolumeTracingSaveRelevantActions,
-  ...FlycamActions,
-  ...ViewModeSaveRelevantActions,
-];
-
 export function* saveTracingTypeAsync(tracingType: "skeleton" | "volume"): Saga<void> {
   yield* take(
     tracingType === "skeleton" ? "INITIALIZE_SKELETONTRACING" : "INITIALIZE_VOLUMETRACING",
@@ -520,9 +508,18 @@ export function* saveTracingTypeAsync(tracingType: "skeleton" | "volume"): Saga<
 
   while (true) {
     if (tracingType === "skeleton") {
-      yield* take(saveRelevantActionsForSkeleton);
+      yield* take([
+        ...SkeletonTracingSaveRelevantActions,
+        ...FlycamActions,
+        ...ViewModeSaveRelevantActions,
+        "SET_TRACING",
+      ]);
     } else {
-      yield* take(saveRelevantActionsForVolume);
+      yield* take([
+        ...VolumeTracingSaveRelevantActions,
+        ...FlycamActions,
+        ...ViewModeSaveRelevantActions,
+      ]);
     }
     // The allowUpdate setting could have changed in the meantime
     const allowUpdate = yield* select(

--- a/frontend/javascripts/oxalis/model/sagas/update_actions.js
+++ b/frontend/javascripts/oxalis/model/sagas/update_actions.js
@@ -52,7 +52,7 @@ export type CreateNodeUpdateAction = {|
   name: "createNode",
   value: NodeWithTreeId,
 |};
-type UpdateNodeUpdateAction = {|
+export type UpdateNodeUpdateAction = {|
   name: "updateNode",
   value: NodeWithTreeId,
 |};
@@ -63,7 +63,7 @@ export type UpdateTreeVisibilityUpdateAction = {|
     isVisible: boolean,
   |},
 |};
-type UpdateTreeGroupVisibilityUpdateAction = {|
+export type UpdateTreeGroupVisibilityUpdateAction = {|
   name: "updateTreeGroupVisibility",
   value: {|
     treeGroupId: ?number,
@@ -77,7 +77,7 @@ export type DeleteNodeUpdateAction = {|
     nodeId: number,
   |},
 |};
-type CreateEdgeUpdateAction = {|
+export type CreateEdgeUpdateAction = {|
   name: "createEdge",
   value: {|
     treeId: number,
@@ -85,7 +85,7 @@ type CreateEdgeUpdateAction = {|
     target: number,
   |},
 |};
-type DeleteEdgeUpdateAction = {|
+export type DeleteEdgeUpdateAction = {|
   name: "deleteEdge",
   value: {|
     treeId: number,
@@ -140,6 +140,10 @@ export type RemoveFallbackLayerAction = {|
   name: "removeFallbackLayer",
   value: {},
 |};
+export type UpdateTdCameraAction = {|
+  name: "updateTdCamera",
+  value: {},
+|};
 
 export type UpdateAction =
   | UpdateTreeUpdateAction
@@ -159,7 +163,8 @@ export type UpdateAction =
   | UpdateTreeGroupVisibilityUpdateAction
   | RevertToVersionUpdateAction
   | UpdateTreeGroupsUpdateAction
-  | RemoveFallbackLayerAction;
+  | RemoveFallbackLayerAction
+  | UpdateTdCameraAction;
 
 // This update action is only created in the frontend for display purposes
 type CreateTracingUpdateAction = {|
@@ -196,7 +201,8 @@ export type ServerUpdateAction =
   | AsServerAction<RevertToVersionUpdateAction>
   | AsServerAction<UpdateTreeGroupsUpdateAction>
   | AsServerAction<CreateTracingUpdateAction>
-  | AsServerAction<RemoveFallbackLayerAction>;
+  | AsServerAction<RemoveFallbackLayerAction>
+  | AsServerAction<UpdateTdCameraAction>;
 
 export function createTree(tree: Tree): UpdateTreeUpdateAction {
   return {
@@ -403,6 +409,13 @@ export function revertToVersion(version: number): RevertToVersionUpdateAction {
 export function removeFallbackLayer(): RemoveFallbackLayerAction {
   return {
     name: "removeFallbackLayer",
+    value: {},
+  };
+}
+
+export function updateTdCamera(): UpdateTdCameraAction {
+  return {
+    name: "updateTdCamera",
     value: {},
   };
 }

--- a/frontend/javascripts/oxalis/view/version_entry.js
+++ b/frontend/javascripts/oxalis/view/version_entry.js
@@ -11,18 +11,46 @@ import type {
   UpdateTreeUpdateAction,
   DeleteTreeUpdateAction,
   RevertToVersionUpdateAction,
+  UpdateNodeUpdateAction,
+  UpdateTreeVisibilityUpdateAction,
+  UpdateTreeGroupVisibilityUpdateAction,
+  CreateEdgeUpdateAction,
+  DeleteEdgeUpdateAction,
 } from "oxalis/model/sagas/update_actions";
 import FormattedDate from "components/formatted_date";
+import { MISSING_GROUP_ID } from "oxalis/view/right-menu/tree_hierarchy_view_helpers";
 
 type Description = { description: string, type: string };
 
+// The order in which the update actions are added to this object,
+// determines the order in which update actions are checked
+// to describe an update action batch. See also the comment
+// of the `getDescriptionForBatch` function.
 const descriptionFns = {
-  deleteTree: (action: DeleteTreeUpdateAction): Description => ({
-    description: `Deleted the tree with id ${action.value.id}.`,
+  importVolumeTracing: (): Description => ({
+    description: "Imported a volume tracing.",
+    type: "plus",
+  }),
+  createTracing: (): Description => ({
+    description: "Created the annotation.",
+    type: "rocket",
+  }),
+  updateUserBoundingBoxes: (): Description => ({
+    description: "Updated a user bounding box.",
+    type: "codepen",
+  }),
+  removeFallbackLayer: (): Description => ({
+    description: "Removed the segmentation fallback layer.",
     type: "delete",
   }),
-  deleteNode: (action: DeleteNodeUpdateAction): Description => ({
-    description: `Deleted the node with id ${action.value.nodeId}.`,
+  deleteTree: (action: DeleteTreeUpdateAction, count: number): Description => ({
+    description:
+      count > 1 ? `Deleted ${count} trees.` : `Deleted the tree with id ${action.value.id}.`,
+    type: "delete",
+  }),
+  deleteNode: (action: DeleteNodeUpdateAction, count: number): Description => ({
+    description:
+      count > 1 ? `Deleted ${count} nodes.` : `Deleted the node with id ${action.value.nodeId}.`,
     type: "delete",
   }),
   revertToVersion: (action: RevertToVersionUpdateAction): Description => ({
@@ -49,13 +77,35 @@ const descriptionFns = {
     description: "Updated the segmentation.",
     type: "picture",
   }),
-  importVolumeTracing: (): Description => ({
-    description: "Imported a Volume Tracing.",
+  updateNode: (action: UpdateNodeUpdateAction): Description => ({
+    description: `Updated the node with id ${action.value.id}.`,
+    type: "edit",
+  }),
+  updateTreeVisibility: (action: UpdateTreeVisibilityUpdateAction): Description => ({
+    description: `Updated the visibility of the tree with id ${action.value.treeId}.`,
+    type: "eye",
+  }),
+  updateTreeGroupVisibility: (action: UpdateTreeGroupVisibilityUpdateAction): Description => ({
+    description: `Updated the visibility of the group with id ${
+      action.value.treeGroupId != null ? action.value.treeGroupId : MISSING_GROUP_ID
+    }.`,
+    type: "eye",
+  }),
+  createEdge: (action: CreateEdgeUpdateAction): Description => ({
+    description: `Created the edge between node ${action.value.source} and node ${
+      action.value.target
+    }.`,
     type: "plus",
   }),
-  createTracing: (): Description => ({
-    description: "Created the annotation.",
-    type: "rocket",
+  deleteEdge: (action: DeleteEdgeUpdateAction): Description => ({
+    description: `Deleted the edge between node ${action.value.source} and node ${
+      action.value.target
+    }.`,
+    type: "delete",
+  }),
+  updateTdCamera: (): Description => ({
+    description: "Updated the 3D view.",
+    type: "code-sandbox",
   }),
 };
 
@@ -67,9 +117,20 @@ function getDescriptionForSpecificBatch(
   if (firstAction.name !== type) {
     throw new Error("Flow constraint violated");
   }
-  return descriptionFns[type](firstAction);
+  return descriptionFns[type](firstAction, actions.length);
 }
 
+// An update action batch can consist of more than one update action as a single user action
+// can lead to multiple update actions. For example, deleting a node in a tree with multiple
+// nodes will also delete an edge, so the batch contains those two update actions.
+// This particular action and many more actions modify the active node of the tracing
+// which results in an updateTracing action being part of the batch as well.
+// The key of this function is to identify the most prominent action of a batch and label the
+// batch with a description of this action.
+// The order in which the actions are checked is, therefore, important. Check for
+// "more expressive" update actions first and for more general ones later.
+// The order is determined by the order in which the update actions are added to the
+// `descriptionFns` object.
 function getDescriptionForBatch(actions: Array<ServerUpdateAction>): Description {
   const groupedUpdateActions = _.groupBy(actions, "name");
 
@@ -96,6 +157,7 @@ function getDescriptionForBatch(actions: Array<ServerUpdateAction>): Description
 
   // If more than one createNode update actions are part of one batch, that is not a tree merge or split
   // an NML was uploaded.
+  // TODO: This could've also been an undo/redo action.
   const createNodeUAs = groupedUpdateActions.createNode;
   if (createNodeUAs != null && createNodeUAs.length > 1) {
     return {
@@ -104,56 +166,14 @@ function getDescriptionForBatch(actions: Array<ServerUpdateAction>): Description
     };
   }
 
-  const deleteTreeUAs = groupedUpdateActions.deleteTree;
-  if (deleteTreeUAs != null) {
-    return getDescriptionForSpecificBatch(deleteTreeUAs, "deleteTree");
+  for (const key of Object.keys(descriptionFns)) {
+    const updateActions = groupedUpdateActions[key];
+    if (updateActions != null) {
+      return getDescriptionForSpecificBatch(updateActions, key);
+    }
   }
 
-  const deleteNodeUAs = groupedUpdateActions.deleteNode;
-  if (deleteNodeUAs != null) {
-    return getDescriptionForSpecificBatch(deleteNodeUAs, "deleteNode");
-  }
-
-  const revertToVersionUAs = groupedUpdateActions.revertToVersion;
-  if (revertToVersionUAs != null) {
-    return getDescriptionForSpecificBatch(revertToVersionUAs, "revertToVersion");
-  }
-
-  if (createNodeUAs != null) {
-    return getDescriptionForSpecificBatch(createNodeUAs, "createNode");
-  }
-
-  const createTreeUAs = groupedUpdateActions.createTree;
-  if (createTreeUAs != null) {
-    return getDescriptionForSpecificBatch(createTreeUAs, "createTree");
-  }
-
-  const updateTreeGroupsUAs = groupedUpdateActions.updateTreeGroups;
-  if (updateTreeGroupsUAs != null) {
-    return getDescriptionForSpecificBatch(updateTreeGroupsUAs, "updateTreeGroups");
-  }
-
-  const updateTreeUAs = groupedUpdateActions.updateTree;
-  if (updateTreeUAs != null) {
-    return getDescriptionForSpecificBatch(updateTreeUAs, "updateTree");
-  }
-
-  const updateBucketUAs = groupedUpdateActions.updateBucket;
-  if (updateBucketUAs != null) {
-    return getDescriptionForSpecificBatch(updateBucketUAs, "updateBucket");
-  }
-
-  const importVolumeTracingUAs = groupedUpdateActions.importVolumeTracing;
-  if (importVolumeTracingUAs != null) {
-    return getDescriptionForSpecificBatch(importVolumeTracingUAs, "importVolumeTracing");
-  }
-
-  const createTracingUAs = groupedUpdateActions.createTracing;
-  if (createTracingUAs != null) {
-    return getDescriptionForSpecificBatch(createTracingUAs, "createTracing");
-  }
-
-  // Catch-all for other update actions, currently updateNode and updateTracing.
+  // Catch-all for other update actions, currently updateTracing.
   return {
     description: "Modified the annotation.",
     type: "edit",

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -105,6 +105,7 @@ class VolumeTracingService @Inject()(
               case a: UpdateUserBoundingBoxVisibility => updateBoundingBoxVisibility(t, a.boundingBoxId, a.isVisible)
               case _: RemoveFallbackLayer             => Fox.successful(t.clearFallbackLayer)
               case a: ImportVolumeData                => Fox.successful(t.withLargestSegmentId(a.largestSegmentId))
+              case _: UpdateTdCamera                  => Fox.successful(t)
               case _                                  => Fox.failure("Unknown action.")
             }
           case Empty =>

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
@@ -113,6 +113,20 @@ object ImportVolumeData {
   implicit val importVolumeData = Json.format[ImportVolumeData]
 }
 
+case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[String] = None)
+    extends VolumeUpdateAction {
+
+  override def addTimestamp(timestamp: Long): VolumeUpdateAction =
+    this.copy(actionTimestamp = Some(timestamp))
+
+  override def transformToCompact: CompactVolumeUpdateAction =
+    CompactVolumeUpdateAction("updateTdCamera", actionTimestamp, Json.obj())
+}
+
+object UpdateTdCamera {
+  implicit val updateTdCameraFormat = Json.format[UpdateTdCamera]
+}
+
 case class CompactVolumeUpdateAction(name: String, actionTimestamp: Option[Long], value: JsObject)
     extends VolumeUpdateAction
 
@@ -142,6 +156,7 @@ object VolumeUpdateAction {
         case "updateUserBoundingBoxVisibility" => (json \ "value").validate[UpdateUserBoundingBoxVisibility]
         case "removeFallbackLayer"             => (json \ "value").validate[RemoveFallbackLayer]
         case "importVolumeTracing"             => (json \ "value").validate[ImportVolumeData]
+        case "updateTdCamera"                  => (json \ "value").validate[UpdateTdCamera]
         case unknownAction: String             => JsError(s"Invalid update action s'$unknownAction'")
       }
 
@@ -165,6 +180,8 @@ object VolumeUpdateAction {
         Json.obj("name" -> "removeFallbackLayer", "value" -> Json.toJson(s)(RemoveFallbackLayer.removeFallbackLayer))
       case s: ImportVolumeData =>
         Json.obj("name" -> "importVolumeTracing", "value" -> Json.toJson(s)(ImportVolumeData.importVolumeData))
+      case s: UpdateTdCamera =>
+        Json.obj("name" -> "updateTdCamera", "value" -> Json.toJson(s)(UpdateTdCamera.updateTdCameraFormat))
       case s: CompactVolumeUpdateAction => Json.toJson(s)(CompactVolumeUpdateAction.compactVolumeUpdateActionFormat)
     }
   }


### PR DESCRIPTION
- Added a new `updateTdCamera` update action which is triggered if the user modified the 3D view, so that these actions can be time tracked. The action is empty otherwise.
- While I was at it I spent some love on the version view, added a lot of missing descriptions for certain update actions (tree/group visibility, user bounding boxes, fallback layer removal, node updates, edge deletion/addition) and extended the tree deletion message as by now multiple trees can be deleted at once.
- I added save queue compaction for `updateNode` update actions as otherwise lots of new versions are created if the radius of a node is changed or a node is moved. `updateTdCamera` actions are also compacted and only the last one within one save interval is kept.
- I've also noticed that the Undo of a tree deletion is misinterpreted as an NML upload by the version view (as multiple nodes are created at once which is not possible otherwise). Looking at the update actions one cannot be distinguished from the other, so I'm not sure how to fix this.

TODO:
- [x] Rotation in the 3D view is not picked up as a change yet, because the action that is used for that is also used when hovering over the 3D view and when initializing the tracing (those should not be counted as actions). I'll probably dispatch another action for the 3D view rotation so that it can be recognized and told apart from the other actions. _(Solved by introducing a duplicate action that doesn't trigger the save queue diffing which is used accordingly)_

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Move/Zoom/Rotate the 3D view - the save button should indicate that there are changes which need to be saved.
- Create a task and exclusively do stuff in the 3D view - time should be tracked.
- Check the version view to see whether the action is correctly labeled and also that subsequent movements in the 3D view within one save interval are compacted to only one version.
- Do some of the other mentioned actions with new descriptions/compactions and check the version view afterwards.

### Issues:
- fixes #4825 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
