### PR TITLE
Fix project usersWithActiveTasks query

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed a bug where the user could delete teams that were still referenced in annotations, projects or task types, thus creating invalid state. [#5108](https://github.com/scalableminds/webknossos/pull/5108/files)
+- Fixed a bug where the listing of users that have open tasks of a project failed. [#5115](https://github.com/scalableminds/webknossos/pull/5115)
 
 ### Removed
 - The isosurface setting was removed. Instead, isosurfaces can be generated via the "Meshes" tab. Also note that the Shift+Click binding for generating an isosurface was removed (for now). Please refer to the "Meshes" tab, too. [#4917](https://github.com/scalableminds/webknossos/pull/4917)

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -124,16 +124,17 @@ class ProjectDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
 
   def findUsersWithActiveTasks(name: String): Fox[List[(String, String, String, Int)]] =
     for {
-      rSeq <- run(sql"""select u.email, u.firstName, u.lastName, count(a._id)
+      rSeq <- run(sql"""select m.email, u.firstName, u.lastName, count(a._id)
                          from
                          webknossos.annotations_ a
                          join webknossos.tasks_ t on a._task = t._id
                          join webknossos.projects_ p on t._project = p._id
                          join webknossos.users_ u on a._user = u._id
+                         join webknossos.multiusers_ m on u._multiUser = m._id
                          where p.name = $name
                          and a.state = '#${AnnotationState.Active.toString}'
                          and a.typ = '#${AnnotationType.Task}'
-                         group by u.email, u.firstName, u.lastName
+                         group by m.email, u.firstName, u.lastName
                      """.as[(String, String, String, Int)])
     } yield rSeq.toList
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create second user (*member* of organization team), give them sampleExp:1, create task
- Log in as that user, fetch the task
- In Admin Project view, “Show active users” modal should list the user with the open task, not crash

### Issues:
- fixes #5114

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
