### PR TITLE
Allow Dataset Managers to create explorative annotations on all datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added the possibility to generate skeletons from an HDF5 agglomerate file mapping on-the-fly. With an activated agglomerate file mapping, use `Shift + Middle Mouse Click` to import a skeleton of the cell into the annotation. Alternatively, use the button in the segmentation tab to import a skeleton of the centered cell into the annotation.
 
 ### Changed
--
+- Dataset Manager role now additionally grants permission to create explorative annotations on all datasets.
 
 ### Fixed
 - Fixed a bug where importing NMLs failed if they had unescaped greater-than signs inside of attributes. [#5003](https://github.com/scalableminds/webknossos/pull/5003)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added the possibility to generate skeletons from an HDF5 agglomerate file mapping on-the-fly. With an activated agglomerate file mapping, use `Shift + Middle Mouse Click` to import a skeleton of the cell into the annotation. Alternatively, use the button in the segmentation tab to import a skeleton of the centered cell into the annotation.
 
 ### Changed
-- Dataset Manager role now additionally grants permission to create explorative annotations on all datasets.
+- Dataset Manager role now additionally grants permission to create explorative annotations on all datasets. [#5037](https://github.com/scalableminds/webknossos/pull/5037)
 
 ### Fixed
 - Fixed a bug where importing NMLs failed if they had unescaped greater-than signs inside of attributes. [#5003](https://github.com/scalableminds/webknossos/pull/5003)

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -97,7 +97,7 @@ class AnnotationService @Inject()(annotationInformationProvider: AnnotationInfor
         case None =>
           for {
             isTeamManagerOrAdminOfOrg <- userService.isTeamManagerOrAdminOfOrg(user, user._organization)
-            _ <- bool2Fox(isTeamManagerOrAdminOfOrg || dataSet.isPublic)
+            _ <- bool2Fox(isTeamManagerOrAdminOfOrg || dataSet.isPublic || user.isDatasetManager)
             organizationTeamId <- organizationDAO.findOrganizationTeamId(user._organization)
           } yield organizationTeamId
       }
@@ -202,7 +202,7 @@ class AnnotationService @Inject()(annotationInformationProvider: AnnotationInfor
                                                    tracingType,
                                                    withFallback,
                                                    organization.name)
-      teamId <- selectSuitableTeam(user, dataSet)
+      teamId <- selectSuitableTeam(user, dataSet) ?~> "annotation.create.forbidden"
       annotation = Annotation(
         ObjectId.generate,
         _dataSet,

--- a/conf/messages
+++ b/conf/messages
@@ -198,6 +198,7 @@ tracing=Annotation
 tracing.notFound=Tracing couldn’t be found
 
 annotation.create.failed=Failed to create annotation.
+annotation.create.forbidden=You do not have permission to create annotations for this dataset.
 annotation.volume.uint64=Creating volume annotations with uint64 fallback layer is not supported by wK yet.
 annotation.volume.resolutionRestrictionsTooTight=Task type resolution restrictions are too tight, resulting annotation has no resolutions.
 annotation.volume.resolutionsDoNotMatch=Could not merge volume annotations, as their resolutions differ. Please ensure each annotation has the same set of resolutions.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://datasetmanagercreateexplorative.webknossos.xyz

### Steps to test:
- Register additional user, grant Dataset Manager role
- as that user, try to create Explorative Annotation on a dataset that has zero allowed teams
- should be allowed

### Issues:
- fixes #5036

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
