### PR TITLE
Fix that largest segment id is never bumped from 0 to 1

### DIFF
--- a/frontend/javascripts/oxalis/model/actions/volumetracing_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/volumetracing_actions.js
@@ -74,6 +74,7 @@ export const VolumeTracingSaveRelevantActions = [
   "SET_ACTIVE_CELL",
   "SET_USER_BOUNDING_BOXES",
   "ADD_USER_BOUNDING_BOXES",
+  "FINISH_ANNOTATION_STROKE",
 ];
 
 export const VolumeTracingUndoRelevantActions = ["START_EDITING", "COPY_SEGMENTATION_LAYER"];

--- a/frontend/javascripts/oxalis/model/actions/volumetracing_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/volumetracing_actions.js
@@ -17,7 +17,7 @@ type InitializeVolumeTracingAction = {
   type: "INITIALIZE_VOLUMETRACING",
   tracing: ServerVolumeTracing,
 };
-type CreateCellAction = { type: "CREATE_CELL", cellId: ?number };
+type CreateCellAction = { type: "CREATE_CELL" };
 type StartEditingAction = { type: "START_EDITING", position: Vector3, planeId: OrthoView };
 type AddToLayerAction = { type: "ADD_TO_LAYER", position: Vector3 };
 type FloodFillAction = { type: "FLOOD_FILL", position: Vector3, planeId: OrthoView };
@@ -86,9 +86,8 @@ export const initializeVolumeTracingAction = (
   tracing,
 });
 
-export const createCellAction = (cellId: ?number): CreateCellAction => ({
+export const createCellAction = (): CreateCellAction => ({
   type: "CREATE_CELL",
-  cellId,
 });
 
 export const startEditingAction = (position: Vector3, planeId: OrthoView): StartEditingAction => ({

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.js
@@ -107,7 +107,13 @@ function VolumeTracingReducer(state: OxalisState, action: VolumeTracingAction): 
         }
 
         case "SET_MAX_CELL": {
-          return setMaxCellReducer(state, volumeTracing, action.cellId);
+          return setMaxCellReducer(state, action.cellId);
+        }
+
+        case "FINISH_ANNOTATION_STROKE": {
+          // Possibly update the maxCellId after volume annotation
+          const { activeCellId, maxCellId } = volumeTracing;
+          return setMaxCellReducer(state, Math.max(activeCellId, maxCellId));
         }
 
         default:

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.js
@@ -83,7 +83,7 @@ function VolumeTracingReducer(state: OxalisState, action: VolumeTracingAction): 
         }
 
         case "CREATE_CELL": {
-          return createCellReducer(state, volumeTracing, action.cellId);
+          return createCellReducer(state, volumeTracing);
         }
 
         case "UPDATE_DIRECTION": {

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.js
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.js
@@ -46,7 +46,7 @@ export function setActiveCellReducer(state: OxalisState, volumeTracing: VolumeTr
   });
 }
 
-export function createCellReducer(state: OxalisState, volumeTracing: VolumeTracing, id: ?number) {
+export function createCellReducer(state: OxalisState, volumeTracing: VolumeTracing, id?: number) {
   if (id === 0) {
     // cellId 0 means there is no annotation, so there must not be a cell with id 0
     return state;
@@ -59,17 +59,27 @@ export function createCellReducer(state: OxalisState, volumeTracing: VolumeTraci
     id = Math.max(activeCellId, maxCellId) + 1;
   }
 
-  // Create the new VolumeCell
-  const cell: VolumeCell = { id };
+  if (volumeTracing.cells[id] == null) {
+    // Create the new VolumeCell
+    const cell: VolumeCell = { id };
 
-  return update(state, {
-    tracing: {
-      volume: {
-        activeCellId: { $set: cell.id },
-        cells: { [cell.id]: { $set: cell } },
+    return update(state, {
+      tracing: {
+        volume: {
+          activeCellId: { $set: id },
+          cells: { [id]: { $set: cell } },
+        },
       },
-    },
-  });
+    });
+  } else {
+    return update(state, {
+      tracing: {
+        volume: {
+          activeCellId: { $set: id },
+        },
+      },
+    });
+  }
 }
 
 export function updateDirectionReducer(

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.js
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.js
@@ -51,12 +51,12 @@ export function createCellReducer(state: OxalisState, volumeTracing: VolumeTraci
     // cellId 0 means there is no annotation, so there must not be a cell with id 0
     return state;
   }
-  let newMaxCellId = volumeTracing.maxCellId;
+
+  // The maxCellId is only updated if a voxel using that id was annotated. Therefore, it can happen
+  // that the activeCellId is larger than the maxCellId. Choose the larger of the two ids and increase it by one.
+  const { activeCellId, maxCellId } = volumeTracing;
   if (id == null) {
-    newMaxCellId++;
-    id = newMaxCellId;
-  } else {
-    newMaxCellId = Math.max(id, newMaxCellId);
+    id = Math.max(activeCellId, maxCellId) + 1;
   }
 
   // Create the new VolumeCell
@@ -67,7 +67,6 @@ export function createCellReducer(state: OxalisState, volumeTracing: VolumeTraci
       volume: {
         activeCellId: { $set: cell.id },
         cells: { [cell.id]: { $set: cell } },
-        maxCellId: { $set: newMaxCellId },
       },
     },
   });
@@ -141,11 +140,11 @@ export function setContourTracingModeReducer(state: OxalisState, mode: ContourMo
   });
 }
 
-export function setMaxCellReducer(state: OxalisState, volumeTracing: VolumeTracing, id: number) {
+export function setMaxCellReducer(state: OxalisState, id: number) {
   return update(state, {
     tracing: {
       volume: {
-        largestSegmentId: { $set: id },
+        maxCellId: { $set: id },
       },
     },
   });

--- a/frontend/javascripts/test/reducers/volumetracing_reducer.spec.js
+++ b/frontend/javascripts/test/reducers/volumetracing_reducer.spec.js
@@ -118,7 +118,7 @@ test("VolumeTracing should set active but not create a cell 0", t => {
 });
 
 test("VolumeTracing should not create a cell 0", t => {
-  const createCellAction = VolumeTracingActions.createCellAction(0);
+  const createCellAction = VolumeTracingActions.setActiveCellAction(0);
 
   // Try to create cell 0
   const newState = VolumeTracingReducer(initialState, createCellAction);
@@ -126,17 +126,17 @@ test("VolumeTracing should not create a cell 0", t => {
 });
 
 test("VolumeTracing should create a cell and set it as the activeCell", t => {
-  const createCellAction = VolumeTracingActions.createCellAction(4);
+  const createCellAction = VolumeTracingActions.createCellAction();
 
   // Create cell
   const newState = VolumeTracingReducer(initialState, createCellAction);
   getVolumeTracingOrFail(newState.tracing).map(tracing => {
-    t.is(tracing.activeCellId, 4);
+    t.is(tracing.activeCellId, 1);
   });
 });
 
 test("VolumeTracing should create a non-existing cell and not update the maxCellId", t => {
-  const createCellAction = VolumeTracingActions.createCellAction(4);
+  const createCellAction = VolumeTracingActions.createCellAction();
 
   // Create a cell with an id that is higher than the maxCellId
   const newState = VolumeTracingReducer(initialState, createCellAction);
@@ -146,7 +146,7 @@ test("VolumeTracing should create a non-existing cell and not update the maxCell
 });
 
 test("VolumeTracing should create an existing cell and not update the maxCellId", t => {
-  const createCellAction = VolumeTracingActions.createCellAction(2);
+  const createCellAction = VolumeTracingActions.createCellAction();
   const alteredState = update(initialState, {
     tracing: {
       volume: { maxCellId: { $set: 5 } },

--- a/frontend/javascripts/test/sagas/volumetracing_saga_integration.spec.js
+++ b/frontend/javascripts/test/sagas/volumetracing_saga_integration.spec.js
@@ -1,0 +1,76 @@
+// @flow
+import mockRequire from "mock-require";
+import test from "ava";
+
+import "test/sagas/saga_integration.mock.js";
+import { __setupOxalis } from "test/helpers/apiHelpers";
+import { enforceVolumeTracing } from "oxalis/model/accessors/volumetracing_accessor";
+import { OrthoViews } from "oxalis/constants";
+import { restartSagaAction, wkReadyAction } from "oxalis/model/actions/actions";
+import Store from "oxalis/store";
+import { getVolumeTracingOrFail } from "../reducers/volumetracing_reducer.spec";
+
+const {
+  createCellAction,
+  floodFillAction,
+  copySegmentationLayerAction,
+  startEditingAction,
+  finishEditingAction,
+} = mockRequire.reRequire("oxalis/model/actions/volumetracing_actions");
+const { discardSaveQueuesAction } = mockRequire.reRequire("oxalis/model/actions/save_actions");
+
+test.beforeEach(async t => {
+  // Setup oxalis, this will execute model.fetch(...) and initialize the store with the tracing, etc.
+  Store.dispatch(restartSagaAction());
+  Store.dispatch(discardSaveQueuesAction());
+  await __setupOxalis(t, "volume");
+
+  // Dispatch the wkReadyAction, so the sagas are started
+  Store.dispatch(wkReadyAction());
+});
+
+test.serial("Executing a floodfill with a new segment id should update the maxCellId", t => {
+  const volumeTracing = enforceVolumeTracing(Store.getState().tracing);
+  const oldMaxCellId = volumeTracing.maxCellId;
+
+  const newCellId = 13371337;
+  Store.dispatch(createCellAction(newCellId));
+
+  // maxCellId should not have changed since no voxel was annotated yet
+  getVolumeTracingOrFail(Store.getState().tracing).map(tracing => {
+    t.is(tracing.maxCellId, oldMaxCellId);
+  });
+
+  Store.dispatch(floodFillAction([12, 12, 12], OrthoViews.PLANE_XY));
+
+  // maxCellId should be updated after flood fill
+  getVolumeTracingOrFail(Store.getState().tracing).map(tracing => {
+    t.is(tracing.maxCellId, newCellId);
+  });
+});
+
+test.serial(
+  "Executing copySegmentationLayer with a new segment id should update the maxCellId",
+  t => {
+    const newCellId = 13371338;
+    Store.dispatch(createCellAction(newCellId));
+    Store.dispatch(copySegmentationLayerAction());
+
+    // maxCellId should be updated after copySegmentationLayer
+    getVolumeTracingOrFail(Store.getState().tracing).map(tracing => {
+      t.is(tracing.maxCellId, newCellId);
+    });
+  },
+);
+
+test.serial("Brushing/Tracing with a new segment id should update the maxCellId", t => {
+  const newCellId = 13371339;
+  Store.dispatch(createCellAction(newCellId));
+  Store.dispatch(startEditingAction([12, 12, 12], OrthoViews.PLANE_XY));
+  Store.dispatch(finishEditingAction());
+
+  // maxCellId should be updated after brushing/tracing
+  getVolumeTracingOrFail(Store.getState().tracing).map(tracing => {
+    t.is(tracing.maxCellId, newCellId);
+  });
+});

--- a/frontend/javascripts/test/sagas/volumetracing_saga_integration.spec.js
+++ b/frontend/javascripts/test/sagas/volumetracing_saga_integration.spec.js
@@ -11,7 +11,7 @@ import Store from "oxalis/store";
 import { getVolumeTracingOrFail } from "../reducers/volumetracing_reducer.spec";
 
 const {
-  createCellAction,
+  setActiveCellAction,
   floodFillAction,
   copySegmentationLayerAction,
   startEditingAction,
@@ -34,7 +34,7 @@ test.serial("Executing a floodfill with a new segment id should update the maxCe
   const oldMaxCellId = volumeTracing.maxCellId;
 
   const newCellId = 13371337;
-  Store.dispatch(createCellAction(newCellId));
+  Store.dispatch(setActiveCellAction(newCellId));
 
   // maxCellId should not have changed since no voxel was annotated yet
   getVolumeTracingOrFail(Store.getState().tracing).map(tracing => {
@@ -53,7 +53,7 @@ test.serial(
   "Executing copySegmentationLayer with a new segment id should update the maxCellId",
   t => {
     const newCellId = 13371338;
-    Store.dispatch(createCellAction(newCellId));
+    Store.dispatch(setActiveCellAction(newCellId));
     Store.dispatch(copySegmentationLayerAction());
 
     // maxCellId should be updated after copySegmentationLayer
@@ -65,7 +65,7 @@ test.serial(
 
 test.serial("Brushing/Tracing with a new segment id should update the maxCellId", t => {
   const newCellId = 13371339;
-  Store.dispatch(createCellAction(newCellId));
+  Store.dispatch(setActiveCellAction(newCellId));
   Store.dispatch(startEditingAction([12, 12, 12], OrthoViews.PLANE_XY));
   Store.dispatch(finishEditingAction());
 


### PR DESCRIPTION
See [this comment](https://github.com/scalableminds/webknossos/issues/4937#issuecomment-738130505) for an in-depth description of the bug and fix. I've opted to use the `FINISH_ANNOTATION_STROKE` action to signify that voxels were annotated as that is the same action that should always be triggered after a volume annotation to make undo/redo work. It's not checked whether voxels were actually annotated (in the copySegmentationLayer case the copy could be empty), but in my opinion a stricter check wouldn't really have a benefit and complicate things.
I've added integration tests to check that the `maxCellId` is updated whenever voxels are annotated. Are there other cases than floodfill, copyLayer, brush/trace? For undo the `activeCellId` and `maxCellId` are not undone, but that "problem" existed before and doesn't break this fix as far as I can see.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Check this branch out locally. In the `save_saga.js` search for `compress: true` and change it to `compress: false`.
- Open a volume tracing without a fallback layer. Open the network tab. Make a single brush stroke and save afterwards. You should see an `updateTracing` update action in the request to `.../update` which contains a `largestSegmentId` of 1.

### Issues:
- fixes #4937 

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
