### PR TITLE
Fix Bounding Box Checks for Tiff Export

### DIFF
--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -138,7 +138,7 @@ class JobService @Inject()(wkConf: WkConf, jobDAO: JobDAO, rpc: RPC, analyticsSe
 
   def assertTiffExportBoundingBoxLimits(bbox: String): Fox[Unit] =
     for {
-      boundingBox <- BoundingBox.fromForm(bbox).toFox
+      boundingBox <- BoundingBox.createFrom(bbox).toFox ?~> "job.export.tiff.invalidBoundingBox"
       _ <- bool2Fox(boundingBox.volume <= wkConf.Features.exportTiffMaxVolumeMVx * 1024 * 1024) ?~> "job.export.tiff.volumeExceeded"
       _ <- bool2Fox(boundingBox.dimensions.maxDim <= wkConf.Features.exportTiffMaxEdgeLengthVx) ?~> "job.export.tiff.edgeLengthExceeded"
     } yield ()

--- a/conf/messages
+++ b/conf/messages
@@ -316,6 +316,7 @@ job.couldNotRunCubing = Failed to start WKW conversion job.
 job.couldNotRunTiffExport = Failed to start Tiff export job.
 job.disabled = Long-running jobs are not enabled for this webKnossos instance.
 job.export.fileNotFound = Exported file not found. The link may be expired.
+job.export.tiff.invalidBoundingBox = The selected bounding box could not be parsed, must be x,y,z,width,height,depth
 job.export.tiff.volumeExceeded = The volume of the selected bounding box is too large.
 job.export.tiff.edgeLengthExceeded = An edge length of the selected bounding box is too large.
 

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -4,7 +4,7 @@ import net.liftweb.common.{Box, Empty, Full}
 
 case class BoundingBox(topLeft: Point3D, width: Int, height: Int, depth: Int) {
 
-  val bottomRight = topLeft.move(width, height, depth)
+  val bottomRight: Point3D = topLeft.move(width, height, depth)
 
   def intersects(other: BoundingBox): Boolean =
     math.max(topLeft.x, other.topLeft.x) < math.min(bottomRight.x, other.bottomRight.x) &&
@@ -29,14 +29,14 @@ case class BoundingBox(topLeft: Point3D, width: Int, height: Int, depth: Int) {
   def center: Point3D =
     topLeft.move(bottomRight).scale(0.5f)
 
-  def scale(s: Float) =
+  def scale(s: Float): BoundingBox =
     BoundingBox(topLeft.scale(s), (width * s).toInt, (height * s).toInt, (depth * s).toInt)
 
   def toSql =
     List(topLeft.x, topLeft.y, topLeft.z, width, height, depth)
 
   def volume: Long =
-    width * height * depth
+    width.toLong * height.toLong * depth.toLong
 
   def dimensions: Point3D =
     Point3D(width, height, depth)
@@ -47,31 +47,27 @@ object BoundingBox {
 
   import play.api.libs.json._
 
-  val formRx = "\\s*([0-9]+),\\s*([0-9]+),\\s*([0-9]+)\\s*,\\s*([0-9]+),\\s*([0-9]+),\\s*([0-9]+)\\s*".r
+  private val formRx = "\\s*([0-9]+),\\s*([0-9]+),\\s*([0-9]+)\\s*,\\s*([0-9]+),\\s*([0-9]+),\\s*([0-9]+)\\s*".r
 
-  def empty =
+  def empty: BoundingBox =
     BoundingBox(Point3D(0, 0, 0), 0, 0, 0)
 
-  def toForm(b: BoundingBox): Some[String] =
-    Some(
-      "%d, %d, %d, %d, %d, %d".format(
-        b.topLeft.x,
-        b.topLeft.y,
-        b.topLeft.z,
-        b.topLeft.x + b.width,
-        b.topLeft.y + b.height,
-        b.topLeft.z + b.depth
-      ))
-
-  def fromForm(s: String): Box[BoundingBox] =
+  def createFrom(s: String): Box[BoundingBox] =
     s match {
-      case formRx(minX, minY, minZ, maxX, maxY, maxZ) =>
-        createFrom(
-          Point3D(Integer.parseInt(minX), Integer.parseInt(minY), Integer.parseInt(minZ)),
-          Point3D(Integer.parseInt(maxX), Integer.parseInt(maxY), Integer.parseInt(maxZ))
-        )
+      case formRx(minX, minY, minZ, width, height, depth) =>
+        try {
+          Full(
+            BoundingBox(
+              Point3D(Integer.parseInt(minX), Integer.parseInt(minY), Integer.parseInt(minZ)),
+              Integer.parseInt(width),
+              Integer.parseInt(height),
+              Integer.parseInt(depth)
+            ))
+        } catch {
+          case _: NumberFormatException => Empty
+        }
       case _ =>
-        null
+        Empty
     }
 
   def combine(bbs: List[BoundingBox]): BoundingBox =
@@ -98,14 +94,11 @@ object BoundingBox {
     else
       Empty
 
-  def createFrom(width: Int, height: Int, deph: Int, topLeft: Point3D): BoundingBox =
-    BoundingBox(topLeft, width, height, deph)
-
-  def fromSQL(ints: List[Int]) =
+  def fromSQL(ints: List[Int]): Option[BoundingBox] =
     if (ints.length == 6)
       Some(BoundingBox(Point3D(ints(0), ints(1), ints(2)), ints(3), ints(4), ints(5)))
     else
       None
 
-  implicit val boundingBoxFormat = Json.format[BoundingBox]
+  implicit val boundingBoxFormat: OFormat[BoundingBox] = Json.format[BoundingBox]
 }


### PR DESCRIPTION
Follow-up Bugfix for #5195 

 - Correctly parse bounding box for size assertions (assume width,height,depth instead of xmax,ymax,zmax)
 - Use Long multiplication for volume to avoid int overflow
 - Remove some unused util methods in BoundingBox class
 - Add some typing to public methods in BoundingBox class

### Steps to test:
- with jobsEnabled, go to routes 
- `GET http://localhost:9000/api/jobs/run/tiffExport/sample_organization/testDataset/color?bbox=50,50,50,5000,5000,5000` (should say volume too large)
- `GET http://localhost:9000/api/jobs/run/tiffExport/sample_organization/testDataset/color?bbox=50,50,50,10,10,10` (check should go through, attempt contacting jobs broker. this was broken before, as 10,10,10 was assumed to be bottom-right, which was invalid)
- (I did test these locally)
- CI should run through

- [x] Ready for review
