### PR TITLE
Treat zero layer dataset as unusable

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/20.12.0...HEAD)
 
 ### Added
--
+- Datasets without any layer are now considered unimported. [#4959](https://github.com/scalableminds/webknossos/pull/4959)
 
 ### Changed
 -

--- a/app/models/binary/DataSet.scala
+++ b/app/models/binary/DataSet.scala
@@ -448,7 +448,7 @@ class DataSetDataLayerDAO @Inject()(sqlClient: SQLClient, dataSetResolutionsDAO:
     val clearQuery = sqlu"delete from webknossos.dataset_layers where _dataSet = ${_dataSet}"
 
     val queries = source.toUsable match {
-      case Some(usable) if usable.dataLayers.nonEmpty =>
+      case Some(usable) =>
         getSpecificClearQuery(usable.dataLayers) :: usable.dataLayers.map(insertLayerQuery(_dataSet, _))
       case _ => List(clearQuery)
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -210,7 +210,8 @@ class DataSourceService @Inject()(
     if (new File(propertiesFile.toString).exists()) {
       JsonHelper.validatedJsonFromFile[DataSource](propertiesFile, path) match {
         case Full(dataSource) =>
-          dataSource.copy(id)
+          if (dataSource.dataLayers.nonEmpty) dataSource.copy(id)
+          else UnusableDataSource(id, "Error: Zero layer Dataset")
         case e =>
           UnusableDataSource(id, s"Error: Invalid json format in $propertiesFile: $e")
       }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- upload a zero layer dataset
- should be marked as unusable in the frontend, but not throw an error

### Issues:
- fixes #4941 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [x] Needs datastore update after deployment
- [x] Ready for review
