### PR TITLE
Don’t reference issue 123 in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 - abc
 
 ### Issues:
-- fixes #123
+- fixes #
 
 ------
 - [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)


### PR DESCRIPTION
The automatic connections by github and zenhub have been expanded, so referencing issue 123 from many PRs creates unwanted connections

- [x] Ready for review
