### PR TITLE
Bump wkw version to 1.1.9

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed the disappearing of dataset settings after switching between view mode and annotation mode. [#4845](https://github.com/scalableminds/webknossos/pull/4845)
 - Fixed a rare error in the agglomerate mapping for large datasets. [#4904](https://github.com/scalableminds/webknossos/pull/4904)
+- Fixed a bug where in volume annotation zip upload some buckets were discarded. [#4914](https://github.com/scalableminds/webknossos/pull/4914)
 
 ### Removed
 -

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
   val akkaVersion = "2.5.22"
   val log4jVersion = "2.13.3"
-  val webknossosWrapVersion = "1.1.7"
+  val webknossosWrapVersion = "1.1.8"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % akkaVersion
   val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
   val akkaVersion = "2.5.22"
   val log4jVersion = "2.13.3"
-  val webknossosWrapVersion = "1.1.8"
+  val webknossosWrapVersion = "1.1.9"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % akkaVersion
   val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion


### PR DESCRIPTION
- new webknossos-wrap version 1.1.9 includes fix in https://github.com/scalableminds/webknossos-wrap/pull/57 so it should fix the volume annotation upload bug where some data is missing.

### Steps to test:
- download + reupload relatively large volume annotation
- all buckets should be present

### Issues:
- fixes #4905 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracing update after deployment
- [x] Ready for review
