### PR TITLE
Make SSO opt-in in config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -30,6 +30,13 @@ play {
     http.idleTimeout = 10000s
     akka.requestTimeout = 10000s
   }
+  assets {
+    cache {
+      /public/bundle = null # recommended for production: "public, max-age=31536000, immutable"
+      /public/fonts = null # recommended for production: "public, max-age=604800"
+      /public/images = null # recommended for production: "public, max-age=604800"
+    }
+  }
 }
 
 # Actor settings
@@ -56,7 +63,7 @@ application {
       token = "secretScmBoyToken"
       isSuperUser = true
     }
-    ssoKey = "something secure"
+    ssoKey = ""
     inviteExpiry = 14 days
   }
 }


### PR DESCRIPTION
The code considers SSO is disabled when the config key is an empty string.

I also added the config part related to #5313 (but the null values are equal to how this behaved before. Only added those lines as hints how to set this in production).

### Steps to test:
- try SSO route, logging should say that it is disabled

### Issues:
- fixes #5317
- contributes to #5298
------
- [x] Ready for review
