### PR TITLE
Increase Standalone Stores Request Timeout

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - A user needs to confirm his choice if he really wants to leave the dataset upload view while it's still loading. [#5051](https://github.com/scalableminds/webknossos/pull/5049)
 - Mailer now uses only TLS1.2 instead of JDK default. [#5138](https://github.com/scalableminds/webknossos/pull/5138)
 - User experienced domains are now separated by organization. [#5149](https://github.com/scalableminds/webknossos/pull/5149)
+- Changed the default request timeouts for standalone datastores and tracingstores to match those of local ones (10000s instead of 75s). [#5174](https://github.com/scalableminds/webknossos/pull/5174)
 
 ### Fixed
 - Fixed a bug where the user could delete teams that were still referenced in annotations, projects or task types, thus creating invalid state. [#5108](https://github.com/scalableminds/webknossos/pull/5108/files)

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -64,3 +64,8 @@ play.http.filters = "com.scalableminds.webknossos.datastore.Filters"
 # we do not want to set *all* of the security filters, though:
 play.filters.headers.contentSecurityPolicy = null
 play.filters.headers.contentTypeOptions = null
+
+
+# Note that these take effect only in production mode (timeouts are shorter in dev)
+play.server.http.idleTimeout = 10000s
+play.server.akka.requestTimeout = 10000s

--- a/webknossos-tracingstore/conf/standalone-tracingstore.conf
+++ b/webknossos-tracingstore/conf/standalone-tracingstore.conf
@@ -49,3 +49,8 @@ play.http.filters = "com.scalableminds.webknossos.datastore.Filters"
 # we do not want to set *all* of the security filters, though:
 play.filters.headers.contentSecurityPolicy = null
 play.filters.headers.contentTypeOptions = null
+
+
+# Note that these take effect only in production mode (timeouts are shorter in dev)
+play.server.http.idleTimeout = 10000s
+play.server.akka.requestTimeout = 10000s


### PR DESCRIPTION
Turns out we had those timeouts set to the large value only in `application.conf` but not for the standalone versions of the stores.

From the changelog:
> Changed the default request timeouts for standalone datastores and tracingstores to match those of local ones (10000s instead of 75s)

### Steps to test

I tested it on data1 with an artificial sleep in a request (got error 502 from nginx after 75s before this change, got my reply after the 5min sleep afterwards)

### Issues
- fixes #4271

- [x] ready for review