### PR TITLE
Fix broken overwrite-mode behavior

### DIFF
--- a/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -52,6 +52,7 @@ import Constants, {
   type ContourMode,
   type OverwriteMode,
   ContourModeEnum,
+  OverwriteModeEnum,
   type OrthoView,
   type VolumeTool,
   type Vector2,
@@ -303,7 +304,7 @@ function* labelWithVoxelBuffer2D(
     }
   }
 
-  const shouldOverwrite = contourTracingMode === ContourModeEnum.DRAW;
+  const shouldOverwrite = overwriteMode === OverwriteModeEnum.OVERWRITE_ALL;
 
   // Since the LabeledVoxelMap is created in the current magnification,
   // we only need to annotate one slice in this mag.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I used both brush and trace tool with left/right click (for draw vs delete) to test both overwrite-behaviors (via ctrl and mode switch)

### Issues:
- this bug was introduced with #4755 

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
