### PR TITLE
Don’t scroll up when showing confirm modals

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,14 +11,14 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/21.04.0...HEAD)
 
 ### Added
-- 
+-
 
 ### Changed
 - webKnossos is now part of the [image.sc support community](https://forum.image.sc/tag/webknossos). [#5332](https://github.com/scalableminds/webknossos/pull/5332)
 - Meshes that are imported by the user in the meshes tab are now rendered the same way as generated isosurface meshes. [#5326](https://github.com/scalableminds/webknossos/pull/5326)
 
 ### Fixed
--
+- Fixed a bug where the page would scroll up unexpectedly when showing various confirm modals. [#5340](https://github.com/scalableminds/webknossos/pull/5340)
 
 ### Removed
 -

--- a/frontend/javascripts/admin/scripts/script_list_view.js
+++ b/frontend/javascripts/admin/scripts/script_list_view.js
@@ -65,7 +65,8 @@ class ScriptListView extends React.PureComponent<Props, State> {
     this.setState({ searchQuery: event.target.value });
   };
 
-  deleteScript = (script: APIScript) => {
+  deleteScript = (script: APIScript, event: SyntheticInputEvent<>) => {
+    event.preventDefault();
     Modal.confirm({
       title: messages["script.delete"],
       onOk: async () => {

--- a/frontend/javascripts/admin/task/task_list_view.js
+++ b/frontend/javascripts/admin/task/task_list_view.js
@@ -85,7 +85,8 @@ class TaskListView extends React.PureComponent<Props, State> {
     this.setState({ searchQuery: event.target.value });
   };
 
-  deleteTask = (task: APITask) => {
+  deleteTask = (task: APITask, event: SyntheticInputEvent<>) => {
+    event.preventDefault();
     Modal.confirm({
       title: messages["task.delete"],
       onOk: async () => {

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.js
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.js
@@ -70,7 +70,8 @@ class TaskTypeListView extends React.PureComponent<Props, State> {
     this.setState({ searchQuery: event.target.value });
   };
 
-  deleteTaskType = (taskType: APITaskType) => {
+  deleteTaskType = (taskType: APITaskType, event: SyntheticInputEvent<>) => {
+    event.preventDefault();
     Modal.confirm({
       title: messages["taskType.delete"],
       onOk: async () => {

--- a/frontend/javascripts/admin/team/team_list_view.js
+++ b/frontend/javascripts/admin/team/team_list_view.js
@@ -67,7 +67,8 @@ class TeamListView extends React.PureComponent<Props, State> {
     this.setState({ searchQuery: event.target.value });
   };
 
-  deleteTeam = (team: APITeam) => {
+  deleteTeam = (team: APITeam, event: SyntheticInputEvent<>) => {
+    event.preventDefault();
     Modal.confirm({
       title: messages["team.delete"],
       onOk: async () => {

--- a/frontend/javascripts/admin/user/user_list_view.js
+++ b/frontend/javascripts/admin/user/user_list_view.js
@@ -95,7 +95,12 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
     });
   }
 
-  activateUser = (selectedUser: APIUser, isActive: boolean = true): void => {
+  setUserActiveState = (
+    selectedUser: APIUser,
+    isActive: boolean,
+    event: SyntheticInputEvent<>,
+  ): void => {
+    event.preventDefault();
     this.setState(prevState => {
       const newUsers = prevState.users.map(user => {
         if (selectedUser.id === user.id) {
@@ -114,8 +119,12 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
     });
   };
 
-  deactivateUser = (user: APIUser): void => {
-    this.activateUser(user, false);
+  activateUser = (user: APIUser, event: SyntheticInputEvent<>): void => {
+    this.setUserActiveState(user, true, event);
+  };
+
+  deactivateUser = (user: APIUser, event: SyntheticInputEvent<>): void => {
+    this.setUserActiveState(user, false, event);
   };
 
   changeEmail = (selectedUser: APIUser, newEmail: string): void => {
@@ -190,7 +199,7 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
           <Row key={user.id} gutter={16}>
             <Col span={6}>{`${user.lastName}, ${user.firstName} (${user.email}) `}</Col>
             <Col span={4}>
-              <a href="#" onClick={() => this.activateUser(user)}>
+              <a href="#" onClick={event => this.activateUser(user, event)}>
                 <Icon type="user-add" />
                 Activate User
               </a>
@@ -497,13 +506,13 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
                   {// eslint-disable-next-line no-nested-ternary
                   user.isActive ? (
                     this.props.activeUser.isAdmin ? (
-                      <a href="#" onClick={() => this.deactivateUser(user)}>
+                      <a href="#" onClick={event => this.deactivateUser(user, event)}>
                         <Icon type="user-delete" />
                         Deactivate User
                       </a>
                     ) : null
                   ) : (
-                    <a href="#" onClick={() => this.activateUser(user)}>
+                    <a href="#" onClick={event => this.activateUser(user, event)}>
                       <Icon type="user-add" />
                       Activate User
                     </a>

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.js
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.js
@@ -137,7 +137,8 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
     });
   };
 
-  confirmFinish(task: APITaskWithAnnotation) {
+  confirmFinish(task: APITaskWithAnnotation, event: SyntheticInputEvent<>) {
+    event.preventDefault();
     Modal.confirm({
       content: messages["annotation.finish"],
       onOk: async () => {
@@ -206,7 +207,8 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
     );
   };
 
-  openTransferModal(annotationId: string) {
+  openTransferModal(annotationId: string, event: SyntheticInputEvent<>) {
+    event.preventDefault();
     this.setState({
       isTransferModalVisible: true,
       currentAnnotationId: annotationId,
@@ -247,7 +249,7 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
         <br />
         {isAdmin || this.props.isAdminView ? (
           <div>
-            <a href="#" onClick={() => this.openTransferModal(annotation.id)}>
+            <a href="#" onClick={event => this.openTransferModal(annotation.id, event)}>
               <Icon type="team" />
               Transfer
             </a>
@@ -267,12 +269,12 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
               Download
             </AsyncLink>
             <br />
-            <a href="#" onClick={() => this.resetTask(annotation)}>
+            <a href="#" onClick={event => this.resetTask(annotation, event)}>
               <Icon type="rollback" />
               Reset
             </a>
             <br />
-            <a href="#" onClick={() => this.cancelAnnotation(annotation)}>
+            <a href="#" onClick={event => this.cancelAnnotation(annotation, event)}>
               <Icon type="delete" />
               Reset and Cancel
             </a>
@@ -280,7 +282,7 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
           </div>
         ) : null}
         {this.props.isAdminView ? null : (
-          <a href="#" onClick={() => this.confirmFinish(task)}>
+          <a href="#" onClick={event => this.confirmFinish(task, event)}>
             <Icon type="check-circle-o" />
             Finish
           </a>
@@ -289,7 +291,8 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
     );
   };
 
-  resetTask(annotation: APIAnnotation) {
+  resetTask(annotation: APIAnnotation, event: SyntheticInputEvent<>) {
+    event.preventDefault();
     Modal.confirm({
       content: messages["task.confirm_reset"],
       cancelText: messages.no,
@@ -301,7 +304,8 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
     });
   }
 
-  cancelAnnotation(annotation: APIAnnotation) {
+  cancelAnnotation(annotation: APIAnnotation, event: SyntheticInputEvent<>) {
+    event.preventDefault();
     const annotationId = annotation.id;
 
     Modal.confirm({


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://modaldontscrollup.webknossos.xyz

### Steps to test:
- Create a bunch of tasks
- in task list, scroll down, click »delete«, confirmation modal should show, but page should not scroll up to top
- same for task types, users, projects, scripts, teams
- same for own tasks in dashboard (cancel / reset actions etc)

### Issues:
- fixes #5053 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
