### PR TITLE
Allow Parsing NML Nodes Without Radius Attribute

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The menu for viewing, editing and creating annotations for a dataset in the dashboard was cleaned up a bit. Creating a hybrid (skeleton + volume) annotation is now the default way of annotating a dataset. The other options are still available via a dropdown. [#4939](https://github.com/scalableminds/webknossos/pull/4939)
 - For 2d-only datasets the view mode toggle is hidden. [#4952](https://github.com/scalableminds/webknossos/pull/4952)
 - Persist the selected overwrite behavior for hybrid and volume annotations. [#4962](https://github.com/scalableminds/webknossos/pull/4962)
+- Backend NML parser now allows NML nodes without radius attribute. Instead, their radius now defaults to a value of 30. [#4982](https://github.com/scalableminds/webknossos/pull/4982)
 
 ### Fixed
 - Fix crash for trees with high comment count (> 100000 nodes). [#4965](https://github.com/scalableminds/webknossos/pull/4965)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The menu for viewing, editing and creating annotations for a dataset in the dashboard was cleaned up a bit. Creating a hybrid (skeleton + volume) annotation is now the default way of annotating a dataset. The other options are still available via a dropdown. [#4939](https://github.com/scalableminds/webknossos/pull/4939)
 - For 2d-only datasets the view mode toggle is hidden. [#4952](https://github.com/scalableminds/webknossos/pull/4952)
 - Persist the selected overwrite behavior for hybrid and volume annotations. [#4962](https://github.com/scalableminds/webknossos/pull/4962)
-- Backend NML parser now allows NML nodes without radius attribute. Instead, their radius now defaults to a value of 30. [#4982](https://github.com/scalableminds/webknossos/pull/4982)
+- Backend NML parser now allows NML nodes without radius attribute. Instead, their radius now defaults to a value of 1.0, which is also the new default value for initial nodes. Note that the node radius is only relevant when default setting “overwrite node radius” is disabled. [#4982](https://github.com/scalableminds/webknossos/pull/4982)
 
 ### Fixed
 - Fix crash for trees with high comment count (> 100000 nodes). [#4965](https://github.com/scalableminds/webknossos/pull/4965)

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -33,7 +33,6 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits with ColorGener
   private val DEFAULT_DESCRIPTION = ""
   private val DEFAULT_INTERPOLATION = false
   private val DEFAULT_TIMESTAMP = 0L
-  private val DEFAULT_NODE_RADIUS: Float = 30.0f
 
   @SuppressWarnings(Array("TraversableHead")) //We check if volumes are empty before accessing the head
   def parse(name: String,
@@ -386,7 +385,7 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits with ColorGener
     val nodeIdText = getSingleAttribute(node, "id")
     for {
       id <- nodeIdText.toIntOpt ?~ Messages("nml.node.id.invalid", "", nodeIdText)
-      radius = getSingleAttribute(node, "radius").toFloatOpt.getOrElse(DEFAULT_NODE_RADIUS)
+      radius = getSingleAttribute(node, "radius").toFloatOpt.getOrElse(NodeDefaults.radius)
       position <- parsePoint3D(node) ?~ Messages("nml.node.attribute.invalid", "position", id)
     } yield {
       val viewport = parseViewport(node)

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -33,6 +33,7 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits with ColorGener
   private val DEFAULT_DESCRIPTION = ""
   private val DEFAULT_INTERPOLATION = false
   private val DEFAULT_TIMESTAMP = 0L
+  private val DEFAULT_NODE_RADIUS = 30.0
 
   @SuppressWarnings(Array("TraversableHead")) //We check if volumes are empty before accessing the head
   def parse(name: String,
@@ -385,7 +386,7 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits with ColorGener
     val nodeIdText = getSingleAttribute(node, "id")
     for {
       id <- nodeIdText.toIntOpt ?~ Messages("nml.node.id.invalid", "", nodeIdText)
-      radius <- getSingleAttribute(node, "radius").toFloatOpt ?~ Messages("nml.node.attribute.invalid", "radius", id)
+      radius = getSingleAttribute(node, "radius").toFloatOpt.getOrElse(DEFAULT_NODE_RADIUS)
       position <- parsePoint3D(node) ?~ Messages("nml.node.attribute.invalid", "position", id)
     } yield {
       val viewport = parseViewport(node)

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -33,7 +33,7 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits with ColorGener
   private val DEFAULT_DESCRIPTION = ""
   private val DEFAULT_INTERPOLATION = false
   private val DEFAULT_TIMESTAMP = 0L
-  private val DEFAULT_NODE_RADIUS = 30.0
+  private val DEFAULT_NODE_RADIUS: Float = 30.0f
 
   @SuppressWarnings(Array("TraversableHead")) //We check if volumes are empty before accessing the head
   def parse(name: String,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,7 +92,7 @@ features {
   autoBrushReadyDatasets = []
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
-  jobsEnabled = true
+  jobsEnabled = false
 }
 
 # Actor settings

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,7 +92,7 @@ features {
   autoBrushReadyDatasets = []
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
-  jobsEnabled = false 
+  jobsEnabled = true
 }
 
 # Actor settings

--- a/frontend/javascripts/oxalis/default_state.js
+++ b/frontend/javascripts/oxalis/default_state.js
@@ -66,7 +66,6 @@ const defaultState: OxalisState = {
     newNodeNewTree: false,
     overrideNodeRadius: true,
     particleSize: 5,
-    radius: 5,
     rotateValue: 0.01,
     sortCommentsAsc: true,
     sortTreesByName: false,

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -7,6 +7,7 @@ import type { APIBuildInfo } from "types/api_flow_types";
 import {
   getMaximumGroupId,
   getMaximumTreeId,
+  DEFAULT_NODE_RADIUS,
 } from "oxalis/model/reducers/skeletontracing_reducer_helpers";
 import { getPosition, getRotation } from "oxalis/model/accessors/flycam_accessor";
 import Date from "libs/date";
@@ -39,7 +40,6 @@ const DEFAULT_INTERPOLATION = false;
 const DEFAULT_TIMESTAMP = 0;
 const DEFAULT_ROTATION = [0, 0, 0];
 const DEFAULT_GROUP_ID = null;
-const DEFAULT_RADIUS = 30;
 const DEFAULT_USER_BOUNDING_BOX_VISIBILITY = true;
 
 // SERIALIZE NML
@@ -635,7 +635,7 @@ export function parseNml(
               bitDepth: _parseInt(attr, "bitDepth", DEFAULT_BITDEPTH),
               viewport: _parseInt(attr, "inVp", DEFAULT_VIEWPORT),
               resolution: _parseInt(attr, "inMag", DEFAULT_RESOLUTION),
-              radius: _parseFloat(attr, "radius", DEFAULT_RADIUS),
+              radius: _parseFloat(attr, "radius", DEFAULT_NODE_RADIUS),
               timestamp: _parseTimestamp(attr, "time", DEFAULT_TIMESTAMP),
             };
             if (currentTree == null)

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
@@ -32,7 +32,6 @@ import type {
   ServerNode,
   ServerBranchPoint,
 } from "types/api_flow_types";
-import { getBaseVoxel } from "oxalis/model/scaleinfo";
 import {
   getSkeletonTracing,
   getActiveNodeFromTree,
@@ -46,6 +45,8 @@ import Constants, { NODE_ID_REF_REGEX, type Vector3 } from "oxalis/constants";
 import DiffableMap from "libs/diffable_map";
 import EdgeCollection from "oxalis/model/edge_collection";
 import * as Utils from "libs/utils";
+
+export const DEFAULT_NODE_RADIUS = 1.0;
 
 export function generateTreeName(state: OxalisState, timestamp: number, treeId: number) {
   let user = "";
@@ -132,8 +133,9 @@ export function createNode(
 
   if (allowUpdate) {
     // Use the same radius as current active node or revert to default value
-    const defaultRadius = 10 * getBaseVoxel(state.dataset.dataSource.scale);
-    const radius = activeNodeMaybe.map(activeNode => activeNode.radius).getOrElse(defaultRadius);
+    const radius = activeNodeMaybe
+      .map(activeNode => activeNode.radius)
+      .getOrElse(DEFAULT_NODE_RADIUS);
 
     // Find new node id by increasing the max node id.
     const nextNewId = skeletonTracing.cachedMaxNodeId + 1;

--- a/frontend/javascripts/oxalis/store.js
+++ b/frontend/javascripts/oxalis/store.js
@@ -303,7 +303,6 @@ export type UserConfiguration = {|
   +newNodeNewTree: boolean,
   +overrideNodeRadius: boolean,
   +particleSize: number,
-  +radius: number,
   +rotateValue: number,
   +sortCommentsAsc: boolean,
   +sortTreesByName: boolean,

--- a/frontend/javascripts/test/reducers/skeletontracing_reducer.spec.js
+++ b/frontend/javascripts/test/reducers/skeletontracing_reducer.spec.js
@@ -112,7 +112,7 @@ test("SkeletonTracing should add a new node", t => {
     viewport,
     resolution,
     id: 1,
-    radius: 50,
+    radius: 1,
   });
 });
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonElementDefaults.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonElementDefaults.scala
@@ -33,7 +33,7 @@ object NodeDefaults extends ProtoGeometryImplicits {
   val id = 0
   val rotation = Vector3D(0, 0, 0)
   val position = Point3D(0, 0, 0)
-  val radius = 120
+  val radius = 1.0f
   val viewport = 1
   val resolution = 1
   val bitDepth = 0


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://nmlparserdefaultradius.webknossos.xyz

### Steps to test:
- via dashboard, upload an NML file with nodes that do not have radius attribute
- should not be rejected, nodes should get default radius

### Issues:
- fixes #4953

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
