### PR TITLE
Expose default user initial token to config

### DIFF
--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -54,6 +54,7 @@ class InitialDataService @Inject()(userService: UserService,
 
   private val defaultUserEmail = conf.Application.Authentication.DefaultUser.email
   private val defaultUserPassword = conf.Application.Authentication.DefaultUser.password
+  private val defaultUserToken = conf.Application.Authentication.DefaultUser.token
   private val additionalInformation = """**Sample Organization**
 
 Sample Street 123
@@ -151,7 +152,7 @@ Samplecountry
       case _ =>
         val newToken = Token(
           ObjectId.generate,
-          "secretScmBoyToken",
+          defaultUserToken,
           LoginInfo("credentials", defaultUser._id.id),
           new DateTime(System.currentTimeMillis()),
           new DateTime(System.currentTimeMillis() + expiryTime),

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -19,6 +19,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader {
       object DefaultUser {
         val email: String = get[String]("application.authentication.defaultUser.email")
         val password: String = get[String]("application.authentication.defaultUser.password")
+        val token: String = get[String]("application.authentication.defaultUser.token")
         val isSuperUser: Boolean = get[Boolean]("application.authentication.defaultUser.isSuperUser")
       }
       val ssoKey: String = get[String]("application.authentication.ssoKey")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -53,6 +53,7 @@ application {
     defaultUser = {
       email = "scmboy@scalableminds.com"
       password = "secret"
+      token = "secretScmBoyToken"
       isSuperUser = true
     }
     ssoKey = "something secure"


### PR DESCRIPTION
Expose default user token to config, to allow setting it to secret but known value for nightly tests

### Steps to test:
- change `application.authentication.defaultUser.token` in application.conf
- should show in UI at `/auth/token`

### Issues:
- contributes to #5298

------
- [x] Ready for review
