### PR TITLE
In diff schema, replace escaped carriage return by two spaces

### DIFF
--- a/tools/postgres/diff_schema.js
+++ b/tools/postgres/diff_schema.js
@@ -104,7 +104,7 @@ function generateRandomName() {
 function sortAndClean(dumpedDir) {
   glob.sync(dumpedDir + "/**", { nodir: true }).forEach(function(fileName) {
     replace({ files: fileName, replace: /,$/gm, with: "" });
-    replace({ files: fileName, replace: /\\r/gm, with: "" });
+    replace({ files: fileName, replace: /\\r/gm, with: "  " });
     sortFile(fileName);
   });
 }


### PR DESCRIPTION
Replacing by emptystring did not work because the functions file is structured as a table, where the cells are padded with spaces.
So let’s try again by replacing them with the padding that would have been there in their place.

- [x] Ready for review
