### PR TITLE
Remove K/L from intro shortcut list

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -114,19 +114,6 @@ const shortcuts = [
     ],
     action: "Rotate 3D View",
   },
-  {
-    key: "5",
-    keybinding: [
-      <span key="scale-1" className="keyboard-key-icon">
-        K
-      </span>,
-      "/",
-      <span key="scale-2" className="keyboard-key-icon">
-        L
-      </span>,
-    ],
-    action: "Scale Up/Down Viewports",
-  },
 ];
 
 export function convertPixelsToNm(


### PR DESCRIPTION
We don't really want people to use K and L anymore, because it is more complicated than resizing with the mouse.

- [x] Ready for review
