### PR TITLE
add mapping name to title tag of dropdown options

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/mapping_info_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/mapping_info_view.js
@@ -377,6 +377,7 @@ class MappingInfoView extends React.Component<Props, State> {
           <Option
             key={packMappingNameAndCategory(optionString, category)}
             value={packMappingNameAndCategory(optionString, category)}
+            title={optionString}
           >
             {optionString}
           </Option>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://mappingnametitle.webknossos.xyz

### Steps to test:
- open dataset with segmentation that has mappings
- hover over the mapping names in the dropdown menu should show full name

### Issues:
- fixes #4927

- [x] Ready for review
