### PR TITLE
Make settings background white again

### DIFF
--- a/frontend/stylesheets/antd_overwrites.less
+++ b/frontend/stylesheets/antd_overwrites.less
@@ -159,3 +159,8 @@ label.ant-checkbox-wrapper {
   // UI unusable
   pointer-events: none;
 }
+
+// Make settings background plain white
+.ant-collapse-borderless {
+  background-color: white;
+}


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
On master it looks like this:
![image](https://user-images.githubusercontent.com/2486553/106255152-f0e25000-6219-11eb-8426-7b423449fe56.png)
With this PR:
![image](https://user-images.githubusercontent.com/2486553/106255158-f475d700-6219-11eb-8e17-6c312bfaf71f.png)

I also verified that the other collapsibles are not affected in a negative way.

### Issues:
- follow-up to antd update in #4761 

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
