### PR TITLE
Add is_superuser property to analytics events

### DIFF
--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -47,10 +47,9 @@ class AnalyticsLookUpService @Inject()(userDAO: UserDAO, multiUserDAO: MultiUser
     extends LazyLogging {
   implicit val ctx: DBAccessContext = GlobalAccessContext
 
-  def isSuperUser(userId: ObjectId): Fox[Boolean] =
+  def isSuperUser(multiUserId: ObjectId): Fox[Boolean] =
     for {
-      user <- userDAO.findOne(userId)
-      multiUser <- multiUserDAO.findOne(user._multiUser)
+      multiUser <- multiUserDAO.findOne(multiUserId)
     } yield multiUser.isSuperUser
 
   def multiUserIdFor(userId: ObjectId): Fox[String] =
@@ -67,7 +66,7 @@ trait AnalyticsEvent {
   def userId: String = user._multiUser.toString
   def userProperties(analyticsLookUpService: AnalyticsLookUpService): Fox[JsObject] =
     for {
-      isSuperUser <- analyticsLookUpService.isSuperUser(user._id)
+      isSuperUser <- analyticsLookUpService.isSuperUser(user._multiUser)
     } yield {
       Json.obj(
         "organization_id" -> user._organization.id,

--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -1,6 +1,6 @@
 package models.analytics
 
-import com.scalableminds.util.accesscontext.GlobalAccessContext
+import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.scalalogging.LazyLogging
@@ -8,7 +8,7 @@ import javax.inject.Inject
 import models.annotation.Annotation
 import models.binary.{DataSet, DataStore}
 import models.team.Organization
-import models.user.{User, UserDAO}
+import models.user.{MultiUserDAO, User, UserDAO}
 import org.joda.time.DateTime
 import play.api.libs.json._
 import utils.{ObjectId, WkConf}
@@ -43,10 +43,19 @@ class AnalyticsService @Inject()(rpc: RPC, wkConf: WkConf, analyticsLookUpServic
   }
 }
 
-class AnalyticsLookUpService @Inject()(userDAO: UserDAO, wkConf: WkConf) extends LazyLogging {
+class AnalyticsLookUpService @Inject()(userDAO: UserDAO, multiUserDAO: MultiUserDAO, wkConf: WkConf)
+    extends LazyLogging {
+  implicit val ctx: DBAccessContext = GlobalAccessContext
+
+  def isSuperUser(userId: ObjectId): Fox[Boolean] =
+    for {
+      user <- userDAO.findOne(userId)
+      multiUser <- multiUserDAO.findOne(user._multiUser)
+    } yield multiUser.isSuperUser
+
   def multiUserIdFor(userId: ObjectId): Fox[String] =
     for {
-      user <- userDAO.findOne(userId)(GlobalAccessContext)
+      user <- userDAO.findOne(userId)
     } yield user._multiUser.id
 
   def webknossos_uri: String = wkConf.Http.uri
@@ -56,10 +65,17 @@ trait AnalyticsEvent {
   def eventType: String
   def eventProperties(analyticsLookUpService: AnalyticsLookUpService): Fox[JsObject]
   def userId: String = user._multiUser.toString
-  def userProperties(analyticsLookUpService: AnalyticsLookUpService): JsObject =
-    Json.obj("organization_id" -> user._organization.id,
-             "is_organization_admin" -> user.isAdmin,
-             "webknossos_uri" -> analyticsLookUpService.webknossos_uri)
+  def userProperties(analyticsLookUpService: AnalyticsLookUpService): Fox[JsObject] =
+    for {
+      isSuperUser <- analyticsLookUpService.isSuperUser(user._id)
+    } yield {
+      Json.obj(
+        "organization_id" -> user._organization.id,
+        "is_organization_admin" -> user.isAdmin,
+        "is_superuser" -> isSuperUser,
+        "webknossos_uri" -> analyticsLookUpService.webknossos_uri
+      )
+    }
   def timestamp: String = DateTime.now().getMillis.toString
 
   def user: User
@@ -67,12 +83,13 @@ trait AnalyticsEvent {
   def toJson(analyticsLookUpService: AnalyticsLookUpService): Fox[JsObject] =
     for {
       eventProperties <- eventProperties(analyticsLookUpService)
+      userProperties <- userProperties(analyticsLookUpService)
     } yield {
       Json.obj(
         "event_type" -> eventType,
         "user_id" -> userId,
         "time" -> timestamp,
-        "user_properties" -> userProperties(analyticsLookUpService),
+        "user_properties" -> userProperties,
         "event_properties" -> eventProperties,
       )
     }


### PR DESCRIPTION
Superusers (i.e. employees) are noise for analytics, so it may be desirable to filter out their events.

### Steps to test:
- in application.conf set `backendAnalytics.verboseLoggingEnabled = true`, open a dataset
- in analytics logging, the is_superuser property should show (and be true iff the requesting user is a superuser)

### Issues:
- fixes #5211

------
- [x] Ready for review
