### PR TITLE
Fix style of tracing-button-group

### DIFF
--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -10,7 +10,6 @@ import {
   Modal,
   Tooltip,
   notification,
-  Space,
 } from "antd";
 import {
   DownloadOutlined,
@@ -696,7 +695,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
                 >
                   <Spin />
                 </Modal>
-                <Space size={0}>
+                <div className="antd-legacy-group">
                   <AdvancedSearchPopover
                     onSelect={this.handleSearchSelect}
                     data={this.getTreeAndTreeGroupList(trees, treeGroups, orderAttribute)}
@@ -734,7 +733,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
                       <DownOutlined />
                     </ButtonComponent>
                   </Dropdown>
-                </Space>
+                </div>
                 <InputGroup compact>
                   <ButtonComponent onClick={this.props.onSelectNextTreeBackward}>
                     <i className="fas fa-arrow-left" />


### PR DESCRIPTION
The rounded corners were wrong and the overflow behavior was also missing.
Before:
![image](https://user-images.githubusercontent.com/2486553/114568493-7485d780-9c74-11eb-8eb6-dd358fc05a36.png)

After:
![image](https://user-images.githubusercontent.com/2486553/114568520-7a7bb880-9c74-11eb-80b8-4a6287b8f683.png)

The overflow behavior is still not optimal, but I'd argue that the change in the antd upgrade was not really intentional.

### Issues:
- contributes to #5368 

------
- [X] Ready for review
