### PR TITLE
Enforce TLS 1.2 in Mailer

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Support for the old invite links was removed. These contained the organization name in the URL. The new links contain a token (can be generated in the users view). For instances with a single organization the old invite links should still work. [#5091](https://github.com/scalableminds/webknossos/pull/5091/files)
 - Users are no longer allowed to deactivate their own accounts.  [#5070](https://github.com/scalableminds/webknossos/pull/5070)
 - A user needs to confirm his choice if he really wants to leave the dataset upload view while it's still loading. [#5051](https://github.com/scalableminds/webknossos/pull/5049)
+- Mailer now uses only TLS1.2 instead of JDK default. [#5138](https://github.com/scalableminds/webknossos/pull/5138)
 
 ### Fixed
 - Fixed a bug where the user could delete teams that were still referenced in annotations, projects or task types, thus creating invalid state. [#5108](https://github.com/scalableminds/webknossos/pull/5108/files)

--- a/util/src/main/scala/com/scalableminds/util/mail/Mailer.scala
+++ b/util/src/main/scala/com/scalableminds/util/mail/Mailer.scala
@@ -58,6 +58,8 @@ class Mailer(conf: MailerConfig) extends Actor with LazyLogging {
       multiPartMail.setStartTLSEnabled(conf.smtpTls)
       multiPartMail.setAuthenticator(new DefaultAuthenticator(conf.smtpUser, conf.smtpPass))
       multiPartMail.setDebug(false)
+      multiPartMail.getMailSession.getProperties.put("mail.smtp.ssl.protocols", "TLSv1.2")
+
       multiPartMail.send
     } else {
       ""


### PR DESCRIPTION
Mailer now uses only TLS 1.2 instead of JDK default. TLS 1.0 and 1.1 have been deprecated by many mailing hosts, as they are now deemed less secure.

### Steps to test:
- set up mailer credentials in application.conf
- register
- mail should be sent (no stacktrace in logging)

### Issues:
- fixes #5136 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
