### PR TITLE
Isosurface List

### DIFF
--- a/frontend/javascripts/oxalis/default_state.js
+++ b/frontend/javascripts/oxalis/default_state.js
@@ -205,6 +205,7 @@ const defaultState: OxalisState = {
     hasOrganizations: false,
     isRefreshingIsosurfaces: false,
   },
+  isosurfaces: [],
 };
 
 export default defaultState;

--- a/frontend/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/annotation_actions.js
@@ -93,6 +93,11 @@ export type RemoveIsosurfaceAction = {
   cellId: number,
 };
 
+export type UpdateIsosurfaceListAction = {
+  type: "UPDATE_ISOSURFACE_LIST",
+  segmentIdList: Array<number>,
+};
+
 export type AnnotationActionTypes =
   | InitializeAnnotationAction
   | SetAnnotationNameAction
@@ -110,7 +115,8 @@ export type AnnotationActionTypes =
   | RefreshIsosurfacesAction
   | FinishedRefreshingIsosurfacesAction
   | ImportIsosurfaceFromStlAction
-  | RemoveIsosurfaceAction;
+  | RemoveIsosurfaceAction
+  | UpdateIsosurfaceListAction;
 
 export const initializeAnnotationAction = (
   annotation: APIAnnotation,
@@ -220,4 +226,9 @@ export const importIsosurfaceFromStlAction = (
 export const removeIsosurfaceAction = (cellId: number): RemoveIsosurfaceAction => ({
   type: "REMOVE_ISOSURFACE",
   cellId,
+});
+
+export const addIsosurfaceAction = (segmentIdList: Array<number>): UpdateIsosurfaceListAction => ({
+  type: "UPDATE_ISOSURFACE_LIST",
+  segmentIdList,
 });

--- a/frontend/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/annotation_actions.js
@@ -93,9 +93,9 @@ export type RemoveIsosurfaceAction = {
   cellId: number,
 };
 
-export type UpdateIsosurfaceListAction = {
-  type: "UPDATE_ISOSURFACE_LIST",
-  segmentIdList: Array<number>,
+export type AddIsosurfaceAction = {
+  type: "ADD_ISOSURFACE",
+  cellId: number,
 };
 
 export type AnnotationActionTypes =
@@ -116,7 +116,7 @@ export type AnnotationActionTypes =
   | FinishedRefreshingIsosurfacesAction
   | ImportIsosurfaceFromStlAction
   | RemoveIsosurfaceAction
-  | UpdateIsosurfaceListAction;
+  | AddIsosurfaceAction;
 
 export const initializeAnnotationAction = (
   annotation: APIAnnotation,
@@ -228,7 +228,7 @@ export const removeIsosurfaceAction = (cellId: number): RemoveIsosurfaceAction =
   cellId,
 });
 
-export const addIsosurfaceAction = (segmentIdList: Array<number>): UpdateIsosurfaceListAction => ({
-  type: "UPDATE_ISOSURFACE_LIST",
-  segmentIdList,
+export const addIsosurfaceAction = (cellId: number): AddIsosurfaceAction => ({
+  type: "ADD_ISOSURFACE",
+  cellId,
 });

--- a/frontend/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/annotation_actions.js
@@ -71,8 +71,13 @@ export type CreateMeshFromBufferAction = {
   name: string,
 };
 
+export type TriggerActiveIsosurfaceDownloadAction = {
+  type: "TRIGGER_ACTIVE_ISOSURFACE_DOWNLOAD",
+};
+
 export type TriggerIsosurfaceDownloadAction = {
   type: "TRIGGER_ISOSURFACE_DOWNLOAD",
+  cellId: number,
 };
 
 export type RefreshIsosurfacesAction = {
@@ -111,6 +116,7 @@ export type AnnotationActionTypes =
   | DeleteMeshAction
   | CreateMeshFromBufferAction
   | UpdateLocalMeshMetaDataAction
+  | TriggerActiveIsosurfaceDownloadAction
   | TriggerIsosurfaceDownloadAction
   | RefreshIsosurfacesAction
   | FinishedRefreshingIsosurfacesAction
@@ -204,8 +210,15 @@ export const createMeshFromBufferAction = (
   name,
 });
 
-export const triggerIsosurfaceDownloadAction = (): TriggerIsosurfaceDownloadAction => ({
+export const triggerActiveIsosurfaceDownloadAction = (): TriggerActiveIsosurfaceDownloadAction => ({
+  type: "TRIGGER_ACTIVE_ISOSURFACE_DOWNLOAD",
+});
+
+export const triggerIsosurfaceDownloadAction = (
+  cellId: number,
+): TriggerIsosurfaceDownloadAction => ({
   type: "TRIGGER_ISOSURFACE_DOWNLOAD",
+  cellId,
 });
 
 export const refreshIsosurfacesAction = (): RefreshIsosurfacesAction => ({

--- a/frontend/javascripts/oxalis/model/reducers/annotation_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/annotation_reducer.js
@@ -117,7 +117,8 @@ function AnnotationReducer(state: OxalisState, action: Action): OxalisState {
 
     case "ADD_ISOSURFACE": {
       const { cellId } = action;
-      const newIsosurfaceList = state.isosurfaces.filter(id => id !== cellId).push(cellId);
+      const newIsosurfaceList = state.isosurfaces.filter(id => id !== cellId);
+      newIsosurfaceList.push(cellId);
       return update(state, {
         isosurfaces: { $set: newIsosurfaceList },
       });

--- a/frontend/javascripts/oxalis/model/reducers/annotation_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/annotation_reducer.js
@@ -107,10 +107,19 @@ function AnnotationReducer(state: OxalisState, action: Action): OxalisState {
       return updateKey(state, "tracing", { meshes: newMeshes });
     }
 
-    case "UPDATE_ISOSURFACE_LIST": {
-      const { segmentIdList } = action;
+    case "REMOVE_ISOSURFACE": {
+      const { cellId } = action;
+      const newIsosurfaceList = state.isosurfaces.filter(id => id !== cellId);
       return update(state, {
-        isosurfaces: { $set: segmentIdList },
+        isosurfaces: { $set: newIsosurfaceList },
+      });
+    }
+
+    case "ADD_ISOSURFACE": {
+      const { cellId } = action;
+      const newIsosurfaceList = state.isosurfaces.filter(id => id !== cellId).push(cellId);
+      return update(state, {
+        isosurfaces: { $set: newIsosurfaceList },
       });
     }
 

--- a/frontend/javascripts/oxalis/model/reducers/annotation_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/annotation_reducer.js
@@ -107,6 +107,13 @@ function AnnotationReducer(state: OxalisState, action: Action): OxalisState {
       return updateKey(state, "tracing", { meshes: newMeshes });
     }
 
+    case "UPDATE_ISOSURFACE_LIST": {
+      const { segmentIdList } = action;
+      return update(state, {
+        isosurfaces: { $set: segmentIdList },
+      });
+    }
+
     default:
       return state;
   }

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -10,6 +10,7 @@ import { type Vector3 } from "oxalis/constants";
 import { type FlycamAction, FlycamActions } from "oxalis/model/actions/flycam_actions";
 import {
   removeIsosurfaceAction,
+  addIsosurfaceAction,
   finishedRefreshingIsosurfacesAction,
   type ImportIsosurfaceFromStlAction,
   type RemoveIsosurfaceAction,
@@ -182,6 +183,7 @@ function* loadIsosurfaceWithNeighbors(
 ): Saga<void> {
   let isInitialRequest = true;
   let positionsToRequest = [clippedPosition];
+  yield* put(addIsosurfaceAction(segmentId));
   while (positionsToRequest.length > 0) {
     const position = positionsToRequest.shift();
     const neighbors = yield* call(

--- a/frontend/javascripts/oxalis/store.js
+++ b/frontend/javascripts/oxalis/store.js
@@ -463,6 +463,7 @@ export type OxalisState = {|
   +viewModeData: ViewModeData,
   +activeUser: ?APIUser,
   +uiInformation: UiInformation,
+  +isosurfaces: Array<number>,
 |};
 
 const sagaMiddleware = createSagaMiddleware();

--- a/frontend/javascripts/oxalis/view/right-menu/meshes_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/meshes_view.js
@@ -134,6 +134,20 @@ class MeshesView extends React.Component<Props, { currentlyEditedMesh: ?MeshMeta
   };
 
   render() {
+    const reloadButton = (
+      <Icon
+        key="reload-button"
+        type="redo"
+        onClick={(__, segmentId: number) => console.log(segmentId)}
+      />
+    );
+    const downloadButton = (
+      <Icon
+        key="reload-button"
+        type="vertical-align-bottom"
+        onClick={(__, segmentId: number) => console.log(segmentId)}
+      />
+    );
     const convertHSLAToCSSString = ([h, s, l, a]) =>
       `hsla(${360 * h}, ${100 * s}%, ${100 * l}%, ${a})`;
 
@@ -141,13 +155,12 @@ class MeshesView extends React.Component<Props, { currentlyEditedMesh: ?MeshMeta
       convertHSLAToCSSString(jsConvertCellIdToHSLA(id, this.props.mappingColors));
 
     const renderIsosurfaceListItem = (cellId: number) => (
-      <List.Item>
+      <List.Item actions={[reloadButton, downloadButton]}>
         {" "}
         <span
-          className="colored-circle"
+          className="circle"
           style={{ backgroundColor: convertCellIdToCSS(cellId) }}
-        />{" "}
-        Segment {cellId}
+        /> Segment {cellId}
       </List.Item>
     );
 
@@ -178,7 +191,11 @@ class MeshesView extends React.Component<Props, { currentlyEditedMesh: ?MeshMeta
             </Tooltip>
           )}
         </ButtonGroup>
-        <List dataSource={this.props.isosurfaces} renderItem={renderIsosurfaceListItem} />
+        <List
+          dataSource={this.props.isosurfaces}
+          renderItem={renderIsosurfaceListItem}
+          split={false}
+        />
         {this.state.currentlyEditedMesh != null ? (
           <EditMeshModal
             initialMesh={this.state.currentlyEditedMesh}

--- a/frontend/javascripts/oxalis/view/right-menu/meshes_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/meshes_view.js
@@ -136,11 +136,6 @@ class MeshesView extends React.Component<Props, { currentlyEditedMesh: ?MeshMeta
   };
 
   render() {
-    const refreshButton = (segmentId: number) => (
-      <Tooltip title="refresh isosurface">
-        <Icon key="refresh-button" type="redo" onClick={console.log(segmentId)} />
-      </Tooltip>
-    );
     const downloadButton = (segmentId: number) => (
       <Tooltip title="download isosurface">
         <Icon
@@ -156,10 +151,7 @@ class MeshesView extends React.Component<Props, { currentlyEditedMesh: ?MeshMeta
       convertHSLAToCSSString(jsConvertCellIdToHSLA(id, this.props.mappingColors));
 
     const renderListItem = (cellId: number) => (
-      <List.Item
-        actions={[refreshButton(cellId), downloadButton(cellId)]}
-        style={{ marginBottom: -15 }}
-      >
+      <List.Item actions={[downloadButton(cellId)]} style={{ marginBottom: -15 }}>
         <span
           className="circle"
           style={{

--- a/frontend/stylesheets/_general.less
+++ b/frontend/stylesheets/_general.less
@@ -35,3 +35,11 @@ p {
   filter: FlipH;
   -ms-filter: "FlipH";
 }
+
+.circle {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 5px;
+}


### PR DESCRIPTION
This PR adds a list of isosurfaces in the meshes tab while viewing a dataset.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- view a dataset
- enable isosurfaces
- open meshes tab
- create isosufaces by pressing shift and clicking on a cell
- the list shoul diplay evey isosurface
- delete isosurfaces by pressing ctrl and clicking on the isosurface
- deleted isosurfaces should not be in the list
- download an isosurface by clicking on its download icon in the list

### Issues:
- #4835 
------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
