### PR TITLE
Fix scale json schema

### DIFF
--- a/frontend/javascripts/types/schemas/datasource.schema.js
+++ b/frontend/javascripts/types/schemas/datasource.schema.js
@@ -139,7 +139,7 @@ export default {
         },
         scale: {
           type: "array",
-          items: { type: "number", minimum: 0, exclusiveMinimum: true },
+          items: { type: "number", exclusiveMinimum: 0 },
           minItems: 3,
           maxItems: 3,
         },

--- a/frontend/javascripts/types/schemas/datasource.types.js
+++ b/frontend/javascripts/types/schemas/datasource.types.js
@@ -62,6 +62,5 @@ export type DatasourceConfiguration = {
     team: string,
   },
   dataLayers: Array<DataLayer>,
-  // Add minimum=0 and exclusiveMinimum=true to items
   scale: Array<number>,
 };


### PR DESCRIPTION
I fixed the schema by using the [docs](https://json-schema.org/understanding-json-schema/reference/numeric.html#range). The docs say, that there is a difference between how `exclusiveMinimum` is used in version 4  and how it is used in later versions like 6 that we use. We simply used the outdated way of defining a minimum.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the edit view of a dataset, activate the advanced view, and fiddle around with the scale. 
  - Try to use only two numbers for the scale. -> Validation should fail.
  - Try to use four numbers for the scale. -> Validation should fail.
  - Try to use 0 as any number in the scale array. -> Validation should fail.
  - Try to use 0.4 as any number in the scale array. -> Validation should succeed.
  - Try to enter `[1,1,1]` as a valid scale.  -> Validation should succeed.
  - and more :)

### Issues:
- fixes #5129

------
- ~~[ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~~
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
