### PR TITLE
Fix multiuser email lookup

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where the user could delete teams that were still referenced in annotations, projects or task types, thus creating invalid state. [#5108](https://github.com/scalableminds/webknossos/pull/5108/files)
 - Fixed a bug where an error occurred when clicking on the hours/week graph in the statistics overview page. [#4779](https://github.com/scalableminds/webknossos/pull/5113)
 - Fixed a bug where the listing of users that have open tasks of a project failed. [#5115](https://github.com/scalableminds/webknossos/pull/5115)
+- Fixed a bug where the user (and telemetry) would get a cryptic error message when trying to register with an email that is already in use. [#5152](https://github.com/scalableminds/webknossos/pull/5152)
 
 ### Removed
 - Support for KNOSSOS cubes data format was removed. Use the [webKnossos cuber](https://github.com/scalableminds/webknossos-cuber) tool to convert existing datasets saved as KNOSSOS cubes. [#5085](https://github.com/scalableminds/webknossos/pull/5085)

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -342,7 +342,6 @@ class UserController @Inject()(userService: UserService,
           _ <- ensureProperTeamAdministration(user, teamsWithUpdate)
           trimmedExperiences = experiences.map { case (key, value) => key.trim -> value }
           updatedTeams = teamsWithUpdate.map(_._1) ++ teamsWithoutUpdate
-          oldMultiUser <- multiUserDAO.findOne(user._multiUser)
           _ <- userService.update(user,
                                   firstName.trim,
                                   lastName.trim,

--- a/app/models/user/MultiUser.scala
+++ b/app/models/user/MultiUser.scala
@@ -108,7 +108,7 @@ class MultiUserDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext
   def emailNotPresentYet(email: String)(implicit ctx: DBAccessContext): Fox[Boolean] =
     for {
       accessQuery <- readAccessQuery
-      idList <- run(sql"select _id from #$existingCollectionName where email = $email and #$accessQuery".as[Int])
+      idList <- run(sql"select _id from #$existingCollectionName where email = $email and #$accessQuery".as[String])
     } yield idList.isEmpty
 
 }


### PR DESCRIPTION
When users signed up with an email adress that was already in use, an SQL error was produced. The end user presumably still got the correct error message on the top level, albeit with a strange error tail.

Also in this PR: removed a superfluous multiUser lookup in user update

### Steps to test:
- CI should be green
- Try registering with existing email, should get readable error

### Issues:
- fixes #5127 
------
- [x] Ready for review
