### PR TITLE
Only show latest API in docs

### DIFF
--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -140,6 +140,12 @@ function assertVolume(tracing: Tracing): VolumeTracing {
  * All tracing related API methods. This is the newest version of the API (version 3).
  * @version 3
  * @class
+ * @example
+ * window.webknossos.apiReady(3).then(api => {
+ *   api.tracing.getActiveNodeId();
+ *   api.tracing.getActiveTreeId();
+ *   ...
+ * }
  */
 class TracingApi {
   model: OxalisModel;
@@ -823,6 +829,12 @@ class TracingApi {
 
 /**
  * All binary data / layer related API methods.
+ * @example
+ * window.webknossos.apiReady(3).then(api => {
+ *   api.data.getLayerNames();
+ *   api.data.reloadBuckets(...);
+ *   ...
+ * }
  */
 class DataApi {
   model: OxalisModel;
@@ -1323,6 +1335,12 @@ class DataApi {
 
 /**
  * All user configuration related API methods.
+ * @example
+ * window.webknossos.apiReady(3).then(api => {
+ *   api.user.getConfiguration(...);
+ *   api.user.setConfiguration(...);
+ *   ...
+ * }
  */
 class UserApi {
   model: OxalisModel;
@@ -1383,6 +1401,12 @@ type Handler = {
 
 /**
  * Utility API methods to control wK.
+ * @example
+ * window.webknossos.apiReady(3).then(api => {
+ *   api.utils.sleep(...);
+ *   api.utils.showToast(...);
+ *   ...
+ * }
  */
 class UtilsApi {
   model: OxalisModel;

--- a/frontend/javascripts/oxalis/api/api_loader.js
+++ b/frontend/javascripts/oxalis/api/api_loader.js
@@ -35,7 +35,7 @@ class Api {
    * @param {number} version
    *
    * @example
-   * window.webknossos.apiReady(2).then((api) => {
+   * window.webknossos.apiReady(3).then((api) => {
    *   // Your cool user script / wK plugin
    *   const nodes = api.tracing.getAllNodes();
    *   ...

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "am-i-pretty": "node_modules/.bin/prettier --list-different --config .prettierrc \"frontend/javascripts/**/*.js\" \"tools/**/*.js\"",
     "lint-fix": "node_modules/.bin/eslint --cache --fix --quiet frontend/javascripts/ tools/",
     "flow-coverage": "node_modules/flow-coverage-report/bin/flow-coverage-report.js -i \"./frontend/javascripts/**/*.js\" -x \"./frontend/javascripts/test/**/*.js\" -t html -t text",
-    "docs": "node_modules/.bin/documentation build frontend/javascripts/oxalis/api/api_loader.js --github --project-name \"webKnossos Frontend API\" --format html --output public/docs/frontend-api",
+    "docs": "node_modules/.bin/documentation build --shallow frontend/javascripts/oxalis/api/api_loader.js frontend/javascripts/oxalis/api/api_latest.js --github --project-name \"webKnossos Frontend API\" --format html --output public/docs/frontend-api",
     "refresh-schema": "./tools/postgres/refresh_schema.sh && rm -f target/scala-2.12/src_managed/schema/com/scalableminds/webknossos/schema/Tables.scala",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "postcheckout": "echo 'Deleting auto-generated flow files...' && rm -f frontend/javascripts/test/snapshots/flow-check/*.js",


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://onlylatestdocs.webknossos.xyz

### Steps to test:
- run `yarn docs` and open `public/docs/frontend-api/index.html`. will look like this:
![image](https://user-images.githubusercontent.com/2486553/109166657-3a707d00-777d-11eb-9644-bf766c3beafb.png)


### Issues:
- fixes #3855

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
