### PR TITLE
Add requested url to rejection reason for better error reporting

### DIFF
--- a/frontend/javascripts/libs/request.js
+++ b/frontend/javascripts/libs/request.js
@@ -300,13 +300,15 @@ class Request {
               // to a datastore. Then, ping the datastore
               pingMentionedDataStores(text);
 
-              return Promise.reject(json);
+              /* eslint-disable-next-line prefer-promise-reject-errors */
+              return Promise.reject({ ...json, url: requestedUrl });
             } catch (jsonError) {
               if (showErrorToast) Toast.error(text);
               /* eslint-disable-next-line prefer-promise-reject-errors */
               return Promise.reject({
                 errors: [text],
                 status: error.status != null ? error.status : -1,
+                url: requestedUrl,
               });
             }
           },


### PR DESCRIPTION
@fm3 and I noticed that airbrake shows frequent failed bucket requests with a `404` status. It's unclear where this status is coming from. Unfortunately, the failing request reports don't show any url which is why I added that url.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I tested the following things:
  - break the actual bucket fetching url (failing url will be printed)
  - break the token request url (failing url will be printed)
  - add a "throw error" into the buffer extraction code (error will be printed)

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
