### PR TITLE
Clean up and improve how mismatching resolutions are detected

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,12 +260,13 @@ jobs:
       #       -X POST
       #       -H "X-Auth-Token: $RELEASE_API_TOKEN"
       #       https://kube.scm.io/hooks/install/webknossos/dev/master?user=CI+%28nightly%29
-      # - run:
-      #     name: Install dependencies and sleep at least 3min
-      #     command: |
-      #       yarn install --frozen-lockfile &
-      #       sleep 180 &
-      #       wait
+      - run:
+          name: Install dependencies and sleep at least 3min
+          command: |
+            yarn install --frozen-lockfile
+      # &
+      # sleep 180 &
+      # wait
       # - run:
       #     name: Refresh datasets
       #     command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,36 +243,36 @@ jobs:
       - image: scalableminds/puppeteer:master
     steps:
       - checkout
-      - run:
-          name: Remove dev-deployment
-          command: >
-            curl
-            -X POST
-            -H "X-Auth-Token: $RELEASE_API_TOKEN"
-            https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
-      - run:
-          name: Wait 3min
-          command: sleep 180
-      - run:
-          name: Install dev-deployment
-          command: >
-            curl
-            -X POST
-            -H "X-Auth-Token: $RELEASE_API_TOKEN"
-            https://kube.scm.io/hooks/install/webknossos/dev/master?user=CI+%28nightly%29
-      - run:
-          name: Install dependencies and sleep at least 3min
-          command: |
-            yarn install --frozen-lockfile &
-            sleep 180 &
-            wait
-      - run:
-          name: Refresh datasets
-          command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
+      # - run:
+      #     name: Remove dev-deployment
+      #     command: >
+      #       curl
+      #       -X POST
+      #       -H "X-Auth-Token: $RELEASE_API_TOKEN"
+      #       https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
+      # - run:
+      #     name: Wait 3min
+      #     command: sleep 180
+      # - run:
+      #     name: Install dev-deployment
+      #     command: >
+      #       curl
+      #       -X POST
+      #       -H "X-Auth-Token: $RELEASE_API_TOKEN"
+      #       https://kube.scm.io/hooks/install/webknossos/dev/master?user=CI+%28nightly%29
+      # - run:
+      #     name: Install dependencies and sleep at least 3min
+      #     command: |
+      #       yarn install --frozen-lockfile &
+      #       sleep 180 &
+      #       wait
+      # - run:
+      #     name: Refresh datasets
+      #     command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
       - run:
           name: Run screenshot-tests
           command: |
-            URL=https://master.webknossos.xyz/ \
+            URL=https://fixresolutionassertion.webknossos.xyz/ \
             yarn test-screenshot
 
       - store_artifacts:
@@ -282,10 +282,11 @@ workflows:
   version: 2
   circleci_build:
     jobs:
-      - build_test_deploy:
-          filters:
-            tags:
-              only: /.*/
+      # - build_test_deploy:
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      - nightly
   circleci_nightly:
     jobs:
       - nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,37 +243,36 @@ jobs:
       - image: scalableminds/puppeteer:master
     steps:
       - checkout
-      # - run:
-      #     name: Remove dev-deployment
-      #     command: >
-      #       curl
-      #       -X POST
-      #       -H "X-Auth-Token: $RELEASE_API_TOKEN"
-      #       https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
-      # - run:
-      #     name: Wait 3min
-      #     command: sleep 180
-      # - run:
-      #     name: Install dev-deployment
-      #     command: >
-      #       curl
-      #       -X POST
-      #       -H "X-Auth-Token: $RELEASE_API_TOKEN"
-      #       https://kube.scm.io/hooks/install/webknossos/dev/master?user=CI+%28nightly%29
+      - run:
+          name: Remove dev-deployment
+          command: >
+            curl
+            -X POST
+            -H "X-Auth-Token: $RELEASE_API_TOKEN"
+            https://kube.scm.io/hooks/remove/webknossos/dev/master?user=CI+%28nightly%29
+      - run:
+          name: Wait 3min
+          command: sleep 180
+      - run:
+          name: Install dev-deployment
+          command: >
+            curl
+            -X POST
+            -H "X-Auth-Token: $RELEASE_API_TOKEN"
+            https://kube.scm.io/hooks/install/webknossos/dev/master?user=CI+%28nightly%29
       - run:
           name: Install dependencies and sleep at least 3min
           command: |
-            yarn install --frozen-lockfile
-      # &
-      # sleep 180 &
-      # wait
-      # - run:
-      #     name: Refresh datasets
-      #     command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
+            yarn install --frozen-lockfile &
+            sleep 180 &
+            wait
+      - run:
+          name: Refresh datasets
+          command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
       - run:
           name: Run screenshot-tests
           command: |
-            URL=https://fixresolutionassertion.webknossos.xyz/ \
+            URL=https://master.webknossos.xyz/ \
             yarn test-screenshot
 
       - store_artifacts:
@@ -283,11 +282,10 @@ workflows:
   version: 2
   circleci_build:
     jobs:
-      # - build_test_deploy:
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      - nightly
+      - build_test_deploy:
+          filters:
+            tags:
+              only: /.*/
   circleci_nightly:
     jobs:
       - nightly

--- a/frontend/javascripts/oxalis/model_initialization.js
+++ b/frontend/javascripts/oxalis/model_initialization.js
@@ -22,10 +22,9 @@ import {
   getBoundaries,
   getColorLayers,
   getDatasetCenter,
-  getMostExtensiveResolutions,
+  getResolutionUnion,
   getSegmentationLayer,
   isElementClassSupported,
-  convertToDenseResolution,
 } from "oxalis/model/accessors/dataset_accessor";
 import { getSomeServerTracing } from "oxalis/model/accessors/tracing_accessor";
 import {
@@ -337,15 +336,11 @@ function initializeDataset(
 }
 
 export function ensureMatchingLayerResolutions(dataset: APIDataset): void {
-  const mostExtensiveResolutions = convertToDenseResolution(getMostExtensiveResolutions(dataset));
-
-  for (const layer of dataset.dataSource.dataLayers) {
-    const denseResolutions = convertToDenseResolution(layer.resolutions, mostExtensiveResolutions);
-    for (const resolution of denseResolutions) {
-      if (mostExtensiveResolutions.find(element => _.isEqual(resolution, element)) == null) {
-        Toast.error(messages["dataset.resolution_mismatch"], { sticky: true });
-      }
-    }
+  try {
+    getResolutionUnion(dataset, true);
+  } catch (exception) {
+    console.warn(exception);
+    Toast.error(messages["dataset.resolution_mismatch"], { sticky: true });
   }
 }
 

--- a/frontend/javascripts/test/model/model_resolutions.spec.js
+++ b/frontend/javascripts/test/model/model_resolutions.spec.js
@@ -4,7 +4,7 @@ import test from "ava";
 import { ensureMatchingLayerResolutions } from "oxalis/model_initialization";
 import {
   convertToDenseResolution,
-  getMostExtensiveResolutions,
+  getResolutionUnion,
 } from "oxalis/model/accessors/dataset_accessor";
 
 test("Simple convertToDenseResolution", t => {
@@ -26,17 +26,62 @@ test("Complex convertToDenseResolution", t => {
     },
   };
   ensureMatchingLayerResolutions(dataset);
-  const expectedResolutions = [
-    [1, 1, 1],
-    [2, 2, 1],
-    [4, 4, 1],
-    [8, 8, 1],
-    [16, 16, 2],
-    [32, 32, 4],
-  ];
-  const mostExtensiveResolutions = convertToDenseResolution(getMostExtensiveResolutions(dataset));
-  const densify = layer => convertToDenseResolution(layer.resolutions, mostExtensiveResolutions);
+  const expectedResolutions = {
+    "0": [[1, 1, 1], [2, 2, 1], [4, 4, 1], [8, 8, 1], [16, 16, 2], [32, 32, 4]],
+    "1": [[1, 1, 1], [2, 2, 2], [4, 4, 4], [8, 8, 8], [16, 16, 16], [32, 32, 4]],
+  };
+  const densify = layer => convertToDenseResolution(layer.resolutions);
 
-  t.deepEqual(densify(dataset.dataSource.dataLayers[0]), expectedResolutions);
-  t.deepEqual(densify(dataset.dataSource.dataLayers[1]), expectedResolutions);
+  t.deepEqual(densify(dataset.dataSource.dataLayers[0]), expectedResolutions[0]);
+  t.deepEqual(densify(dataset.dataSource.dataLayers[1]), expectedResolutions[1]);
+});
+
+test("Test empty getResolutionUnion", t => {
+  const dataset = {
+    dataSource: {
+      dataLayers: [],
+    },
+  };
+  ensureMatchingLayerResolutions(dataset);
+  const expectedResolutions = [];
+  const union = getResolutionUnion(dataset);
+
+  t.deepEqual(union, expectedResolutions);
+});
+
+test("Test getResolutionUnion", t => {
+  const dataset = {
+    dataSource: {
+      dataLayers: [
+        {
+          resolutions: [[4, 4, 1], [8, 8, 1], [16, 16, 2], [32, 32, 4]],
+        },
+        {
+          resolutions: [[2, 2, 1], [8, 8, 1], [32, 32, 4]],
+        },
+      ],
+    },
+  };
+  ensureMatchingLayerResolutions(dataset);
+  const expectedResolutions = [[2, 2, 1], [4, 4, 1], [8, 8, 1], [16, 16, 2], [32, 32, 4]];
+  const union = getResolutionUnion(dataset);
+
+  t.deepEqual(union, expectedResolutions);
+});
+
+test("getResolutionUnion should fail since 8-8-1 != 8-8-2", t => {
+  const dataset = {
+    dataSource: {
+      dataLayers: [
+        {
+          resolutions: [[4, 4, 1], [8, 8, 1], [16, 16, 2], [32, 32, 4]],
+        },
+        {
+          resolutions: [[2, 2, 1], [8, 8, 2], [32, 32, 4]],
+        },
+      ],
+    },
+  };
+
+  t.throws(() => ensureMatchingLayerResolutions(dataset));
 });


### PR DESCRIPTION
The nightly test fails in one test case due to "mismatching resolutions". However that failure was a false positive, which is caused by the fact that we keep the original resolutions per layer instead of storing the "densified version". The code had problems with a dataset where the resolutions were like this:
- mag 1, mag 2, mag 4, mag 8
- mag 32

The old code densified the resolutions (i.e., padded all the missing resolutions for the second layer) and assumed that the longest resolution list covers all resolutions. The new code constructs a union of all resolutions and checks that there are no mismatches while doing so.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- see new automated tests
- [x] execute nightly

### Issues:
- follow-up to #4755 

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
