### PR TITLE
Fix Dataset Tiff Conversion

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_upload_view.js
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.js
@@ -132,7 +132,7 @@ class DatasetUploadView extends React.PureComponent<PropsWithFormAndRouter, Stat
             organization: datasetId.owningOrganization,
             name: datasetId.name,
             initialTeams: formValues.initialTeams.map(team => team.id),
-            needsConversion: formValues.needsConversion,
+            needsConversion: this.state.needsConversion,
           };
 
           finishDatasetUpload(formValues.datastore, uploadInfo).then(


### PR DESCRIPTION
The finishUpload route needs a valid value for needsConversion to unzip to the correct target directory.
needsConversion is no longer part of formValues, so this was undefined

### Steps to test:
- set up webknossos-worker, enable jobs in application.conf
- upload zipped tiff dataset

------
- [x] Ready for review
