### PR TITLE
Await Server Replies When Updating User

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug in Safari which could cause an error message (which is safe to ignore). [#5373](https://github.com/scalableminds/webknossos/pull/5373)
 - Fixed artifacts in screenshots near the dataset border. [#5324](https://github.com/scalableminds/webknossos/pull/5324)
 - Fixed a bug where the page would scroll up unexpectedly when showing various confirm modals. [#5371](https://github.com/scalableminds/webknossos/pull/5371)
+- Fixed a bug where user changes (email, activation) would show as successful even if they actually failed. [#5392](https://github.com/scalableminds/webknossos/pull/5392)
 
 ### Removed
 -

--- a/frontend/javascripts/admin/user/user_list_view.js
+++ b/frontend/javascripts/admin/user/user_list_view.js
@@ -111,10 +111,7 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
     const newUserPromises = this.state.users.map(user => {
       if (selectedUser.id === user.id) {
         const newUser = Object.assign({}, user, { isActive });
-        return updateUser(newUser).then(
-          serverUser => Promise.resolve(serverUser),
-          () => Promise.reject(user),
-        );
+        return updateUser(newUser);
       }
       return Promise.resolve(user);
     });
@@ -139,10 +136,7 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
     const newUserPromises = this.state.users.map(user => {
       if (selectedUser.id === user.id) {
         const newUser = Object.assign({}, user, { email: newEmail });
-        return updateUser(newUser).then(
-          serverUser => Promise.resolve(serverUser),
-          () => Promise.reject(user),
-        );
+        return updateUser(newUser);
       }
       return Promise.resolve(user);
     });

--- a/frontend/javascripts/admin/user/user_list_view.js
+++ b/frontend/javascripts/admin/user/user_list_view.js
@@ -107,48 +107,57 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
     });
   }
 
-  activateUser = (selectedUser: APIUser, isActive: boolean = true): void => {
-    this.setState(prevState => {
-      const newUsers = prevState.users.map(user => {
-        if (selectedUser.id === user.id) {
-          const newUser = Object.assign({}, user, { isActive });
-          updateUser(newUser);
-          return newUser;
-        }
-        return user;
-      });
-
-      return {
-        users: newUsers,
-        selectedUserIds: [selectedUser.id],
-        isTeamRoleModalVisible: isActive,
-      };
+  activateUser = async (selectedUser: APIUser, isActive: boolean = true) => {
+    const newUserPromises = this.state.users.map(user => {
+      if (selectedUser.id === user.id) {
+        const newUser = Object.assign({}, user, { isActive });
+        return updateUser(newUser).then(
+          serverUser => Promise.resolve(serverUser),
+          () => Promise.reject(user),
+        );
+      }
+      return Promise.resolve(user);
     });
+
+    Promise.all(newUserPromises).then(
+      newUsers => {
+        this.setState({
+          users: newUsers,
+          selectedUserIds: [selectedUser.id],
+          isTeamRoleModalVisible: isActive,
+        });
+      },
+      () => {}, // Do nothing, change did not succeed
+    );
   };
 
   deactivateUser = (user: APIUser): void => {
     this.activateUser(user, false);
   };
 
-  changeEmail = (selectedUser: APIUser, newEmail: string): void => {
-    this.setState(prevState => {
-      const newUsers = prevState.users.map(user => {
-        if (selectedUser.id === user.id) {
-          const newUser = Object.assign({}, user, { email: newEmail });
-          updateUser(newUser);
-          return newUser;
-        }
-        return user;
-      });
-
-      return {
-        users: newUsers,
-        selectedUserIds: [selectedUser.id],
-      };
+  changeEmail = async (selectedUser: APIUser, newEmail: string) => {
+    const newUserPromises = this.state.users.map(user => {
+      if (selectedUser.id === user.id) {
+        const newUser = Object.assign({}, user, { email: newEmail });
+        return updateUser(newUser).then(
+          serverUser => Promise.resolve(serverUser),
+          () => Promise.reject(user),
+        );
+      }
+      return Promise.resolve(user);
     });
-    Toast.success(messages["users.change_email_confirmation"]);
 
-    if (this.props.activeUser.email === selectedUser.email) Store.dispatch(logoutUserAction());
+    Promise.all(newUserPromises).then(
+      newUsers => {
+        this.setState({
+          users: newUsers,
+          selectedUserIds: [selectedUser.id],
+        });
+        Toast.success(messages["users.change_email_confirmation"]);
+        if (this.props.activeUser.email === selectedUser.email) Store.dispatch(logoutUserAction());
+      },
+      () => {}, // Do nothing, change did not succeed
+    );
   };
 
   handleUsersChange = (updatedUsers: Array<APIUser>): void => {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create second user
- In admin view, activate, deactivate, change email, should work
- try deactivating yourself, should fail, and not show as succeeded
- insert `          _ <- Fox.failure("nope")` in line 319 of UserController.scala
- subsequent user email/activation updates should fail, and should not seem successful in frontend

### Issues:
- fixes #4988 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
