### PR TITLE
Hotfix exceeded localStorage quota

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed a bug where importing NMLs failed if they had unescaped greater-than signs inside of attributes. [#5003](https://github.com/scalableminds/webknossos/pull/5003)
-- Mitigate errors concerning localStorage quotas in the datasets dashboard. [#5038](https://github.com/scalableminds/webknossos/issues/5038)
+- Mitigate errors concerning localStorage quotas in the datasets dashboard. [#5039](https://github.com/scalableminds/webknossos/pull/5039)
 
 ### Removed
 -

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed a bug where importing NMLs failed if they had unescaped greater-than signs inside of attributes. [#5003](https://github.com/scalableminds/webknossos/pull/5003)
+- Mitigate errors concerning localStorage quotas in the datasets dashboard. [#5038](https://github.com/scalableminds/webknossos/issues/5038)
 
 ### Removed
 -

--- a/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
@@ -25,6 +25,7 @@ type Context = {
   ) => Promise<void>,
 };
 
+const oldWkDatasetsCacheKey = "wk.datasets";
 const wkDatasetsCacheKey = "wk.datasets-v2";
 export const datasetCache = {
   set(datasets: APIMaybeUnimportedDataset[]): void {
@@ -66,6 +67,10 @@ export default function DatasetCacheProvider({ children }: { children: Node }) {
       const newDatasets = await getDatasets(
         mapFilterModeToUnreportedParameter[datasetFilteringMode],
       );
+      // Hotfix for https://github.com/scalableminds/webknossos/issues/5038
+      // The deprecated cache key can still block a considerable amount of data in the localStorage (around 2 MB
+      // for some wk instances while the localStorage quota is at 5 MB for Chrome).
+      UserLocalStorage.removeItem(oldWkDatasetsCacheKey);
       datasetCache.set(newDatasets);
       if (applyUpdatePredicate(newDatasets)) {
         setDatasets(newDatasets);

--- a/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_cache_provider.js
@@ -71,6 +71,7 @@ export default function DatasetCacheProvider({ children }: { children: Node }) {
       // The deprecated cache key can still block a considerable amount of data in the localStorage (around 2 MB
       // for some wk instances while the localStorage quota is at 5 MB for Chrome).
       UserLocalStorage.removeItem(oldWkDatasetsCacheKey);
+      UserLocalStorage.removeItem(oldWkDatasetsCacheKey, false);
       datasetCache.set(newDatasets);
       if (applyUpdatePredicate(newDatasets)) {
         setDatasets(newDatasets);


### PR DESCRIPTION
... by removing deprecated wk datasets cache key

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I started wk locally with the fix, since I knew that the localStorage on localhost already contained some other dataset cache keys (can be verified by executing `localStorage` in the devtools before checking out this branch)
- open the dashboard
- inspect `localStorage` and check that there's only one dataset cache entry for the current user

### Issues:
- hotfixes #5038

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
