### PR TITLE
Aggressive Caching for assets

### DIFF
--- a/app/RequestHandler.scala
+++ b/app/RequestHandler.scala
@@ -34,7 +34,7 @@ class RequestHandler @Inject()(webCommands: WebCommands,
       super.routeRequest(request)
     } else if (request.uri.matches("^(/assets/).*$")) {
       val path = request.path.replaceFirst("^(/assets/)", "")
-      Some(assets.at(path = "/public", file = path))
+      Some(assets.at(path = "/public", file = path, aggressiveCaching = true))
     } else if (request.uri.matches("""^/sitemap.xml$""") && conf.Features.isDemoInstance) {
       Some(sitemapController.getSitemap(conf.Http.uri))
     } else if (request.uri == "/favicon.ico") {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### TODO
- [ ] differentiate between those assets with cache busters and those without
- [ ] check out configuration, something like
```
     *   "play.assets.cache./public/css"="max-age=100"
     *   "play.assets.cache./public/javascript"="max-age=200"
     *   "play.assets.cache./public/javascript/main.js"="max-age=300"
```

### Steps to test:
- abc

### Issues:
- fixes #123

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [ ] Ready for review
