### PR TITLE
Small Fixes for Tiff Export

### DIFF
--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -190,7 +190,7 @@ class JobsController @Inject()(jobDAO: JobDAO,
       for {
         organization <- organizationDAO.findOneByName(organizationName) ?~> Messages("organization.notFound",
                                                                                      organizationName)
-        _ <- bool2Fox(request.identity._organization == organization._id) ~> FORBIDDEN
+        _ <- bool2Fox(request.identity._organization == organization._id) ?~> "job.export.notAllowed.organization" ~> FORBIDDEN
         _ <- jobService.assertTiffExportBoundingBoxLimits(bbox)
         command = "export_tiff"
         exportFileName = s"${formatDateForFilename(new Date())}__${dataSetName}__${layerName}.zip"

--- a/conf/messages
+++ b/conf/messages
@@ -319,6 +319,7 @@ job.export.fileNotFound = Exported file not found. The link may be expired.
 job.export.tiff.invalidBoundingBox = The selected bounding box could not be parsed, must be x,y,z,width,height,depth
 job.export.tiff.volumeExceeded = The volume of the selected bounding box is too large.
 job.export.tiff.edgeLengthExceeded = An edge length of the selected bounding box is too large.
+job.export.notAllowed.organization = Currently tiff export is only allowed for datasets of your own organization.
 
 agglomerateSkeleton.failed=Could not generate agglomerate skeleton.
 

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -796,6 +796,7 @@ export async function getJobs(): Promise<Array<APIJob>> {
     datasetName: job.commandArgs.kwargs.dataset_name,
     organizationName: job.commandArgs.kwargs.organization_name,
     layerName: job.commandArgs.kwargs.layer_name,
+    boundingBox: job.commandArgs.kwargs.bbox,
     exportFileName: job.commandArgs.kwargs.export_file_name,
     state: job.celeryInfo.state || "UNKNOWN",
     createdAt: job.created,

--- a/frontend/javascripts/admin/job/job_list_view.js
+++ b/frontend/javascripts/admin/job/job_list_view.js
@@ -92,7 +92,7 @@ class JobListView extends React.PureComponent<Props, State> {
           <Link to={`/datasets/${job.organizationName}/${job.datasetName}/view`}>
             {job.datasetName}
           </Link>{" "}
-          (Box {job.boundingBox})
+          (Bounding Box {job.boundingBox})
         </span>
       );
     } else {

--- a/frontend/javascripts/admin/job/job_list_view.js
+++ b/frontend/javascripts/admin/job/job_list_view.js
@@ -91,7 +91,8 @@ class JobListView extends React.PureComponent<Props, State> {
           Tiff export from {job.layerName || "a"} layer of{" "}
           <Link to={`/datasets/${job.organizationName}/${job.datasetName}/view`}>
             {job.datasetName}
-          </Link>
+          </Link>{" "}
+          (Box {job.boundingBox})
         </span>
       );
     } else {

--- a/frontend/javascripts/oxalis/view/settings/export_bounding_box_modal.js
+++ b/frontend/javascripts/oxalis/view/settings/export_bounding_box_modal.js
@@ -10,10 +10,11 @@ import * as Utils from "libs/utils";
 type Props = {
   destroy: () => void,
   dataset: APIDataset,
+  hasVolumeTracing: boolean,
   boundingBox: BoundingBoxType,
 };
 
-const ExportBoundingBoxModal = ({ destroy, dataset, boundingBox }: Props) => {
+const ExportBoundingBoxModal = ({ destroy, dataset, hasVolumeTracing, boundingBox }: Props) => {
   const [startedExports, setStartedExports] = useState([]);
 
   const handleClose = () => {
@@ -31,12 +32,15 @@ const ExportBoundingBoxModal = ({ destroy, dataset, boundingBox }: Props) => {
   };
 
   const layerNames = dataset.dataSource.dataLayers.map(layer => {
-    const nameIfColor = layer.category === "color" ? layer.name : null;
+    const nameIfFromDataset = layer.category === "color" || !hasVolumeTracing ? layer.name : null;
     const nameIfVolume =
-      layer.category === "segmentation" && layer.fallbackLayerInfo && layer.fallbackLayerInfo.name
+      hasVolumeTracing &&
+      layer.category === "segmentation" &&
+      layer.fallbackLayerInfo &&
+      layer.fallbackLayerInfo.name
         ? layer.fallbackLayerInfo.name
         : null;
-    return nameIfColor || nameIfVolume;
+    return nameIfFromDataset || nameIfVolume;
   });
 
   const exportButtonsList = layerNames.map(layerName =>

--- a/frontend/javascripts/oxalis/view/settings/export_bounding_box_modal.js
+++ b/frontend/javascripts/oxalis/view/settings/export_bounding_box_modal.js
@@ -34,10 +34,7 @@ const ExportBoundingBoxModal = ({ destroy, dataset, hasVolumeTracing, boundingBo
   const layerNames = dataset.dataSource.dataLayers.map(layer => {
     const nameIfFromDataset = layer.category === "color" || !hasVolumeTracing ? layer.name : null;
     const nameIfVolume =
-      hasVolumeTracing &&
-      layer.category === "segmentation" &&
-      layer.fallbackLayerInfo &&
-      layer.fallbackLayerInfo.name
+      hasVolumeTracing && layer.category === "segmentation" && layer.fallbackLayerInfo != null
         ? layer.fallbackLayerInfo.name
         : null;
     return nameIfFromDataset || nameIfVolume;

--- a/frontend/javascripts/oxalis/view/settings/user_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/user_settings_view.js
@@ -146,6 +146,7 @@ class UserSettingsView extends PureComponent<UserSettingsViewProps> {
       renderIndependently(destroy => (
         <ExportBoundingBoxModal
           dataset={this.props.dataset}
+          hasVolumeTracing={this.props.tracing.volume != null}
           boundingBox={selectedBoundingBox.boundingBox}
           destroy={destroy}
         />

--- a/frontend/javascripts/types/api_flow_types.js
+++ b/frontend/javascripts/types/api_flow_types.js
@@ -551,6 +551,7 @@ export type APIJob = {
   +exportFileName: ?string,
   +layerName: ?string,
   +organizationName: ?string,
+  +boundingBox: ?string,
   +type: string,
   +state: string,
   +createdAt: number,


### PR DESCRIPTION
### Steps to test:
- set `jobsEnabled = true` in application.conf
- bounding box of export jobs should now be visible in jobs list view
- when attempting to export from a dataset of a different orga, a readable error message should be shown
- when exporting from view mode or skeleton-only annotation, segmentation layer should be available in export modal (volume without fallback is the only case where it should be hidden)

### Issues:
- fixes #5248 
- fixes #5249 
- fixes #5251

------
- [x] Ready for review
