### PR TITLE
Allow handling dataset configurations for datasets not normally visible

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where importing NMLs failed if they had unescaped greater-than signs inside of attributes. [#5003](https://github.com/scalableminds/webknossos/pull/5003)
 - Mitigate errors concerning localStorage quotas in the datasets dashboard. [#5039](https://github.com/scalableminds/webknossos/pull/5039)
+- Fixed a bug where viewing a dataset via sharingToken crashed. [#5047](https://github.com/scalableminds/webknossos/pull/5047)
 
 ### Removed
 -

--- a/app/controllers/ConfigurationController.scala
+++ b/app/controllers/ConfigurationController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.mohiva.play.silhouette.api.Silhouette
+import com.scalableminds.util.accesscontext.GlobalAccessContext
 import models.binary.{DataSetDAO, DataSetService}
 import models.configuration.{DataSetConfigurationService, UserConfiguration}
 import models.user.UserService
@@ -9,8 +10,8 @@ import play.api.i18n.Messages
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json._
 import play.api.mvc.PlayBodyParsers
-
 import javax.inject.Inject
+
 import scala.concurrent.ExecutionContext
 
 class ConfigurationController @Inject()(
@@ -42,9 +43,11 @@ class ConfigurationController @Inject()(
   def readDataSetViewConfiguration(organizationName: String, dataSetName: String) =
     sil.UserAwareAction.async(validateJson[List[String]]) { implicit request =>
       request.identity.toFox
-        .flatMap(user =>
-          dataSetConfigurationService
-            .getDataSetViewConfigurationForUserAndDataset(request.body, user, dataSetName, organizationName))
+        .flatMap(
+          user =>
+            dataSetConfigurationService
+              .getDataSetViewConfigurationForUserAndDataset(request.body, user, dataSetName, organizationName)(
+                GlobalAccessContext))
         .orElse(
           dataSetConfigurationService.getDataSetViewConfigurationForDataset(request.body, dataSetName, organizationName)
         )

--- a/app/models/configuration/DataSetConfigurationService.scala
+++ b/app/models/configuration/DataSetConfigurationService.scala
@@ -5,11 +5,11 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.models.datasource.DataLayerLike
 import com.scalableminds.webknossos.datastore.models.datasource.DataSetViewConfiguration.DataSetViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
+import javax.inject.Inject
 import models.binary.{DataSet, DataSetDAO, DataSetDataLayerDAO, DataSetService}
 import models.user.{User, UserDataSetConfigurationDAO, UserDataSetLayerConfigurationDAO}
 import play.api.libs.json._
 
-import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
 class DataSetConfigurationService @Inject()(dataSetService: DataSetService,

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -213,7 +213,7 @@ class UserService @Inject()(conf: WkConf,
       dataSetConfiguration: DataSetViewConfiguration,
       layerConfiguration: Option[JsValue])(implicit ctx: DBAccessContext, m: MessagesProvider): Fox[Unit] =
     for {
-      dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName) ?~> Messages(
+      dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName)(GlobalAccessContext) ?~> Messages(
         "dataSet.notFound",
         dataSetName)
       layerMap = layerConfiguration.flatMap(_.asOpt[Map[String, JsValue]]).getOrElse(Map.empty)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://datasetconfglobal.webknossos.xyz

### Steps to test:
- create a second user not allowed to see a particular dataset
- as orga admin, copy sharing link from dataset settings page, open as that second user
- should be allowed to view and to change view settings in sidebar

### Issues:
- fixes #5045 

### On Privacy
- Privacy impact should be minimal, since dataset default view configurations do not contain any problematic information, and the requester needs to already know the dataset name (usually only happens when they received a sharing link anyway)

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
