### PR TITLE
Add API methods to get/set the active group and to set the camera position

### DIFF
--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -40,6 +40,7 @@ import {
   getNodeAndTreeOrNull,
   getActiveNode,
   getActiveTree,
+  getActiveGroup,
   getTree,
   getFlatTreeGroups,
   getTreeGroupsMap,
@@ -74,6 +75,7 @@ import {
   setNodeRadiusAction,
   setTreeNameAction,
   setActiveTreeAction,
+  setActiveGroupAction,
   setActiveTreeByNameAction,
   setTreeColorIndexAction,
   setTreeVisibilityAction,
@@ -180,6 +182,16 @@ class TracingApi {
     const tracing = assertSkeleton(Store.getState().tracing);
     return getActiveTree(tracing)
       .map(tree => tree.treeId)
+      .getOrElse(null);
+  }
+
+  /**
+   * Returns the id of the current active group.
+   */
+  getActiveGroupId(): ?number {
+    const tracing = assertSkeleton(Store.getState().tracing);
+    return getActiveGroup(tracing)
+      .map(group => group.groupId)
       .getOrElse(null);
   }
 
@@ -330,6 +342,18 @@ class TracingApi {
     const { tracing } = Store.getState();
     assertSkeleton(tracing);
     Store.dispatch(setActiveTreeByNameAction(treeName));
+  }
+
+  /**
+   * Makes the specified group active. Nodes cannot be added through the UI when a group is active.
+   *
+   * @example
+   * api.tracing.setActiveGroup(3);
+   */
+  setActiveGroup(groupId: number) {
+    const { tracing } = Store.getState();
+    assertSkeleton(tracing);
+    Store.dispatch(setActiveGroupAction(groupId));
   }
 
   /**
@@ -752,6 +776,16 @@ class TracingApi {
    */
   getCameraPosition(): Vector3 {
     return getPosition(Store.getState().flycam);
+  }
+
+  /**
+   * Sets the current camera position.
+   *
+   * @example
+   * api.tracing.setCameraPosition([100, 100, 100])
+   */
+  setCameraPosition(position: Vector3) {
+    Store.dispatch(setPositionAction(position));
   }
 
   //  VOLUMETRACING API

--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -712,7 +712,7 @@ class TracingApi {
   }
 
   /**
-   * Starts an animation to center the given position.
+   * Starts an animation to center the given position. See setCameraPosition for a non-animated version of this function.
    *
    * @param position - Vector3
    * @param skipDimensions - Boolean which decides whether the third dimension shall also be animated (defaults to true)
@@ -779,7 +779,7 @@ class TracingApi {
   }
 
   /**
-   * Sets the current camera position.
+   * Sets the current camera position. See centerPositionAnimated for an animated version of this function.
    *
    * @example
    * api.tracing.setCameraPosition([100, 100, 100])

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -79,6 +79,11 @@ type State = {
   activeTreeDropdownId: ?number,
 };
 
+const didTreeDataChange = (prevProps: Props, nextProps: Props): boolean =>
+  prevProps.trees !== nextProps.trees ||
+  prevProps.treeGroups !== nextProps.treeGroups ||
+  prevProps.sortBy !== nextProps.sortBy;
+
 class TreeHierarchyView extends React.PureComponent<Props, State> {
   state = {
     expandedGroupIds: { [MISSING_GROUP_ID]: true },
@@ -89,12 +94,7 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
-    if (
-      prevState.prevProps == null ||
-      prevState.prevProps.trees !== nextProps.trees ||
-      prevState.prevProps.treeGroups !== nextProps.treeGroups ||
-      prevState.prevProps.sortBy !== nextProps.sortBy
-    ) {
+    if (prevState.prevProps == null || didTreeDataChange(prevState.prevProps, nextProps)) {
       // Insert the trees into the corresponding groups and create a
       // groupTree object that can be rendered using a SortableTree component
       const groupToTreesMap = createGroupToTreesMap(nextProps.trees);
@@ -125,10 +125,10 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
   async componentDidUpdate(prevProps: Props) {
     // TODO: Workaround, remove after https://github.com/frontend-collective/react-sortable-tree/issues/305 is fixed
     // Also remove the searchFocusOffset from the state and hard-code it as 0
-    if (
-      prevProps.trees !== this.props.trees &&
-      prevProps.activeTreeId !== this.props.activeTreeId
-    ) {
+    const didSearchTermChange =
+      prevProps.activeTreeId !== this.props.activeTreeId ||
+      prevProps.activeGroupId !== this.props.activeGroupId;
+    if (didTreeDataChange(prevProps, this.props) && didSearchTermChange) {
       // eslint-disable-next-line react/no-did-update-set-state
       await this.setState({ searchFocusOffset: 1 });
       // eslint-disable-next-line react/no-did-update-set-state

--- a/frontend/javascripts/test/api/api_skeleton_latest.spec.js
+++ b/frontend/javascripts/test/api/api_skeleton_latest.spec.js
@@ -28,6 +28,17 @@ test("getActiveTree should get the active tree id", t => {
   t.is(api.tracing.getActiveTreeId(), 2);
 });
 
+test("getActiveGroupId should get the active group id", t => {
+  const api = t.context.api;
+  t.is(api.tracing.getActiveGroupId(), null);
+});
+
+test("setActiveGroupId should set the active group id", t => {
+  const api = t.context.api;
+  api.tracing.setActiveGroup(3);
+  t.is(api.tracing.getActiveGroupId(), 3);
+});
+
 test("getAllNodes should get a list of all nodes", t => {
   const api = t.context.api;
   const nodes = api.tracing.getAllNodes();
@@ -62,6 +73,13 @@ test("getCameraPosition should return the current camera position", t => {
   const api = t.context.api;
   const cameraPosition = api.tracing.getCameraPosition();
   t.deepEqual(cameraPosition, [1, 2, 3]);
+});
+
+test("setCameraPosition should set the current camera position", t => {
+  const api = t.context.api;
+  api.tracing.setCameraPosition([7, 8, 9]);
+  const cameraPosition = api.tracing.getCameraPosition();
+  t.deepEqual(cameraPosition, [7, 8, 9]);
 });
 
 test("Data Api: getLayerNames should get an array of all layer names", t => {

--- a/frontend/javascripts/test/fixtures/skeletontracing_server_objects.js
+++ b/frontend/javascripts/test/fixtures/skeletontracing_server_objects.js
@@ -62,7 +62,10 @@ export const tracing: ServerSkeletonTracing = {
       name: "explorative_2017-08-09_SCM_Boy_001",
     },
   ],
-  treeGroups: [],
+  treeGroups: [
+    { children: [], name: "Group 1", groupId: 1 },
+    { children: [{ children: [], name: "Group 3", groupId: 3 }], name: "Group 2", groupId: 2 },
+  ],
   dataSetName: "ROI2017_wkw",
   createdTimestamp: 1502302761387,
   userBoundingBoxes: [],


### PR DESCRIPTION
These fairly basic api functions have been missing which I noticed while writing a project-related user script.
I also fixed a bug in the tree list, where we have to work around a bug in the `react-sortable-tree` library which messes with the highlighting of the `active{Tree,Group}`. The condition when this workaround should be applied was incomplete.

### URL of deployed dev instance (used for testing):
- https://apiextension.webknossos.xyz

### Steps to test:
- Can be tested from the dev console:
  - `webknossos.apiReady(3).then(api => api.tracing.setActiveGroup(2))`
  - `webknossos.apiReady(3).then(api => console.log(api.tracing.getActiveGroupId()))`
  - `webknossos.apiReady(3).then(api => api.tracing.setCameraPosition([100, 100, 200]))`

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
