### PR TITLE
breakWord for layer name above histogram

### DIFF
--- a/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
+++ b/frontend/javascripts/oxalis/view/settings/dataset_settings_view.js
@@ -347,7 +347,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
       <Row>
         <Col span={24}>
           {this.getEnableDisableLayerSwitch(isDisabled, onChange)}
-          <span style={{ fontWeight: 700 }}>
+          <span style={{ fontWeight: 700, wordWrap: "break-word" }}>
             {!isColorLayer && isVolumeTracing ? "Volume Annotation" : layerName}
           </span>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1390035/110780999-9f3fd300-8265-11eb-9bb6-1af28ec66a57.png)

### Steps to test:
- rename the layer of a dataset to a very long name but no hyphens
- refresh datasource-properties.json
- open in webKnossos viewer, open settings pane
- name should be fully readable
- name should not overlap with other UI elemnts (like the histogram data)

### Issues:
- fixes #5094 

------
- [x] Ready for review
