### PR TITLE
Allow accessing dataset admin view configuration via sharing token

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where the listing of users that have open tasks of a project failed. [#5115](https://github.com/scalableminds/webknossos/pull/5115)
 - Fixed some scenarios where the Meshes tab could cause errors (e.g., when the UI was used but no segmentation layer was available). [#5142](https://github.com/scalableminds/webknossos/pull/5142)
 - Fixed a bug where the user (and telemetry) would get a cryptic error message when trying to register with an email that is already in use. [#5152](https://github.com/scalableminds/webknossos/pull/5152)
+- Fixed a bug where default dataset configuration could not be loaded if a dataset was accessed via sharing token [#5164](https://github.com/scalableminds/webknossos/pull/5164)
 
 ### Removed
 - Support for KNOSSOS cubes data format was removed. Use the [webKnossos cuber](https://github.com/scalableminds/webknossos-cuber) tool to convert existing datasets saved as KNOSSOS cubes. [#5085](https://github.com/scalableminds/webknossos/pull/5085)

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -30,7 +30,7 @@ POST          /auth/createOrganizationWithAdmin                                 
 # Configurations
 GET           /user/userConfiguration                                           controllers.ConfigurationController.read
 PUT           /user/userConfiguration                                           controllers.ConfigurationController.update
-POST          /dataSetConfigurations/:organizationName/:dataSetName             controllers.ConfigurationController.readDataSetViewConfiguration(organizationName: String, dataSetName: String)
+POST          /dataSetConfigurations/:organizationName/:dataSetName             controllers.ConfigurationController.readDataSetViewConfiguration(organizationName: String, dataSetName: String, sharingToken: Option[String])
 PUT           /dataSetConfigurations/:organizationName/:dataSetName             controllers.ConfigurationController.updateDataSetViewConfiguration(organizationName: String, dataSetName: String)
 GET           /dataSetConfigurations/default/:organizationName/:dataSetName     controllers.ConfigurationController.readDataSetAdminViewConfiguration(organizationName: String, dataSetName: String)
 PUT           /dataSetConfigurations/default/:organizationName/:dataSetName     controllers.ConfigurationController.updateDataSetAdminViewConfiguration(organizationName: String, dataSetName: String)

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -873,9 +873,11 @@ export function updateDataset(datasetId: APIDatasetId, dataset: APIDataset): Pro
 export async function getDatasetViewConfiguration(
   dataset: APIDataset,
   displayedVolumeTracings: Array<string>,
+  sharingToken?: ?string,
 ): Promise<DatasetConfiguration> {
+  const sharingTokenSuffix = sharingToken != null ? `?sharingToken=${sharingToken}` : "";
   const settings = await Request.sendJSONReceiveJSON(
-    `/api/dataSetConfigurations/${dataset.owningOrganization}/${dataset.name}`,
+    `/api/dataSetConfigurations/${dataset.owningOrganization}/${dataset.name}${sharingTokenSuffix}`,
     {
       data: displayedVolumeTracings,
       method: "POST",

--- a/frontend/javascripts/oxalis/model_initialization.js
+++ b/frontend/javascripts/oxalis/model_initialization.js
@@ -126,6 +126,7 @@ export async function initialize(
   const initialDatasetSettings = await getDatasetViewConfiguration(
     dataset,
     displayedVolumeTracings,
+    getSharingToken(),
   );
   initializeSettings(initialUserSettings, initialDatasetSettings);
 


### PR DESCRIPTION
### Steps to test:
- give a dataset an admin view configuration (e.g. layer configuration in settings view)
- open private tab, open dataset there
- should see the respective settings

### Issues:
- fixes #3240

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
