### PR TITLE
change debug logging to info for agglomerate skeleton perf

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
@@ -197,7 +197,7 @@ class AgglomerateService @Inject()(config: DataStoreConfig)(implicit ec: Executi
       )
       val duration = System.nanoTime() - startTime
       if (duration > 100 * 1e6) {
-        logger.debug(s"Generating skeleton from agglomerate file took ${math
+        logger.info(s"Generating skeleton from agglomerate file took ${math
           .round(duration / 1e6)} ms (${skeletonEdges.length} edges, ${nodes.length} nodes).")
       }
 


### PR DESCRIPTION
Stand-alone datastores currently omit DEBUG logging, which I had accidentally used for this particular output.
Since #5034 is still open, the easiest change seemed to change the line in question.

Contributes to #5032