### PR TITLE
Unify job names, prepare for auto-detect cuber

### DIFF
--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -6,7 +6,7 @@ This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 
 ## Unreleased
--
+- Instances with long-running jobs only: the `tiff_cubing` job was renamed to `convert_to_wkw`. For old jobs to be listed properly, execute sql `update webknossos.jobs set command = 'convert_to_wkw' where command = 'tiff_cubing';`
 
 ### Postgres Evolutions:
 - [066-publications-foreign-key.sql](conf/evolutions/066-publications-foreign-key.sql)

--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -169,13 +169,13 @@ class JobsController @Inject()(jobDAO: JobDAO,
     } yield Ok(js)
   }
 
-  def runCubingJob(organizationName: String, dataSetName: String, scale: String): Action[AnyContent] =
+  def runConvertToWkwJob(organizationName: String, dataSetName: String, scale: String): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {
         organization <- organizationDAO.findOneByName(organizationName) ?~> Messages("organization.notFound",
                                                                                      organizationName)
         _ <- bool2Fox(request.identity._organization == organization._id) ~> FORBIDDEN
-        command = "tiff_cubing"
+        command = "convert_to_wkw"
         commandArgs = Json.obj("organization_name" -> organizationName, "dataset_name" -> dataSetName, "scale" -> scale)
 
         job <- jobService.runJob(command, commandArgs, request.identity) ?~> "job.couldNotRunCubing"
@@ -183,7 +183,7 @@ class JobsController @Inject()(jobDAO: JobDAO,
       } yield Ok(js)
     }
 
-  def runTiffExportJob(organizationName: String,
+  def runExportTiffJob(organizationName: String,
                        dataSetName: String,
                        bbox: String,
                        layerName: Option[String],

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -195,4 +195,4 @@ GET           /jobs                                                            c
 GET           /jobs/:id                                                        controllers.JobsController.get(id: String)
 GET           /jobs/:id/downloadExport/:exportFileName                         controllers.JobsController.downloadExport(id: String, exportFileName: String)
 GET           /jobs/run/convertToWkw/:organizationName/:dataSetName            controllers.JobsController.runConvertToWkwJob(organizationName: String, dataSetName: String, scale: String)
-GET           /jobs/run/exportTiff/:organizationName/:dataSetName              controllers.JobsController.runTiffExportJob(organizationName: String, dataSetName: String, bbox: String, layerName: Option[String], tracingId: Option[String], tracingVersion: Option[String])
+GET           /jobs/run/exportTiff/:organizationName/:dataSetName              controllers.JobsController.runExportTiffJob(organizationName: String, dataSetName: String, bbox: String, layerName: Option[String], tracingId: Option[String], tracingVersion: Option[String])

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -194,5 +194,5 @@ GET           /time/user/:userId                                               c
 GET           /jobs                                                            controllers.JobsController.list
 GET           /jobs/:id                                                        controllers.JobsController.get(id: String)
 GET           /jobs/:id/downloadExport/:exportFileName                         controllers.JobsController.downloadExport(id: String, exportFileName: String)
-GET           /jobs/run/cubing/:organizationName/:dataSetName                  controllers.JobsController.runCubingJob(organizationName: String, dataSetName: String, scale: String)
-GET           /jobs/run/tiffExport/:organizationName/:dataSetName              controllers.JobsController.runTiffExportJob(organizationName: String, dataSetName: String, bbox: String, layerName: Option[String], tracingId: Option[String], tracingVersion: Option[String])
+GET           /jobs/run/convertToWkw/:organizationName/:dataSetName            controllers.JobsController.runConvertToWkwJob(organizationName: String, dataSetName: String, scale: String)
+GET           /jobs/run/exportTiff/:organizationName/:dataSetName              controllers.JobsController.runTiffExportJob(organizationName: String, dataSetName: String, bbox: String, layerName: Option[String], tracingId: Option[String], tracingVersion: Option[String])

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -827,17 +827,17 @@ export async function getJobs(): Promise<Array<APIJob>> {
   }));
 }
 
-export async function startCubingJob(
+export async function startConvertToWkwJob(
   datasetName: string,
   organizationName: string,
   scale: Vector3,
 ): Promise<Array<APIJob>> {
   return Request.receiveJSON(
-    `/api/jobs/run/cubing/${organizationName}/${datasetName}?scale=${scale.toString()}`,
+    `/api/jobs/run/convertToWkw/${organizationName}/${datasetName}?scale=${scale.toString()}`,
   );
 }
 
-export async function startTiffExportJob(
+export async function startExportTiffJob(
   datasetName: string,
   organizationName: string,
   bbox: Vector6,
@@ -849,7 +849,7 @@ export async function startTiffExportJob(
   const tracingIdSuffix = tracingId != null ? `&tracingId=${tracingId}` : "";
   const tracingVersionSuffix = tracingVersion != null ? `&tracingVersion=${tracingVersion}` : "";
   return Request.receiveJSON(
-    `/api/jobs/run/tiffExport/${organizationName}/${datasetName}?bbox=${bbox.join(
+    `/api/jobs/run/exportTiff/${organizationName}/${datasetName}?bbox=${bbox.join(
       ",",
     )}${layerNameSuffix}${tracingIdSuffix}${tracingVersionSuffix}`,
   );

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.js
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.js
@@ -12,7 +12,7 @@ import type { OxalisState } from "oxalis/store";
 import {
   finishDatasetUpload,
   createResumableUpload,
-  startCubingJob,
+  startConvertToWkwJob,
   sendFailedRequestAnalyticsEvent,
 } from "admin/admin_rest_api";
 import Toast from "libs/toast";
@@ -151,7 +151,11 @@ class DatasetUploadView extends React.PureComponent<PropsWithFormAndRouter, Stat
               let maybeError;
               if (this.state.needsConversion) {
                 try {
-                  await startCubingJob(formValues.name, activeUser.organization, formValues.scale);
+                  await startConvertToWkwJob(
+                    formValues.name,
+                    activeUser.organization,
+                    formValues.scale,
+                  );
                 } catch (error) {
                   maybeError = error;
                 }

--- a/frontend/javascripts/admin/job/job_list_view.js
+++ b/frontend/javascripts/admin/job/job_list_view.js
@@ -83,7 +83,7 @@ class JobListView extends React.PureComponent<Props, State> {
   };
 
   renderDescription = (__: any, job: APIJob) => {
-    if (job.type === "tiff_cubing" && job.datasetName) {
+    if (job.type === "convert_to_wkw" && job.datasetName) {
       return <span>{`Tiff to WKW conversion of ${job.datasetName}`}</span>;
     } else if (job.type === "export_tiff" && job.organizationName && job.datasetName) {
       const layerLabel = job.tracingId != null ? "volume annotation" : job.layerName || "a";
@@ -102,7 +102,7 @@ class JobListView extends React.PureComponent<Props, State> {
   };
 
   renderActions = (__: any, job: APIJob) => {
-    if (job.type === "tiff_cubing") {
+    if (job.type === "convert_to_wkw") {
       return (
         <span>
           {job.state === "SUCCESS" && job.datasetName && this.props.activeUser && (

--- a/frontend/javascripts/oxalis/view/settings/export_bounding_box_modal.js
+++ b/frontend/javascripts/oxalis/view/settings/export_bounding_box_modal.js
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import type { BoundingBoxType } from "oxalis/constants";
 import type { VolumeTracing } from "oxalis/store";
 import type { APIDataset, APIDataLayer } from "types/api_flow_types";
-import { startTiffExportJob } from "admin/admin_rest_api";
+import { startExportTiffJob } from "admin/admin_rest_api";
 import { getResolutionInfo } from "oxalis/model/accessors/dataset_accessor";
 import Model from "oxalis/model";
 import features from "features";
@@ -31,7 +31,7 @@ const ExportBoundingBoxModal = ({ destroy, dataset, boundingBox, volumeTracing }
     if (layerInfos.tracingId) {
       await Model.ensureSavedState();
     }
-    await startTiffExportJob(
+    await startExportTiffJob(
       dataset.name,
       dataset.owningOrganization,
       Utils.computeArrayFromBoundingBox(boundingBox),


### PR DESCRIPTION
Corresponding worker pr: https://github.com/scalableminds/webknossos-worker/pull/11

### Steps to test:
- set up https://github.com/scalableminds/webknossos-worker/pull/11
- upload dataset (any format that the cuber now understands)
- should be converted and then be usable

### Issues:
- fixes #5299

------
- [x] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Ready for review
