### PR TITLE
Adapt Agglomerate Mapping Max Mag to correct value

### DIFF
--- a/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
@@ -15,6 +15,8 @@ import constants from "oxalis/constants";
 import messages from "messages";
 import { getRequestLogZoomStep } from "oxalis/model/accessors/flycam_accessor";
 
+/* Note that this must stay in sync with the back-end constant
+  compare https://github.com/scalableminds/webknossos/issues/5223 */
 const MAX_MAG_FOR_AGGLOMERATE_MAPPING = 16;
 
 export function* pushAnnotationUpdateAsync(): Saga<void> {

--- a/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/annotation_saga.js
@@ -15,7 +15,7 @@ import constants from "oxalis/constants";
 import messages from "messages";
 import { getRequestLogZoomStep } from "oxalis/model/accessors/flycam_accessor";
 
-const MAX_MAG_FOR_AGGLOMERATE_MAPPING = 8;
+const MAX_MAG_FOR_AGGLOMERATE_MAPPING = 16;
 
 export function* pushAnnotationUpdateAsync(): Saga<void> {
   const tracing = yield* select(state => state.tracing);

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -19,6 +19,9 @@ class BinaryDataService(val dataBaseDir: Path, maxCacheSize: Int, val agglomerat
     with DataSetDeleter
     with LazyLogging {
 
+  /* Note that this must stay in sync with the back-end constant
+    compare https://github.com/scalableminds/webknossos/issues/5223 */
+  private val MaxMagForAgglomerateMapping = 16;
   lazy val cache = new DataCubeCache(maxCacheSize)
 
   def handleDataRequest(request: DataServiceDataRequest): Fox[Array[Byte]] = {
@@ -51,7 +54,7 @@ class BinaryDataService(val dataBaseDir: Path, maxCacheSize: Int, val agglomerat
         for {
           data <- handleDataRequest(request)
           mappedData = convertIfNecessary(
-            request.settings.appliedAgglomerate.isDefined && request.dataLayer.category == Category.segmentation && request.cuboid.resolution.maxDim <= 16,
+            request.settings.appliedAgglomerate.isDefined && request.dataLayer.category == Category.segmentation && request.cuboid.resolution.maxDim <= MaxMagForAgglomerateMapping,
             data,
             agglomerateService.applyAgglomerate(request)
           )


### PR DESCRIPTION
https://github.com/scalableminds/webknossos/pull/4706 increased the threshold from 8 to 16, so message should also appear only starting at 16.

Long-term it would be nice to have a single place for this value, but that is not trivial since the datastore config is not exposed to the frontend. We could instead add a flag to the data requests when this limit was exceeded or something. But for now I think this is ok.

- [x] Ready for review
