### PR TITLE
Track failed jobs to slack + analytics

### DIFF
--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -176,6 +176,12 @@ case class RunJobEvent(user: User, command: String)(implicit ec: ExecutionContex
     Fox.successful(Json.obj("command" -> command))
 }
 
+case class FailedJobEvent(user: User, command: String)(implicit ec: ExecutionContext) extends AnalyticsEvent {
+  def eventType: String = "failed_job"
+  def eventProperties(analyticsLookUpService: AnalyticsLookUpService): Fox[JsObject] =
+    Fox.successful(Json.obj("command" -> command))
+}
+
 case class UploadDatasetEvent(user: User, dataSet: DataSet, dataStore: DataStore, dataSetSizeBytes: Long)(
     implicit ec: ExecutionContext)
     extends AnalyticsEvent {


### PR DESCRIPTION
Log failed worker jobs to slack + backend analytics

### Steps to test:
- in application.conf set `features.jobsEnabled = true`, `backendAnalytics.verboseLoggingEnabled = true`, `slackNotifications.verboseLoggingEnabled = true`
- set up worker, but modify it so that jobs fail (e.g. raise an exception in a task)
- call that task from wk
- open jobs list, see failed job
- backend logging should show what messages would have been sent to analytics + slack
- while jobs list stays open, celery infos are repeatedly fetched, but messages should only fire for *newly* failed jobs.

### Issues:
- fixes #5286 

------
- [x] Ready for review
