### PR TITLE
Disable parallel dataset upload requests for now

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -919,7 +919,7 @@ export function createResumableUpload(datasetId: APIDatasetId, datastoreUrl: str
         query: datasetId,
         chunkSize: 10 * 1024 * 1024, // set chunk size to 10MB
         permanentErrors: [400, 403, 404, 409, 415, 500, 501],
-        simultaneousUploads: 3,
+        simultaneousUploads: 1,
         chunkRetryInterval: 2000,
         maxChunkRetries: undefined,
         generateUniqueIdentifier: getRandomString,

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -919,6 +919,7 @@ export function createResumableUpload(datasetId: APIDatasetId, datastoreUrl: str
         query: datasetId,
         chunkSize: 10 * 1024 * 1024, // set chunk size to 10MB
         permanentErrors: [400, 403, 404, 409, 415, 500, 501],
+        // Only increase this value when https://github.com/scalableminds/webknossos/issues/5056 is fixed
         simultaneousUploads: 1,
         chunkRetryInterval: 2000,
         maxChunkRetries: undefined,


### PR DESCRIPTION
The name-reserving logic of the wk backend leads to errors if upload chunk requests come in parallel. Since that fix looks nontrivial I suggest we disable parallel requests for the moment, to fix the uploads.

### Steps to test:
- upload a dataset with a fresh name
- should not show name conflict errors

- [x] Needs datastore update after deployment
- [x] Ready for review
