### PR TITLE
Disable 'use existing segmentation layer' when that layer doesn't exist

### DIFF
--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
@@ -11,8 +11,11 @@ import messages from "messages";
 const createTracingOverlayMenu = (dataset: APIMaybeUnimportedDataset, type: TracingType) => {
   const typeCapitalized = type.charAt(0).toUpperCase() + type.slice(1);
 
-  const hasSegmentationLayer = dataset.dataSource.dataLayers != null ? dataset.dataSource.dataLayers.find(layer => layer.category === "segmentation") != null : false;
-  const disabledLinkStyle = {pointerEvents: "none", color: "rgb(173, 173, 173)"}
+  const hasSegmentationLayer =
+    dataset.dataSource.dataLayers != null
+      ? dataset.dataSource.dataLayers.find(layer => layer.category === "segmentation") != null
+      : false;
+  const disabledLinkStyle = { pointerEvents: "none", color: "rgb(173, 173, 173)" };
 
   return (
     <Menu>

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.js
@@ -10,14 +10,19 @@ import messages from "messages";
 
 const createTracingOverlayMenu = (dataset: APIMaybeUnimportedDataset, type: TracingType) => {
   const typeCapitalized = type.charAt(0).toUpperCase() + type.slice(1);
+
+  const hasSegmentationLayer = dataset.dataSource.dataLayers != null ? dataset.dataSource.dataLayers.find(layer => layer.category === "segmentation") != null : false;
+  const disabledLinkStyle = {pointerEvents: "none", color: "rgb(173, 173, 173)"}
+
   return (
     <Menu>
-      <Menu.Item key="existing">
+      <Menu.Item key="existing" disabled={!hasSegmentationLayer}>
         <Link
           to={`/datasets/${dataset.owningOrganization}/${
             dataset.name
           }/createExplorative/${type}/true`}
           title={`Create ${typeCapitalized} Annotation`}
+          style={hasSegmentationLayer ? {} : disabledLinkStyle}
         >
           Use Existing Segmentation Layer
         </Link>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open dashboard and use "create volume tracing" and "create hybrid tracing". verify that "use existing segmentation layer" is disabled if it doesn't exist

Superseded by https://github.com/scalableminds/webknossos/pull/4939, but this PR is meant as a a hotfix.