### PR TITLE
Ignore escaped carriage return in diff schema

### DIFF
--- a/tools/postgres/diff_schema.js
+++ b/tools/postgres/diff_schema.js
@@ -101,7 +101,6 @@ function generateRandomName() {
   return "wk_tmp_" + random;
 }
 
-
 function sortAndClean(dumpedDir) {
   glob.sync(dumpedDir + "/**", { nodir: true }).forEach(function(fileName) {
     replace({ files: fileName, replace: /,$/gm, with: "" });

--- a/tools/postgres/diff_schema.js
+++ b/tools/postgres/diff_schema.js
@@ -101,6 +101,15 @@ function generateRandomName() {
   return "wk_tmp_" + random;
 }
 
+
+function sortAndClean(dumpedDir) {
+  glob.sync(dumpedDir + "/**", { nodir: true }).forEach(function(fileName) {
+    replace({ files: fileName, replace: /,$/gm, with: "" });
+    replace({ files: fileName, replace: /\\r/gm, with: "" });
+    sortFile(fileName);
+  });
+}
+
 function sortFile(fileName) {
   try {
     const content = fs.readFileSync(fileName);
@@ -134,16 +143,9 @@ try {
   program.parse(process.argv);
   dir1 = dump(p1);
   dir2 = dump(p2);
-  // sort and remove commas
-  glob.sync(dir1 + "/**", { nodir: true }).forEach(function(fileName) {
-    replace({ files: fileName, replace: /,$/gm, with: "" });
-    sortFile(fileName);
-  });
-  glob.sync(dir2 + "/**", { nodir: true }).forEach(function(fileName) {
-    replace({ files: fileName, replace: /,$/gm, with: "" });
-    sortFile(fileName);
-  });
-
+  // sort and remove commas and occurences of "\r"
+  sortAndClean(dir1);
+  sortAndClean(dir2);
   // diff
   try {
     execSync("diff --strip-trailing-cr -r " + dir1 + " " + dir2);


### PR DESCRIPTION
Turns out psql escapes carriage returns in function definitions.
These should be ignored when checking schema diffs.

This creates a potential for false negatives (if the real difference is the existence of `\r' in the schema), but as discussed this seems rare enough to take the risk.

### Steps to test:
- Insert '\r' somewhere in the schema (while preserving sql validity)
- run diff_schema.js
- should not show differences induced by `\r`occurences, should still show other differences

### Issues:
- fixes #5293 

------
- [x] Ready for review
