### PR TITLE
Re-enable continuous brush and fix perf + edge-case bugs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - In the tree tab, all groups but the root group are now collapsed instead of expanded when opening a tracing. [#4897](https://github.com/scalableminds/webknossos/pull/4897)
 - New volume/hybrid annotations are now automatically multi-resolution volume annotations. [#4755](https://github.com/scalableminds/webknossos/pull/4755)
 - Improved performance of volume annotations (brush and trace tool). [#4848](https://github.com/scalableminds/webknossos/pull/4848)
+- Re-enabled continuous brush strokes. This feature ensures that even fast brush strokes are continuous and don't have "holes". [#4924](https://github.com/scalableminds/webknossos/pull/4924)
 
 ### Fixed
 - Fixed the disappearing of dataset settings after switching between view mode and annotation mode. [#4845](https://github.com/scalableminds/webknossos/pull/4845)

--- a/frontend/javascripts/libs/mjs.js
+++ b/frontend/javascripts/libs/mjs.js
@@ -1,7 +1,7 @@
-/**
- * mjs.js
- * @flow
- */
+// @flow
+// See
+//   https://github.com/imbcmdth/mjs/blob/master/index.js
+// for all functions in M4x4, V2 and V3.
 
 import _ from "lodash";
 

--- a/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -624,7 +624,7 @@ export function* finishLayer(
   if (activeTool === VolumeToolEnum.TRACE || activeTool === VolumeToolEnum.BRUSH) {
     yield* call(
       labelWithVoxelBuffer2D,
-      layer.getVoxelBuffer2D(activeTool),
+      layer.getFillingVoxelBuffer2D(activeTool),
       contourTracingMode,
       overwriteMode,
       labeledZoomStep,

--- a/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -146,7 +146,7 @@ export function* editVolumeLayerAsync(): Generator<any, any, any> {
       );
     }
 
-    // let lastPosition = startEditingAction.position;
+    let lastPosition = startEditingAction.position;
     while (true) {
       const { addToLayerAction, finishEditingAction } = yield* race({
         addToLayerAction: _take("ADD_TO_LAYER"),
@@ -171,19 +171,19 @@ export function* editVolumeLayerAsync(): Generator<any, any, any> {
       }
       if (activeTool === VolumeToolEnum.BRUSH) {
         // Disable continuous drawing for performance reasons
-        // const rectangleVoxelBuffer2D = currentLayer.getRectangleVoxelBuffer2D(
-        //   lastPosition,
-        //   addToLayerAction.position,
-        // );
-        // if (rectangleVoxelBuffer2D) {
-        //   yield* call(
-        //     labelWithVoxelBuffer2D,
-        //     rectangleVoxelBuffer2D,
-        //     contourTracingMode,
-        //     overwriteMode,
-        //     labeledZoomStep,
-        //   );
-        // }
+        const rectangleVoxelBuffer2D = currentLayer.getRectangleVoxelBuffer2D(
+          lastPosition,
+          addToLayerAction.position,
+        );
+        if (rectangleVoxelBuffer2D && !window.disableContinuousDrawing) {
+          yield* call(
+            labelWithVoxelBuffer2D,
+            rectangleVoxelBuffer2D,
+            contourTracingMode,
+            overwriteMode,
+            labeledZoomStep,
+          );
+        }
         yield* call(
           labelWithVoxelBuffer2D,
           currentLayer.getCircleVoxelBuffer2D(addToLayerAction.position),
@@ -192,7 +192,7 @@ export function* editVolumeLayerAsync(): Generator<any, any, any> {
           labeledZoomStep,
         );
       }
-      // lastPosition = addToLayerAction.position;
+      lastPosition = addToLayerAction.position;
     }
 
     yield* call(

--- a/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.js
@@ -175,7 +175,7 @@ export function* editVolumeLayerAsync(): Generator<any, any, any> {
           lastPosition,
           addToLayerAction.position,
         );
-        if (rectangleVoxelBuffer2D && !window.disableContinuousDrawing) {
+        if (rectangleVoxelBuffer2D) {
           yield* call(
             labelWithVoxelBuffer2D,
             rectangleVoxelBuffer2D,

--- a/frontend/javascripts/oxalis/model/volumetracing/volumelayer.js
+++ b/frontend/javascripts/oxalis/model/volumetracing/volumelayer.js
@@ -20,7 +20,7 @@ import Constants, {
   type VolumeTool,
   Vector2Indicies,
 } from "oxalis/constants";
-import { V3 } from "libs/mjs";
+import { V2, V3 } from "libs/mjs";
 import { enforceVolumeTracing } from "oxalis/model/accessors/volumetracing_accessor";
 import { getBaseVoxelFactors } from "oxalis/model/scaleinfo";
 import Dimensions from "oxalis/model/dimensions";
@@ -187,7 +187,7 @@ class VolumeLayer {
     const width = maxCoord2d[0] - minCoord2d[0] + 1;
     const height = maxCoord2d[1] - minCoord2d[1] + 1;
 
-    const map = new Uint8Array(width * height).fill(1);
+    const map = this.createMap(width, height, 1);
 
     const setMap = (x: number, y: number, value: number = 1) => {
       x = Math.floor(x);
@@ -233,7 +233,7 @@ class VolumeLayer {
       const gradient = (pos2[1] - pos1[1]) / dx;
       perpendicularVector = [gradient, -1];
       const norm = this.vector2Norm(perpendicularVector);
-      perpendicularVector = this.vector2ScalarMultiplication(perpendicularVector, 1 / norm);
+      perpendicularVector = V2.scale(perpendicularVector, 1 / norm);
     }
     return perpendicularVector;
   }
@@ -246,22 +246,6 @@ class VolumeLayer {
     return Math.sqrt(norm);
   }
 
-  vector2Sum(vector1: Vector2, vector2: Vector2): Vector2 {
-    const sum = [0, 0];
-    for (const i of Vector2Indicies) {
-      sum[i] = vector1[i] + vector2[i];
-    }
-    return sum;
-  }
-
-  vector2ScalarMultiplication(vector: Vector2, scalar: number): Vector2 {
-    const product = [0, 0];
-    for (const i of Vector2Indicies) {
-      product[i] = vector[i] * scalar;
-    }
-    return product;
-  }
-
   vector2DistanceWithScale(pos1: Vector2, pos2: Vector2, scale: Vector2): number {
     let distance = 0;
     for (const i of Vector2Indicies) {
@@ -270,16 +254,12 @@ class VolumeLayer {
     return Math.sqrt(distance);
   }
 
-  vector2WithScale(vector: Vector2, scale: Vector2): Vector2 {
-    const result = [0, 0];
-    for (const i of Vector2Indicies) {
-      result[i] = vector[i] * scale[i];
+  createMap(width: number, height: number, fillValue: number = 0): Uint8Array {
+    const map = new Uint8Array(width * height);
+    if (fillValue !== 0) {
+      map.fill(fillValue);
     }
-    return result;
-  }
-
-  createMap(width: number, height: number): Uint8Array {
-    return new Uint8Array(width * height).fill(0);
+    return map;
   }
 
   getRectangleBetweenCircles(
@@ -289,17 +269,14 @@ class VolumeLayer {
     scale: Vector2,
   ): [number, number, number, number, number, number, number, number] {
     const normedPerpendicularVector = this.vector2PerpendicularVector(centre1, centre2);
-    const shiftVector = this.vector2WithScale(
-      this.vector2ScalarMultiplication(normedPerpendicularVector, radius),
-      scale,
-    );
-    const negShiftVector = this.vector2ScalarMultiplication(shiftVector, -1);
+    const shiftVector = V2.scale2(normedPerpendicularVector, V2.scale(scale, radius));
+    const negShiftVector = V2.scale(shiftVector, -1);
 
     // calculate the rectangle's corners
-    const [xa, ya] = this.vector2Sum(centre2, negShiftVector);
-    const [xb, yb] = this.vector2Sum(centre2, shiftVector);
-    const [xc, yc] = this.vector2Sum(centre1, shiftVector);
-    const [xd, yd] = this.vector2Sum(centre1, negShiftVector);
+    const [xa, ya] = V2.add(centre2, negShiftVector);
+    const [xb, yb] = V2.add(centre2, shiftVector);
+    const [xc, yc] = V2.add(centre1, shiftVector);
+    const [xd, yd] = V2.add(centre1, negShiftVector);
     return [xa, ya, xb, yb, xc, yc, xd, yd];
   }
 
@@ -317,7 +294,12 @@ class VolumeLayer {
 
     const radius = Math.round(brushSize / 2);
     // Use the baseVoxelFactors to scale the rectangle, otherwise it'll become deformed
-    const scale = this.get2DCoordinate(getBaseVoxelFactors(state.dataset.dataSource.scale));
+    const scale = this.get2DCoordinate(
+      scaleGlobalPositionWithResolutionFloat(
+        getBaseVoxelFactors(state.dataset.dataSource.scale),
+        this.activeResolution,
+      ),
+    );
     const floatingCoord2dLastPosition = this.get2DCoordinate(lastPosition);
     const floatingCoord2dPosition = this.get2DCoordinate(position);
 
@@ -335,7 +317,7 @@ class VolumeLayer {
     );
     const minCoord2d = [Math.floor(Math.min(xa, xb, xc, xd)), Math.floor(Math.min(ya, yb, yc, yd))];
     const maxCoord2d = [Math.ceil(Math.max(xa, xb, xc, xd)), Math.ceil(Math.max(ya, yb, yc, yd))];
-    const [width, height] = maxCoord2d;
+    const [width, height] = V3.sub(maxCoord2d, minCoord2d);
     const map = this.createMap(width, height);
 
     const setMap = (x, y) => {
@@ -434,13 +416,13 @@ class VolumeLayer {
       } else if (mode === VolumeToolEnum.BRUSH) {
         // we don't want to connect the last and the first circle with a rectangle
         if (i !== contourList.length - 1) {
-          const [xa, ya, xb, yb, xc, yc, xd, yd] = this.getRectangleBetweenCircles(p1, p2, radius, [
-            scaleX / this.activeResolution[dimIndices[0]],
-            scaleY / this.activeResolution[dimIndices[1]],
-          ]);
-          if (this.vector2DistanceWithScale(p1, p2, [scaleX, scaleY]) > 1.5 * radius) {
-            Drawing.fillRectangle(xa, ya, xb, yb, xc, yc, xd, yd, setMap);
-          }
+          // const [xa, ya, xb, yb, xc, yc, xd, yd] = this.getRectangleBetweenCircles(p1, p2, radius, [
+          //   scaleX / this.activeResolution[dimIndices[0]],
+          //   scaleY / this.activeResolution[dimIndices[1]],
+          // ]);
+          // if (this.vector2DistanceWithScale(p1, p2, [scaleX, scaleY]) > 1.5 * radius) {
+          //   Drawing.fillRectangle(xa, ya, xb, yb, xc, yc, xd, yd, setMap);
+          // }
         }
         Drawing.fillCircle(
           p1[0],


### PR DESCRIPTION
I had disabled the continuous brushing feature after I merged it into the multi-res volume branch. One reason was performance and the other was an issue with the scale in higher mags (which was likely produced during the merge).
With this PR the continuous brush feature gets re-enabled. The scale-bug should be fixed now and I also fixed #4877. Additionally, I could greatly improve the performance by ensuring that the allocated buffer only covers the area from "min to max" (instead of from "0 to max"). This caused major problems for me since my dataset's origin wasn't at 0,0,0.

### URL of deployed dev instance (used for testing):
- https://fixcontinuousbrush.webknossos.xyz

### Steps to test:
- use the brush in a very quick manner
- brush in different mags

### Issues:
- fixes #4859 
- fixes #4877

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
