### PR TITLE
Type annotations and Scala Style

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -16,7 +16,7 @@ import models.user.{User, UserService}
 import oxalis.security.WkEnv
 import play.api.i18n.{Messages, MessagesProvider}
 import play.api.libs.json.{JsArray, _}
-import play.api.mvc.PlayBodyParsers
+import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import utils.{ObjectId, WkConf}
 import javax.inject.Inject
 import models.analytics.{AnalyticsService, CreateAnnotationEvent, OpenAnnotationEvent}
@@ -26,7 +26,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 case class CreateExplorationalParameters(typ: String, withFallback: Option[Boolean])
-object CreateExplorationalParameters { implicit val jsonFormat = Json.format[CreateExplorationalParameters] }
+object CreateExplorationalParameters {
+  implicit val jsonFormat: OFormat[CreateExplorationalParameters] = Json.format[CreateExplorationalParameters]
+}
 
 class AnnotationController @Inject()(
     annotationDAO: AnnotationDAO,
@@ -49,53 +51,48 @@ class AnnotationController @Inject()(
     extends Controller
     with FoxImplicits {
 
-  implicit val timeout = Timeout(5 seconds)
-  val taskReopenAllowed = (conf.Features.taskReopenAllowed + (10 seconds)).toMillis
+  implicit val timeout: Timeout = Timeout(5 seconds)
+  private val taskReopenAllowed = (conf.Features.taskReopenAllowed + (10 seconds)).toMillis
 
-  def info(typ: String, id: String, timestamp: Long) = sil.UserAwareAction.async { implicit request =>
-    log {
-      val notFoundMessage =
-        if (request.identity.isEmpty) "annotation.notFound.considerLoggingIn" else "annotation.notFound"
-      for {
-        annotation <- provider.provideAnnotation(typ, id, request.identity) ?~> notFoundMessage ~> NOT_FOUND
-        _ <- bool2Fox(annotation.state != Cancelled) ?~> "annotation.cancelled"
-        restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
-        _ <- restrictions.allowAccess(request.identity) ?~> "notAllowed" ~> FORBIDDEN
-        typedTyp <- AnnotationType.fromString(typ).toFox ?~> "annotationType.notFound" ~> NOT_FOUND
-        js <- annotationService
-          .publicWrites(annotation, request.identity, Some(restrictions)) ?~> "annotation.write.failed"
-        _ <- Fox.runOptional(request.identity) { user =>
-          if (typedTyp == AnnotationType.Task || typedTyp == AnnotationType.Explorational) {
-            timeSpanService.logUserInteraction(timestamp, user, annotation) // log time when a user starts working
-          } else Fox.successful(())
-        }
-        _ = request.identity.map { user =>
-          analyticsService.track(OpenAnnotationEvent(user, annotation))
-        }
-      } yield {
-        Ok(js)
+  def info(typ: String, id: String, timestamp: Long): Action[AnyContent] = sil.UserAwareAction.async {
+    implicit request =>
+      log {
+        val notFoundMessage =
+          if (request.identity.isEmpty) "annotation.notFound.considerLoggingIn" else "annotation.notFound"
+        for {
+          annotation <- provider.provideAnnotation(typ, id, request.identity) ?~> notFoundMessage ~> NOT_FOUND
+          _ <- bool2Fox(annotation.state != Cancelled) ?~> "annotation.cancelled"
+          restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
+          _ <- restrictions.allowAccess(request.identity) ?~> "notAllowed" ~> FORBIDDEN
+          typedTyp <- AnnotationType.fromString(typ).toFox ?~> "annotationType.notFound" ~> NOT_FOUND
+          js <- annotationService
+            .publicWrites(annotation, request.identity, Some(restrictions)) ?~> "annotation.write.failed"
+          _ <- Fox.runOptional(request.identity) { user =>
+            if (typedTyp == AnnotationType.Task || typedTyp == AnnotationType.Explorational) {
+              timeSpanService.logUserInteraction(timestamp, user, annotation) // log time when a user starts working
+            } else Fox.successful(())
+          }
+          _ = request.identity.map { user =>
+            analyticsService.track(OpenAnnotationEvent(user, annotation))
+          }
+        } yield Ok(js)
       }
-    }
   }
 
-  def merge(typ: String, id: String, mergedTyp: String, mergedId: String) = sil.SecuredAction.async {
-    implicit request =>
+  def merge(typ: String, id: String, mergedTyp: String, mergedId: String): Action[AnyContent] =
+    sil.SecuredAction.async { implicit request =>
       for {
         annotationA <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
         annotationB <- provider.provideAnnotation(mergedTyp, mergedId, request.identity) ~> NOT_FOUND
-        mergedAnnotation <- annotationMerger
-          .mergeTwo(annotationA, annotationB, true, request.identity) ?~> "annotation.merge.failed"
+        mergedAnnotation <- annotationMerger.mergeTwo(annotationA, annotationB, persistTracing = true, request.identity) ?~> "annotation.merge.failed"
         restrictions = annotationRestrictionDefaults.defaultsFor(mergedAnnotation)
         _ <- restrictions.allowAccess(request.identity) ?~> Messages("notAllowed") ~> FORBIDDEN
         _ <- annotationDAO.insertOne(mergedAnnotation)
-        js <- annotationService
-          .publicWrites(mergedAnnotation, Some(request.identity), Some(restrictions)) ?~> "annotation.write.failed"
-      } yield {
-        JsonOk(js, Messages("annotation.merge.success"))
-      }
-  }
+        js <- annotationService.publicWrites(mergedAnnotation, Some(request.identity), Some(restrictions)) ?~> "annotation.write.failed"
+      } yield JsonOk(js, Messages("annotation.merge.success"))
+    }
 
-  def loggedTime(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def loggedTime(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       annotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
       restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
@@ -113,19 +110,17 @@ class AnnotationController @Inject()(
     }
   }
 
-  def reset(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def reset(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       annotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
       _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(request.identity, annotation._team))
       _ <- annotationService.resetToBase(annotation) ?~> "annotation.reset.failed"
       updated <- provider.provideAnnotation(typ, id, request.identity)
       json <- annotationService.publicWrites(updated, Some(request.identity))
-    } yield {
-      JsonOk(json, Messages("annotation.reset.success"))
-    }
+    } yield JsonOk(json, Messages("annotation.reset.success"))
   }
 
-  def reopen(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def reopen(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     def isReopenAllowed(user: User, annotation: Annotation) =
       for {
         isAdminOrTeamManager <- userService.isTeamManagerOrAdminOf(user, annotation._team)
@@ -138,16 +133,14 @@ class AnnotationController @Inject()(
       annotation <- provider.provideAnnotation(typ, id, request.identity)
       _ <- isReopenAllowed(request.identity, annotation) ?~> "annotation.reopen.failed"
       _ = logger.info(
-        s"Reopening annotation ${id.toString}, new state will be ${AnnotationState.Active.toString}, access context: ${request.identity.toStringAnonymous}")
+        s"Reopening annotation $id, new state will be ${AnnotationState.Active.toString}, access context: ${request.identity.toStringAnonymous}")
       _ <- annotationDAO.updateState(annotation._id, AnnotationState.Active) ?~> "annotation.invalid"
       updatedAnnotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
       json <- annotationService.publicWrites(updatedAnnotation, Some(request.identity)) ?~> "annotation.write.failed"
-    } yield {
-      JsonOk(json, Messages("annotation.reopened"))
-    }
+    } yield JsonOk(json, Messages("annotation.reopened"))
   }
 
-  def createExplorational(organizationName: String, dataSetName: String) =
+  def createExplorational(organizationName: String, dataSetName: String): Action[CreateExplorationalParameters] =
     sil.SecuredAction.async(validateJson[CreateExplorationalParameters]) { implicit request =>
       for {
         organization <- organizationDAO.findOneByName(organizationName)(GlobalAccessContext) ?~> Messages(
@@ -164,12 +157,10 @@ class AnnotationController @Inject()(
           request.body.withFallback.getOrElse(true)) ?~> "annotation.create.failed"
         _ = analyticsService.track(CreateAnnotationEvent(request.identity: User, annotation: Annotation))
         json <- annotationService.publicWrites(annotation, Some(request.identity)) ?~> "annotation.write.failed"
-      } yield {
-        JsonOk(json)
-      }
+      } yield JsonOk(json)
     }
 
-  def makeHybrid(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def makeHybrid(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       _ <- bool2Fox(AnnotationType.Explorational.toString == typ) ?~> "annotation.makeHybrid.explorationalsOnly"
       annotation <- provider.provideAnnotation(typ, id, request.identity)
@@ -177,24 +168,20 @@ class AnnotationController @Inject()(
       _ <- annotationService.makeAnnotationHybrid(annotation, organization.name) ?~> "annotation.makeHybrid.failed"
       updated <- provider.provideAnnotation(typ, id, request.identity)
       json <- annotationService.publicWrites(updated, Some(request.identity)) ?~> "annotation.write.failed"
-    } yield {
-      JsonOk(json)
-    }
+    } yield JsonOk(json)
   }
 
-  def downsample(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def downsample(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       _ <- bool2Fox(AnnotationType.Explorational.toString == typ) ?~> "annotation.downsample.explorationalsOnly"
       annotation <- provider.provideAnnotation(typ, id, request.identity)
       _ <- annotationService.downsampleAnnotation(annotation) ?~> "annotation.downsample.failed"
       updated <- provider.provideAnnotation(typ, id, request.identity)
       json <- annotationService.publicWrites(updated, Some(request.identity)) ?~> "annotation.write.failed"
-    } yield {
-      JsonOk(json)
-    }
+    } yield JsonOk(json)
   }
 
-  def unlinkFallback(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def unlinkFallback(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       _ <- bool2Fox(AnnotationType.Explorational.toString == typ) ?~> "annotation.unlinkFallback.explorationalsOnly"
       restrictions <- provider.restrictionsFor(typ, id)
@@ -220,58 +207,56 @@ class AnnotationController @Inject()(
       message <- annotationService.finish(annotation, issuingUser, restrictions) ?~> "annotation.finish.failed"
       updated <- provider.provideAnnotation(typ, id, issuingUser)
       _ <- timeSpanService.logUserInteraction(timestamp, issuingUser, annotation) // log time on tracing end
-    } yield {
-      (updated, message)
-    }
+    } yield (updated, message)
 
-  def finish(typ: String, id: String, timestamp: Long) = sil.SecuredAction.async { implicit request =>
-    log {
+  def finish(typ: String, id: String, timestamp: Long): Action[AnyContent] = sil.SecuredAction.async {
+    implicit request =>
+      log {
+        for {
+          (updated, message) <- finishAnnotation(typ, id, request.identity, timestamp) ?~> "annotation.finish.failed"
+          restrictions <- provider.restrictionsFor(typ, id)
+          json <- annotationService.publicWrites(updated, Some(request.identity), Some(restrictions))
+        } yield JsonOk(json, Messages(message))
+      }
+  }
+
+  def finishAll(typ: String, timestamp: Long): Action[JsValue] = sil.SecuredAction.async(parse.json) {
+    implicit request =>
+      log {
+        withJsonAs[JsArray](request.body \ "annotations") { annotationIds =>
+          val results = Fox.serialSequence(annotationIds.value.toList) { jsValue =>
+            jsValue.asOpt[String].toFox.flatMap(id => finishAnnotation(typ, id, request.identity, timestamp))
+          }
+
+          results.map { _ =>
+            JsonOk(Messages("annotation.allFinished"))
+          }
+        }
+      }
+  }
+
+  def editAnnotation(typ: String, id: String): Action[JsValue] = sil.SecuredAction.async(parse.json) {
+    implicit request =>
       for {
-        (updated, message) <- finishAnnotation(typ, id, request.identity, timestamp) ?~> "annotation.finish.failed"
-        restrictions <- provider.restrictionsFor(typ, id)
-        json <- annotationService.publicWrites(updated, Some(request.identity), Some(restrictions))
-      } yield {
-        JsonOk(json, Messages(message))
-      }
-    }
+        annotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
+        restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
+        _ <- restrictions.allowUpdate(request.identity) ?~> "notAllowed" ~> FORBIDDEN
+        name = (request.body \ "name").asOpt[String]
+        description = (request.body \ "description").asOpt[String]
+        visibility = (request.body \ "visibility").asOpt[String]
+        _ <- if (visibility.contains("Private"))
+          annotationService.updateTeamsForSharedAnnotation(annotation._id, List.empty)
+        else Fox.successful(())
+        tags = (request.body \ "tags").asOpt[List[String]]
+        _ <- Fox.runOptional(name)(annotationDAO.updateName(annotation._id, _)) ?~> "annotation.edit.failed"
+        _ <- Fox
+          .runOptional(description)(annotationDAO.updateDescription(annotation._id, _)) ?~> "annotation.edit.failed"
+        _ <- Fox.runOptional(visibility)(annotationDAO.updateVisibility(annotation._id, _)) ?~> "annotation.edit.failed"
+        _ <- Fox.runOptional(tags)(annotationDAO.updateTags(annotation._id, _)) ?~> "annotation.edit.failed"
+      } yield JsonOk(Messages("annotation.edit.success"))
   }
 
-  def finishAll(typ: String, timestamp: Long) = sil.SecuredAction.async(parse.json) { implicit request =>
-    log {
-      withJsonAs[JsArray](request.body \ "annotations") { annotationIds =>
-        val results = Fox.serialSequence(annotationIds.value.toList) { jsValue =>
-          jsValue.asOpt[String].toFox.flatMap(id => finishAnnotation(typ, id, request.identity, timestamp))
-        }
-
-        results.map { results =>
-          JsonOk(Messages("annotation.allFinished"))
-        }
-      }
-    }
-  }
-
-  def editAnnotation(typ: String, id: String) = sil.SecuredAction.async(parse.json) { implicit request =>
-    for {
-      annotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
-      restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
-      _ <- restrictions.allowUpdate(request.identity) ?~> "notAllowed" ~> FORBIDDEN
-      name = (request.body \ "name").asOpt[String]
-      description = (request.body \ "description").asOpt[String]
-      visibility = (request.body \ "visibility").asOpt[String]
-      _ <- if (visibility.contains("Private"))
-        annotationService.updateTeamsForSharedAnnotation(annotation._id, List.empty)
-      else Fox.successful(())
-      tags = (request.body \ "tags").asOpt[List[String]]
-      _ <- Fox.runOptional(name)(annotationDAO.updateName(annotation._id, _)) ?~> "annotation.edit.failed"
-      _ <- Fox.runOptional(description)(annotationDAO.updateDescription(annotation._id, _)) ?~> "annotation.edit.failed"
-      _ <- Fox.runOptional(visibility)(annotationDAO.updateVisibility(annotation._id, _)) ?~> "annotation.edit.failed"
-      _ <- Fox.runOptional(tags)(annotationDAO.updateTags(annotation._id, _)) ?~> "annotation.edit.failed"
-    } yield {
-      JsonOk(Messages("annotation.edit.success"))
-    }
-  }
-
-  def annotationsForTask(taskId: String) = sil.SecuredAction.async { implicit request =>
+  def annotationsForTask(taskId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       taskIdValidated <- ObjectId.parse(taskId)
       task <- taskDAO.findOne(taskIdValidated) ?~> "task.notFound" ~> NOT_FOUND
@@ -279,17 +264,15 @@ class AnnotationController @Inject()(
       _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(request.identity, project._team))
       annotations <- annotationService.annotationsFor(task._id) ?~> "task.annotation.failed"
       jsons <- Fox.serialSequence(annotations)(a => annotationService.publicWrites(a, Some(request.identity)))
-    } yield {
-      Ok(JsArray(jsons.flatten))
-    }
+    } yield Ok(JsArray(jsons.flatten))
   }
 
-  def cancel(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def cancel(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     def tryToCancel(annotation: Annotation) =
       annotation match {
         case t if t.typ == AnnotationType.Task =>
           logger.info(
-            s"Canceling annotation ${id.toString}, new state will be ${AnnotationState.Cancelled.toString}, access context: ${request.identity.toStringAnonymous}")
+            s"Canceling annotation $id, new state will be ${AnnotationState.Cancelled.toString}, access context: ${request.identity.toStringAnonymous}")
           annotationDAO.updateState(annotation._id, Cancelled).map { _ =>
             JsonOk(Messages("task.finished"))
           }
@@ -304,7 +287,7 @@ class AnnotationController @Inject()(
     } yield result
   }
 
-  def transfer(typ: String, id: String) = sil.SecuredAction.async(parse.json) { implicit request =>
+  def transfer(typ: String, id: String): Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     for {
       restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
       _ <- restrictions.allowFinish(request.identity) ?~> "notAllowed" ~> FORBIDDEN
@@ -312,24 +295,20 @@ class AnnotationController @Inject()(
       newUserIdValidated <- ObjectId.parse(newUserId)
       updated <- annotationService.transferAnnotationToUser(typ, id, newUserIdValidated, request.identity)
       json <- annotationService.publicWrites(updated, Some(request.identity), Some(restrictions))
-    } yield {
-      JsonOk(json)
-    }
+    } yield JsonOk(json)
   }
 
-  def duplicate(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def duplicate(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       annotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
       newAnnotation <- duplicateAnnotation(annotation, request.identity)
       restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound"
       json <- annotationService
         .publicWrites(newAnnotation, Some(request.identity), Some(restrictions)) ?~> "annotation.write.failed"
-    } yield {
-      JsonOk(json)
-    }
+    } yield JsonOk(json)
   }
 
-  def sharedAnnotations() = sil.SecuredAction.async { implicit request =>
+  def sharedAnnotations: Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       userTeams <- userService.teamIdsFor(request.identity._id)
       sharedAnnotations <- annotationService.sharedAnnotationsFor(userTeams)
@@ -337,7 +316,7 @@ class AnnotationController @Inject()(
     } yield Ok(Json.toJson(json))
   }
 
-  def getSharedTeams(typ: String, id: String) = sil.SecuredAction.async { implicit request =>
+  def getSharedTeams(typ: String, id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       annotation <- provider.provideAnnotation(typ, id, request.identity)
       _ <- bool2Fox(annotation._user == request.identity._id) ?~> "notAllowed" ~> FORBIDDEN
@@ -346,17 +325,19 @@ class AnnotationController @Inject()(
     } yield Ok(Json.toJson(json))
   }
 
-  def updateSharedTeams(typ: String, id: String) = sil.SecuredAction.async(parse.json) { implicit request =>
-    withJsonBodyAs[List[String]] { teams =>
-      for {
-        annotation <- provider.provideAnnotation(typ, id, request.identity)
-        _ <- bool2Fox(annotation._user == request.identity._id && annotation.visibility != AnnotationVisibility.Private) ?~> "notAllowed" ~> FORBIDDEN
-        teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.parse(_))
-        userTeams <- userService.teamIdsFor(request.identity._id)
-        updateTeams = teamIdsValidated.intersect(userTeams)
-        _ <- annotationService.updateTeamsForSharedAnnotation(annotation._id, updateTeams)
-      } yield Ok(Json.toJson(updateTeams.map(_.toString)))
-    }
+  def updateSharedTeams(typ: String, id: String): Action[JsValue] = sil.SecuredAction.async(parse.json) {
+    implicit request =>
+      withJsonBodyAs[List[String]] { teams =>
+        for {
+          annotation <- provider.provideAnnotation(typ, id, request.identity)
+          _ <- bool2Fox(
+            annotation._user == request.identity._id && annotation.visibility != AnnotationVisibility.Private) ?~> "notAllowed" ~> FORBIDDEN
+          teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.parse(_))
+          userTeams <- userService.teamIdsFor(request.identity._id)
+          updateTeams = teamIdsValidated.intersect(userTeams)
+          _ <- annotationService.updateTeamsForSharedAnnotation(annotation._id, updateTeams)
+        } yield Ok(Json.toJson(updateTeams.map(_.toString)))
+      }
   }
 
   private def duplicateAnnotation(annotation: Annotation, user: User)(implicit ctx: DBAccessContext,

--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -12,12 +12,9 @@ import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
 import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.mail._
 import com.scalableminds.util.tools.{Fox, FoxImplicits, TextUtils}
-import com.scalableminds.webknossos.datastore.rpc.RPC
 import javax.inject.Inject
 import models.analytics.{AnalyticsService, InviteEvent, JoinOrganizationEvent, SignupEvent}
-import models.binary.DataStoreDAO
 import models.organization.{OrganizationDAO, OrganizationService}
-import models.team._
 import models.user._
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import org.apache.commons.codec.binary.Base64
@@ -39,10 +36,7 @@ class AuthenticationController @Inject()(
     actorSystem: ActorSystem,
     credentialsProvider: CredentialsProvider,
     passwordHasher: PasswordHasher,
-    initialDataService: InitialDataService,
     userService: UserService,
-    dataStoreDAO: DataStoreDAO,
-    teamDAO: TeamDAO,
     organizationService: OrganizationService,
     inviteService: InviteService,
     inviteDAO: InviteDAO,
@@ -52,7 +46,6 @@ class AuthenticationController @Inject()(
     userDAO: UserDAO,
     multiUserDAO: MultiUserDAO,
     defaultMails: DefaultMails,
-    rpc: RPC,
     conf: WkConf,
     wkSilhouetteEnvironment: WkSilhouetteEnvironment,
     sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)

--- a/app/controllers/ConfigurationController.scala
+++ b/app/controllers/ConfigurationController.scala
@@ -7,9 +7,9 @@ import models.configuration.{DataSetConfigurationService, UserConfiguration}
 import models.user.UserService
 import oxalis.security.{URLSharing, WkEnv}
 import play.api.i18n.Messages
-import play.api.libs.json.JsObject
+import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.json.Json._
-import play.api.mvc.PlayBodyParsers
+import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import javax.inject.Inject
 
 import scala.concurrent.ExecutionContext
@@ -22,7 +22,7 @@ class ConfigurationController @Inject()(
     sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller {
 
-  def read = sil.UserAwareAction.async { implicit request =>
+  def read: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     request.identity.toFox.flatMap { user =>
       for {
         userConfig <- user.userConfigurationStructured
@@ -30,17 +30,17 @@ class ConfigurationController @Inject()(
     }.getOrElse(UserConfiguration.default.configuration).map(configuration => Ok(toJson(configuration)))
   }
 
-  def update = sil.SecuredAction.async(parse.json(maxLength = 20480)) { implicit request =>
+  def update: Action[JsValue] = sil.SecuredAction.async(parse.json(maxLength = 20480)) { implicit request =>
     for {
       jsConfiguration <- request.body.asOpt[JsObject] ?~> "user.configuration.invalid"
       conf = jsConfiguration.fields.toMap
       _ <- userService.updateUserConfiguration(request.identity, UserConfiguration(conf))
-    } yield {
-      JsonOk(Messages("user.configuration.updated"))
-    }
+    } yield JsonOk(Messages("user.configuration.updated"))
   }
 
-  def readDataSetViewConfiguration(organizationName: String, dataSetName: String, sharingToken: Option[String]) =
+  def readDataSetViewConfiguration(organizationName: String,
+                                   dataSetName: String,
+                                   sharingToken: Option[String]): Action[List[String]] =
     sil.UserAwareAction.async(validateJson[List[String]]) { implicit request =>
       val ctx = URLSharing.fallbackTokenAccessContext(sharingToken)
       request.identity.toFox
@@ -58,7 +58,7 @@ class ConfigurationController @Inject()(
         .map(configuration => Ok(toJson(configuration)))
     }
 
-  def updateDataSetViewConfiguration(organizationName: String, dataSetName: String) =
+  def updateDataSetViewConfiguration(organizationName: String, dataSetName: String): Action[JsValue] =
     sil.SecuredAction.async(parse.json(maxLength = 20480)) { implicit request =>
       for {
         jsConfiguration <- request.body.asOpt[JsObject] ?~> "user.configuration.dataset.invalid"
@@ -70,27 +70,23 @@ class ConfigurationController @Inject()(
                                                         organizationName,
                                                         dataSetConf,
                                                         layerConf)
-      } yield {
-        JsonOk(Messages("user.configuration.dataset.updated"))
-      }
+      } yield JsonOk(Messages("user.configuration.dataset.updated"))
     }
 
-  def readDataSetAdminViewConfiguration(organizationName: String, dataSetName: String) = sil.SecuredAction.async {
-    implicit request =>
+  def readDataSetAdminViewConfiguration(organizationName: String, dataSetName: String): Action[AnyContent] =
+    sil.SecuredAction.async { implicit request =>
       dataSetConfigurationService
         .getCompleteAdminViewConfiguration(dataSetName, organizationName)
         .map(configuration => Ok(toJson(configuration)))
-  }
+    }
 
-  def updateDataSetAdminViewConfiguration(organizationName: String, dataSetName: String) =
+  def updateDataSetAdminViewConfiguration(organizationName: String, dataSetName: String): Action[JsValue] =
     sil.SecuredAction.async(parse.json(maxLength = 20480)) { implicit request =>
       for {
         dataset <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName) ?~> "dataset.notFound" ~> NOT_FOUND
         _ <- dataSetService.isEditableBy(dataset, Some(request.identity)) ?~> "notAllowed" ~> FORBIDDEN
         jsObject <- request.body.asOpt[JsObject].toFox ?~> "user.configuration.dataset.invalid"
         _ <- dataSetConfigurationService.updateAdminViewConfigurationFor(dataset, jsObject.fields.toMap)
-      } yield {
-        JsonOk(Messages("user.configuration.dataset.updated"))
-      }
+      } yield JsonOk(Messages("user.configuration.dataset.updated"))
     }
 }

--- a/app/controllers/DataStoreController.scala
+++ b/app/controllers/DataStoreController.scala
@@ -4,23 +4,22 @@ import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import javax.inject.Inject
 import models.binary.{DataStore, DataStoreDAO, DataStoreService}
-import models.user.UserService
 import net.liftweb.common.Empty
 import oxalis.security.WkEnv
 import play.api.i18n.Messages
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class DataStoreController @Inject()(dataStoreDAO: DataStoreDAO,
                                     dataStoreService: DataStoreService,
-                                    userService: UserService,
                                     sil: Silhouette[WkEnv])(implicit ec: ExecutionContext)
     extends Controller
     with FoxImplicits {
 
-  val dataStoreReads: Reads[DataStore] =
+  private val dataStoreReads: Reads[DataStore] =
     ((__ \ 'name).read[String] and
       (__ \ 'url).read[String] and
       (__ \ 'publicUrl).read[String] and
@@ -30,7 +29,7 @@ class DataStoreController @Inject()(dataStoreDAO: DataStoreDAO,
       (__ \ 'isConnector).readNullable[Boolean] and
       (__ \ 'allowsUpload).readNullable[Boolean])(DataStore.fromForm _)
 
-  val dataStorePublicReads: Reads[DataStore] =
+  private val dataStorePublicReads: Reads[DataStore] =
     ((__ \ 'name).read[String] and
       (__ \ 'url).read[String] and
       (__ \ 'publicUrl).read[String] and
@@ -39,7 +38,7 @@ class DataStoreController @Inject()(dataStoreDAO: DataStoreDAO,
       (__ \ 'isConnector).readNullable[Boolean] and
       (__ \ 'allowsUpload).readNullable[Boolean])(DataStore.fromUpdateForm _)
 
-  def list = sil.UserAwareAction.async { implicit request =>
+  def list: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     for {
       dataStores <- dataStoreDAO.findAll ?~> "dataStore.list.failed"
       js <- Fox.serialCombined(dataStores)(d => dataStoreService.publicWrites(d))
@@ -48,7 +47,7 @@ class DataStoreController @Inject()(dataStoreDAO: DataStoreDAO,
     }
   }
 
-  def create = sil.SecuredAction.async(parse.json) { implicit request =>
+  def create: Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     withJsonBodyUsing(dataStoreReads) { dataStore =>
       dataStoreDAO.findOneByName(dataStore.name).futureBox.flatMap {
         case Empty =>
@@ -62,14 +61,14 @@ class DataStoreController @Inject()(dataStoreDAO: DataStoreDAO,
     }
   }
 
-  def delete(name: String) = sil.SecuredAction.async { implicit request =>
+  def delete(name: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       _ <- bool2Fox(request.identity.isAdmin) ?~> "notAllowed" ~> FORBIDDEN
       _ <- dataStoreDAO.deleteOneByName(name) ?~> "dataStore.remove.failure"
     } yield Ok
   }
 
-  def update(name: String) = sil.SecuredAction.async(parse.json) { implicit request =>
+  def update(name: String): Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     withJsonBodyUsing(dataStorePublicReads) { dataStore =>
       for {
         _ <- bool2Fox(request.identity.isAdmin)

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -43,9 +43,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
     for {
       task <- taskDAO.findOne(ObjectId(taskId)) ?~> "task.notFound" ~> NOT_FOUND
       js <- taskService.publicWrites(task)
-    } yield {
-      Ok(js)
-    }
+    } yield Ok(js)
   }
 
   def create: Action[List[TaskParameters]] = sil.SecuredAction.async(validateJson[List[TaskParameters]]) {
@@ -93,9 +91,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
 
       fullParamsWithTracings = taskCreationService.combineParamsWithTracings(fullParams, skeletonBases, volumeBases)
       result <- taskCreationService.createTasks(fullParamsWithTracings, request.identity)
-    } yield {
-      Ok(Json.toJson(result))
-    }
+    } yield Ok(Json.toJson(result))
   }
 
   def update(taskId: String): Action[TaskParameters] = sil.SecuredAction.async(validateJson[TaskParameters]) {
@@ -110,9 +106,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
         _ <- taskDAO.updateTotalInstances(task._id, task.totalInstances + params.openInstances - task.openInstances)
         updatedTask <- taskDAO.findOne(taskIdValidated)
         json <- taskService.publicWrites(updatedTask)
-      } yield {
-        JsonOk(json, Messages("task.editSuccess"))
-      }
+      } yield JsonOk(json, Messages("task.editSuccess"))
   }
 
   def delete(taskId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
@@ -123,9 +117,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
       _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(request.identity, project._team)) ?~> Messages(
         "notAllowed")
       _ <- taskDAO.removeOneAndItsAnnotations(task._id) ?~> "task.remove.failed"
-    } yield {
-      JsonOk(Messages("task.removed"))
-    }
+    } yield JsonOk(Messages("task.removed"))
   }
 
   def listTasksForType(taskTypeId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
@@ -133,9 +125,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
       taskTypeIdValidated <- ObjectId.parse(taskTypeId) ?~> "taskType.id.invalid"
       tasks <- taskDAO.findAllByTaskType(taskTypeIdValidated) ?~> "taskType.notFound" ~> NOT_FOUND
       js <- Fox.serialCombined(tasks)(taskService.publicWrites(_))
-    } yield {
-      Ok(Json.toJson(js))
-    }
+    } yield Ok(Json.toJson(js))
   }
 
   def listTasks: Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
@@ -152,9 +142,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
                                                                 userIdOpt,
                                                                 randomizeOpt)
       jsResult <- Fox.serialCombined(tasks)(taskService.publicWrites(_))
-    } yield {
-      Ok(Json.toJson(jsResult))
-    }
+    } yield Ok(Json.toJson(jsResult))
   }
 
   def request: Action[AnyContent] = sil.SecuredAction.async { implicit request =>
@@ -169,9 +157,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
         _ <- annotationService.abortInitializedAnnotationOnFailure(initializingAnnotationId, insertedAnnotationBox)
         annotation <- insertedAnnotationBox.toFox
         annotationJSON <- annotationService.publicWrites(annotation, Some(user))
-      } yield {
-        JsonOk(annotationJSON, Messages("task.assigned"))
-      }
+      } yield JsonOk(annotationJSON, Messages("task.assigned"))
     }
   }
 

--- a/app/controllers/TracingStoreController.scala
+++ b/app/controllers/TracingStoreController.scala
@@ -6,8 +6,9 @@ import models.annotation.{TracingStore, TracingStoreDAO, TracingStoreService}
 import oxalis.security.WkEnv
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-
 import javax.inject.Inject
+import play.api.mvc.{Action, AnyContent}
+
 import scala.concurrent.ExecutionContext
 
 class TracingStoreController @Inject()(tracingStoreService: TracingStoreService,
@@ -15,12 +16,12 @@ class TracingStoreController @Inject()(tracingStoreService: TracingStoreService,
                                        sil: Silhouette[WkEnv])(implicit ec: ExecutionContext)
     extends Controller
     with FoxImplicits {
-  val tracingStorePublicReads: Reads[TracingStore] =
+  private val tracingStorePublicReads: Reads[TracingStore] =
     ((__ \ 'name).read[String] and
       (__ \ 'url).read[String] and
       (__ \ 'publicUrl).read[String])(TracingStore.fromUpdateForm _)
 
-  def listOne = sil.UserAwareAction.async { implicit request =>
+  def listOne: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     for {
       tracingStore <- tracingStoreDAO.findFirst ?~> "tracingStore.list.failed"
       js <- tracingStoreService.publicWrites(tracingStore)
@@ -29,7 +30,7 @@ class TracingStoreController @Inject()(tracingStoreService: TracingStoreService,
     }
   }
 
-  def update(name: String) = sil.SecuredAction.async(parse.json) { implicit request =>
+  def update(name: String): Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     withJsonBodyUsing(tracingStorePublicReads) { tracingStore =>
       for {
         _ <- bool2Fox(request.identity.isAdmin)

--- a/app/models/annotation/AnnotationIdentifier.scala
+++ b/app/models/annotation/AnnotationIdentifier.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext
 
 case class AnnotationIdentifier(annotationType: AnnotationType, identifier: ObjectId) {
 
-  def toUniqueString =
+  def toUniqueString: String =
     annotationType + "__" + identifier
 
 }

--- a/app/models/annotation/AnnotationState.scala
+++ b/app/models/annotation/AnnotationState.scala
@@ -6,10 +6,10 @@ import utils.EnumUtils
 object AnnotationState extends Enumeration {
   type AnnotationState = Value
 
-  val Cancelled = Value("Cancelled")
-  val Active = Value("Active")
-  val Finished = Value("Finished")
-  val Initializing = Value("Initializing")
+  val Cancelled: AnnotationState = Value("Cancelled")
+  val Active: AnnotationState = Value("Active")
+  val Finished: AnnotationState = Value("Finished")
+  val Initializing: AnnotationState = Value("Initializing")
 
   implicit val enumReads: Reads[AnnotationState] = EnumUtils.enumReads(AnnotationState)
 

--- a/app/models/annotation/AnnotationStore.scala
+++ b/app/models/annotation/AnnotationStore.scala
@@ -50,7 +50,7 @@ class AnnotationStore @Inject()(
     }
   }
 
-  private def storeInCache(id: AnnotationIdentifier, annotation: Annotation) =
+  private def storeInCache(id: AnnotationIdentifier, annotation: Annotation): Unit =
     temporaryAnnotationStore.insert(id.toUniqueString, annotation, Some(cacheTimeout))
 
   private def getFromCache(annotationId: AnnotationIdentifier): Option[Fox[Annotation]] =
@@ -58,7 +58,7 @@ class AnnotationStore @Inject()(
 
   def findCachedByTracingId(tracingId: String): Box[Annotation] = {
     val annotationOpt = temporaryAnnotationStore.findAll.find(a =>
-      a.skeletonTracingId == Some(tracingId) || a.volumeTracingId == Some(tracingId))
+      a.skeletonTracingId.contains(tracingId) || a.volumeTracingId.contains(tracingId))
     annotationOpt match {
       case Some(annotation) => Full(annotation)
       case None             => Empty

--- a/app/models/annotation/handler/SavedTracingInformationHandler.scala
+++ b/app/models/annotation/handler/SavedTracingInformationHandler.scala
@@ -30,7 +30,7 @@ class SavedTracingInformationHandler @Inject()(annotationDAO: AnnotationDAO,
       task = annotation._task.map(_.toString).getOrElse("explorational")
     } yield {
       val id = formatHash(annotation.id)
-      normalize(s"${dataSetName}__${task}__${userName}__${id}")
+      normalize(s"${dataSetName}__${task}__${userName}__$id")
     }
 
   def provideAnnotation(annotationId: ObjectId, userOpt: Option[User])(implicit ctx: DBAccessContext): Fox[Annotation] =

--- a/app/models/annotation/handler/TaskInformationHandler.scala
+++ b/app/models/annotation/handler/TaskInformationHandler.scala
@@ -40,7 +40,7 @@ class TaskInformationHandler @Inject()(taskDAO: TaskDAO,
                                                   finishedAnnotations) ?~> "annotation.merge.failed.compound"
     } yield mergedAnnotation
 
-  def restrictionsFor(taskId: ObjectId)(implicit ctx: DBAccessContext) =
+  def restrictionsFor(taskId: ObjectId)(implicit ctx: DBAccessContext): Fox[AnnotationRestrictions] =
     for {
       task <- taskDAO.findOne(taskId) ?~> "task.notFound"
       project <- projectDAO.findOne(task._project)

--- a/app/models/annotation/handler/TaskTypeInformationHandler.scala
+++ b/app/models/annotation/handler/TaskTypeInformationHandler.scala
@@ -42,7 +42,7 @@ class TaskTypeInformationHandler @Inject()(taskTypeDAO: TaskTypeDAO,
                                                   finishedAnnotations) ?~> "annotation.merge.failed.compound"
     } yield mergedAnnotation
 
-  override def restrictionsFor(taskTypeId: ObjectId)(implicit ctx: DBAccessContext) =
+  override def restrictionsFor(taskTypeId: ObjectId)(implicit ctx: DBAccessContext): Fox[AnnotationRestrictions] =
     for {
       taskType <- taskTypeDAO.findOne(taskTypeId) ?~> "taskType.notFound"
     } yield {

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -184,7 +184,7 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits with ColorGener
         Left(bb)
       } else {
         val newId = if (userBoundingBoxes.isEmpty) 0 else userBoundingBoxes.map(_.id).max + 1
-        Right(NamedBoundingBox(newId, Some("task bounding box"), None, Some(getRandomColor()), bb))
+        Right(NamedBoundingBox(newId, Some("task bounding box"), None, Some(getRandomColor), bb))
       }
     }
 

--- a/app/models/configuration/DataSetConfigurationService.scala
+++ b/app/models/configuration/DataSetConfigurationService.scala
@@ -50,7 +50,8 @@ class DataSetConfigurationService @Inject()(dataSetService: DataSetService,
     defaultVC ++ adminVC
   }
 
-  def getCompleteAdminViewConfiguration(dataSetName: String, organizationName: String)(implicit ctx: DBAccessContext) =
+  def getCompleteAdminViewConfiguration(dataSetName: String, organizationName: String)(
+      implicit ctx: DBAccessContext): Fox[DataSetViewConfiguration] =
     for {
       dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName)
       dataSetViewConfiguration = getDataSetViewConfigurationFromDefaultAndAdmin(dataSet)

--- a/app/models/configuration/UserConfiguration.scala
+++ b/app/models/configuration/UserConfiguration.scala
@@ -4,16 +4,16 @@ import play.api.libs.json.{JsBoolean, JsValue, _}
 
 case class UserConfiguration(configuration: Map[String, JsValue]) {
 
-  def configurationOrDefaults =
+  def configurationOrDefaults: Map[String, JsValue] =
     UserConfiguration.default.configuration ++ configuration
 
 }
 
 object UserConfiguration {
 
-  implicit val userConfigurationFormat = Json.format[UserConfiguration]
+  implicit val userConfigurationFormat: OFormat[UserConfiguration] = Json.format[UserConfiguration]
 
-  val default = UserConfiguration(
+  val default: UserConfiguration = UserConfiguration(
     Map(
       "moveValue" -> JsNumber(300),
       "moveValue3d" -> JsNumber(300),

--- a/app/models/mesh/Mesh.scala
+++ b/app/models/mesh/Mesh.scala
@@ -37,7 +37,7 @@ object MeshInfoParameters {
       MeshInfoParameters(ObjectId(annotationId), description, position))
 }
 
-class MeshService @Inject()(meshDAO: MeshDAO)(implicit ec: ExecutionContext) {
+class MeshService @Inject()()(implicit ec: ExecutionContext) {
   def publicWrites(meshInfo: MeshInfo): Fox[JsObject] =
     Fox.successful(
       Json.obj(
@@ -64,10 +64,11 @@ class MeshDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
 
   def isDeletedColumn(x: Meshes): Rep[Boolean] = x.isdeleted
 
-  def infoColumns = (columnsList diff Seq("data")).mkString(", ")
+  private val infoColumns = (columnsList diff Seq("data")).mkString(", ")
   type InfoTuple = (String, String, String, String, java.sql.Timestamp, Boolean)
 
-  def parse(r: MeshesRow) = Fox.failure("not implemented, use parseInfo or get the data directly")
+  override def parse(r: MeshesRow): Fox[MeshInfo] =
+    Fox.failure("not implemented, use parseInfo or get the data directly")
 
   def parseInfo(r: InfoTuple): Fox[MeshInfo] =
     for {
@@ -87,8 +88,7 @@ class MeshDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
     for {
       accessQuery <- readAccessQuery
       rList <- run(
-        sql"select #${infoColumns} from #${existingCollectionName} where _id = ${id.id} and #${accessQuery}"
-          .as[InfoTuple])
+        sql"select #$infoColumns from #$existingCollectionName where _id = ${id.id} and #$accessQuery".as[InfoTuple])
       r <- rList.headOption.toFox ?~> ("Could not find object " + id + " in " + collectionName)
       parsed <- parseInfo(r) ?~> ("SQLDAO Error: Could not parse database row for object " + id + " in " + collectionName)
     } yield parsed
@@ -97,7 +97,8 @@ class MeshDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
     for {
       accessQuery <- readAccessQuery
       resultTuples <- run(
-        sql"select #${infoColumns} from #${existingCollectionName} where _annotation = ${_annotation}".as[InfoTuple])
+        sql"select #$infoColumns from #$existingCollectionName where _annotation = ${_annotation} and #$accessQuery"
+          .as[InfoTuple])
       resultsParsed <- Fox.serialCombined(resultTuples.toList)(parseInfo)
     } yield resultsParsed
 
@@ -114,14 +115,14 @@ class MeshDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- assertUpdateAccess(id)
-      _ <- run(sqlu"""update webknossos.meshes set _annotation = ${_annotation}, description = ${description},
-                            position = '#${writeStructTuple(position.toList.map(_.toString))}' where _id = ${id}""")
+      _ <- run(sqlu"""update webknossos.meshes set _annotation = ${_annotation}, description = $description,
+                            position = '#${writeStructTuple(position.toList.map(_.toString))}' where _id = $id""")
     } yield ()
 
   def getData(id: ObjectId)(implicit ctx: DBAccessContext): Fox[Array[Byte]] =
     for {
       accessQuery <- readAccessQuery
-      rList <- run(sql"select data from webknossos.meshes where _id = ${id} and #${accessQuery}".as[Option[String]])
+      rList <- run(sql"select data from webknossos.meshes where _id = $id and #$accessQuery".as[Option[String]])
       r <- rList.headOption.flatten.toFox ?~> ("Could not find object " + id + " in " + collectionName)
       binary = BaseEncoding.base64().decode(r)
     } yield binary
@@ -129,7 +130,7 @@ class MeshDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
   def updateData(id: ObjectId, data: Array[Byte])(implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- assertUpdateAccess(id)
-      _ <- run(sqlu"update webknossos.meshes set data = ${BaseEncoding.base64().encode(data)} where _id = ${id}")
+      _ <- run(sqlu"update webknossos.meshes set data = ${BaseEncoding.base64().encode(data)} where _id = $id")
     } yield ()
 
 }

--- a/app/models/user/Experience.scala
+++ b/app/models/user/Experience.scala
@@ -1,6 +1,6 @@
 package models.user
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 import scala.collection.breakOut
 import scala.language.implicitConversions
@@ -12,9 +12,9 @@ import scala.language.implicitConversions
   */
 case class Experience(domain: String, value: Int) {
 
-  override def toString = if (isEmpty) "" else s"$domain: $value"
+  override def toString: String = if (isEmpty) "" else s"$domain: $value"
 
-  def isEmpty = domain == "" && value == 0
+  def isEmpty: Boolean = domain == "" && value == 0
 
   def toMap: Map[String, Int] =
     if (isEmpty)
@@ -24,7 +24,7 @@ case class Experience(domain: String, value: Int) {
 }
 
 object Experience {
-  implicit val experienceFormat = Json.format[Experience]
+  implicit val experienceFormat: OFormat[Experience] = Json.format[Experience]
 
   type Experiences = Map[String, Int]
 
@@ -33,7 +33,7 @@ object Experience {
       case (domain, value) => Experience(domain, value)
     }(breakOut)
 
-  def empty = Experience("", 0)
+  def empty: Experience = Experience("", 0)
 
-  def fromForm(domain: String, value: Int) = Experience(domain.trim, value)
+  def fromForm(domain: String, value: Int): Experience = Experience(domain.trim, value)
 }

--- a/app/models/user/Invite.scala
+++ b/app/models/user/Invite.scala
@@ -117,7 +117,7 @@ class InviteDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
                     ${new java.sql.Timestamp(i.expirationDateTime.getMillis)}, ${new java.sql.Timestamp(i.created)}, ${i.isDeleted})""")
     } yield ()
 
-  def deleteAllExpired: Fox[Unit] = {
+  def deleteAllExpired(): Fox[Unit] = {
     val q = for {
       row <- collection if notdel(row) && row.expirationdatetime <= new java.sql.Timestamp(System.currentTimeMillis)
     } yield isDeletedColumn(row)

--- a/app/models/user/time/Interval.scala
+++ b/app/models/user/time/Interval.scala
@@ -1,7 +1,7 @@
 package models.user.time
 
 import org.joda.time.{DateTime, DateTimeConstants}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 trait Interval {
   def start: DateTime
@@ -23,17 +23,17 @@ case class Month(month: Int, year: Int) extends Interval with Ordered[Month] {
 
   override def toString = f"$year%d-$month%02d"
 
-  def start =
+  def start: DateTime =
     jodaMonth.dayOfMonth().withMinimumValue().millisOfDay().withMinimumValue()
 
-  def jodaMonth = new DateTime().withYear(year).withMonthOfYear(month)
+  private def jodaMonth: DateTime = new DateTime().withYear(year).withMonthOfYear(month)
 
-  def end =
+  def end: DateTime =
     jodaMonth.dayOfMonth().withMaximumValue().millisOfDay().withMaximumValue()
 }
 
 object Month {
-  implicit val monthFormat = Json.format[Month]
+  implicit val monthFormat: OFormat[Month] = Json.format[Month]
 }
 
 case class Week(week: Int, year: Int) extends Interval with Ordered[Week] {
@@ -50,17 +50,17 @@ case class Week(week: Int, year: Int) extends Interval with Ordered[Week] {
 
   override def toString = f"$year%d-W$week%02d"
 
-  def start =
+  def start: DateTime =
     jodaWeek.withDayOfWeek(DateTimeConstants.MONDAY).millisOfDay().withMinimumValue()
 
-  def jodaWeek = new DateTime().withYear(year).withWeekOfWeekyear(week)
+  private def jodaWeek: DateTime = new DateTime().withYear(year).withWeekOfWeekyear(week)
 
-  def end =
+  def end: DateTime =
     jodaWeek.dayOfWeek().withMaximumValue().millisOfDay().withMaximumValue()
 }
 
 object Week {
-  implicit val weekFormat = Json.format[Week]
+  implicit val weekFormat: OFormat[Week] = Json.format[Week]
 }
 
 case class Day(day: Int, month: Int, year: Int) extends Interval with Ordered[Day] {
@@ -77,15 +77,15 @@ case class Day(day: Int, month: Int, year: Int) extends Interval with Ordered[Da
 
   override def toString = f"$year%d-$month%02d-$day%02d"
 
-  def start =
+  def start: DateTime =
     jodaDay.millisOfDay().withMinimumValue()
 
-  def jodaDay = new DateTime().withDate(year, month, day)
+  private def jodaDay = new DateTime().withDate(year, month, day)
 
-  def end =
+  def end: DateTime =
     jodaDay.millisOfDay().withMaximumValue()
 }
 
 object Day {
-  implicit val dayFormat = Json.format[Day]
+  implicit val dayFormat: OFormat[Day] = Json.format[Day]
 }

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -112,7 +112,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
         timeSpan.addTime(duration, timestamp)
       } else {
         logger.info(
-          s"Not updating previous timespan due to negative duration ${duration} ms. (user ${timeSpan._user}, last timespan id ${timeSpan._id}, this=${this})")
+          s"Not updating previous timespan due to negative duration $duration ms. (user ${timeSpan._user}, last timespan id ${timeSpan._id}, this=$this)")
         timeSpan
       }
     }
@@ -150,7 +150,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
     val duration = current - last.lastUpdate
     if (duration < 0) {
       logger.info(
-        s"Negative timespan duration ${duration} ms to previous entry. (user ${last._user}, last timespan id ${last._id}, this=${this})")
+        s"Negative timespan duration $duration ms to previous entry. (user ${last._user}, last timespan id ${last._id}, this=$this)")
     }
     duration < MaxTracingPause
   }

--- a/app/oxalis/security/CombinedAuthenticatorService.scala
+++ b/app/oxalis/security/CombinedAuthenticatorService.scala
@@ -17,11 +17,11 @@ import scala.util.{Success, Try}
  */
 
 case class CombinedAuthenticator(actualAuthenticator: StorableAuthenticator) extends StorableAuthenticator {
-  def id = actualAuthenticator.id
+  def id: String = actualAuthenticator.id
   override type Value = Cookie
   override type Settings = this.type
 
-  override def loginInfo = actualAuthenticator.loginInfo
+  override def loginInfo: LoginInfo = actualAuthenticator.loginInfo
   override def isValid: Boolean = actualAuthenticator.isValid
 }
 

--- a/app/oxalis/security/CompactRandomIDGenerator.scala
+++ b/app/oxalis/security/CompactRandomIDGenerator.scala
@@ -16,7 +16,7 @@ object CompactRandomIDGenerator {
     encode(randomValue)
   }
 
-  def encode(bytes: Array[Byte]) = Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+  def encode(bytes: Array[Byte]): String = Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
 }
 
 class CompactRandomIDGenerator(sizeInBytes: Int = 16)(implicit ec: ExecutionContext) extends IDGenerator {

--- a/app/oxalis/security/WkSilhouetteEnvironment.scala
+++ b/app/oxalis/security/WkSilhouetteEnvironment.scala
@@ -23,9 +23,9 @@ class WkSilhouetteEnvironment @Inject()(
     userService: UserService,
     cookieHeaderEncoding: CookieHeaderEncoding)(implicit val executionContext: ExecutionContext)
     extends Environment[WkEnv] {
-  val eventBusObject = EventBus()
+  private val eventBusObject = EventBus()
 
-  val cookieSettings = CookieAuthenticatorSettings(
+  private val cookieSettings = CookieAuthenticatorSettings(
     conf.Silhouette.CookieAuthenticator.cookieName,
     conf.Silhouette.CookieAuthenticator.cookiePath,
     None,
@@ -38,16 +38,16 @@ class WkSilhouetteEnvironment @Inject()(
     conf.Silhouette.CookieAuthenticator.authenticatorExpiry.toMillis millis
   )
 
-  val tokenSettings = BearerTokenAuthenticatorSettings(
+  private val tokenSettings = BearerTokenAuthenticatorSettings(
     authenticatorIdleTimeout = Some(conf.Silhouette.TokenAuthenticator.authenticatorIdleTimeout.toMillis millis),
     authenticatorExpiry = conf.Silhouette.TokenAuthenticator.authenticatorExpiry.toMillis millis
   )
 
-  val fingerprintGenerator = new DefaultFingerprintGenerator(false)
-  val idGenerator = new CompactRandomIDGenerator
-  val bearerTokenAuthenticatorDAO = new BearerTokenAuthenticatorRepository(tokenDAO)
+  private val fingerprintGenerator = new DefaultFingerprintGenerator(false)
+  private val idGenerator = new CompactRandomIDGenerator
+  private val bearerTokenAuthenticatorDAO = new BearerTokenAuthenticatorRepository(tokenDAO)
 
-  val combinedAuthenticatorService = CombinedAuthenticatorService(
+  val combinedAuthenticatorService: CombinedAuthenticatorService = CombinedAuthenticatorService(
     cookieSettings,
     tokenSettings,
     bearerTokenAuthenticatorDAO,

--- a/app/utils/EnumUtils.scala
+++ b/app/utils/EnumUtils.scala
@@ -4,22 +4,17 @@ import play.api.libs.json._
 
 object EnumUtils {
 
-  def enumReads[E <: Enumeration](enum: E): Reads[E#Value] = new Reads[E#Value] {
-    def reads(json: JsValue): JsResult[E#Value] = json match {
-      case JsString(s) => {
-        try {
-          JsSuccess(enum.withName(s))
-        } catch {
-          case _: NoSuchElementException =>
-            JsError(
-              s"Enumeration expected of type: '${enum.getClass}', but it does not appear to contain the value: '$s'")
-        }
+  def enumReads[E <: Enumeration](enum: E): Reads[E#Value] = {
+    case JsString(s) =>
+      try {
+        JsSuccess(enum.withName(s))
+      } catch {
+        case _: NoSuchElementException =>
+          JsError(
+            s"Enumeration expected of type: '${enum.getClass}', but it does not appear to contain the value: '$s'")
       }
-      case _ => JsError("String value expected")
-    }
+    case _ => JsError("String value expected")
   }
 
-  implicit def enumWrites[E <: Enumeration]: Writes[E#Value] = new Writes[E#Value] {
-    def writes(v: E#Value): JsValue = JsString(v.toString)
-  }
+  implicit def enumWrites[E <: Enumeration]: Writes[E#Value] = (v: E#Value) => JsString(v.toString)
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
@@ -4,9 +4,8 @@ import akka.actor.ActorSystem
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
 import com.scalableminds.webknossos.datastore.services._
-import play.api.{Configuration, Environment}
 
-class DataStoreModule(environment: Environment, configuration: Configuration) extends AbstractModule {
+class DataStoreModule extends AbstractModule {
 
   val system: ActorSystem = ActorSystem("webknossos-datastore")
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -4,7 +4,6 @@ import java.io.{ByteArrayOutputStream, OutputStream}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.Base64
 
-import akka.actor.ActorSystem
 import akka.stream.scaladsl.StreamConverters
 import com.google.inject.Inject
 import com.scalableminds.util.geometry.Point3D
@@ -13,24 +12,14 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.DataStoreConfig
 import com.scalableminds.webknossos.datastore.models.DataRequestCollection._
 import com.scalableminds.webknossos.datastore.models.datasource._
-import com.scalableminds.webknossos.datastore.models.requests.{
-  DataServiceDataRequest,
-  DataServiceMappingRequest,
-  DataServiceRequestSettings
-}
-import com.scalableminds.webknossos.datastore.models.{
-  DataRequest,
-  ImageThumbnail,
-  VoxelPosition,
-  WebKnossosDataRequest,
-  _
-}
+import com.scalableminds.webknossos.datastore.models.requests.{DataServiceDataRequest, DataServiceMappingRequest, DataServiceRequestSettings}
+import com.scalableminds.webknossos.datastore.models.{DataRequest, ImageThumbnail, VoxelPosition, WebKnossosDataRequest, _}
 import com.scalableminds.webknossos.datastore.services._
 import net.liftweb.util.Helpers.tryo
 import play.api.http.HttpEntity
 import play.api.i18n.{Messages, MessagesProvider}
 import play.api.libs.json.Json
-import play.api.mvc.{PlayBodyParsers, ResponseHeader, Result}
+import play.api.mvc.{Action, AnyContent, PlayBodyParsers, RawBuffer, ResponseHeader, Result}
 
 import scala.concurrent.ExecutionContext
 
@@ -42,7 +31,6 @@ class BinaryDataController @Inject()(
     mappingService: MappingService,
     isosurfaceServiceHolder: IsosurfaceServiceHolder,
     findDataService: FindDataService,
-    actorSystem: ActorSystem
 )(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller {
 
@@ -60,7 +48,7 @@ class BinaryDataController @Inject()(
       organizationName: String,
       dataSetName: String,
       dataLayerName: String
-  ) = Action.async(validateJson[List[WebKnossosDataRequest]]) { implicit request =>
+  ): Action[List[WebKnossosDataRequest]] = Action.async(validateJson[List[WebKnossosDataRequest]]) { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         val t = System.currentTimeMillis()
@@ -81,8 +69,8 @@ class BinaryDataController @Inject()(
   }
 
   def getMissingBucketsHeaders(indices: List[Int]): Seq[(String, String)] =
-    List(("MISSING-BUCKETS" -> formatMissingBucketList(indices)),
-         ("Access-Control-Expose-Headers" -> "MISSING-BUCKETS"))
+    List("MISSING-BUCKETS" -> formatMissingBucketList(indices),
+         "Access-Control-Expose-Headers" -> "MISSING-BUCKETS")
 
   def formatMissingBucketList(indices: List[Int]): String =
     "[" + indices.mkString(", ") + "]"
@@ -102,7 +90,7 @@ class BinaryDataController @Inject()(
       depth: Int,
       resolution: Int,
       halfByte: Boolean
-  ) = Action.async { implicit request =>
+  ): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -133,7 +121,7 @@ class BinaryDataController @Inject()(
       z: Int,
       resolution: Int,
       halfByte: Boolean
-  ) =
+  ): Action[AnyContent] =
     requestRawCuboid(organizationName,
                      dataSetName,
                      dataLayerName,
@@ -156,7 +144,7 @@ class BinaryDataController @Inject()(
                         x: Int,
                         y: Int,
                         z: Int,
-                        cubeSize: Int) = Action.async { implicit request =>
+                        cubeSize: Int): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -190,7 +178,7 @@ class BinaryDataController @Inject()(
       z: Int,
       resolution: Int,
       halfByte: Boolean
-  ) = Action.async(parse.raw) { implicit request =>
+  ): Action[RawBuffer] = Action.async(parse.raw) { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -230,7 +218,7 @@ class BinaryDataController @Inject()(
                    z: Int,
                    resolution: Int,
                    halfByte: Boolean,
-                   blackAndWhite: Boolean) = Action.async(parse.raw) { implicit request =>
+                   blackAndWhite: Boolean): Action[RawBuffer] = Action.async(parse.raw) { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -264,7 +252,7 @@ class BinaryDataController @Inject()(
                                 centerX: Option[Int],
                                 centerY: Option[Int],
                                 centerZ: Option[Int],
-                                zoom: Option[Double]) = Action.async(parse.raw) { implicit request =>
+                                zoom: Option[Double]): Action[RawBuffer] = Action.async(parse.raw) { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -302,7 +290,7 @@ class BinaryDataController @Inject()(
       centerY: Option[Int],
       centerZ: Option[Int],
       zoom: Option[Double]
-  ) = Action.async(parse.raw) { implicit request =>
+  ): Action[RawBuffer] = Action.async(parse.raw) { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -332,7 +320,7 @@ class BinaryDataController @Inject()(
       dataSetName: String,
       dataLayerName: String,
       mappingName: String
-  ) = Action.async { implicit request =>
+  ): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -340,9 +328,7 @@ class BinaryDataController @Inject()(
           segmentationLayer <- tryo(dataLayer.asInstanceOf[SegmentationLayer]).toFox ?~> Messages("dataLayer.notFound")
           mappingRequest = DataServiceMappingRequest(dataSource, segmentationLayer, mappingName)
           result <- mappingService.handleMappingRequest(mappingRequest)
-        } yield {
-          Ok(result)
-        }
+        } yield Ok(result)
       }
     }
   }
@@ -350,7 +336,7 @@ class BinaryDataController @Inject()(
   /**
     * Handles isosurface requests.
     */
-  def requestIsosurface(organizationName: String, dataSetName: String, dataLayerName: String) =
+  def requestIsosurface(organizationName: String, dataSetName: String, dataLayerName: String): Action[WebKnossosIsosurfaceRequest] =
     Action.async(validateJson[WebKnossosIsosurfaceRequest]) { implicit request =>
       accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
         AllowRemoteOrigin {
@@ -384,12 +370,12 @@ class BinaryDataController @Inject()(
     }
 
   private def getNeighborIndices(neighbors: List[Int]) =
-    List(("NEIGHBORS" -> formatNeighborList(neighbors)), ("Access-Control-Expose-Headers" -> "NEIGHBORS"))
+    List("NEIGHBORS" -> formatNeighborList(neighbors), "Access-Control-Expose-Headers" -> "NEIGHBORS")
 
   private def formatNeighborList(neighbors: List[Int]): String =
     "[" + neighbors.mkString(", ") + "]"
 
-  def colorStatistics(organizationName: String, dataSetName: String, dataLayerName: String) = Action.async {
+  def colorStatistics(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] = Action.async {
     implicit request =>
       accessTokenService
         .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
@@ -405,7 +391,7 @@ class BinaryDataController @Inject()(
         }
   }
 
-  def findData(organizationName: String, dataSetName: String, dataLayerName: String) = Action.async {
+  def findData(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] = Action.async {
     implicit request =>
       accessTokenService
         .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
@@ -421,7 +407,7 @@ class BinaryDataController @Inject()(
         }
   }
 
-  def createHistogram(organizationName: String, dataSetName: String, dataLayerName: String) = Action.async {
+  def createHistogram(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] = Action.async {
     implicit request =>
       accessTokenService
         .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
@@ -444,9 +430,7 @@ class BinaryDataController @Inject()(
       dataSource <- dataSourceRepository.findUsable(DataSourceId(dataSetName, organizationName)).toFox ?~> Messages(
         "dataSource.notFound") ~> 404
       dataLayer <- dataSource.getDataLayer(dataLayerName) ?~> Messages("dataLayer.notFound", dataLayerName) ~> 404
-    } yield {
-      (dataSource, dataLayer)
-    }
+    } yield (dataSource, dataLayer)
 
   private def requestData(
       dataSource: DataSource,
@@ -466,7 +450,7 @@ class BinaryDataController @Inject()(
       request: DataRequest,
       imagesPerRow: Int,
       blackAndWhite: Boolean
-  )(implicit m: MessagesProvider): Fox[(OutputStream) => Unit] = {
+  )(implicit m: MessagesProvider): Fox[OutputStream => Unit] = {
     val params = ImageCreatorParameters(
       dataLayer.bytesPerElement,
       request.settings.halfByte,
@@ -477,15 +461,13 @@ class BinaryDataController @Inject()(
       isSegmentation = dataLayer.category == Category.segmentation
     )
     for {
-      (data, indices) <- requestData(dataSource, dataLayer, request)
+      (data, _) <- requestData(dataSource, dataLayer, request)
       dataWithFallback = if (data.length == 0)
         new Array[Byte](params.slideHeight * params.slideWidth * params.bytesPerElement)
       else data
       spriteSheet <- ImageCreator.spriteSheetFor(dataWithFallback, params) ?~> Messages("image.create.failed")
       firstSheet <- spriteSheet.pages.headOption ?~> Messages("image.page.failed")
-    } yield {
-      new JPEGWriter().writeToOutputStream(firstSheet.image)(_)
-    }
+    } yield new JPEGWriter().writeToOutputStream(firstSheet.image)(_)
   }
 
   private def respondWithImageThumbnail(
@@ -498,13 +480,11 @@ class BinaryDataController @Inject()(
       centerY: Option[Int],
       centerZ: Option[Int],
       zoom: Option[Double]
-  )(implicit m: MessagesProvider): Fox[(OutputStream) => Unit] =
+  )(implicit m: MessagesProvider): Fox[OutputStream => Unit] =
     for {
       (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName)
       position = ImageThumbnail.goodThumbnailParameters(dataLayer, width, height, centerX, centerY, centerZ, zoom)
       request = DataRequest(position, width, height, 1)
       image <- respondWithSpriteSheet(dataSource, dataLayer, request, 1, blackAndWhite = false)
-    } yield {
-      image
-    }
+    } yield image
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -12,8 +12,18 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.DataStoreConfig
 import com.scalableminds.webknossos.datastore.models.DataRequestCollection._
 import com.scalableminds.webknossos.datastore.models.datasource._
-import com.scalableminds.webknossos.datastore.models.requests.{DataServiceDataRequest, DataServiceMappingRequest, DataServiceRequestSettings}
-import com.scalableminds.webknossos.datastore.models.{DataRequest, ImageThumbnail, VoxelPosition, WebKnossosDataRequest, _}
+import com.scalableminds.webknossos.datastore.models.requests.{
+  DataServiceDataRequest,
+  DataServiceMappingRequest,
+  DataServiceRequestSettings
+}
+import com.scalableminds.webknossos.datastore.models.{
+  DataRequest,
+  ImageThumbnail,
+  VoxelPosition,
+  WebKnossosDataRequest,
+  _
+}
 import com.scalableminds.webknossos.datastore.services._
 import net.liftweb.util.Helpers.tryo
 import play.api.http.HttpEntity
@@ -69,8 +79,7 @@ class BinaryDataController @Inject()(
   }
 
   def getMissingBucketsHeaders(indices: List[Int]): Seq[(String, String)] =
-    List("MISSING-BUCKETS" -> formatMissingBucketList(indices),
-         "Access-Control-Expose-Headers" -> "MISSING-BUCKETS")
+    List("MISSING-BUCKETS" -> formatMissingBucketList(indices), "Access-Control-Expose-Headers" -> "MISSING-BUCKETS")
 
   def formatMissingBucketList(indices: List[Int]): String =
     "[" + indices.mkString(", ") + "]"
@@ -336,7 +345,9 @@ class BinaryDataController @Inject()(
   /**
     * Handles isosurface requests.
     */
-  def requestIsosurface(organizationName: String, dataSetName: String, dataLayerName: String): Action[WebKnossosIsosurfaceRequest] =
+  def requestIsosurface(organizationName: String,
+                        dataSetName: String,
+                        dataLayerName: String): Action[WebKnossosIsosurfaceRequest] =
     Action.async(validateJson[WebKnossosIsosurfaceRequest]) { implicit request =>
       accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
         AllowRemoteOrigin {
@@ -375,54 +386,50 @@ class BinaryDataController @Inject()(
   private def formatNeighborList(neighbors: List[Int]): String =
     "[" + neighbors.mkString(", ") + "]"
 
-  def colorStatistics(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] = Action.async {
-    implicit request =>
-      accessTokenService
-        .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
-          AllowRemoteOrigin {
-            for {
-              (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName)
-              meanAndStdDev <- findDataService.meanAndStdDev(dataSource, dataLayer)
-            } yield
-              Ok(
-                Json.obj("mean" -> meanAndStdDev._1, "stdDev" -> meanAndStdDev._2)
-              )
-          }
+  def colorStatistics(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
+        AllowRemoteOrigin {
+          for {
+            (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName)
+            meanAndStdDev <- findDataService.meanAndStdDev(dataSource, dataLayer)
+          } yield
+            Ok(
+              Json.obj("mean" -> meanAndStdDev._1, "stdDev" -> meanAndStdDev._2)
+            )
         }
-  }
+      }
+    }
 
-  def findData(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] = Action.async {
-    implicit request =>
-      accessTokenService
-        .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
-          AllowRemoteOrigin {
-            for {
-              (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName)
-              positionAndResolutionOpt <- findDataService.findPositionWithData(dataSource, dataLayer)
-            } yield
-              Ok(
-                Json.obj("position" -> positionAndResolutionOpt.map(_._1),
-                         "resolution" -> positionAndResolutionOpt.map(_._2)))
-          }
+  def findData(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
+        AllowRemoteOrigin {
+          for {
+            (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName)
+            positionAndResolutionOpt <- findDataService.findPositionWithData(dataSource, dataLayer)
+          } yield
+            Ok(
+              Json.obj("position" -> positionAndResolutionOpt.map(_._1),
+                       "resolution" -> positionAndResolutionOpt.map(_._2)))
         }
-  }
+      }
+    }
 
-  def createHistogram(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] = Action.async {
-    implicit request =>
-      accessTokenService
-        .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
-          AllowRemoteOrigin {
-            for {
-              (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName) ?~> Messages(
-                "histogram.layerMissing",
-                dataLayerName)
-              listOfHistograms <- findDataService.createHistogram(dataSource, dataLayer) ?~> Messages(
-                "histogram.failed",
-                dataLayerName)
-            } yield Ok(Json.toJson(listOfHistograms))
-          }
+  def createHistogram(organizationName: String, dataSetName: String, dataLayerName: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
+        AllowRemoteOrigin {
+          for {
+            (dataSource, dataLayer) <- getDataSourceAndDataLayer(organizationName, dataSetName, dataLayerName) ?~> Messages(
+              "histogram.layerMissing",
+              dataLayerName)
+            listOfHistograms <- findDataService.createHistogram(dataSource, dataLayer) ?~> Messages("histogram.failed",
+                                                                                                    dataLayerName)
+          } yield Ok(Json.toJson(listOfHistograms))
         }
-  }
+      }
+    }
 
   private def getDataSourceAndDataLayer(organizationName: String, dataSetName: String, dataLayerName: String)(
       implicit m: MessagesProvider): Fox[(DataSource, DataLayer)] =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -2,18 +2,14 @@ package com.scalableminds.webknossos.datastore.controllers
 
 import com.google.inject.Inject
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
-import com.scalableminds.webknossos.datastore.models.datasource.inbox.{
-  InboxDataSource,
-  InboxDataSourceLike,
-  UnusableInboxDataSource
-}
+import com.scalableminds.webknossos.datastore.models.datasource.inbox.{InboxDataSource, InboxDataSourceLike, UnusableInboxDataSource}
 import com.scalableminds.webknossos.datastore.models.datasource.{DataSource, DataSourceId}
 import com.scalableminds.webknossos.datastore.services._
 import play.api.data.Form
 import play.api.data.Forms.{longNumber, nonEmptyText, number, tuple}
 import play.api.i18n.Messages
 import play.api.libs.json.Json
-import play.api.mvc.{Action, MultipartFormData, PlayBodyParsers}
+import play.api.mvc.{Action, AnyContent, MultipartFormData, PlayBodyParsers}
 import java.io.File
 
 import play.api.libs.Files
@@ -32,7 +28,7 @@ class DataSourceController @Inject()(
     extends Controller
     with FoxImplicits {
 
-  def list() = Action.async { implicit request =>
+  def list(): Action[AnyContent] = Action.async { implicit request =>
     {
       accessTokenService.validateAccessForSyncBlock(UserAccessRequest.listDataSources) {
         AllowRemoteOrigin {
@@ -43,7 +39,7 @@ class DataSourceController @Inject()(
     }
   }
 
-  def read(organizationName: String, dataSetName: String, returnFormatLike: Boolean) = Action.async {
+  def read(organizationName: String, dataSetName: String, returnFormatLike: Boolean): Action[AnyContent] = Action.async {
     implicit request =>
       {
         accessTokenService.validateAccessForSyncBlock(
@@ -52,11 +48,10 @@ class DataSourceController @Inject()(
             val dsOption: Option[InboxDataSource] =
               dataSourceRepository.find(DataSourceId(dataSetName, organizationName))
             dsOption match {
-              case Some(ds) => {
+              case Some(ds) =>
                 val dslike: InboxDataSourceLike = ds
                 if (returnFormatLike) Ok(Json.toJson(dslike))
                 else Ok(Json.toJson(ds))
-              }
               case _ => Ok
             }
           }
@@ -64,7 +59,7 @@ class DataSourceController @Inject()(
       }
   }
 
-  def triggerInboxCheck() = Action.async { implicit request =>
+  def triggerInboxCheck(): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(UserAccessRequest.administrateDataSources) {
       AllowRemoteOrigin {
         dataSourceService.checkInbox(verbose = true)
@@ -73,7 +68,7 @@ class DataSourceController @Inject()(
     }
   }
 
-  def triggerInboxCheckBlocking() = Action.async { implicit request =>
+  def triggerInboxCheckBlocking(): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.administrateDataSources) {
       AllowRemoteOrigin {
         for {
@@ -138,7 +133,7 @@ class DataSourceController @Inject()(
 
   }
 
-  def fetchSampleDataSource(organizationName: String, dataSetName: String) = Action.async { implicit request =>
+  def fetchSampleDataSource(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.administrateDataSources) {
       AllowRemoteOrigin {
         for {
@@ -148,7 +143,7 @@ class DataSourceController @Inject()(
     }
   }
 
-  def listSampleDataSources(organizationName: String) = Action.async { implicit request =>
+  def listSampleDataSources(organizationName: String): Action[AnyContent] = Action.async { implicit request =>
     AllowRemoteOrigin {
       accessTokenService.validateAccessForSyncBlock(UserAccessRequest.administrateDataSources) {
         Ok(Json.toJson(sampleDatasetService.listWithStatus(organizationName)))
@@ -156,7 +151,7 @@ class DataSourceController @Inject()(
     }
   }
 
-  def explore(organizationName: String, dataSetName: String) = Action.async { implicit request =>
+  def explore(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(
       UserAccessRequest.writeDataSource(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
@@ -189,7 +184,7 @@ class DataSourceController @Inject()(
       organizationName: String,
       dataSetName: String,
       dataLayerName: String
-  ) = Action.async { implicit request =>
+  ): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(
       UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
@@ -202,7 +197,7 @@ class DataSourceController @Inject()(
       organizationName: String,
       dataSetName: String,
       dataLayerName: String
-  ) = Action.async { implicit request =>
+  ): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(
       UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
@@ -219,7 +214,7 @@ class DataSourceController @Inject()(
       dataLayerName: String,
       mappingName: String,
       agglomerateId: Long
-  ) = Action.async { implicit request =>
+  ): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {
@@ -234,7 +229,7 @@ class DataSourceController @Inject()(
     }
   }
 
-  def update(organizationName: String, dataSetName: String) = Action.async(validateJson[DataSource]) {
+  def update(organizationName: String, dataSetName: String): Action[DataSource] = Action.async(validateJson[DataSource]) {
     implicit request =>
       accessTokenService
         .validateAccess(UserAccessRequest.writeDataSource(DataSourceId(dataSetName, organizationName))) {
@@ -251,7 +246,7 @@ class DataSourceController @Inject()(
         }
   }
 
-  def createOrganizationDirectory(organizationName: String) = Action.async { implicit request =>
+  def createOrganizationDirectory(organizationName: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(UserAccessRequest.administrateDataSources) {
       AllowRemoteOrigin {
         val newOrganizationFolder = new File(dataSourceService.dataBaseDir + "/" + organizationName)
@@ -264,7 +259,7 @@ class DataSourceController @Inject()(
     }
   }
 
-  def reload(organizationName: String, dataSetName: String, layerName: Option[String] = None) = Action.async {
+  def reload(organizationName: String, dataSetName: String, layerName: Option[String] = None): Action[AnyContent] = Action.async {
     implicit request =>
       accessTokenService.validateAccess(UserAccessRequest.administrateDataSources) {
         AllowRemoteOrigin {
@@ -281,7 +276,7 @@ class DataSourceController @Inject()(
       }
   }
 
-  def deleteOnDisk(organizationName: String, dataSetName: String) = Action.async { implicit request =>
+  def deleteOnDisk(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.deleteDataSource(DataSourceId(dataSetName, organizationName))) {
       AllowRemoteOrigin {
         for {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -2,7 +2,11 @@ package com.scalableminds.webknossos.datastore.controllers
 
 import com.google.inject.Inject
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
-import com.scalableminds.webknossos.datastore.models.datasource.inbox.{InboxDataSource, InboxDataSourceLike, UnusableInboxDataSource}
+import com.scalableminds.webknossos.datastore.models.datasource.inbox.{
+  InboxDataSource,
+  InboxDataSourceLike,
+  UnusableInboxDataSource
+}
 import com.scalableminds.webknossos.datastore.models.datasource.{DataSource, DataSourceId}
 import com.scalableminds.webknossos.datastore.services._
 import play.api.data.Form
@@ -39,8 +43,8 @@ class DataSourceController @Inject()(
     }
   }
 
-  def read(organizationName: String, dataSetName: String, returnFormatLike: Boolean): Action[AnyContent] = Action.async {
-    implicit request =>
+  def read(organizationName: String, dataSetName: String, returnFormatLike: Boolean): Action[AnyContent] =
+    Action.async { implicit request =>
       {
         accessTokenService.validateAccessForSyncBlock(
           UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
@@ -57,7 +61,7 @@ class DataSourceController @Inject()(
           }
         }
       }
-  }
+    }
 
   def triggerInboxCheck(): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(UserAccessRequest.administrateDataSources) {
@@ -133,14 +137,15 @@ class DataSourceController @Inject()(
 
   }
 
-  def fetchSampleDataSource(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async { implicit request =>
-    accessTokenService.validateAccess(UserAccessRequest.administrateDataSources) {
-      AllowRemoteOrigin {
-        for {
-          _ <- sampleDatasetService.initDownload(organizationName, dataSetName)
-        } yield JsonOk(Json.obj("messages" -> "downloadInitiated"))
+  def fetchSampleDataSource(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async {
+    implicit request =>
+      accessTokenService.validateAccess(UserAccessRequest.administrateDataSources) {
+        AllowRemoteOrigin {
+          for {
+            _ <- sampleDatasetService.initDownload(organizationName, dataSetName)
+          } yield JsonOk(Json.obj("messages" -> "downloadInitiated"))
+        }
       }
-    }
   }
 
   def listSampleDataSources(organizationName: String): Action[AnyContent] = Action.async { implicit request =>
@@ -229,22 +234,21 @@ class DataSourceController @Inject()(
     }
   }
 
-  def update(organizationName: String, dataSetName: String): Action[DataSource] = Action.async(validateJson[DataSource]) {
-    implicit request =>
-      accessTokenService
-        .validateAccess(UserAccessRequest.writeDataSource(DataSourceId(dataSetName, organizationName))) {
-          AllowRemoteOrigin {
-            for {
-              _ <- Fox.successful(())
-              dataSource <- dataSourceRepository.find(DataSourceId(dataSetName, organizationName)).toFox ?~> Messages(
-                "dataSource.notFound") ~> 404
-              _ <- dataSourceService.updateDataSource(request.body.copy(id = dataSource.id))
-            } yield {
-              Ok
-            }
+  def update(organizationName: String, dataSetName: String): Action[DataSource] =
+    Action.async(validateJson[DataSource]) { implicit request =>
+      accessTokenService.validateAccess(UserAccessRequest.writeDataSource(DataSourceId(dataSetName, organizationName))) {
+        AllowRemoteOrigin {
+          for {
+            _ <- Fox.successful(())
+            dataSource <- dataSourceRepository.find(DataSourceId(dataSetName, organizationName)).toFox ?~> Messages(
+              "dataSource.notFound") ~> 404
+            _ <- dataSourceService.updateDataSource(request.body.copy(id = dataSource.id))
+          } yield {
+            Ok
           }
         }
-  }
+      }
+    }
 
   def createOrganizationDirectory(organizationName: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessForSyncBlock(UserAccessRequest.administrateDataSources) {
@@ -259,8 +263,8 @@ class DataSourceController @Inject()(
     }
   }
 
-  def reload(organizationName: String, dataSetName: String, layerName: Option[String] = None): Action[AnyContent] = Action.async {
-    implicit request =>
+  def reload(organizationName: String, dataSetName: String, layerName: Option[String] = None): Action[AnyContent] =
+    Action.async { implicit request =>
       accessTokenService.validateAccess(UserAccessRequest.administrateDataSources) {
         AllowRemoteOrigin {
           val count = binaryDataServiceHolder.binaryDataService.clearCache(organizationName, dataSetName, layerName)
@@ -274,19 +278,19 @@ class DataSourceController @Inject()(
           } yield Ok(Json.toJson(reloadedDataSource))
         }
       }
-  }
-
-  def deleteOnDisk(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async { implicit request =>
-    accessTokenService.validateAccess(UserAccessRequest.deleteDataSource(DataSourceId(dataSetName, organizationName))) {
-      AllowRemoteOrigin {
-        for {
-          _ <- binaryDataServiceHolder.binaryDataService.deleteOnDisk(organizationName,
-                                                                      dataSetName,
-                                                                      reason =
-                                                                        Some("the user wants to delete the dataset"))
-        } yield Ok
-      }
     }
+
+  def deleteOnDisk(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async {
+    implicit request =>
+      accessTokenService
+        .validateAccess(UserAccessRequest.deleteDataSource(DataSourceId(dataSetName, organizationName))) {
+          AllowRemoteOrigin {
+            for {
+              _ <- binaryDataServiceHolder.binaryDataService
+                .deleteOnDisk(organizationName, dataSetName, reason = Some("the user wants to delete the dataset"))
+            } yield Ok
+          }
+        }
   }
 
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/SkeletonElementDefaults.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/SkeletonElementDefaults.scala
@@ -4,18 +4,18 @@ import com.scalableminds.util.geometry.{Point3D, Vector3D}
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{Node, SkeletonTracing}
 
 object SkeletonTracingDefaults extends ProtoGeometryImplicits {
-  val dataSetName = ""
-  val trees = Seq()
-  def createdTimestamp = System.currentTimeMillis()
-  val boundingBox = None
-  val activeNodeId = None
-  val editPosition = Point3D(0, 0, 0)
-  val editRotation = Vector3D(0, 0, 0)
-  val zoomLevel = 2.0
-  val version = 0
-  val userBoundingBox = None
+  private val dataSetName = ""
+  private val trees = Seq()
+  private def createdTimestamp = System.currentTimeMillis()
+  private val boundingBox = None
+  private val activeNodeId = None
+  val editPosition: Point3D = Point3D(0, 0, 0)
+  val editRotation: Vector3D = Vector3D()
+  val zoomLevel: Double = 2.0
+  private val version = 0
+  private val userBoundingBox = None
 
-  def createInstance =
+  def createInstance: SkeletonTracing =
     SkeletonTracing(dataSetName,
                     trees,
                     createdTimestamp,
@@ -29,16 +29,16 @@ object SkeletonTracingDefaults extends ProtoGeometryImplicits {
 }
 
 object NodeDefaults extends ProtoGeometryImplicits {
-  val id = 0
-  val rotation = Vector3D(0, 0, 0)
-  val position = Point3D(0, 0, 0)
-  val radius = 1.0f
-  val viewport = 1
-  val resolution = 1
-  val bitDepth = 0
-  val interpolation = false
-  def createdTimestamp = System.currentTimeMillis()
+  val id: Int = 0
+  val rotation: Vector3D = Vector3D()
+  val position: Point3D = Point3D(0, 0, 0)
+  val radius: Float = 1.0f
+  val viewport: Int = 1
+  val resolution: Int = 1
+  val bitDepth: Int = 0
+  val interpolation: Boolean = false
+  def createdTimestamp: Long = System.currentTimeMillis()
 
-  def createInstance =
+  def createInstance: Node =
     Node(id, position, rotation, radius, viewport, resolution, bitDepth, interpolation, createdTimestamp)
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/ImageThumbnail.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/ImageThumbnail.scala
@@ -9,7 +9,7 @@ case class ImageThumbnail(mimeType: String, value: String)
 object ImageThumbnail {
   implicit val jsonFormat: OFormat[ImageThumbnail] = Json.format[ImageThumbnail]
 
-  def bestResolutionExponent(dataLayer: DataLayerLike, width: Int, height: Int, zoom: Option[Double]): Int =
+  def bestResolutionExponent(dataLayer: DataLayerLike, zoom: Option[Double]): Int =
     // We're either using the supplied zoom value (higher = zoomed out) or we're using the best resolution
     zoom match {
       case Some(z) => math.max(0, math.min(math.floor(math.log(z) / math.log(2)).toInt, dataLayer.resolutions.size - 1))
@@ -29,7 +29,7 @@ object ImageThumbnail {
       if (centerX.isDefined && centerY.isDefined && centerZ.isDefined)
         Point3D(centerX.get, centerY.get, centerZ.get)
       else dataLayer.boundingBox.center
-    val resolutionExponent = bestResolutionExponent(dataLayer, width, height, zoomOpt)
+    val resolutionExponent = bestResolutionExponent(dataLayer, zoomOpt)
     val resolution = dataLayer.lookUpResolution(resolutionExponent, snapToClosest = true)
     val x = Math.max(0, center.x - width * resolution.x / 2)
     val y = Math.max(0, center.y - height * resolution.y / 2)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -21,7 +21,7 @@ class BinaryDataService(val dataBaseDir: Path, maxCacheSize: Int, val agglomerat
 
   /* Note that this must stay in sync with the back-end constant
     compare https://github.com/scalableminds/webknossos/issues/5223 */
-  private val MaxMagForAgglomerateMapping = 16;
+  private val MaxMagForAgglomerateMapping = 16
   lazy val cache = new DataCubeCache(maxCacheSize)
 
   def handleDataRequest(request: DataServiceDataRequest): Fox[Array[Byte]] = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceRepository.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceRepository.scala
@@ -31,7 +31,7 @@ class DataSourceRepository @Inject()(
   def updateDataSources(dataSources: List[InboxDataSource]): Fox[Unit] =
     for {
       _ <- Fox.successful(())
-      _ = removeAll
+      _ = removeAll()
       _ = dataSources.foreach(dataSource => insert(dataSource.id, dataSource))
       _ <- webKnossosServer.reportDataSources(dataSources)
     } yield ()

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/RedisTemporaryStore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/RedisTemporaryStore.scala
@@ -71,10 +71,9 @@ class RedisTemporaryStore @Inject()(config: TracingStoreConfig)(implicit val ec:
       logger.info(s"Successfully tested Redis health at $address:$port. Reply: $reply)")
       Fox.successful(())
     } catch {
-      case e: Exception => {
+      case e: Exception =>
         logger.error(s"Redis health check failed at $address:$port (reply: ${e.getMessage})")
         Fox.failure(s"Redis health check failed")
-      }
     }
 
   def withExceptionHandler[B](f: => B): Fox[B] =
@@ -83,11 +82,10 @@ class RedisTemporaryStore @Inject()(config: TracingStoreConfig)(implicit val ec:
         Fox.successful(f)
       }
     } catch {
-      case e: Exception => {
+      case e: Exception =>
         val msg = "Redis access exception: " + e.getMessage
         logger.error(msg)
         Fox.failure(msg)
-      }
     }
 
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreModule.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreModule.scala
@@ -3,16 +3,15 @@ package com.scalableminds.webknossos.tracingstore
 import akka.actor.ActorSystem
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
-import play.api.{Configuration, Environment}
 import com.scalableminds.webknossos.tracingstore.tracings.TracingDataStore
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.SkeletonTracingService
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeTracingService
 
-class TracingStoreModule(environment: Environment, configuration: Configuration) extends AbstractModule {
+class TracingStoreModule extends AbstractModule {
 
-  val system = ActorSystem("webknossos-tracingstore")
+  private val system: ActorSystem = ActorSystem("webknossos-tracingstore")
 
-  override def configure() = {
+  override def configure(): Unit = {
     bind(classOf[ActorSystem]).annotatedWith(Names.named("webknossos-tracingstore")).toInstance(system)
     bind(classOf[TracingDataStore]).asEagerSingleton()
     bind(classOf[SkeletonTracingService]).asEagerSingleton()

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -8,7 +8,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.skeleton._
 import com.scalableminds.webknossos.tracingstore.{TracingStoreAccessTokenService, TracingStoreWkRpcClient}
 import play.api.i18n.Messages
 import play.api.libs.json.Json
-import play.api.mvc.PlayBodyParsers
+import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 
 import scala.concurrent.ExecutionContext
 
@@ -20,7 +20,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
     val bodyParsers: PlayBodyParsers)
     extends TracingController[SkeletonTracing, SkeletonTracings] {
 
-  implicit val tracingsCompanion = SkeletonTracings
+  implicit val tracingsCompanion: SkeletonTracings.type = SkeletonTracings
 
   implicit def packMultiple(tracings: List[SkeletonTracing]): SkeletonTracings =
     SkeletonTracings(tracings.map(t => SkeletonTracingOpt(Some(t))))
@@ -31,7 +31,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
   implicit def unpackMultiple(tracings: SkeletonTracings): List[Option[SkeletonTracing]] =
     tracings.tracings.toList.map(_.tracing)
 
-  def mergedFromContents(persist: Boolean) = Action.async(validateProto[SkeletonTracings]) { implicit request =>
+  def mergedFromContents(persist: Boolean): Action[SkeletonTracings] = Action.async(validateProto[SkeletonTracings]) { implicit request =>
     log {
       accessTokenService.validateAccess(UserAccessRequest.webknossos) {
         AllowRemoteOrigin {
@@ -45,7 +45,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
     }
   }
 
-  def duplicate(tracingId: String, version: Option[Long], fromTask: Option[Boolean]) = Action.async {
+  def duplicate(tracingId: String, version: Option[Long], fromTask: Option[Boolean]): Action[AnyContent] = Action.async {
     implicit request =>
       log {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
@@ -61,7 +61,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
       }
   }
 
-  def updateActionLog(tracingId: String) = Action.async { implicit request =>
+  def updateActionLog(tracingId: String): Action[AnyContent] = Action.async { implicit request =>
     log {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
@@ -75,7 +75,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
     }
   }
 
-  def updateActionStatistics(tracingId: String) = Action.async { implicit request =>
+  def updateActionStatistics(tracingId: String): Action[AnyContent] = Action.async { implicit request =>
     log {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -31,22 +31,23 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
   implicit def unpackMultiple(tracings: SkeletonTracings): List[Option[SkeletonTracing]] =
     tracings.tracings.toList.map(_.tracing)
 
-  def mergedFromContents(persist: Boolean): Action[SkeletonTracings] = Action.async(validateProto[SkeletonTracings]) { implicit request =>
-    log {
-      accessTokenService.validateAccess(UserAccessRequest.webknossos) {
-        AllowRemoteOrigin {
-          val tracings: List[Option[SkeletonTracing]] = request.body
-          val mergedTracing = tracingService.merge(tracings.flatten)
-          tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist).map { newId =>
-            Ok(Json.toJson(newId))
+  def mergedFromContents(persist: Boolean): Action[SkeletonTracings] = Action.async(validateProto[SkeletonTracings]) {
+    implicit request =>
+      log {
+        accessTokenService.validateAccess(UserAccessRequest.webknossos) {
+          AllowRemoteOrigin {
+            val tracings: List[Option[SkeletonTracing]] = request.body
+            val mergedTracing = tracingService.merge(tracings.flatten)
+            tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist).map { newId =>
+              Ok(Json.toJson(newId))
+            }
           }
         }
       }
-    }
   }
 
-  def duplicate(tracingId: String, version: Option[Long], fromTask: Option[Boolean]): Action[AnyContent] = Action.async {
-    implicit request =>
+  def duplicate(tracingId: String, version: Option[Long], fromTask: Option[Boolean]): Action[AnyContent] =
+    Action.async { implicit request =>
       log {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
@@ -59,7 +60,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
           }
         }
       }
-  }
+    }
 
   def updateActionLog(tracingId: String): Action[AnyContent] = Action.async { implicit request =>
     log {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/NamedBoundingBox.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/NamedBoundingBox.scala
@@ -1,6 +1,6 @@
 package com.scalableminds.webknossos.tracingstore.tracings
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import com.scalableminds.util.geometry.BoundingBox
 import com.scalableminds.util.image.Color
 import com.scalableminds.webknossos.datastore.geometry.{NamedBoundingBox => ProtoBoundingBox}
@@ -17,4 +17,4 @@ case class NamedBoundingBox(id: Int,
   def toProto: ProtoBoundingBox = ProtoBoundingBox(id, name, isVisible, convertColorOpt(color), boundingBox)
 }
 
-object NamedBoundingBox { implicit val jsonFormat = Json.format[NamedBoundingBox] }
+object NamedBoundingBox { implicit val jsonFormat: OFormat[NamedBoundingBox] = Json.format[NamedBoundingBox] }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
@@ -23,7 +23,7 @@ class TracingDataStore @Inject()(config: TracingStoreConfig, lifecycle: Applicat
 
   lazy val volumeUpdates = new FossilDBClient("volumeUpdates", config)
 
-  def shutdown() = {
+  def shutdown(): Unit = {
     healthClient.shutdown()
     skeletons.shutdown()
     skeletonUpdates.shutdown()

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingMigrationService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingMigrationService.scala
@@ -10,11 +10,11 @@ import scalapb.{GeneratedMessage, Message}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait ColorGenerator {
-  private def getRandomComponent(): Double =
+  private def getRandomComponent: Double =
     Math.random()
 
-  def getRandomColor(): Color =
-    Color(getRandomComponent(), getRandomComponent(), getRandomComponent(), 1.0)
+  def getRandomColor: Color =
+    Color(getRandomComponent, getRandomComponent, getRandomComponent, 1.0)
 }
 
 trait TracingMigrationService[T <: GeneratedMessage with Message[T]] extends FoxImplicits {
@@ -40,10 +40,10 @@ trait TracingMigrationService[T <: GeneratedMessage with Message[T]] extends Fox
 object SkeletonTracingMigrationService extends TracingMigrationService[SkeletonTracing] with ColorGenerator {
   override val migrations = List(removeSingleUserBoundingBox)
 
-  def removeSingleUserBoundingBox(tracing: SkeletonTracing) = {
+  def removeSingleUserBoundingBox(tracing: SkeletonTracing): Fox[(SkeletonTracing, Boolean)] = {
     val newUserBoundingBox: Option[ProtoBox] = tracing.userBoundingBox.map { bb =>
       val newId = if (tracing.userBoundingBoxes.isEmpty) 1 else tracing.userBoundingBoxes.map(_.id).max + 1
-      ProtoBox(newId, color = Some(getRandomColor()), boundingBox = bb)
+      ProtoBox(newId, color = Some(getRandomColor), boundingBox = bb)
     }
     Fox.successful(
       (tracing.clearUserBoundingBox.addAllUserBoundingBoxes(newUserBoundingBox), tracing.userBoundingBox.isDefined))
@@ -53,10 +53,10 @@ object SkeletonTracingMigrationService extends TracingMigrationService[SkeletonT
 object VolumeTracingMigrationService extends TracingMigrationService[VolumeTracing] with ColorGenerator {
   override val migrations = List(removeSingleUserBoundingBox)
 
-  def removeSingleUserBoundingBox(tracing: VolumeTracing) = {
+  def removeSingleUserBoundingBox(tracing: VolumeTracing): Fox[(VolumeTracing, Boolean)] = {
     val newUserBoundingBox: Option[ProtoBox] = tracing.userBoundingBox.map { bb =>
       val newId = if (tracing.userBoundingBoxes.isEmpty) 1 else tracing.userBoundingBoxes.map(_.id).max + 1
-      ProtoBox(newId, color = Some(getRandomColor()), boundingBox = bb)
+      ProtoBox(newId, color = Some(getRandomColor), boundingBox = bb)
     }
     Fox.successful(
       (tracing.clearUserBoundingBox.addAllUserBoundingBoxes(newUserBoundingBox), tracing.userBoundingBox.isDefined))

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingSelector.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingSelector.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.tracingstore.tracings
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class TracingSelector(tracingId: String, version: Option[Long] = None)
 
-object TracingSelector { implicit val jsonFormat = Json.format[TracingSelector] }
+object TracingSelector { implicit val jsonFormat: OFormat[TracingSelector] = Json.format[TracingSelector] }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingType.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingType.scala
@@ -7,5 +7,5 @@ object TracingType extends Enumeration {
 
   def fromString(s: String): Option[Value] = values.find(_.toString == s)
 
-  implicit val format = Format(Reads.enumNameReads(TracingType), Writes.enumNameWrites)
+  implicit val format: Format[TracingType.Value] = Format(Reads.enumNameReads(TracingType), Writes.enumNameWrites)
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/UpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/UpdateActions.scala
@@ -37,9 +37,8 @@ case class UpdateActionGroup[T <: GeneratedMessage with Message[T]](
 object UpdateActionGroup {
 
   implicit def updateActionGroupReads[T <: GeneratedMessage with Message[T]](
-      implicit fmt: Reads[UpdateAction[T]]): Reads[UpdateActionGroup[T]] = new Reads[UpdateActionGroup[T]] {
-
-    override def reads(json: JsValue): JsResult[UpdateActionGroup[T]] =
+      implicit fmt: Reads[UpdateAction[T]]): Reads[UpdateActionGroup[T]] =
+    (json: JsValue) =>
       for {
         version <- json.validate((JsPath \ "version").read[Long])
         timestamp <- json.validate((JsPath \ "timestamp").read[Long])
@@ -58,13 +57,11 @@ object UpdateActionGroup {
                              transactionId,
                              transactionGroupCount,
                              transactionGroupIndex)
-      }
-  }
+    }
 
   implicit def updateActionGroupWrites[T <: GeneratedMessage with Message[T]](
-      implicit fmt: Writes[UpdateAction[T]]): Writes[UpdateActionGroup[T]] = new Writes[UpdateActionGroup[T]] {
-
-    override def writes(value: UpdateActionGroup[T]): JsValue =
+      implicit fmt: Writes[UpdateAction[T]]): Writes[UpdateActionGroup[T]] =
+    (value: UpdateActionGroup[T]) =>
       Json.obj(
         "version" -> value.version,
         "timestamp" -> value.timestamp,
@@ -74,7 +71,6 @@ object UpdateActionGroup {
         "transactionId" -> value.transactionId,
         "transactionGroupCount" -> value.transactionGroupCount,
         "transactionGroupIndex" -> value.transactionGroupIndex
-      )
-  }
+    )
 
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -7,10 +7,10 @@ import com.scalableminds.webknossos.datastore.geometry.NamedBoundingBox
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryImplicits
 import com.scalableminds.webknossos.tracingstore.RedisTemporaryStore
 import com.scalableminds.webknossos.tracingstore.tracings.UpdateAction.SkeletonUpdateAction
-import com.scalableminds.webknossos.tracingstore.tracings._
+import com.scalableminds.webknossos.tracingstore.tracings.{TracingType, _}
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating._
 import net.liftweb.common.{Empty, Full}
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsObject, JsValue, Json}
 
 import scala.concurrent.ExecutionContext
 
@@ -24,15 +24,15 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
     with ProtoGeometryImplicits
     with FoxImplicits {
 
-  val tracingType = TracingType.skeleton
+  val tracingType: TracingType.Value = TracingType.skeleton
 
-  val tracingStore = tracingDataStore.skeletons
+  val tracingStore: FossilDBClient = tracingDataStore.skeletons
 
-  val tracingMigrationService = SkeletonTracingMigrationService
+  val tracingMigrationService: SkeletonTracingMigrationService.type = SkeletonTracingMigrationService
 
-  implicit val tracingCompanion = SkeletonTracing
+  implicit val tracingCompanion: SkeletonTracing.type = SkeletonTracing
 
-  implicit val updateActionJsonFormat = SkeletonUpdateAction.skeletonUpdateActionFormat
+  implicit val updateActionJsonFormat: SkeletonUpdateAction.skeletonUpdateActionFormat.type = SkeletonUpdateAction.skeletonUpdateActionFormat
 
   def currentVersion(tracingId: String): Fox[Long] =
     tracingDataStore.skeletonUpdates.getVersion(tracingId, mayBeEmpty = Some(true), emptyFallback = Some(0L))
@@ -113,26 +113,23 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
                    remainingUpdates: List[SkeletonUpdateAction]): Fox[SkeletonTracing] =
       tracingFox.futureBox.flatMap {
         case Empty => Fox.empty
-        case Full(tracing) => {
+        case Full(tracing) =>
           remainingUpdates match {
             case List() => Fox.successful(tracing)
-            case RevertToVersionAction(sourceVersion, _, _) :: tail => {
+            case RevertToVersionAction(sourceVersion, _, _) :: tail =>
               val sourceTracing = find(tracingId, Some(sourceVersion), useCache = false, applyUpdates = true)
               updateIter(sourceTracing, tail)
-            }
             case update :: tail => updateIter(Full(update.applyOn(tracing)), tail)
           }
-        }
         case _ => tracingFox
       }
 
     updates match {
       case List() => Full(tracing)
-      case head :: tail => {
+      case _ :: _ =>
         for {
           updated <- updateIter(Some(tracing), updates)
         } yield updated.withVersion(newVersion)
-      }
     }
   }
 
@@ -184,7 +181,7 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
                       newTracing: SkeletonTracing,
                       toCache: Boolean): Fox[Unit] = Fox.successful(())
 
-  def updateActionLog(tracingId: String) = {
+  def updateActionLog(tracingId: String): Fox[JsValue] = {
     def versionedTupleToJson(tuple: (Long, List[SkeletonUpdateAction])): JsObject =
       Json.obj(
         "version" -> tuple._1,
@@ -194,31 +191,28 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
       updateActionGroups <- tracingDataStore.skeletonUpdates.getMultipleVersionsAsVersionValueTuple(tracingId)(
         fromJson[List[SkeletonUpdateAction]])
       updateActionGroupsJs = updateActionGroups.map(versionedTupleToJson)
-    } yield (Json.toJson(updateActionGroupsJs))
+    } yield Json.toJson(updateActionGroupsJs)
   }
 
-  def updateActionStatistics(tracingId: String) =
+  def updateActionStatistics(tracingId: String): Fox[JsObject] =
     for {
       updateActionGroups <- tracingDataStore.skeletonUpdates.getMultipleVersions(tracingId)(
         fromJson[List[SkeletonUpdateAction]])
       updateActions = updateActionGroups.flatten
     } yield {
       Json.obj(
-        "updateTracingActionCount" -> updateActions.count(updateAction =>
-          updateAction match {
-            case a: UpdateTracingSkeletonAction => true
-            case _                              => false
-        }),
-        "createNodeActionCount" -> updateActions.count(updateAction =>
-          updateAction match {
-            case a: CreateNodeSkeletonAction => true
-            case _                           => false
-        }),
-        "deleteNodeActionCount" -> updateActions.count(updateAction =>
-          updateAction match {
-            case a: DeleteNodeSkeletonAction => true
-            case _                           => false
-        })
+        "updateTracingActionCount" -> updateActions.count {
+          case _: UpdateTracingSkeletonAction => true
+          case _ => false
+        },
+        "createNodeActionCount" -> updateActions.count {
+          case _: CreateNodeSkeletonAction => true
+          case _ => false
+        },
+        "deleteNodeActionCount" -> updateActions.count {
+          case _: DeleteNodeSkeletonAction => true
+          case _ => false
+        }
       )
     }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -32,7 +32,8 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
 
   implicit val tracingCompanion: SkeletonTracing.type = SkeletonTracing
 
-  implicit val updateActionJsonFormat: SkeletonUpdateAction.skeletonUpdateActionFormat.type = SkeletonUpdateAction.skeletonUpdateActionFormat
+  implicit val updateActionJsonFormat: SkeletonUpdateAction.skeletonUpdateActionFormat.type =
+    SkeletonUpdateAction.skeletonUpdateActionFormat
 
   def currentVersion(tracingId: String): Fox[Long] =
     tracingDataStore.skeletonUpdates.getVersion(tracingId, mayBeEmpty = Some(true), emptyFallback = Some(0L))
@@ -137,7 +138,7 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
     val taskBoundingBox = if (fromTask) {
       tracing.boundingBox.map { bb =>
         val newId = if (tracing.userBoundingBoxes.isEmpty) 1 else tracing.userBoundingBoxes.map(_.id).max + 1
-        NamedBoundingBox(newId, Some("task bounding box"), Some(true), Some(getRandomColor()), bb)
+        NamedBoundingBox(newId, Some("task bounding box"), Some(true), Some(getRandomColor), bb)
       }
     } else None
 
@@ -203,15 +204,15 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
       Json.obj(
         "updateTracingActionCount" -> updateActions.count {
           case _: UpdateTracingSkeletonAction => true
-          case _ => false
+          case _                              => false
         },
         "createNodeActionCount" -> updateActions.count {
           case _: CreateNodeSkeletonAction => true
-          case _ => false
+          case _                           => false
         },
         "deleteNodeActionCount" -> updateActions.count {
           case _: DeleteNodeSkeletonAction => true
-          case _ => false
+          case _                           => false
         }
       )
     }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
@@ -103,7 +103,9 @@ object TreeUtils {
       math.max(targetGroupMaxId + 1 - sourceGroupMinId, 0)
     }
 
-  def mergeGroups(sourceGroups: Seq[TreeGroup], targetGroups: Seq[TreeGroup], groupMapping: FunctionalGroupMapping): Seq[TreeGroup] = {
+  def mergeGroups(sourceGroups: Seq[TreeGroup],
+                  targetGroups: Seq[TreeGroup],
+                  groupMapping: FunctionalGroupMapping): Seq[TreeGroup] = {
     def applyGroupMappingRecursive(groups: Seq[TreeGroup]): Seq[TreeGroup] =
       groups.map(group =>
         group.withGroupId(groupMapping(group.groupId)).withChildren(applyGroupMappingRecursive(group.children)))

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeValidator.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeValidator.scala
@@ -4,6 +4,7 @@ import com.scalableminds.webknossos.datastore.SkeletonTracing._
 import com.scalableminds.util.datastructures.UnionFind
 import net.liftweb.common.{Box, Failure, Full}
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 object TreeValidator {
@@ -145,6 +146,7 @@ object TreeValidator {
         f
     }
 
+  @tailrec
   private def getAllTreeGroupIds(treeGroups: Seq[TreeGroup], ids: Seq[Int]): Seq[Int] =
     treeGroups match {
       case head :: tail => getAllTreeGroupIds(tail ++ head.children, head.groupId +: ids)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
@@ -11,18 +11,18 @@ trait SkeletonUpdateActionHelper {
   protected def mapAllTrees(tracing: SkeletonTracing, transformTree: Tree => Tree): Seq[Tree] =
     tracing.trees.map(transformTree)
 
-  protected def treeById(tracing: SkeletonTracing, treeId: Int) =
+  protected def treeById(tracing: SkeletonTracing, treeId: Int): Tree =
     tracing.trees
       .find(_.treeId == treeId)
       .getOrElse(throw new NoSuchElementException("Tracing does not contain tree with requested id " + treeId))
 
-  protected def convertColor(aColor: com.scalableminds.util.image.Color) =
+  protected def convertColor(aColor: com.scalableminds.util.image.Color): Color =
     Color(aColor.r, aColor.g, aColor.b, aColor.a)
-  protected def convertBranchPoint(aBranchPoint: UpdateActionBranchPoint) =
+  protected def convertBranchPoint(aBranchPoint: UpdateActionBranchPoint): BranchPoint =
     BranchPoint(aBranchPoint.nodeId, aBranchPoint.timestamp)
-  protected def convertComment(aComment: UpdateActionComment) =
+  protected def convertComment(aComment: UpdateActionComment): Comment =
     Comment(aComment.nodeId, aComment.content)
-  protected def convertColorOpt(aColorOpt: Option[com.scalableminds.util.image.Color]) = aColorOpt match {
+  protected def convertColorOpt(aColorOpt: Option[com.scalableminds.util.image.Color]): Option[Color] = aColorOpt match {
     case Some(aColor) => Some(convertColor(aColor))
     case None         => None
   }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
@@ -22,10 +22,11 @@ trait SkeletonUpdateActionHelper {
     BranchPoint(aBranchPoint.nodeId, aBranchPoint.timestamp)
   protected def convertComment(aComment: UpdateActionComment): Comment =
     Comment(aComment.nodeId, aComment.content)
-  protected def convertColorOpt(aColorOpt: Option[com.scalableminds.util.image.Color]): Option[Color] = aColorOpt match {
-    case Some(aColor) => Some(convertColor(aColor))
-    case None         => None
-  }
+  protected def convertColorOpt(aColorOpt: Option[com.scalableminds.util.image.Color]): Option[Color] =
+    aColorOpt match {
+      case Some(aColor) => Some(convertColor(aColor))
+      case None         => None
+    }
   protected def convertTreeGroup(aTreeGroup: UpdateActionTreeGroup): TreeGroup =
     TreeGroup(aTreeGroup.name, aTreeGroup.groupId, aTreeGroup.children.map(convertTreeGroup))
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
@@ -17,19 +17,19 @@ case class CreateTreeSkeletonAction(id: Int,
                                     isVisible: Option[Boolean],
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     val newTree = Tree(id,
-                       Nil,
-                       Nil,
-                       convertColorOpt(color),
-                       branchPoints.map(convertBranchPoint),
-                       comments.map(convertComment),
-                       name,
-                       timestamp,
-                       groupId,
-                       isVisible)
+      Nil,
+      Nil,
+      convertColorOpt(color),
+      branchPoints.map(convertBranchPoint),
+      comments.map(convertComment),
+      name,
+      timestamp,
+      groupId,
+      isVisible)
     tracing.withTrees(newTree +: tracing.trees)
   }
 
@@ -39,8 +39,8 @@ case class CreateTreeSkeletonAction(id: Int,
 }
 
 case class DeleteTreeSkeletonAction(id: Int, actionTimestamp: Option[Long] = None, info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction {
-  override def applyOn(tracing: SkeletonTracing) = tracing.withTrees(tracing.trees.filter(_.treeId != id))
+  extends UpdateAction.SkeletonUpdateAction {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = tracing.withTrees(tracing.trees.filter(_.treeId != id))
 
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
@@ -56,9 +56,9 @@ case class UpdateTreeSkeletonAction(id: Int,
                                     groupId: Option[Int],
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) =
       tree.copy(
         color = if (color.isDefined) convertColorOpt(color) else tree.color,
@@ -81,12 +81,12 @@ case class MergeTreeSkeletonAction(sourceId: Int,
                                    targetId: Int,
                                    actionTimestamp: Option[Long] = None,
                                    info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   // only nodes and edges are merged here,
   // other properties are managed explicitly
   // by the frontend with extra actions
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(targetTree: Tree) = {
       val sourceTree = treeById(tracing, sourceId)
       targetTree.withNodes(targetTree.nodes.union(sourceTree.nodes)).withEdges(targetTree.edges.union(sourceTree.edges))
@@ -105,11 +105,11 @@ case class MoveTreeComponentSkeletonAction(nodeIds: List[Int],
                                            targetId: Int,
                                            actionTimestamp: Option[Long] = None,
                                            info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   // this should only move a whole component,
   // that is disjoint from the rest of the tree
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     val sourceTree = treeById(tracing, sourceId)
     val targetTree = treeById(tracing, targetId)
 
@@ -140,9 +140,9 @@ case class CreateEdgeSkeletonAction(source: Int,
                                     treeId: Int,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) = tree.withEdges(Edge(source, target) +: tree.edges)
     tracing.withTrees(mapTrees(tracing, treeId, treeTransform))
   }
@@ -157,9 +157,9 @@ case class DeleteEdgeSkeletonAction(source: Int,
                                     treeId: Int,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) = tree.copy(edges = tree.edges.filter(_ != Edge(source, target)))
     tracing.withTrees(mapTrees(tracing, treeId, treeTransform))
   }
@@ -181,10 +181,10 @@ case class CreateNodeSkeletonAction(id: Int,
                                     timestamp: Long,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper
     with ProtoGeometryImplicits {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     val rotationOrDefault = rotation getOrElse NodeDefaults.rotation
     val newNode = Node(
       id,
@@ -220,10 +220,10 @@ case class UpdateNodeSkeletonAction(id: Int,
                                     timestamp: Long,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper
     with ProtoGeometryImplicits {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
 
     val rotationOrDefault = rotation getOrElse NodeDefaults.rotation
     val newNode = Node(
@@ -254,9 +254,9 @@ case class DeleteNodeSkeletonAction(nodeId: Int,
                                     treeId: Int,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
 
     def treeTransform(tree: Tree) =
       tree.withNodes(tree.nodes.filter(_.id != nodeId))
@@ -272,9 +272,9 @@ case class DeleteNodeSkeletonAction(nodeId: Int,
 case class UpdateTreeGroupsSkeletonAction(treeGroups: List[UpdateActionTreeGroup],
                                           actionTimestamp: Option[Long] = None,
                                           info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) =
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     tracing.withTreeGroups(treeGroups.map(convertTreeGroup))
 
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
@@ -289,14 +289,14 @@ case class UpdateTracingSkeletonAction(activeNode: Option[Int],
                                        userBoundingBox: Option[com.scalableminds.util.geometry.BoundingBox],
                                        actionTimestamp: Option[Long] = None,
                                        info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with ProtoGeometryImplicits {
-  override def applyOn(tracing: SkeletonTracing) =
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     tracing.copy(editPosition = editPosition,
-                 editRotation = editRotation,
-                 zoomLevel = zoomLevel,
-                 userBoundingBox = userBoundingBox,
-                 activeNodeId = activeNode)
+      editRotation = editRotation,
+      zoomLevel = zoomLevel,
+      userBoundingBox = userBoundingBox,
+      activeNodeId = activeNode)
 
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
@@ -304,8 +304,8 @@ case class UpdateTracingSkeletonAction(activeNode: Option[Int],
 }
 
 case class RevertToVersionAction(sourceVersion: Long, actionTimestamp: Option[Long] = None, info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction {
-  override def applyOn(tracing: SkeletonTracing) =
+  extends UpdateAction.SkeletonUpdateAction {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     throw new Exception("RevertToVersionAction applied on unversioned tracing")
 
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
@@ -317,9 +317,9 @@ case class UpdateTreeVisibility(treeId: Int,
                                 isVisible: Boolean,
                                 actionTimestamp: Option[Long] = None,
                                 info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) = tree.copy(isVisible = Some(isVisible))
 
     tracing.withTrees(mapTrees(tracing, treeId, treeTransform))
@@ -334,9 +334,9 @@ case class UpdateTreeGroupVisibility(treeGroupId: Option[Int],
                                      isVisible: Boolean,
                                      actionTimestamp: Option[Long] = None,
                                      info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction
+  extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
-  override def applyOn(tracing: SkeletonTracing) = {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def updateTreeGroups(treeGroups: Seq[TreeGroup]) = {
       def treeTransform(tree: Tree) =
         if (treeGroups.exists(group => tree.groupId.contains(group.groupId)))
@@ -366,8 +366,8 @@ case class UpdateTreeGroupVisibility(treeGroupId: Option[Int],
 case class UpdateUserBoundingBoxes(boundingBoxes: List[NamedBoundingBox],
                                    actionTimestamp: Option[Long] = None,
                                    info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction {
-  override def applyOn(tracing: SkeletonTracing) =
+  extends UpdateAction.SkeletonUpdateAction {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     tracing.withUserBoundingBoxes(boundingBoxes.map(_.toProto))
 
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
@@ -379,8 +379,8 @@ case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
                                            isVisible: Boolean,
                                            actionTimestamp: Option[Long] = None,
                                            info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction {
-  override def applyOn(tracing: SkeletonTracing) = {
+  extends UpdateAction.SkeletonUpdateAction {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def updateUserBoundingBoxes() =
       tracing.userBoundingBoxes.map { boundingBox =>
         if (boundingBoxId.forall(_ == boundingBox.id))
@@ -398,7 +398,7 @@ case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
 }
 
 case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[String] = None)
-    extends UpdateAction.SkeletonUpdateAction {
+  extends UpdateAction.SkeletonUpdateAction {
 
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = tracing
 
@@ -407,24 +407,24 @@ case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[Str
   override def addInfo(info: Option[String]): UpdateAction[SkeletonTracing] = this.copy(info = info)
 }
 
-object CreateTreeSkeletonAction { implicit val jsonFormat = Json.format[CreateTreeSkeletonAction] }
-object DeleteTreeSkeletonAction { implicit val jsonFormat = Json.format[DeleteTreeSkeletonAction] }
-object UpdateTreeSkeletonAction { implicit val jsonFormat = Json.format[UpdateTreeSkeletonAction] }
-object MergeTreeSkeletonAction { implicit val jsonFormat = Json.format[MergeTreeSkeletonAction] }
-object MoveTreeComponentSkeletonAction { implicit val jsonFormat = Json.format[MoveTreeComponentSkeletonAction] }
-object CreateEdgeSkeletonAction { implicit val jsonFormat = Json.format[CreateEdgeSkeletonAction] }
-object DeleteEdgeSkeletonAction { implicit val jsonFormat = Json.format[DeleteEdgeSkeletonAction] }
-object CreateNodeSkeletonAction { implicit val jsonFormat = Json.format[CreateNodeSkeletonAction] }
-object DeleteNodeSkeletonAction { implicit val jsonFormat = Json.format[DeleteNodeSkeletonAction] }
-object UpdateNodeSkeletonAction { implicit val jsonFormat = Json.format[UpdateNodeSkeletonAction] }
-object UpdateTreeGroupsSkeletonAction { implicit val jsonFormat = Json.format[UpdateTreeGroupsSkeletonAction] }
-object UpdateTracingSkeletonAction { implicit val jsonFormat = Json.format[UpdateTracingSkeletonAction] }
-object RevertToVersionAction { implicit val jsonFormat = Json.format[RevertToVersionAction] }
-object UpdateTreeVisibility { implicit val jsonFormat = Json.format[UpdateTreeVisibility] }
-object UpdateTreeGroupVisibility { implicit val jsonFormat = Json.format[UpdateTreeGroupVisibility] }
-object UpdateUserBoundingBoxes { implicit val jsonFormat = Json.format[UpdateUserBoundingBoxes] }
-object UpdateUserBoundingBoxVisibility { implicit val jsonFormat = Json.format[UpdateUserBoundingBoxVisibility] }
-object UpdateTdCamera { implicit val jsonFormat = Json.format[UpdateTdCamera] }
+object CreateTreeSkeletonAction { implicit val jsonFormat: OFormat[CreateTreeSkeletonAction] = Json.format[CreateTreeSkeletonAction] }
+object DeleteTreeSkeletonAction { implicit val jsonFormat: OFormat[DeleteTreeSkeletonAction] = Json.format[DeleteTreeSkeletonAction] }
+object UpdateTreeSkeletonAction { implicit val jsonFormat: OFormat[UpdateTreeSkeletonAction] = Json.format[UpdateTreeSkeletonAction] }
+object MergeTreeSkeletonAction { implicit val jsonFormat: OFormat[MergeTreeSkeletonAction] = Json.format[MergeTreeSkeletonAction] }
+object MoveTreeComponentSkeletonAction { implicit val jsonFormat: OFormat[MoveTreeComponentSkeletonAction] = Json.format[MoveTreeComponentSkeletonAction] }
+object CreateEdgeSkeletonAction { implicit val jsonFormat: OFormat[CreateEdgeSkeletonAction] = Json.format[CreateEdgeSkeletonAction] }
+object DeleteEdgeSkeletonAction { implicit val jsonFormat: OFormat[DeleteEdgeSkeletonAction] = Json.format[DeleteEdgeSkeletonAction] }
+object CreateNodeSkeletonAction { implicit val jsonFormat: OFormat[CreateNodeSkeletonAction] = Json.format[CreateNodeSkeletonAction] }
+object DeleteNodeSkeletonAction { implicit val jsonFormat: OFormat[DeleteNodeSkeletonAction] = Json.format[DeleteNodeSkeletonAction] }
+object UpdateNodeSkeletonAction { implicit val jsonFormat: OFormat[UpdateNodeSkeletonAction] = Json.format[UpdateNodeSkeletonAction] }
+object UpdateTreeGroupsSkeletonAction { implicit val jsonFormat: OFormat[UpdateTreeGroupsSkeletonAction] = Json.format[UpdateTreeGroupsSkeletonAction] }
+object UpdateTracingSkeletonAction { implicit val jsonFormat: OFormat[UpdateTracingSkeletonAction] = Json.format[UpdateTracingSkeletonAction] }
+object RevertToVersionAction { implicit val jsonFormat: OFormat[RevertToVersionAction] = Json.format[RevertToVersionAction] }
+object UpdateTreeVisibility { implicit val jsonFormat: OFormat[UpdateTreeVisibility] = Json.format[UpdateTreeVisibility] }
+object UpdateTreeGroupVisibility { implicit val jsonFormat: OFormat[UpdateTreeGroupVisibility] = Json.format[UpdateTreeGroupVisibility] }
+object UpdateUserBoundingBoxes { implicit val jsonFormat: OFormat[UpdateUserBoundingBoxes] = Json.format[UpdateUserBoundingBoxes] }
+object UpdateUserBoundingBoxVisibility { implicit val jsonFormat: OFormat[UpdateUserBoundingBoxVisibility] = Json.format[UpdateUserBoundingBoxVisibility] }
+object UpdateTdCamera { implicit val jsonFormat: OFormat[UpdateTdCamera] = Json.format[UpdateTdCamera] }
 
 object SkeletonUpdateAction {
 
@@ -497,7 +497,7 @@ object SkeletonUpdateAction {
         Json.obj("name" -> "updateUserBoundingBoxes", "value" -> Json.toJson(s)(UpdateUserBoundingBoxes.jsonFormat))
       case s: UpdateUserBoundingBoxVisibility =>
         Json.obj("name" -> "updateUserBoundingBoxVisibility",
-                 "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.jsonFormat))
+          "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.jsonFormat))
       case s: UpdateTdCamera =>
         Json.obj("name" -> "updateTdCamera", "value" -> Json.toJson(s)(UpdateTdCamera.jsonFormat))
     }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
@@ -17,19 +17,19 @@ case class CreateTreeSkeletonAction(id: Int,
                                     isVisible: Option[Boolean],
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     val newTree = Tree(id,
-      Nil,
-      Nil,
-      convertColorOpt(color),
-      branchPoints.map(convertBranchPoint),
-      comments.map(convertComment),
-      name,
-      timestamp,
-      groupId,
-      isVisible)
+                       Nil,
+                       Nil,
+                       convertColorOpt(color),
+                       branchPoints.map(convertBranchPoint),
+                       comments.map(convertComment),
+                       name,
+                       timestamp,
+                       groupId,
+                       isVisible)
     tracing.withTrees(newTree +: tracing.trees)
   }
 
@@ -39,8 +39,9 @@ case class CreateTreeSkeletonAction(id: Int,
 }
 
 case class DeleteTreeSkeletonAction(id: Int, actionTimestamp: Option[Long] = None, info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction {
-  override def applyOn(tracing: SkeletonTracing): SkeletonTracing = tracing.withTrees(tracing.trees.filter(_.treeId != id))
+    extends UpdateAction.SkeletonUpdateAction {
+  override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
+    tracing.withTrees(tracing.trees.filter(_.treeId != id))
 
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
@@ -56,7 +57,7 @@ case class UpdateTreeSkeletonAction(id: Int,
                                     groupId: Option[Int],
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) =
@@ -81,7 +82,7 @@ case class MergeTreeSkeletonAction(sourceId: Int,
                                    targetId: Int,
                                    actionTimestamp: Option[Long] = None,
                                    info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   // only nodes and edges are merged here,
   // other properties are managed explicitly
@@ -105,7 +106,7 @@ case class MoveTreeComponentSkeletonAction(nodeIds: List[Int],
                                            targetId: Int,
                                            actionTimestamp: Option[Long] = None,
                                            info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   // this should only move a whole component,
   // that is disjoint from the rest of the tree
@@ -140,7 +141,7 @@ case class CreateEdgeSkeletonAction(source: Int,
                                     treeId: Int,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) = tree.withEdges(Edge(source, target) +: tree.edges)
@@ -157,7 +158,7 @@ case class DeleteEdgeSkeletonAction(source: Int,
                                     treeId: Int,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) = tree.copy(edges = tree.edges.filter(_ != Edge(source, target)))
@@ -181,7 +182,7 @@ case class CreateNodeSkeletonAction(id: Int,
                                     timestamp: Long,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper
     with ProtoGeometryImplicits {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
@@ -220,7 +221,7 @@ case class UpdateNodeSkeletonAction(id: Int,
                                     timestamp: Long,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper
     with ProtoGeometryImplicits {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
@@ -254,7 +255,7 @@ case class DeleteNodeSkeletonAction(nodeId: Int,
                                     treeId: Int,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
 
@@ -272,7 +273,7 @@ case class DeleteNodeSkeletonAction(nodeId: Int,
 case class UpdateTreeGroupsSkeletonAction(treeGroups: List[UpdateActionTreeGroup],
                                           actionTimestamp: Option[Long] = None,
                                           info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     tracing.withTreeGroups(treeGroups.map(convertTreeGroup))
@@ -289,14 +290,14 @@ case class UpdateTracingSkeletonAction(activeNode: Option[Int],
                                        userBoundingBox: Option[com.scalableminds.util.geometry.BoundingBox],
                                        actionTimestamp: Option[Long] = None,
                                        info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with ProtoGeometryImplicits {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     tracing.copy(editPosition = editPosition,
-      editRotation = editRotation,
-      zoomLevel = zoomLevel,
-      userBoundingBox = userBoundingBox,
-      activeNodeId = activeNode)
+                 editRotation = editRotation,
+                 zoomLevel = zoomLevel,
+                 userBoundingBox = userBoundingBox,
+                 activeNodeId = activeNode)
 
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
@@ -304,7 +305,7 @@ case class UpdateTracingSkeletonAction(activeNode: Option[Int],
 }
 
 case class RevertToVersionAction(sourceVersion: Long, actionTimestamp: Option[Long] = None, info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction {
+    extends UpdateAction.SkeletonUpdateAction {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     throw new Exception("RevertToVersionAction applied on unversioned tracing")
 
@@ -317,7 +318,7 @@ case class UpdateTreeVisibility(treeId: Int,
                                 isVisible: Boolean,
                                 actionTimestamp: Option[Long] = None,
                                 info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def treeTransform(tree: Tree) = tree.copy(isVisible = Some(isVisible))
@@ -334,7 +335,7 @@ case class UpdateTreeGroupVisibility(treeGroupId: Option[Int],
                                      isVisible: Boolean,
                                      actionTimestamp: Option[Long] = None,
                                      info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction
+    extends UpdateAction.SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def updateTreeGroups(treeGroups: Seq[TreeGroup]) = {
@@ -366,7 +367,7 @@ case class UpdateTreeGroupVisibility(treeGroupId: Option[Int],
 case class UpdateUserBoundingBoxes(boundingBoxes: List[NamedBoundingBox],
                                    actionTimestamp: Option[Long] = None,
                                    info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction {
+    extends UpdateAction.SkeletonUpdateAction {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing =
     tracing.withUserBoundingBoxes(boundingBoxes.map(_.toProto))
 
@@ -379,7 +380,7 @@ case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
                                            isVisible: Boolean,
                                            actionTimestamp: Option[Long] = None,
                                            info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction {
+    extends UpdateAction.SkeletonUpdateAction {
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     def updateUserBoundingBoxes() =
       tracing.userBoundingBoxes.map { boundingBox =>
@@ -398,7 +399,7 @@ case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
 }
 
 case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[String] = None)
-  extends UpdateAction.SkeletonUpdateAction {
+    extends UpdateAction.SkeletonUpdateAction {
 
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = tracing
 
@@ -407,23 +408,57 @@ case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[Str
   override def addInfo(info: Option[String]): UpdateAction[SkeletonTracing] = this.copy(info = info)
 }
 
-object CreateTreeSkeletonAction { implicit val jsonFormat: OFormat[CreateTreeSkeletonAction] = Json.format[CreateTreeSkeletonAction] }
-object DeleteTreeSkeletonAction { implicit val jsonFormat: OFormat[DeleteTreeSkeletonAction] = Json.format[DeleteTreeSkeletonAction] }
-object UpdateTreeSkeletonAction { implicit val jsonFormat: OFormat[UpdateTreeSkeletonAction] = Json.format[UpdateTreeSkeletonAction] }
-object MergeTreeSkeletonAction { implicit val jsonFormat: OFormat[MergeTreeSkeletonAction] = Json.format[MergeTreeSkeletonAction] }
-object MoveTreeComponentSkeletonAction { implicit val jsonFormat: OFormat[MoveTreeComponentSkeletonAction] = Json.format[MoveTreeComponentSkeletonAction] }
-object CreateEdgeSkeletonAction { implicit val jsonFormat: OFormat[CreateEdgeSkeletonAction] = Json.format[CreateEdgeSkeletonAction] }
-object DeleteEdgeSkeletonAction { implicit val jsonFormat: OFormat[DeleteEdgeSkeletonAction] = Json.format[DeleteEdgeSkeletonAction] }
-object CreateNodeSkeletonAction { implicit val jsonFormat: OFormat[CreateNodeSkeletonAction] = Json.format[CreateNodeSkeletonAction] }
-object DeleteNodeSkeletonAction { implicit val jsonFormat: OFormat[DeleteNodeSkeletonAction] = Json.format[DeleteNodeSkeletonAction] }
-object UpdateNodeSkeletonAction { implicit val jsonFormat: OFormat[UpdateNodeSkeletonAction] = Json.format[UpdateNodeSkeletonAction] }
-object UpdateTreeGroupsSkeletonAction { implicit val jsonFormat: OFormat[UpdateTreeGroupsSkeletonAction] = Json.format[UpdateTreeGroupsSkeletonAction] }
-object UpdateTracingSkeletonAction { implicit val jsonFormat: OFormat[UpdateTracingSkeletonAction] = Json.format[UpdateTracingSkeletonAction] }
-object RevertToVersionAction { implicit val jsonFormat: OFormat[RevertToVersionAction] = Json.format[RevertToVersionAction] }
-object UpdateTreeVisibility { implicit val jsonFormat: OFormat[UpdateTreeVisibility] = Json.format[UpdateTreeVisibility] }
-object UpdateTreeGroupVisibility { implicit val jsonFormat: OFormat[UpdateTreeGroupVisibility] = Json.format[UpdateTreeGroupVisibility] }
-object UpdateUserBoundingBoxes { implicit val jsonFormat: OFormat[UpdateUserBoundingBoxes] = Json.format[UpdateUserBoundingBoxes] }
-object UpdateUserBoundingBoxVisibility { implicit val jsonFormat: OFormat[UpdateUserBoundingBoxVisibility] = Json.format[UpdateUserBoundingBoxVisibility] }
+object CreateTreeSkeletonAction {
+  implicit val jsonFormat: OFormat[CreateTreeSkeletonAction] = Json.format[CreateTreeSkeletonAction]
+}
+object DeleteTreeSkeletonAction {
+  implicit val jsonFormat: OFormat[DeleteTreeSkeletonAction] = Json.format[DeleteTreeSkeletonAction]
+}
+object UpdateTreeSkeletonAction {
+  implicit val jsonFormat: OFormat[UpdateTreeSkeletonAction] = Json.format[UpdateTreeSkeletonAction]
+}
+object MergeTreeSkeletonAction {
+  implicit val jsonFormat: OFormat[MergeTreeSkeletonAction] = Json.format[MergeTreeSkeletonAction]
+}
+object MoveTreeComponentSkeletonAction {
+  implicit val jsonFormat: OFormat[MoveTreeComponentSkeletonAction] = Json.format[MoveTreeComponentSkeletonAction]
+}
+object CreateEdgeSkeletonAction {
+  implicit val jsonFormat: OFormat[CreateEdgeSkeletonAction] = Json.format[CreateEdgeSkeletonAction]
+}
+object DeleteEdgeSkeletonAction {
+  implicit val jsonFormat: OFormat[DeleteEdgeSkeletonAction] = Json.format[DeleteEdgeSkeletonAction]
+}
+object CreateNodeSkeletonAction {
+  implicit val jsonFormat: OFormat[CreateNodeSkeletonAction] = Json.format[CreateNodeSkeletonAction]
+}
+object DeleteNodeSkeletonAction {
+  implicit val jsonFormat: OFormat[DeleteNodeSkeletonAction] = Json.format[DeleteNodeSkeletonAction]
+}
+object UpdateNodeSkeletonAction {
+  implicit val jsonFormat: OFormat[UpdateNodeSkeletonAction] = Json.format[UpdateNodeSkeletonAction]
+}
+object UpdateTreeGroupsSkeletonAction {
+  implicit val jsonFormat: OFormat[UpdateTreeGroupsSkeletonAction] = Json.format[UpdateTreeGroupsSkeletonAction]
+}
+object UpdateTracingSkeletonAction {
+  implicit val jsonFormat: OFormat[UpdateTracingSkeletonAction] = Json.format[UpdateTracingSkeletonAction]
+}
+object RevertToVersionAction {
+  implicit val jsonFormat: OFormat[RevertToVersionAction] = Json.format[RevertToVersionAction]
+}
+object UpdateTreeVisibility {
+  implicit val jsonFormat: OFormat[UpdateTreeVisibility] = Json.format[UpdateTreeVisibility]
+}
+object UpdateTreeGroupVisibility {
+  implicit val jsonFormat: OFormat[UpdateTreeGroupVisibility] = Json.format[UpdateTreeGroupVisibility]
+}
+object UpdateUserBoundingBoxes {
+  implicit val jsonFormat: OFormat[UpdateUserBoundingBoxes] = Json.format[UpdateUserBoundingBoxes]
+}
+object UpdateUserBoundingBoxVisibility {
+  implicit val jsonFormat: OFormat[UpdateUserBoundingBoxVisibility] = Json.format[UpdateUserBoundingBoxVisibility]
+}
 object UpdateTdCamera { implicit val jsonFormat: OFormat[UpdateTdCamera] = Json.format[UpdateTdCamera] }
 
 object SkeletonUpdateAction {
@@ -497,7 +532,7 @@ object SkeletonUpdateAction {
         Json.obj("name" -> "updateUserBoundingBoxes", "value" -> Json.toJson(s)(UpdateUserBoundingBoxes.jsonFormat))
       case s: UpdateUserBoundingBoxVisibility =>
         Json.obj("name" -> "updateUserBoundingBoxVisibility",
-          "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.jsonFormat))
+                 "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.jsonFormat))
       case s: UpdateTdCamera =>
         Json.obj("name" -> "updateTdCamera", "value" -> Json.toJson(s)(UpdateTdCamera.jsonFormat))
     }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionBranchPoint.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionBranchPoint.scala
@@ -4,4 +4,6 @@ import play.api.libs.json.{Json, OFormat}
 
 case class UpdateActionBranchPoint(nodeId: Int, timestamp: Long)
 
-object UpdateActionBranchPoint { implicit val jsonFormat: OFormat[UpdateActionBranchPoint] = Json.format[UpdateActionBranchPoint] }
+object UpdateActionBranchPoint {
+  implicit val jsonFormat: OFormat[UpdateActionBranchPoint] = Json.format[UpdateActionBranchPoint]
+}

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionBranchPoint.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionBranchPoint.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class UpdateActionBranchPoint(nodeId: Int, timestamp: Long)
 
-object UpdateActionBranchPoint { implicit val jsonFormat = Json.format[UpdateActionBranchPoint] }
+object UpdateActionBranchPoint { implicit val jsonFormat: OFormat[UpdateActionBranchPoint] = Json.format[UpdateActionBranchPoint] }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionComment.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionComment.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class UpdateActionComment(nodeId: Int, content: String)
 
-object UpdateActionComment { implicit val jsonFormat = Json.format[UpdateActionComment] }
+object UpdateActionComment { implicit val jsonFormat: OFormat[UpdateActionComment] = Json.format[UpdateActionComment] }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionTreeGroup.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionTreeGroup.scala
@@ -4,4 +4,6 @@ import play.api.libs.json.{Json, OFormat}
 
 case class UpdateActionTreeGroup(name: String, groupId: Int, children: List[UpdateActionTreeGroup])
 
-object UpdateActionTreeGroup { implicit val jsonFormat: OFormat[UpdateActionTreeGroup] = Json.format[UpdateActionTreeGroup] }
+object UpdateActionTreeGroup {
+  implicit val jsonFormat: OFormat[UpdateActionTreeGroup] = Json.format[UpdateActionTreeGroup]
+}

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionTreeGroup.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/UpdateActionTreeGroup.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class UpdateActionTreeGroup(name: String, groupId: Int, children: List[UpdateActionTreeGroup])
 
-object UpdateActionTreeGroup { implicit val jsonFormat = Json.format[UpdateActionTreeGroup] }
+object UpdateActionTreeGroup { implicit val jsonFormat: OFormat[UpdateActionTreeGroup] = Json.format[UpdateActionTreeGroup] }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingDefaults.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingDefaults.scala
@@ -5,9 +5,9 @@ import com.scalableminds.webknossos.datastore.geometry.Vector3D
 
 object VolumeTracingDefaults {
 
-  val editRotation = Vector3D(0, 0, 0)
+  val editRotation: Vector3D = Vector3D(0, 0, 0)
 
-  val elementClass = ElementClass.uint32
+  val elementClass: ElementClass.Value = ElementClass.uint32
 
   val largestSegmentId = 0L
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -297,7 +297,7 @@ class VolumeTracingService @Inject()(
       val newId = if (tracing.userBoundingBoxes.isEmpty) 1 else tracing.userBoundingBoxes.map(_.id).max + 1
       tracing
         .addUserBoundingBoxes(
-          NamedBoundingBox(newId, Some("task bounding box"), Some(true), Some(getRandomColor()), tracing.boundingBox))
+          NamedBoundingBox(newId, Some("task bounding box"), Some(true), Some(getRandomColor), tracing.boundingBox))
         .withBoundingBox(dataSetBoundingBox.get)
     } else tracing
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
@@ -13,108 +13,108 @@ case class UpdateBucketVolumeAction(position: Point3D,
                                     base64Data: String,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-    extends VolumeUpdateAction {
-  lazy val data: Array[Byte] = Base64.getDecoder().decode(base64Data)
+  extends VolumeUpdateAction {
+  lazy val data: Array[Byte] = Base64.getDecoder.decode(base64Data)
 
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact = CompactVolumeUpdateAction("updateBucket", actionTimestamp, Json.obj())
+  override def transformToCompact: CompactVolumeUpdateAction = CompactVolumeUpdateAction("updateBucket", actionTimestamp, Json.obj())
 }
 
 object UpdateBucketVolumeAction {
-  implicit val updateBucketVolumeActionFormat = Json.format[UpdateBucketVolumeAction]
+  implicit val jsonFormat: OFormat[UpdateBucketVolumeAction] = Json.format[UpdateBucketVolumeAction]
 }
 
 case class UpdateTracingVolumeAction(
-    activeSegmentId: Long,
-    editPosition: Point3D,
-    editRotation: Vector3D,
-    largestSegmentId: Long,
-    zoomLevel: Double,
-    actionTimestamp: Option[Long] = None,
-    info: Option[String] = None
-) extends VolumeUpdateAction {
+                                      activeSegmentId: Long,
+                                      editPosition: Point3D,
+                                      editRotation: Vector3D,
+                                      largestSegmentId: Long,
+                                      zoomLevel: Double,
+                                      actionTimestamp: Option[Long] = None,
+                                      info: Option[String] = None
+                                    ) extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact = CompactVolumeUpdateAction("updateTracing", actionTimestamp, Json.obj())
+  override def transformToCompact: CompactVolumeUpdateAction = CompactVolumeUpdateAction("updateTracing", actionTimestamp, Json.obj())
 }
 
 object UpdateTracingVolumeAction {
-  implicit val updateTracingVolumeActionFormat = Json.format[UpdateTracingVolumeAction]
+  implicit val jsonFormat: OFormat[UpdateTracingVolumeAction] = Json.format[UpdateTracingVolumeAction]
 }
 
 case class RevertToVersionVolumeAction(sourceVersion: Long,
                                        actionTimestamp: Option[Long] = None,
                                        info: Option[String] = None)
-    extends VolumeUpdateAction {
+  extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact =
+  override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("revertToVersion", actionTimestamp, Json.obj("sourceVersion" -> sourceVersion))
 }
 
 object RevertToVersionVolumeAction {
-  implicit val revertToVersionVolumeActionFormat = Json.format[RevertToVersionVolumeAction]
+  implicit val jsonFormat: OFormat[RevertToVersionVolumeAction] = Json.format[RevertToVersionVolumeAction]
 }
 
 case class UpdateUserBoundingBoxes(boundingBoxes: List[NamedBoundingBox],
                                    actionTimestamp: Option[Long] = None,
                                    info: Option[String] = None)
-    extends VolumeUpdateAction {
+  extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction =
     this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact =
+  override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("updateUserBoundingBoxes", actionTimestamp, Json.obj())
 }
 
 object UpdateUserBoundingBoxes {
-  implicit val updateUserBoundingBoxesFormat = Json.format[UpdateUserBoundingBoxes]
+  implicit val jsonFormat: OFormat[UpdateUserBoundingBoxes] = Json.format[UpdateUserBoundingBoxes]
 }
 
 case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
                                            isVisible: Boolean,
                                            actionTimestamp: Option[Long] = None,
                                            info: Option[String] = None)
-    extends VolumeUpdateAction {
+  extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact =
+  override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("updateUserBoundingBoxVisibility",
-                              actionTimestamp,
-                              Json.obj("boundingBoxId" -> boundingBoxId, "newVisibility" -> isVisible))
+      actionTimestamp,
+      Json.obj("boundingBoxId" -> boundingBoxId, "newVisibility" -> isVisible))
 }
 
 object UpdateUserBoundingBoxVisibility {
-  implicit val updateUserBoundingBoxVisibilityFormat = Json.format[UpdateUserBoundingBoxVisibility]
+  implicit val jsonFormat: OFormat[UpdateUserBoundingBoxVisibility] = Json.format[UpdateUserBoundingBoxVisibility]
 }
 
 case class RemoveFallbackLayer(actionTimestamp: Option[Long] = None, info: Option[String] = None)
-    extends VolumeUpdateAction {
+  extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact =
+  override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("removeFallbackLayer", actionTimestamp, Json.obj())
 }
 
 object RemoveFallbackLayer {
-  implicit val removeFallbackLayer = Json.format[RemoveFallbackLayer]
+  implicit val jsonFormat: OFormat[RemoveFallbackLayer] = Json.format[RemoveFallbackLayer]
 }
 
 case class ImportVolumeData(largestSegmentId: Long, actionTimestamp: Option[Long] = None, info: Option[String] = None)
-    extends VolumeUpdateAction {
+  extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact =
+  override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("importVolumeTracing", actionTimestamp, Json.obj("largestSegmentId" -> largestSegmentId))
 }
 
 object ImportVolumeData {
-  implicit val importVolumeData = Json.format[ImportVolumeData]
+  implicit val jsonFormat: OFormat[ImportVolumeData] = Json.format[ImportVolumeData]
 }
 
 case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[String] = None)
-    extends VolumeUpdateAction {
+  extends VolumeUpdateAction {
 
   override def addTimestamp(timestamp: Long): VolumeUpdateAction =
     this.copy(actionTimestamp = Some(timestamp))
@@ -124,11 +124,11 @@ case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[Str
 }
 
 object UpdateTdCamera {
-  implicit val updateTdCameraFormat = Json.format[UpdateTdCamera]
+  implicit val jsonFormat: OFormat[UpdateTdCamera] = Json.format[UpdateTdCamera]
 }
 
 case class CompactVolumeUpdateAction(name: String, actionTimestamp: Option[Long], value: JsObject)
-    extends VolumeUpdateAction
+  extends VolumeUpdateAction
 
 object CompactVolumeUpdateAction {
   implicit object compactVolumeUpdateActionFormat extends Format[CompactVolumeUpdateAction] {
@@ -163,25 +163,25 @@ object VolumeUpdateAction {
     override def writes(o: VolumeUpdateAction): JsValue = o match {
       case s: UpdateBucketVolumeAction =>
         Json.obj("name" -> "updateBucket",
-                 "value" -> Json.toJson(s)(UpdateBucketVolumeAction.updateBucketVolumeActionFormat))
+          "value" -> Json.toJson(s)(UpdateBucketVolumeAction.jsonFormat))
       case s: UpdateTracingVolumeAction =>
         Json.obj("name" -> "updateTracing",
-                 "value" -> Json.toJson(s)(UpdateTracingVolumeAction.updateTracingVolumeActionFormat))
+          "value" -> Json.toJson(s)(UpdateTracingVolumeAction.jsonFormat))
       case s: RevertToVersionVolumeAction =>
         Json.obj("name" -> "revertToVersion",
-                 "value" -> Json.toJson(s)(RevertToVersionVolumeAction.revertToVersionVolumeActionFormat))
+          "value" -> Json.toJson(s)(RevertToVersionVolumeAction.jsonFormat))
       case s: UpdateUserBoundingBoxes =>
         Json.obj("name" -> "updateUserBoundingBoxes",
-                 "value" -> Json.toJson(s)(UpdateUserBoundingBoxes.updateUserBoundingBoxesFormat))
+          "value" -> Json.toJson(s)(UpdateUserBoundingBoxes.jsonFormat))
       case s: UpdateUserBoundingBoxVisibility =>
         Json.obj("name" -> "updateUserBoundingBoxVisibility",
-                 "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.updateUserBoundingBoxVisibilityFormat))
+          "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.jsonFormat))
       case s: RemoveFallbackLayer =>
-        Json.obj("name" -> "removeFallbackLayer", "value" -> Json.toJson(s)(RemoveFallbackLayer.removeFallbackLayer))
+        Json.obj("name" -> "removeFallbackLayer", "value" -> Json.toJson(s)(RemoveFallbackLayer.jsonFormat))
       case s: ImportVolumeData =>
-        Json.obj("name" -> "importVolumeTracing", "value" -> Json.toJson(s)(ImportVolumeData.importVolumeData))
+        Json.obj("name" -> "importVolumeTracing", "value" -> Json.toJson(s)(ImportVolumeData.jsonFormat))
       case s: UpdateTdCamera =>
-        Json.obj("name" -> "updateTdCamera", "value" -> Json.toJson(s)(UpdateTdCamera.updateTdCameraFormat))
+        Json.obj("name" -> "updateTdCamera", "value" -> Json.toJson(s)(UpdateTdCamera.jsonFormat))
       case s: CompactVolumeUpdateAction => Json.toJson(s)(CompactVolumeUpdateAction.compactVolumeUpdateActionFormat)
     }
   }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
@@ -13,12 +13,13 @@ case class UpdateBucketVolumeAction(position: Point3D,
                                     base64Data: String,
                                     actionTimestamp: Option[Long] = None,
                                     info: Option[String] = None)
-  extends VolumeUpdateAction {
+    extends VolumeUpdateAction {
   lazy val data: Array[Byte] = Base64.getDecoder.decode(base64Data)
 
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact: CompactVolumeUpdateAction = CompactVolumeUpdateAction("updateBucket", actionTimestamp, Json.obj())
+  override def transformToCompact: CompactVolumeUpdateAction =
+    CompactVolumeUpdateAction("updateBucket", actionTimestamp, Json.obj())
 }
 
 object UpdateBucketVolumeAction {
@@ -26,17 +27,18 @@ object UpdateBucketVolumeAction {
 }
 
 case class UpdateTracingVolumeAction(
-                                      activeSegmentId: Long,
-                                      editPosition: Point3D,
-                                      editRotation: Vector3D,
-                                      largestSegmentId: Long,
-                                      zoomLevel: Double,
-                                      actionTimestamp: Option[Long] = None,
-                                      info: Option[String] = None
-                                    ) extends VolumeUpdateAction {
+    activeSegmentId: Long,
+    editPosition: Point3D,
+    editRotation: Vector3D,
+    largestSegmentId: Long,
+    zoomLevel: Double,
+    actionTimestamp: Option[Long] = None,
+    info: Option[String] = None
+) extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
-  override def transformToCompact: CompactVolumeUpdateAction = CompactVolumeUpdateAction("updateTracing", actionTimestamp, Json.obj())
+  override def transformToCompact: CompactVolumeUpdateAction =
+    CompactVolumeUpdateAction("updateTracing", actionTimestamp, Json.obj())
 }
 
 object UpdateTracingVolumeAction {
@@ -46,7 +48,7 @@ object UpdateTracingVolumeAction {
 case class RevertToVersionVolumeAction(sourceVersion: Long,
                                        actionTimestamp: Option[Long] = None,
                                        info: Option[String] = None)
-  extends VolumeUpdateAction {
+    extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
   override def transformToCompact: CompactVolumeUpdateAction =
@@ -60,7 +62,7 @@ object RevertToVersionVolumeAction {
 case class UpdateUserBoundingBoxes(boundingBoxes: List[NamedBoundingBox],
                                    actionTimestamp: Option[Long] = None,
                                    info: Option[String] = None)
-  extends VolumeUpdateAction {
+    extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction =
     this.copy(actionTimestamp = Some(timestamp))
 
@@ -76,13 +78,13 @@ case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
                                            isVisible: Boolean,
                                            actionTimestamp: Option[Long] = None,
                                            info: Option[String] = None)
-  extends VolumeUpdateAction {
+    extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
   override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("updateUserBoundingBoxVisibility",
-      actionTimestamp,
-      Json.obj("boundingBoxId" -> boundingBoxId, "newVisibility" -> isVisible))
+                              actionTimestamp,
+                              Json.obj("boundingBoxId" -> boundingBoxId, "newVisibility" -> isVisible))
 }
 
 object UpdateUserBoundingBoxVisibility {
@@ -90,7 +92,7 @@ object UpdateUserBoundingBoxVisibility {
 }
 
 case class RemoveFallbackLayer(actionTimestamp: Option[Long] = None, info: Option[String] = None)
-  extends VolumeUpdateAction {
+    extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
   override def transformToCompact: CompactVolumeUpdateAction =
@@ -102,7 +104,7 @@ object RemoveFallbackLayer {
 }
 
 case class ImportVolumeData(largestSegmentId: Long, actionTimestamp: Option[Long] = None, info: Option[String] = None)
-  extends VolumeUpdateAction {
+    extends VolumeUpdateAction {
   override def addTimestamp(timestamp: Long): VolumeUpdateAction = this.copy(actionTimestamp = Some(timestamp))
 
   override def transformToCompact: CompactVolumeUpdateAction =
@@ -114,7 +116,7 @@ object ImportVolumeData {
 }
 
 case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[String] = None)
-  extends VolumeUpdateAction {
+    extends VolumeUpdateAction {
 
   override def addTimestamp(timestamp: Long): VolumeUpdateAction =
     this.copy(actionTimestamp = Some(timestamp))
@@ -128,7 +130,7 @@ object UpdateTdCamera {
 }
 
 case class CompactVolumeUpdateAction(name: String, actionTimestamp: Option[Long], value: JsObject)
-  extends VolumeUpdateAction
+    extends VolumeUpdateAction
 
 object CompactVolumeUpdateAction {
   implicit object compactVolumeUpdateActionFormat extends Format[CompactVolumeUpdateAction] {
@@ -162,20 +164,16 @@ object VolumeUpdateAction {
 
     override def writes(o: VolumeUpdateAction): JsValue = o match {
       case s: UpdateBucketVolumeAction =>
-        Json.obj("name" -> "updateBucket",
-          "value" -> Json.toJson(s)(UpdateBucketVolumeAction.jsonFormat))
+        Json.obj("name" -> "updateBucket", "value" -> Json.toJson(s)(UpdateBucketVolumeAction.jsonFormat))
       case s: UpdateTracingVolumeAction =>
-        Json.obj("name" -> "updateTracing",
-          "value" -> Json.toJson(s)(UpdateTracingVolumeAction.jsonFormat))
+        Json.obj("name" -> "updateTracing", "value" -> Json.toJson(s)(UpdateTracingVolumeAction.jsonFormat))
       case s: RevertToVersionVolumeAction =>
-        Json.obj("name" -> "revertToVersion",
-          "value" -> Json.toJson(s)(RevertToVersionVolumeAction.jsonFormat))
+        Json.obj("name" -> "revertToVersion", "value" -> Json.toJson(s)(RevertToVersionVolumeAction.jsonFormat))
       case s: UpdateUserBoundingBoxes =>
-        Json.obj("name" -> "updateUserBoundingBoxes",
-          "value" -> Json.toJson(s)(UpdateUserBoundingBoxes.jsonFormat))
+        Json.obj("name" -> "updateUserBoundingBoxes", "value" -> Json.toJson(s)(UpdateUserBoundingBoxes.jsonFormat))
       case s: UpdateUserBoundingBoxVisibility =>
         Json.obj("name" -> "updateUserBoundingBoxVisibility",
-          "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.jsonFormat))
+                 "value" -> Json.toJson(s)(UpdateUserBoundingBoxVisibility.jsonFormat))
       case s: RemoveFallbackLayer =>
         Json.obj("name" -> "removeFallbackLayer", "value" -> Json.toJson(s)(RemoveFallbackLayer.jsonFormat))
       case s: ImportVolumeData =>


### PR DESCRIPTION
Follow scala style guide as suggested by IntelliJ (in most places)
Mostly 
 - making things private that can be
 - give type annotations to all public members
 - remove redundant braces
 - remove some unused variables

There are a few items remaining (datasource package object, type parameter shadowing in isosurfaceservice, as well as a few unused parameters dictated by superclasses) but those are specific and I didn’t want to touch them now, for fear of breaking something. I think we’re already pretty good with this :)

Note that many line changes in the diff are caused by different line-breaks and indentations the formatter introduced. Sorry about that :see_no_evil: 

### URL of deployed dev instance (used for testing):
- https://typeannotations.webknossos.xyz

### Steps to test:
- CI should run through
- wK should start normally, trace some, data should load, annotation should save

### Issues:
- fixes #3565

------
- [x] Needs datastore update after deployment
- [x] Ready for review
