### PR TITLE
Fix that agglomerate skeleton button was clickable in view or read-only mode

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/mapping_info_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/mapping_info_view.js
@@ -57,6 +57,7 @@ type StateProps = {|
   activeViewport: OrthoView,
   activeCellId: number,
   isMergerModeEnabled: boolean,
+  allowUpdate: boolean,
 |};
 type Props = {| ...OwnProps, ...StateProps |};
 
@@ -339,6 +340,31 @@ class MappingInfoView extends React.Component<Props, State> {
     }
   };
 
+  renderAgglomerateSkeletonButton = () => {
+    const { mappingName, mappingType } = this.props;
+    const isAgglomerateMapping = mappingType === "HDF5";
+
+    // Only show the option to import a skeleton from an agglomerate file if an agglomerate file mapping is activated.
+    const shouldRender = this.props.isMappingEnabled && mappingName != null && isAgglomerateMapping;
+    const isDisabled = !this.props.allowUpdate;
+    const disabledMessage = "Skeletons cannot be imported in view mode or read-only tracings.";
+
+    return shouldRender ? (
+      <Tooltip title={isDisabled ? disabledMessage : null}>
+        {/* Workaround to fix antd bug, see https://github.com/react-component/tooltip/issues/18#issuecomment-650864750 */}
+        <span style={{ cursor: isDisabled ? "not-allowed" : "pointer" }}>
+          <AsyncButton
+            onClick={() => loadAgglomerateSkeletonAtPosition(this.props.position)}
+            disabled={isDisabled}
+            style={isDisabled ? { pointerEvents: "none" } : {}}
+          >
+            Import Skeleton for Centered Cell
+          </AsyncButton>
+        </span>
+      </Tooltip>
+    ) : null;
+  };
+
   render() {
     if (!hasSegmentation()) {
       return "No segmentation available";
@@ -387,12 +413,6 @@ class MappingInfoView extends React.Component<Props, State> {
       (shouldMappingBeEnabled || this.props.isMergerModeEnabled) &&
       this.props.mapping &&
       this.props.hideUnmappedIds != null;
-
-    const { mappingName, mappingType } = this.props;
-    const isAgglomerateMapping = mappingType === "HDF5";
-    // Only show the option to import a skeleton from an agglomerate file if an agglomerate file mapping is activated.
-    const renderAgglomerateSkeletonButton =
-      this.props.isMappingEnabled && mappingName != null && isAgglomerateMapping;
 
     return (
       <div id="volume-mapping-info" className="padded-tab-content" style={{ maxWidth: 500 }}>
@@ -444,11 +464,7 @@ class MappingInfoView extends React.Component<Props, State> {
               />
             </label>
           ) : null}
-          {renderAgglomerateSkeletonButton ? (
-            <AsyncButton onClick={() => loadAgglomerateSkeletonAtPosition(this.props.position)}>
-              Import Skeleton for Centered Cell
-            </AsyncButton>
-          ) : null}
+          {this.renderAgglomerateSkeletonButton()}
         </div>
       </div>
     );
@@ -478,6 +494,7 @@ function mapStateToProps(state: OxalisState) {
       .map(tracing => tracing.activeCellId)
       .getOrElse(0),
     isMergerModeEnabled: state.temporaryConfiguration.isMergerModeEnabled,
+    allowUpdate: state.tracing.restrictions.allowUpdate,
   };
 }
 


### PR DESCRIPTION
See title. I had to add a rather ugly workaround for an antd tooltip bug, but I wanted to show the disabled button and tooltip in view and read-only mode so that users understand why they cannot import skeletons.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a dataset with an agglomerate file in View mode. Activate and select an agglomerate file mapping. -> The “Import Skeleton for Centered Cell” button should be disabled and a tooltip should be shown.
- The same should happen in a hybrid tracing if the Version View is opened (which switches the tracing to read-only mode).
- In other cases, the button should still be enabled and work as expected.

### Issues:
- see https://discuss.webknossos.org/t/add-import-skeleton-from-agglomerate-file/1623/4

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
