### PR TITLE
Use auth token from environment variable during nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,10 +282,11 @@ workflows:
   version: 2
   circleci_build:
     jobs:
-      - build_test_deploy:
-          filters:
-            tags:
-              only: /.*/
+      - nightly
+      #- build_test_deploy:
+      #    filters:
+      #      tags:
+      #        only: /.*/
   circleci_nightly:
     jobs:
       - nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,11 +282,10 @@ workflows:
   version: 2
   circleci_build:
     jobs:
-      - nightly
-      #- build_test_deploy:
-      #    filters:
-      #      tags:
-      #        only: /.*/
+      - build_test_deploy:
+          filters:
+            tags:
+              only: /.*/
   circleci_nightly:
     jobs:
       - nightly

--- a/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
@@ -13,6 +13,10 @@ import {
   WK_AUTH_TOKEN,
 } from "./dataset_rendering_helpers";
 
+if (!WK_AUTH_TOKEN) {
+  throw new Error("No WK_AUTH_TOKEN specified.");
+}
+
 process.on("unhandledRejection", (err, promise) => {
   console.error("Unhandled rejection (promise: ", promise, ", reason: ", err, ").");
 });

--- a/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering.screenshot.js
@@ -10,7 +10,7 @@ import { compareScreenshot } from "./screenshot_helpers";
 import {
   screenshotDataset,
   screenshotDatasetWithMapping,
-  DEV_AUTH_TOKEN,
+  WK_AUTH_TOKEN,
 } from "./dataset_rendering_helpers";
 
 process.on("unhandledRejection", (err, promise) => {
@@ -43,7 +43,7 @@ async function getNewPage(browser: Browser) {
   const page = await browser.newPage();
   page.setViewport({ width: 1920, height: 1080 });
   page.setExtraHTTPHeaders({
-    "X-Auth-Token": DEV_AUTH_TOKEN,
+    "X-Auth-Token": WK_AUTH_TOKEN,
   });
   return page;
 }

--- a/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
@@ -10,9 +10,9 @@ import pixelmatch from "pixelmatch";
 import type { APIDatasetId } from "../../types/api_flow_types";
 import { createExplorational, updateDatasetConfiguration } from "../../admin/admin_rest_api";
 
-export const { DEV_AUTH_TOKEN } = process.env;
-if (!DEV_AUTH_TOKEN) {
-  throw new Error("No DEV_AUTH_TOKEN specified.");
+export const { WK_AUTH_TOKEN } = process.env;
+if (!WK_AUTH_TOKEN) {
+  throw new Error("No WK_AUTH_TOKEN specified.");
 }
 
 type Screenshot = {
@@ -26,7 +26,7 @@ function getDefaultRequestOptions(baseUrl: string) {
     host: baseUrl,
     doNotInvestigate: true,
     headers: {
-      "X-Auth-Token": DEV_AUTH_TOKEN,
+      "X-Auth-Token": WK_AUTH_TOKEN,
     },
   };
 }

--- a/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
@@ -10,7 +10,10 @@ import pixelmatch from "pixelmatch";
 import type { APIDatasetId } from "../../types/api_flow_types";
 import { createExplorational, updateDatasetConfiguration } from "../../admin/admin_rest_api";
 
-export const DEV_AUTH_TOKEN = "secretScmBoyToken";
+export const { DEV_AUTH_TOKEN } = process.env;
+if (!DEV_AUTH_TOKEN) {
+  throw new Error("No DEV_AUTH_TOKEN specified.");
+}
 
 type Screenshot = {
   screenshot: Buffer,


### PR DESCRIPTION
Our dev deployment is no longer using the public token. The nightly has to know the secret token, it is passed via environment variable.

### Steps to test:
- run nightly from this branch, should run green. (I did that already)

### Issues:
- fixes #5298 (in combination with recent kube changes)

------
- [x] Ready for review
