### PR TITLE
Separate Experience Domains By Organization

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Users are no longer allowed to deactivate their own accounts.  [#5070](https://github.com/scalableminds/webknossos/pull/5070)
 - A user needs to confirm his choice if he really wants to leave the dataset upload view while it's still loading. [#5051](https://github.com/scalableminds/webknossos/pull/5049)
 - Mailer now uses only TLS1.2 instead of JDK default. [#5138](https://github.com/scalableminds/webknossos/pull/5138)
+- User experienced domains are now separated by organization. [#5149](https://github.com/scalableminds/webknossos/pull/5149)
 
 ### Fixed
 - Fixed a bug where the user could delete teams that were still referenced in annotations, projects or task types, thus creating invalid state. [#5108](https://github.com/scalableminds/webknossos/pull/5108/files)

--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -7,8 +7,10 @@ User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 
 ## Unreleased
 - Support for KNOSSOS cubes data format was removed. Use the [webKnossos cuber](https://github.com/scalableminds/webknossos-cuber) tool to convert existing datasets saved as KNOSSOS cubes.
+- Multi-organization instances only: user experience domains are now separated per organization. After postgres evolution 64 (see below), make sure to move existing experience domains to the correct organization in the database. (The evolution just selects any one from the database).
 
 ### Postgres Evolutions:
 - [061-userinfos-view.sql](conf/evolutions/061-userinfos-view)
 - [062-dataset-uploader.sql](conf/evolutions/062-dataset-uploader.sql)
 - [063-novelUserExperienceinfos.sql](conf/evolutions/063-novelUserExperienceinfos.sql)
+- [064-experienceDomains-per-orga.sql](conf/evolutions/064-experienceDomains-per-orga.sql)

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -135,7 +135,7 @@ Samplecountry
         for {
           _ <- multiUserDAO.insertOne(defaultMultiUser)
           _ <- userDAO.insertOne(defaultUser)
-          _ <- userExperiencesDAO.updateExperiencesForUser(defaultUser._id, Map("sampleExp" -> 10))
+          _ <- userExperiencesDAO.updateExperiencesForUser(defaultUser, Map("sampleExp" -> 10))
           _ <- userTeamRolesDAO.insertTeamMembership(defaultUser._id,
                                                      TeamMembership(organizationTeam._id, isTeamManager = true))
           _ = logger.info("Inserted default user scmboy")

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -187,7 +187,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
 
   def listExperienceDomains: Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      experienceDomains <- taskDAO.listExperienceDomains
+      experienceDomains <- taskDAO.listExperienceDomains(request.identity._organization)
     } yield Ok(Json.toJson(experienceDomains))
   }
 }

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -260,9 +260,9 @@ class TaskDAO @Inject()(sqlClient: SQLClient, projectDAO: ProjectDAO)(implicit e
       rowsRaw.toList.map(r => (ObjectId(r._1), r._2)).toMap
     }
 
-  def listExperienceDomains: Fox[List[String]] =
+  def listExperienceDomains(organizationId: ObjectId): Fox[List[String]] =
     for {
-      rowsRaw <- run(sql"select domain from webknossos.experienceDomains".as[String])
+      rowsRaw <- run(sql"select domain from webknossos.experienceDomains where _organization = $organizationId".as[String])
     } yield rowsRaw.toList
 
   def insertOne(t: Task): Fox[Unit] =

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -262,7 +262,8 @@ class TaskDAO @Inject()(sqlClient: SQLClient, projectDAO: ProjectDAO)(implicit e
 
   def listExperienceDomains(organizationId: ObjectId): Fox[List[String]] =
     for {
-      rowsRaw <- run(sql"select domain from webknossos.experienceDomains where _organization = $organizationId".as[String])
+      rowsRaw <- run(
+        sql"select domain from webknossos.experienceDomains where _organization = $organizationId".as[String])
     } yield rowsRaw.toList
 
   def insertOne(t: Task): Fox[Unit] =

--- a/app/models/task/TaskCreationService.scala
+++ b/app/models/task/TaskCreationService.scala
@@ -12,7 +12,15 @@ import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import com.scalableminds.webknossos.tracingstore.tracings.volume.ResolutionRestrictions
 import javax.inject.Inject
 import models.annotation.nml.NmlResults.TracingBoxContainer
-import models.annotation.{Annotation, AnnotationDAO, AnnotationService, AnnotationState, AnnotationType, TracingStoreRpcClient, TracingStoreService}
+import models.annotation.{
+  Annotation,
+  AnnotationDAO,
+  AnnotationService,
+  AnnotationState,
+  AnnotationType,
+  TracingStoreRpcClient,
+  TracingStoreService
+}
 import models.binary.{DataSet, DataSetDAO}
 import models.project.{Project, ProjectDAO}
 import models.team.{Team, TeamDAO}

--- a/app/models/task/TaskCreationService.scala
+++ b/app/models/task/TaskCreationService.scala
@@ -12,19 +12,11 @@ import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import com.scalableminds.webknossos.tracingstore.tracings.volume.ResolutionRestrictions
 import javax.inject.Inject
 import models.annotation.nml.NmlResults.TracingBoxContainer
-import models.annotation.{
-  Annotation,
-  AnnotationDAO,
-  AnnotationService,
-  AnnotationState,
-  AnnotationType,
-  TracingStoreRpcClient,
-  TracingStoreService
-}
+import models.annotation.{Annotation, AnnotationDAO, AnnotationService, AnnotationState, AnnotationType, TracingStoreRpcClient, TracingStoreService}
 import models.binary.{DataSet, DataSetDAO}
 import models.project.{Project, ProjectDAO}
 import models.team.{Team, TeamDAO}
-import models.user.{User, UserService, UserTeamRolesDAO}
+import models.user.{User, UserExperiencesDAO, UserService, UserTeamRolesDAO}
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import oxalis.telemetry.SlackNotificationService.SlackNotificationService
 import play.api.i18n.{Messages, MessagesProvider}
@@ -44,6 +36,7 @@ class TaskCreationService @Inject()(taskTypeService: TaskTypeService,
                                     slackNotificationService: SlackNotificationService,
                                     projectDAO: ProjectDAO,
                                     annotationDAO: AnnotationDAO,
+                                    userExperiencesDAO: UserExperiencesDAO,
                                     scriptDAO: ScriptDAO,
                                     dataSetDAO: DataSetDAO,
                                     tracingStoreService: TracingStoreService,
@@ -521,6 +514,7 @@ class TaskCreationService @Inject()(taskTypeService: TaskTypeService,
         creationInfo = params.creationInfo
       )
       _ <- taskDAO.insertOne(task)
+      _ <- userExperiencesDAO.insertExperienceToListing(params.neededExperience.domain, requestingUser._organization)
     } yield task
 
   private def taskToJsonWithOtherFox(taskFox: Fox[Task], otherFox: Fox[Unit])(

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -303,18 +303,26 @@ class UserExperiencesDAO @Inject()(sqlClient: SQLClient, userDAO: UserDAO)(impli
       rows.map(r => (r.domain, r.value)).toMap
     }
 
-  def updateExperiencesForUser(userId: ObjectId, experiences: Map[String, Int])(
+  def updateExperiencesForUser(user: User, experiences: Map[String, Int])(
       implicit ctx: DBAccessContext): Fox[Unit] = {
-    val clearQuery = sqlu"delete from webknossos.user_experiences where _user = ${userId}"
+    val clearQuery = sqlu"delete from webknossos.user_experiences where _user = ${user._id}"
     val insertQueries = experiences.map {
       case (domain, value) =>
-        sqlu"insert into webknossos.user_experiences(_user, domain, value) values(${userId}, ${domain}, ${value})"
+        sqlu"insert into webknossos.user_experiences(_user, domain, value) values(${user._id}, ${domain}, ${value})"
     }
     for {
-      _ <- userDAO.assertUpdateAccess(userId)
+      _ <- userDAO.assertUpdateAccess(user._id)
       _ <- run(DBIO.sequence(List(clearQuery) ++ insertQueries).transactionally)
+      _ <- Fox.serialCombined(experiences.keySet.toList)(domain => insertExperienceToListing(domain, user._organization))
     } yield ()
   }
+
+  def insertExperienceToListing(experienceDomain: String, organizationId: ObjectId): Fox[Unit] =
+    for {
+      _ <- run(
+        sqlu"""INSERT INTO webknossos.experienceDomains(domain, _organization)
+              values($experienceDomain, $organizationId) ON CONFLICT DO NOTHING;""")
+    } yield ()
 
 }
 

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -186,7 +186,7 @@ class UserService @Inject()(conf: WkConf,
                                 isDeactivated = !activated,
                                 lastTaskTypeId)
       _ <- userTeamRolesDAO.updateTeamMembershipsForUser(user._id, teamMemberships)
-      _ <- userExperiencesDAO.updateExperiencesForUser(user._id, experiences)
+      _ <- userExperiencesDAO.updateExperiencesForUser(user, experiences)
       _ = userCache.invalidateUser(user._id)
       _ <- if (oldEmail == email) Fox.successful(()) else tokenDAO.updateEmail(oldEmail, email)
       updated <- userDAO.findOne(user._id)

--- a/conf/evolutions/064-experienceDomains-per-orga.sql
+++ b/conf/evolutions/064-experienceDomains-per-orga.sql
@@ -7,7 +7,7 @@ ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT experiencedomains_pkey;
 ALTER TABLE webknossos.experienceDomains ADD COLUMN _organization CHAR(24);
 UPDATE webknossos.experienceDomains SET _organization = (SELECT _id from webknossos.organizations_ LIMIT 1);
 ALTER TABLE webknossos.experienceDomains ALTER COLUMN _organization SET NOT NULL;
-ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT experiencedomains_pkey PRIMARY KEY (domain,_organization);
+ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT primarykey__domain_orga PRIMARY KEY (domain,_organization);
 
 ALTER TABLE webknossos.experienceDomains
   ADD CONSTRAINT organization_ref FOREIGN KEY(_organization) REFERENCES webknossos.organizations(_id) DEFERRABLE;

--- a/conf/evolutions/064-experienceDomains-per-orga.sql
+++ b/conf/evolutions/064-experienceDomains-per-orga.sql
@@ -3,12 +3,17 @@
 
 START TRANSACTION;
 
-ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT domain_pkey;
-ALTER TABLE webknossos.experienceDomains ADD COLUMN _organization CHAR(24) NOT NULL;
-ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT domain_orga_pkey PRIMARY KEY (domain,_organization);
+ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT experiencedomains_pkey;
+ALTER TABLE webknossos.experienceDomains ADD COLUMN _organization CHAR(24);
+UPDATE webknossos.experienceDomains SET _organization = (SELECT _id from webknossos.organizations_ LIMIT 1)
+ALTER TABLE webknossos.experienceDomains ALTER COLUMN _organization SET NOT NULL;
+ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT experiencedomains_pkey PRIMARY KEY (domain,_organization);
 
-DROP TRIGGER onDeleteAnnotationTrigger;
-DROP TRIGGER onInsertUserExperienceTrigger;
+ALTER TABLE webknossos.experienceDomains
+  ADD CONSTRAINT organization_ref FOREIGN KEY(_organization) REFERENCES webknossos.organizations(_id) DEFERRABLE;
+
+DROP TRIGGER onDeleteAnnotationTrigger ON webknossos.tasks;
+DROP TRIGGER onInsertUserExperienceTrigger ON webknossos.user_experiences;
 
 DROP FUNCTION webknossos.onInsertTask;
 DROP FUNCTION webknossos.onInsertUserExperience;

--- a/conf/evolutions/064-experienceDomains-per-orga.sql
+++ b/conf/evolutions/064-experienceDomains-per-orga.sql
@@ -5,7 +5,7 @@ START TRANSACTION;
 
 ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT experiencedomains_pkey;
 ALTER TABLE webknossos.experienceDomains ADD COLUMN _organization CHAR(24);
-UPDATE webknossos.experienceDomains SET _organization = (SELECT _id from webknossos.organizations_ LIMIT 1)
+UPDATE webknossos.experienceDomains SET _organization = (SELECT _id from webknossos.organizations_ LIMIT 1);
 ALTER TABLE webknossos.experienceDomains ALTER COLUMN _organization SET NOT NULL;
 ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT experiencedomains_pkey PRIMARY KEY (domain,_organization);
 

--- a/conf/evolutions/064-experienceDomains-per-orga.sql
+++ b/conf/evolutions/064-experienceDomains-per-orga.sql
@@ -1,0 +1,18 @@
+-- https://github.com/scalableminds/webknossos/pull/5149
+
+
+START TRANSACTION;
+
+ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT domain_pkey;
+ALTER TABLE webknossos.experienceDomains ADD COLUMN _organization CHAR(24) NOT NULL;
+ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT domain_orga_pkey PRIMARY KEY (domain,_organization);
+
+DROP TRIGGER onDeleteAnnotationTrigger;
+DROP TRIGGER onInsertUserExperienceTrigger;
+
+DROP FUNCTION webknossos.onInsertTask;
+DROP FUNCTION webknossos.onInsertUserExperience;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 64;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/064-experienceDomains-per-orga.sql
+++ b/conf/evolutions/reversions/064-experienceDomains-per-orga.sql
@@ -3,7 +3,7 @@
 
 START TRANSACTION;
 
-ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT experiencedomains_pkey;
+ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT primarykey__domain_orga;
 ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT organization_ref;
 ALTER TABLE webknossos.experienceDomains DROP COLUMN _organization;
 ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT experiencedomains_pkey PRIMARY KEY (domain);

--- a/conf/evolutions/reversions/064-experienceDomains-per-orga.sql
+++ b/conf/evolutions/reversions/064-experienceDomains-per-orga.sql
@@ -1,0 +1,36 @@
+-- https://github.com/scalableminds/webknossos/pull/5149
+
+
+START TRANSACTION;
+
+ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT experiencedomains_pkey;
+ALTER TABLE webknossos.experienceDomains DROP CONSTRAINT organization_ref;
+ALTER TABLE webknossos.experienceDomains DROP COLUMN _organization;
+ALTER TABLE webknossos.experienceDomains ADD CONSTRAINT experiencedomains_pkey PRIMARY KEY (domain);
+
+CREATE FUNCTION webknossos.onInsertTask() RETURNS trigger AS $$
+  BEGIN
+    INSERT INTO webknossos.experienceDomains(domain) values(NEW.neededExperience_domain) ON CONFLICT DO NOTHING;
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION webknossos.onInsertUserExperience() RETURNS trigger AS $$
+  BEGIN
+    INSERT INTO webknossos.experienceDomains(domain) values(NEW.domain) ON CONFLICT DO NOTHING;
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER onDeleteAnnotationTrigger
+AFTER INSERT ON webknossos.tasks
+FOR EACH ROW EXECUTE PROCEDURE webknossos.onInsertTask();
+
+CREATE TRIGGER onInsertUserExperienceTrigger
+AFTER INSERT ON webknossos.user_experiences
+FOR EACH ROW EXECUTE PROCEDURE webknossos.onInsertUserExperience();
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 63;
+
+COMMIT TRANSACTION;

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ START TRANSACTION;
 CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(63);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(64);
 COMMIT TRANSACTION;
 
 CREATE TABLE webknossos.analytics(
@@ -237,7 +237,9 @@ CREATE TABLE webknossos.tasks(
 );
 
 CREATE TABLE webknossos.experienceDomains(
-  domain VARCHAR(256) PRIMARY KEY
+  domain VARCHAR(256) NOT NULL,
+  _organization CHAR(24) NOT NULL,
+  CONSTRAINT primarykey__domain_orga PRIMARY KEY (domain,_organization)
 );
 
 CREATE TABLE webknossos.teams(

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -563,26 +563,3 @@ CREATE TRIGGER onDeleteAnnotationTrigger
 AFTER DELETE ON webknossos.annotations
 FOR EACH ROW EXECUTE PROCEDURE webknossos.onDeleteAnnotation();
 
-
-CREATE FUNCTION webknossos.onInsertTask() RETURNS trigger AS $$
-  BEGIN
-    INSERT INTO webknossos.experienceDomains(domain) values(NEW.neededExperience_domain) ON CONFLICT DO NOTHING;
-    RETURN NULL;
-  END;
-$$ LANGUAGE plpgsql;
-
-CREATE FUNCTION webknossos.onInsertUserExperience() RETURNS trigger AS $$
-  BEGIN
-    INSERT INTO webknossos.experienceDomains(domain) values(NEW.domain) ON CONFLICT DO NOTHING;
-    RETURN NULL;
-  END;
-$$ LANGUAGE plpgsql;
-
-
-CREATE TRIGGER onDeleteAnnotationTrigger
-AFTER INSERT ON webknossos.tasks
-FOR EACH ROW EXECUTE PROCEDURE webknossos.onInsertTask();
-
-CREATE TRIGGER onInsertUserExperienceTrigger
-AFTER INSERT ON webknossos.user_experiences
-FOR EACH ROW EXECUTE PROCEDURE webknossos.onInsertUserExperience();

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -491,6 +491,8 @@ ALTER TABLE webknossos.user_dataSetLayerConfigurations
   ADD CONSTRAINT dataSet_ref FOREIGN KEY(_dataSet) REFERENCES webknossos.dataSets(_id) ON DELETE CASCADE DEFERRABLE;
 ALTER TABLE webknossos.multiUsers
   ADD CONSTRAINT lastLoggedInIdentity_ref FOREIGN KEY(_lastLoggedInIdentity) REFERENCES webknossos.users(_id) ON DELETE SET NULL;
+ALTER TABLE webknossos.experienceDomains
+  ADD CONSTRAINT organization_ref FOREIGN KEY(_organization) REFERENCES webknossos.organizations(_id) DEFERRABLE;
 
 CREATE FUNCTION webknossos.countsAsTaskInstance(a webknossos.annotations) RETURNS BOOLEAN AS $$
   BEGIN


### PR DESCRIPTION
### Steps to test:
- Create tasks, set user experiences to user, in both cases, the experiences should show up in suggestions next time
- set up second organization (e.g. via isDemoInstance=true), repeat.
- experience domains should only be shown if logged into the orga they were created in

### Issues:
- fixes #5071

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Ready for review
