### PR TITLE
Fix unwanted group expansions

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -9,7 +9,6 @@ import SortableTree from "react-sortable-tree";
 import _ from "lodash";
 import type { Dispatch } from "redux";
 import { type Action } from "oxalis/model/actions/actions";
-import update from "immutability-helper";
 import {
   MISSING_GROUP_ID,
   TYPE_GROUP,
@@ -126,7 +125,11 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
   }
 
   onChange = (treeData: Array<TreeNode>) => {
-    this.setState({ groupTree: treeData });
+    const expandedGroupIds = {};
+    forEachTreeNode(treeData, node => {
+      if (node.type === TYPE_GROUP && node.expanded) expandedGroupIds[node.id] = true;
+    });
+    this.setState({ groupTree: treeData, expandedGroupIds });
   };
 
   onCheck = (evt: SyntheticMouseEvent<*>) => {
@@ -174,15 +177,6 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
     } else {
       this.selectGroupById(groupId);
     }
-  };
-
-  onExpand = (params: { node: TreeNode, expanded: boolean }) => {
-    // Cannot use object destructuring in the parameters here, because the linter will complain
-    // about the Flow types
-    const { node, expanded } = params;
-    this.setState(prevState => ({
-      expandedGroupIds: update(prevState.expandedGroupIds, { [node.id]: { $set: expanded } }),
-    }));
   };
 
   setExpansionOfAllSubgroupsTo = (groupId: number, expanded: boolean) => {
@@ -393,29 +387,6 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
     return node.type === TYPE_GROUP ? node.id : -1 - node.id;
   }
 
-  searchFinishCallback = (matches: Array<{ path: Array<number> }>) => {
-    if (matches.length === 0) return;
-
-    // Nodes which are matched, automatically trigger the expansion of all their parent groups.
-    // However, this does not trigger the onVisibilityToggle, which is why this function is needed.
-    const { path } = matches[0];
-    // Use the latest state to avoid races with the onChange state update
-    this.setState(prevState => {
-      const expandedGroupIds = {};
-      // The last entry in the path is the activated group/tree which should not be expanded
-      for (const groupId of path.slice(0, -1)) {
-        // path contains node keys (see getNodeKey), but as we are looking for a group
-        // where the node key equals the groupId, this is fine
-        findTreeNode(prevState.groupTree, groupId, item => {
-          if (item.expanded && item.type === TYPE_GROUP) expandedGroupIds[groupId] = true;
-        });
-      }
-      return {
-        expandedGroupIds: update(prevState.expandedGroupIds, { $merge: expandedGroupIds }),
-      };
-    });
-  };
-
   canDrop(params: { nextParent: TreeNode }) {
     const { nextParent } = params;
     return nextParent != null && nextParent.type === TYPE_GROUP;
@@ -436,11 +407,9 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
               treeData={this.state.groupTree}
               onChange={this.onChange}
               onMoveNode={this.onMoveNode}
-              onVisibilityToggle={this.onExpand}
               searchMethod={this.keySearchMethod}
               searchQuery={{ activeTreeId, activeGroupId }}
               getNodeKey={this.getNodeKey}
-              searchFinishCallback={this.searchFinishCallback}
               generateNodeProps={this.generateNodeProps}
               canDrop={this.canDrop}
               canDrag={this.canDrag}


### PR DESCRIPTION
This fixes a bug which was introduced in #4897.

The `finishSearchCallback` is not only called if the parent groups of the found node are expanded, but also when the tree data changes (where the parent groups of the found node are not expanded). I implemented a fix for that by checking for each element on the path whether it was actually expanded, but that was rather complicated. Therefore, I solved this issue in a more general way by updating the `expandedGroupIds` list whenever the `onChange` handler of the sortable-tree is called because the tree data changed. This way the two structures are always in sync. I think this solution is much less error-prone and the performance impact should be negligible.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- The bug could be triggered as follows. Create a tracing with this structure:
  - groupA
    - tree1
  - groupB
    - tree2
- Activate tree1 and then collapse groupA. Now change the visibility of groupB or tree2.
- On master this would expand groupA again, which should no longer happen on this branch.

- Also check whether group expansion, toggling of all sub groups works as before.

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
