### PR TITLE
Fix stack overflow in comments tab for trees with many comments

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Persist the selected overwrite behavior for hybrid and volume annotations. [#4962](https://github.com/scalableminds/webknossos/pull/4962)
 
 ### Fixed
--
+- Fix crash for trees with high comment count (> 100000 nodes). [#4965](https://github.com/scalableminds/webknossos/pull/4965)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/comment_tab/comment_tab_view.js
@@ -117,8 +117,13 @@ const memoizedDeriveData = memoizeOne(
     for (const tree of sortedTrees) {
       data.push(tree);
       const isCollapsed = state.collapsedTreeIds[tree.treeId];
-      if (!isCollapsed) {
-        data.push(...tree.comments.slice().sort(commentSorter));
+      if (!isCollapsed && tree.comments.length > 0) {
+        const sortedComments = tree.comments.slice().sort(commentSorter);
+
+        // Don't use concat to avoid creating a new `data` array for each tree
+        for (const comment of sortedComments) {
+          data.push(comment);
+        }
       }
     }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open tracing with multiple comments (or create one first)
- check that the comments are rendered properly

### Issues:
- fixes https://discuss.webknossos.org/t/crash-for-large-number-of-comments/1630/2

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
