### PR TITLE
Fix public annotation sharing

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -68,7 +68,7 @@ class AnnotationController @Inject()(
             timeSpanService.logUserInteraction(timestamp, user, annotation) // log time when a user starts working
           } else Fox.successful(())
         }
-        _ <- request.identity.map { user =>
+        _ = request.identity.map { user =>
           analyticsService.track(OpenAnnotationEvent(user, annotation))
         }
       } yield {


### PR DESCRIPTION
Fixes a bug where publicly shared annotations could not be loaded because the analytics call in the info request was wrapped in a `map` the result of which was flattened into the for comprehension. 

This PR changes the for comprehension so it ignores the result of the `map` (which is `None` if `request.identity` is `None`).

I also scanned the code for other occurrences of `request.identity.map` but the others were already correctly ignored.

The Bug was introduced in #5156 three days ago. It has not been included in a release.

### URL of deployed dev instance (used for testing):
- https://fixpublicannotations.webknossos.xyz

### Steps to test:
- Set an annotation to public (don’t forget to hit save), copy link
- log out
- open link, you should see the annotation

### Issues:
- fixes  #5192

------
- [x] Ready for review
