### PR TITLE
Fix corruption of skeleton when using CTRL+Rightclick in empty tree

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where some values in the project list were displayed incorrectly after pausing/unpausing the project. [#5339](https://github.com/scalableminds/webknossos/pull/5339)
 - Fixed that editing a task type would always re-add the default values to the recommended configuration (if enabled). [#5341](https://github.com/scalableminds/webknossos/pull/5341)
 - Fixed a bug where tasks created from existing volume annotations that did not have a specified bounding box were broken. [#5362](https://github.com/scalableminds/webknossos/pull/5361)
+- Fixed a bug which could cause corrupted trees when CTRL+Rightclick was used in an empty tree. [#5385](https://github.com/scalableminds/webknossos/pull/5385)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
+++ b/frontend/javascripts/oxalis/controller/combinations/skeletontracing_plane_controller.js
@@ -420,8 +420,10 @@ export function setWaypoint(
   const center = state.userConfiguration.centerNewNode && !ctrlIsPressed;
   // Only create a branchpoint if CTRL is pressed. Unless newNodeNewTree is activated (branchpoints make no sense then)
   const branchpoint = ctrlIsPressed && !state.userConfiguration.newNodeNewTree;
-  // Always activate the new node unless CTRL is pressed
-  const activate = !ctrlIsPressed;
+  // Always activate the new node unless CTRL is pressed. If there is no current node,
+  // the new one is still activated regardless of CTRL (otherwise, using CTRL+click in an empty tree multiple times would
+  // not create any edges; see https://github.com/scalableminds/webknossos/issues/5303).
+  const activate = !ctrlIsPressed || activeNodeMaybe.isNothing;
 
   addNode(position, rotation, createNewTree, center, branchpoint, activate);
 }

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
@@ -131,6 +131,11 @@ export function createNode(
   const { allowUpdate } = restrictions;
   const activeNodeMaybe = getActiveNodeFromTree(skeletonTracing, tree);
 
+  if (activeNodeMaybe.isNothing && tree.nodes.size() !== 0) {
+    console.error("Couldn't create a node in non-empty tree, because there is no active node.");
+    return Maybe.Nothing();
+  }
+
   if (allowUpdate) {
     // Use the same radius as current active node or revert to default value
     const radius = activeNodeMaybe


### PR DESCRIPTION
The bug has two facets:
1. Using ctrl+rightclick to add a tree does not select and also not center it. This means, using ctrl+rightclick in an empty tree twice, will try to create two nodes within the same tree. However, if no node is selected, no edge can be constructed for the second node which produces the corruption.
2. The `addNode` reducer helper simply added a node when being told so and only created an edge, if a node was selected. This means, if no node is selected (for whatever reason), corruption can ensue when the tree is not-empty. This should not happen in theory, but (1) provoked this scenario.

To fix this bug, I did 2 things:
1. Ensure that ctrl+rightclick also selects the first node of a tree (it's still not centered). I think, this is a fair behavior.
2. I adapted the `addNode` code so that the corruption cannot happen even if the circumstances would provoke it. The reducer would simply do a noop instead (and log an error message to the console).

### URL of deployed dev instance (used for testing):
- https://fixcorrupttrees.webknossos.xyz

### Steps to test:
- Create/Activate an empty tree
- Use Ctrl + Rightclick to create a first node
- Use Ctrl + Rightclick to create a second node

### Issues:
- fixes #5303

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
