### PR TITLE
Analytics: mark annotation updates that are view-only

### DIFF
--- a/app/controllers/WKTracingStoreController.scala
+++ b/app/controllers/WKTracingStoreController.scala
@@ -2,8 +2,9 @@ package controllers
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import com.scalableminds.webknossos.tracingstore.TracingUpdatesReport
 import javax.inject.Inject
-import models.analytics.{AnalyticsService, UpdateAnnotationEvent}
+import models.analytics.{AnalyticsService, UpdateAnnotationEvent, UpdateAnnotationViewOnlyEvent}
 import models.annotation.AnnotationState._
 import models.annotation.{Annotation, AnnotationDAO, TracingStoreService}
 import models.binary.{DataSetDAO, DataSetService}
@@ -11,48 +12,51 @@ import models.organization.OrganizationDAO
 import models.user.time.TimeSpanService
 import oxalis.security.{WebknossosBearerTokenAuthenticatorService, WkSilhouetteEnvironment}
 import play.api.i18n.Messages
-import play.api.libs.json.{JsObject, JsValue, Json}
-import play.api.mvc.{Action, AnyContent}
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 
 import scala.concurrent.ExecutionContext
 
-class WKTracingStoreController @Inject()(tracingStoreService: TracingStoreService,
-                                         wkSilhouetteEnvironment: WkSilhouetteEnvironment,
-                                         timeSpanService: TimeSpanService,
-                                         dataSetService: DataSetService,
-                                         organizationDAO: OrganizationDAO,
-                                         analyticsService: AnalyticsService,
-                                         dataSetDAO: DataSetDAO,
-                                         annotationDAO: AnnotationDAO)(implicit ec: ExecutionContext)
+class WKTracingStoreController @Inject()(
+    tracingStoreService: TracingStoreService,
+    wkSilhouetteEnvironment: WkSilhouetteEnvironment,
+    timeSpanService: TimeSpanService,
+    dataSetService: DataSetService,
+    organizationDAO: OrganizationDAO,
+    analyticsService: AnalyticsService,
+    dataSetDAO: DataSetDAO,
+    annotationDAO: AnnotationDAO)(implicit ec: ExecutionContext, playBodyParsers: PlayBodyParsers)
     extends Controller
     with FoxImplicits {
 
   val bearerTokenService: WebknossosBearerTokenAuthenticatorService =
     wkSilhouetteEnvironment.combinedAuthenticatorService.tokenAuthenticatorService
 
-  def handleTracingUpdateReport(name: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
-    tracingStoreService.validateAccess(name) { _ =>
-      for {
-        tracingId <- (request.body \ "tracingId").asOpt[String].toFox
-        annotation <- annotationDAO.findOneByTracingId(tracingId)(GlobalAccessContext)
-        _ <- ensureAnnotationNotFinished(annotation)
-        timestamps <- (request.body \ "timestamps").asOpt[List[Long]].toFox
-        statisticsOpt = (request.body \ "statistics").asOpt[JsObject]
-        userTokenOpt = (request.body \ "userToken").asOpt[String]
-        _ <- statisticsOpt match {
-          case Some(statistics) => annotationDAO.updateStatistics(annotation._id, statistics)(GlobalAccessContext)
-          case None             => Fox.successful(())
-        }
-        _ <- annotationDAO.updateModified(annotation._id, System.currentTimeMillis)(GlobalAccessContext)
-        userBox <- bearerTokenService.userForTokenOpt(userTokenOpt)(GlobalAccessContext).futureBox
-        _ <- Fox.runOptional(userBox)(user =>
-          timeSpanService.logUserInteraction(timestamps, user, annotation)(GlobalAccessContext))
-        _ = userBox.map(user => analyticsService.track(UpdateAnnotationEvent(user, annotation)))
-      } yield {
-        Ok
+  def handleTracingUpdateReport(name: String): Action[TracingUpdatesReport] =
+    Action.async(validateJson[TracingUpdatesReport]) { implicit request =>
+      tracingStoreService.validateAccess(name) { _ =>
+        val report = request.body
+        for {
+          annotation <- annotationDAO.findOneByTracingId(report.tracingId)(GlobalAccessContext)
+          _ <- ensureAnnotationNotFinished(annotation)
+          _ <- Fox.runOptional(report.statistics) { statistics =>
+            annotationDAO.updateStatistics(annotation._id, statistics)(GlobalAccessContext)
+          }
+          _ <- annotationDAO.updateModified(annotation._id, System.currentTimeMillis)(GlobalAccessContext)
+          userBox <- bearerTokenService.userForTokenOpt(report.userToken)(GlobalAccessContext).futureBox
+          _ <- Fox.runOptional(userBox)(user =>
+            timeSpanService.logUserInteraction(report.timestamps, user, annotation)(GlobalAccessContext))
+          _ = userBox.map { user =>
+            if (report.significantChangesCount > 0) {
+              analyticsService.track(UpdateAnnotationEvent(user, annotation, report.significantChangesCount))
+            }
+            if (report.viewChangesCount > 0) {
+              analyticsService.track(UpdateAnnotationViewOnlyEvent(user, annotation, report.viewChangesCount))
+            }
+          }
+        } yield Ok
       }
     }
-  }
 
   private def ensureAnnotationNotFinished(annotation: Annotation) =
     if (annotation.state == Finished) Fox.failure("annotation already finshed")

--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -147,11 +147,19 @@ case class DownloadAnnotationEvent(user: User, annotationId: String, annotationT
     Fox.successful(Json.obj("annotation_id" -> annotationId, "annotation_type" -> annotationType))
 }
 
-case class UpdateAnnotationEvent(user: User, annotation: Annotation)(implicit ec: ExecutionContext)
+case class UpdateAnnotationEvent(user: User, annotation: Annotation, changesCount: Int)(implicit ec: ExecutionContext)
     extends AnalyticsEvent {
   def eventType: String = "update_annotation"
   def eventProperties(analyticsLookUpService: AnalyticsLookUpService): Fox[JsObject] =
-    Fox.successful(Json.obj("annotation_id" -> annotation._id.id))
+    Fox.successful(Json.obj("annotation_id" -> annotation._id.id, "changes_count" -> changesCount))
+}
+
+case class UpdateAnnotationViewOnlyEvent(user: User, annotation: Annotation, changesCount: Int)(
+    implicit ec: ExecutionContext)
+    extends AnalyticsEvent {
+  def eventType: String = "update_annotation_view_only"
+  def eventProperties(analyticsLookUpService: AnalyticsLookUpService): Fox[JsObject] =
+    Fox.successful(Json.obj("annotation_id" -> annotation._id.id, "changes_count" -> changesCount))
 }
 
 case class OpenDatasetEvent(user: User, dataSet: DataSet)(implicit ec: ExecutionContext) extends AnalyticsEvent {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -11,10 +11,14 @@ import com.scalableminds.webknossos.tracingstore.tracings.{
   UpdateAction,
   UpdateActionGroup
 }
-import com.scalableminds.webknossos.tracingstore.{TracingStoreAccessTokenService, TracingStoreWkRpcClient}
+import com.scalableminds.webknossos.tracingstore.{
+  TracingStoreAccessTokenService,
+  TracingStoreWkRpcClient,
+  TracingUpdatesReport
+}
 import play.api.i18n.Messages
 import play.api.libs.json.{Format, Json}
-import play.api.mvc.PlayBodyParsers
+import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 
 import scala.concurrent.ExecutionContext
@@ -47,7 +51,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
 
   implicit val bodyParsers: PlayBodyParsers
 
-  def save = Action.async(validateProto[T]) { implicit request =>
+  def save: Action[T] = Action.async(validateProto[T]) { implicit request =>
     log {
       logTime(slackNotificationService.noticeSlowRequest) {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
@@ -62,7 +66,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
     }
   }
 
-  def saveMultiple = Action.async(validateProto[Ts]) { implicit request =>
+  def saveMultiple: Action[Ts] = Action.async(validateProto[Ts]) { implicit request =>
     log {
       logTime(slackNotificationService.noticeSlowRequest) {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
@@ -80,7 +84,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
     }
   }
 
-  def get(tracingId: String, version: Option[Long]) = Action.async { implicit request =>
+  def get(tracingId: String, version: Option[Long]): Action[AnyContent] = Action.async { implicit request =>
     log {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
@@ -94,41 +98,43 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
     }
   }
 
-  def getMultiple = Action.async(validateJson[List[Option[TracingSelector]]]) { implicit request =>
-    log {
-      accessTokenService.validateAccess(UserAccessRequest.webknossos) {
-        AllowRemoteOrigin {
-          for {
-            tracings <- tracingService.findMultiple(request.body, applyUpdates = true)
-          } yield {
-            Ok(tracings.toByteArray).as("application/x-protobuf")
+  def getMultiple: Action[List[Option[TracingSelector]]] = Action.async(validateJson[List[Option[TracingSelector]]]) {
+    implicit request =>
+      log {
+        accessTokenService.validateAccess(UserAccessRequest.webknossos) {
+          AllowRemoteOrigin {
+            for {
+              tracings <- tracingService.findMultiple(request.body, applyUpdates = true)
+            } yield {
+              Ok(tracings.toByteArray).as("application/x-protobuf")
+            }
           }
         }
       }
-    }
   }
 
-  def update(tracingId: String) = Action.async(validateJson[List[UpdateActionGroup[T]]]) { implicit request =>
-    log {
-      logTime(slackNotificationService.noticeSlowRequest) {
-        accessTokenService.validateAccess(UserAccessRequest.writeTracing(tracingId)) {
-          AllowRemoteOrigin {
-            val updateGroups = request.body
-            val userToken = request.getQueryString("token")
-            if (updateGroups.forall(_.transactionGroupCount.getOrElse(1) == 1)) {
-              commitUpdates(tracingId, updateGroups, userToken).map(_ => Ok)
-            } else {
-              updateGroups
-                .foldLeft(tracingService.currentVersion(tracingId)) { (currentCommittedVersionFox, updateGroup) =>
-                  handleUpdateGroupForTransaction(tracingId, currentCommittedVersionFox, updateGroup, userToken)
-                }
-                .map(_ => Ok)
+  def update(tracingId: String): Action[List[UpdateActionGroup[T]]] =
+    Action.async(validateJson[List[UpdateActionGroup[T]]]) { implicit request =>
+      log {
+        logTime(slackNotificationService.noticeSlowRequest) {
+          accessTokenService.validateAccess(UserAccessRequest.writeTracing(tracingId)) {
+            AllowRemoteOrigin {
+              val updateGroups = request.body
+              val userToken = request.getQueryString("token")
+              if (updateGroups.forall(_.transactionGroupCount.getOrElse(1) == 1)) {
+                commitUpdates(tracingId, updateGroups, userToken).map(_ => Ok)
+              } else {
+                updateGroups
+                  .foldLeft(tracingService.currentVersion(tracingId)) { (currentCommittedVersionFox, updateGroup) =>
+                    handleUpdateGroupForTransaction(tracingId, currentCommittedVersionFox, updateGroup, userToken)
+                  }
+                  .map(_ => Ok)
+              }
             }
           }
         }
       }
     }
-  }
 
   val transactionBatchExpiry: FiniteDuration = 20 minutes
 
@@ -179,10 +185,16 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
   private def commitUpdates(tracingId: String,
                             updateGroups: List[UpdateActionGroup[T]],
                             userToken: Option[String]): Fox[Long] = {
-    val timestamps = updateGroups.map(_.timestamp)
-    val latestStatistics = updateGroups.flatMap(_.stats).lastOption
     val currentVersion = tracingService.currentVersion(tracingId)
-    webKnossosServer.reportTracingUpdates(tracingId, timestamps, latestStatistics, userToken).flatMap { _ =>
+    val report = TracingUpdatesReport(
+      tracingId,
+      timestamps = updateGroups.map(_.timestamp),
+      statistics = updateGroups.flatMap(_.stats).lastOption,
+      significantChangesCount = updateGroups.map(_.significantChangesCount).sum,
+      viewChangesCount = updateGroups.map(_.viewChangesCount).sum,
+      userToken
+    )
+    webKnossosServer.reportTracingUpdates(report).flatMap { _ =>
       updateGroups.foldLeft(currentVersion) { (previousVersion, updateGroup) =>
         previousVersion.flatMap { prevVersion: Long =>
           if (prevVersion + 1 == updateGroup.version) {
@@ -212,25 +224,27 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
     }
   }
 
-  def mergedFromIds(persist: Boolean) = Action.async(validateJson[List[Option[TracingSelector]]]) { implicit request =>
-    log {
-      accessTokenService.validateAccess(UserAccessRequest.webknossos) {
-        AllowRemoteOrigin {
-          for {
-            tracings <- tracingService.findMultiple(request.body, applyUpdates = true) ?~> Messages("tracing.notFound")
-            newId = tracingService.generateTracingId
-            mergedTracing = tracingService.merge(tracings.flatten)
-            _ <- tracingService.save(mergedTracing, Some(newId), version = 0, toCache = !persist)
-            _ <- tracingService.mergeVolumeData(request.body.flatten,
-                                                tracings.flatten,
-                                                newId,
-                                                mergedTracing,
-                                                toCache = !persist)
-          } yield {
-            Ok(Json.toJson(newId))
+  def mergedFromIds(persist: Boolean): Action[List[Option[TracingSelector]]] =
+    Action.async(validateJson[List[Option[TracingSelector]]]) { implicit request =>
+      log {
+        accessTokenService.validateAccess(UserAccessRequest.webknossos) {
+          AllowRemoteOrigin {
+            for {
+              tracings <- tracingService.findMultiple(request.body, applyUpdates = true) ?~> Messages(
+                "tracing.notFound")
+              newId = tracingService.generateTracingId
+              mergedTracing = tracingService.merge(tracings.flatten)
+              _ <- tracingService.save(mergedTracing, Some(newId), version = 0, toCache = !persist)
+              _ <- tracingService.mergeVolumeData(request.body.flatten,
+                                                  tracings.flatten,
+                                                  newId,
+                                                  mergedTracing,
+                                                  toCache = !persist)
+            } yield {
+              Ok(Json.toJson(newId))
+            }
           }
         }
       }
     }
-  }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/UpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/UpdateActions.scala
@@ -16,6 +16,10 @@ trait UpdateAction[T <: GeneratedMessage with Message[T]] {
   def addInfo(info: Option[String]): UpdateAction[T] = this
 
   def transformToCompact: UpdateAction[T] = this
+
+  // For analytics we wan to know how many changes are view only (e.g. move camera, toggle tree visibility)
+  // Overridden in subclasses
+  def isViewOnlyChange: Boolean = false
 }
 
 object UpdateAction {
@@ -32,7 +36,10 @@ case class UpdateActionGroup[T <: GeneratedMessage with Message[T]](
     transactionId: Option[String],
     transactionGroupCount: Option[Int],
     transactionGroupIndex: Option[Int]
-)
+) {
+  def significantChangesCount: Int = actions.count(!_.isViewOnlyChange)
+  def viewChangesCount: Int = actions.count(_.isViewOnlyChange)
+}
 
 object UpdateActionGroup {
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
@@ -302,6 +302,7 @@ case class UpdateTracingSkeletonAction(activeNode: Option[Int],
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
   override def addInfo(info: Option[String]): UpdateAction[SkeletonTracing] = this.copy(info = info)
+  override def isViewOnlyChange: Boolean = true
 }
 
 case class RevertToVersionAction(sourceVersion: Long, actionTimestamp: Option[Long] = None, info: Option[String] = None)
@@ -329,6 +330,7 @@ case class UpdateTreeVisibility(treeId: Int,
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
   override def addInfo(info: Option[String]): UpdateAction[SkeletonTracing] = this.copy(info = info)
+  override def isViewOnlyChange: Boolean = true
 }
 
 case class UpdateTreeGroupVisibility(treeGroupId: Option[Int],
@@ -362,6 +364,7 @@ case class UpdateTreeGroupVisibility(treeGroupId: Option[Int],
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
   override def addInfo(info: Option[String]): UpdateAction[SkeletonTracing] = this.copy(info = info)
+  override def isViewOnlyChange: Boolean = true
 }
 
 case class UpdateUserBoundingBoxes(boundingBoxes: List[NamedBoundingBox],
@@ -396,6 +399,7 @@ case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
   override def addInfo(info: Option[String]): UpdateAction[SkeletonTracing] = this.copy(info = info)
+  override def isViewOnlyChange: Boolean = true
 }
 
 case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[String] = None)
@@ -406,6 +410,7 @@ case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[Str
   override def addTimestamp(timestamp: Long): UpdateAction[SkeletonTracing] =
     this.copy(actionTimestamp = Some(timestamp))
   override def addInfo(info: Option[String]): UpdateAction[SkeletonTracing] = this.copy(info = info)
+  override def isViewOnlyChange: Boolean = true
 }
 
 object CreateTreeSkeletonAction {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
@@ -39,6 +39,8 @@ case class UpdateTracingVolumeAction(
 
   override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("updateTracing", actionTimestamp, Json.obj())
+
+  override def isViewOnlyChange: Boolean = true
 }
 
 object UpdateTracingVolumeAction {
@@ -85,6 +87,7 @@ case class UpdateUserBoundingBoxVisibility(boundingBoxId: Option[Int],
     CompactVolumeUpdateAction("updateUserBoundingBoxVisibility",
                               actionTimestamp,
                               Json.obj("boundingBoxId" -> boundingBoxId, "newVisibility" -> isVisible))
+  override def isViewOnlyChange: Boolean = true
 }
 
 object UpdateUserBoundingBoxVisibility {
@@ -123,6 +126,8 @@ case class UpdateTdCamera(actionTimestamp: Option[Long] = None, info: Option[Str
 
   override def transformToCompact: CompactVolumeUpdateAction =
     CompactVolumeUpdateAction("updateTdCamera", actionTimestamp, Json.obj())
+
+  override def isViewOnlyChange: Boolean = true
 }
 
 object UpdateTdCamera {


### PR DESCRIPTION
Some tracing update actions are caused by the owner moving around or toggling tree visibility only. We want to be able to filter those in analytics.
Hence, the `update_annotation_view_only` analytics event is introduced and `update_annotation` is only sent if update actions that are considered “significant” are present.

I also added some type annotations in `TracingController.scala`, which led to some reformatting diff. The only real change in that file is in `commitUpdates`

### Steps to test:
- in `application.conf`, set `backendAnalytics.verboseLoggingEnabled = true`
- create annotation, move around, save, create trees or brush, save
- In backend logging, you should see the analytics events that would be sent.
- If both “significant” and “view only” update actions are present in a save, both events should be sent
- Note that for Hybrid tracings, two may be sent per save (for skeleton and for volume).

### Issues:
- fixes #5243

------
- [x] Needs tracingstore update after deployment
- [x] Ready for review
