### PR TITLE
Fix uploading NML via file picker

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a regression in the task search which could lead to a frontend crash. [#5267](https://github.com/scalableminds/webknossos/pull/5267)
 - Fixed a rendering bug in oblique mode. [#5289](https://github.com/scalableminds/webknossos/pull/5289)
+- Fixed a bug where uploading NMLs from dashboard via file picker was inaccessible. [#5308](https://github.com/scalableminds/webknossos/pull/5308)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.js
@@ -61,20 +61,22 @@ function OverlayDropZone({ children }) {
   );
 }
 
-function NmlDropArea({ showClickHint, isUpdateAllowed }) {
+function NmlDropArea({ clickAllowed, isUpdateAllowed, getInputProps }) {
+  const clickInput = clickAllowed ? <input {...getInputProps()} /> : null;
   return (
-    <React.Fragment>
+    <div style={{ textAlign: "center", cursor: "pointer" }}>
+      {clickInput}
       <div>
         <Icon type="inbox" style={{ fontSize: 180, color: "rgb(58, 144, 255)" }} />
       </div>
       {isUpdateAllowed ? (
-        <h5>Drop NML files here{showClickHint ? " or click to select files" : null}...</h5>
+        <h5>Drop NML files here{clickAllowed ? " or click to select files" : null}...</h5>
       ) : (
         <h5>
           Drop NML files here to <b>create a new tracing</b>.
         </h5>
       )}
-    </React.Fragment>
+    </div>
   );
 }
 
@@ -174,9 +176,13 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
           }}
           onDrop={this.onDrop}
         >
-          {({ getRootProps }) => (
+          {({ getRootProps, getInputProps }) => (
             <div {...getRootProps()}>
-              <NmlDropArea showClickHint isUpdateAllowed={this.props.isUpdateAllowed} />
+              <NmlDropArea
+                clickAllowed
+                isUpdateAllowed={this.props.isUpdateAllowed}
+                getInputProps={getInputProps}
+              />
             </div>
           )}
         </Dropzone>
@@ -237,7 +243,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
         onDragLeave={this.onDragLeave}
         noKeyboard
       >
-        {({ getRootProps }) => (
+        {({ getRootProps, getInputProps }) => (
           <div
             {...getRootProps()}
             style={{ position: "relative", minHeight: `calc(100vh - ${navbarHeight}px)` }}
@@ -248,7 +254,11 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
             }
             {this.state.dropzoneActive && !this.props.showDropzoneModal ? (
               <OverlayDropZone>
-                <NmlDropArea showClickHint={false} isUpdateAllowed={this.props.isUpdateAllowed} />
+                <NmlDropArea
+                  clickAllowed={false}
+                  isUpdateAllowed={this.props.isUpdateAllowed}
+                  getInputProps={getInputProps}
+                />
               </OverlayDropZone>
             ) : null}
             {


### PR DESCRIPTION
Uploading NMLs via file picker was broken (only drag’n’drop still worked)

### URL of deployed dev instance (used for testing):
- https://nmluploadclick.webknossos.xyz

### Steps to test:
- Go to “Dashboard / My Annotations” tab
- Click “Upload Annotation(s)”
- Click blue “inbox” symbol
- File picker should let you pick NMLs
- uploading them should create annotations
- Drag’n’Drop should also still work

### Issues:
- fixes #5300

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
