### PR TITLE
add help block

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_upload_view.js
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.js
@@ -1,5 +1,5 @@
 // @flow
-import { Form, Button, Upload, Icon, Col, Row, Tooltip, Modal, Progress } from "antd";
+import { Form, Button, Upload, Icon, Col, Row, Tooltip, Modal, Progress, Alert } from "antd";
 import { connect } from "react-redux";
 import React from "react";
 import _ from "lodash";
@@ -310,6 +310,21 @@ class DatasetUploadView extends React.PureComponent<PropsWithFormAndRouter, Stat
       <div className="dataset-administration" style={{ padding: 5 }}>
         <CardContainer withoutCard={withoutCard} title="Upload Dataset">
           <Form onSubmit={this.handleSubmit} layout="vertical">
+            {features().isDemoInstance && (
+              <Alert
+                message={
+                  <>
+                    We are happy to help!
+                    <br />
+                    Please <a href="mailto:hello@webknossos.org">contact us</a> if you have any
+                    trouble uploading your data or the uploader doesn&apos;t support your format
+                    yet.
+                  </>
+                }
+                type="info"
+                style={{ marginBottom: 50 }}
+              />
+            )}
             <Row gutter={8}>
               <Col span={12}>
                 <DatasetNameFormItem form={form} activeUser={activeUser} />


### PR DESCRIPTION
I thought it might be a good idea to add a help message like this, because I think data upload will still be an issue for some users.
<img width="1474" alt="Screenshot 2021-02-12 at 21 57 12" src="https://user-images.githubusercontent.com/335438/107822129-dfeb2000-6d7d-11eb-833a-16d40b3668c4.png">


Should be merged as part of #5081.