### PR TITLE
Indicate loading state in tab title during loading

### DIFF
--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -212,11 +212,17 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
   };
 
   getTabTitle = () => {
-    const titleArray: Array<string> = [
-      this.props.displayName,
-      this.props.organization,
-      "webKnossos",
-    ];
+    const getDescriptors = () => {
+      switch (this.state.status) {
+        case "loading":
+          return ["Loading"];
+        case "failedLoading":
+          return ["Error"];
+        default:
+          return [this.props.displayName, this.props.organization];
+      }
+    };
+    const titleArray: Array<string> = [...getDescriptors(), "webKnossos"];
     return titleArray.filter(elem => elem).join(" | ");
   };
 


### PR DESCRIPTION
... instead of values from default state. This should avoid confusion :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Previously, during loading, the tab title showed default values from the store, namely "Test Dateset" and "Connectomics Department". This should no longer be the case. During loading the tab title should show "Loading" and the correct values, afterwards.
- Trigger an error, for example by deleting some part of the annotation id. The tab title should switch to "Error" after the loading phase, instead of showing the default store values.

### Issues:
- fixes #5041 

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
