### PR TITLE
Hide mode toggle for 2d-only datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Changed
--
+- For 2d-only datasets the view mode toggle is hidden. [#4952](https://github.com/scalableminds/webknossos/pull/4952)
 
 ### Fixed
 -

--- a/frontend/javascripts/oxalis/view/action_bar_view.js
+++ b/frontend/javascripts/oxalis/view/action_bar_view.js
@@ -32,6 +32,7 @@ import ViewModesView from "oxalis/view/action-bar/view_modes_view";
 import VolumeActionsView from "oxalis/view/action-bar/volume_actions_view";
 import AuthenticationModal from "admin/auth/authentication_modal";
 import { createTracingOverlayMenuWithCallback } from "dashboard/advanced_dataset/dataset_action_view";
+import { is2dDataset } from "oxalis/model/accessors/dataset_accessor";
 
 const VersionRestoreWarning = (
   <Alert
@@ -51,6 +52,7 @@ type StateProps = {|
   hasSkeleton: boolean,
   showVersionRestore: boolean,
   isReadOnly: boolean,
+  is2d: boolean,
 |};
 type OwnProps = {|
   layoutProps: LayoutProps,
@@ -184,7 +186,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
           {showVersionRestore ? VersionRestoreWarning : null}
           <DatasetPositionView />
           {!isReadOnly && hasVolume && isVolumeSupported ? <VolumeActionsView /> : null}
-          {isArbitrarySupported ? <ViewModesView /> : null}
+          {isArbitrarySupported && !this.props.is2d ? <ViewModesView /> : null}
           {isTraceMode ? null : this.renderStartTracingButton()}
         </div>
         <AddNewLayoutModal
@@ -214,6 +216,7 @@ const mapStateToProps = (state: OxalisState): StateProps => ({
   hasVolumeFallback: state.tracing.volume != null && state.tracing.volume.fallbackLayer != null,
   hasSkeleton: state.tracing.skeleton != null,
   isReadOnly: !state.tracing.restrictions.allowUpdate,
+  is2d: is2dDataset(state.dataset),
 });
 
 export default connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(ActionBarView);


### PR DESCRIPTION
This PR hides the orthogonal/flight/oblique toggle for 2d-only datasets

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a tracing or view of a 2d dataset
- there should be no orthogonal/flight/oblique toggle in the top menu bar

### Issues:
- fixes #4880

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] ~~Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- [ ] ~~Updated [documentation](../blob/master/docs) if applicable~~
- [ ] ~~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [ ] ~~Needs datastore update after deployment~~
- [x] Ready for review
