### PR TITLE
Support arbitrary modes even when data layer is not uint8

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Upgraded UI library antd to version 4, creating a slightly more modern look and behavior of many UI elements. [#5350](https://github.com/scalableminds/webknossos/pull/5350)
 - Added a screenshot of the 3D view when using the screenshot functionality in the tracing view. [#5324](https://github.com/scalableminds/webknossos/pull/5324)
 - Tiff export jobs of volume annotations now show the link back to the annotation in the jobs list. [#5378](https://github.com/scalableminds/webknossos/pull/5378)
+- Added support for flight- and oblique-mode when having non-uint8 dataset layers. [#5396](https://github.com/scalableminds/webknossos/pull/5396)
 
 ### Changed
 - webKnossos is now part of the [image.sc support community](https://forum.image.sc/tag/webknossos). [#5332](https://github.com/scalableminds/webknossos/pull/5332)

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.js
@@ -50,7 +50,7 @@ export class ResolutionInfo {
 
     // This function creates a map which maps from powerOfTwo (2**index) to resolution.
 
-    const resolutions = this.resolutions;
+    const { resolutions } = this;
 
     if (resolutions.length !== _.uniqBy(resolutions.map(_.max)).length) {
       throw new Error("Max dimension in resolutions is not unique.");
@@ -443,16 +443,9 @@ export function determineAllowedModes(
   settings?: Settings,
 ): { preferredMode: ?APIAllowedMode, allowedModes: Array<APIAllowedMode> } {
   // The order of allowedModes should be independent from the server and instead be similar to ViewModeValues
-  let allowedModes = settings
+  const allowedModes = settings
     ? _.intersection(ViewModeValues, settings.allowedModes)
     : ViewModeValues;
-
-  const colorLayer = _.find(dataset.dataSource.dataLayers, {
-    category: "color",
-  });
-  if (colorLayer != null && colorLayer.elementClass !== "uint8") {
-    allowedModes = allowedModes.filter(mode => !constants.MODES_ARBITRARY.includes(mode));
-  }
 
   let preferredMode = null;
   if (settings && settings.preferredMode != null) {


### PR DESCRIPTION
The check which I removed in this PR was faulty anyway. It only checked the datatype of the "first" color layer. This means that we already supported non-uint8 layers in arbitrary modes as long as the "first" color layer was uint8.
I also had a look at a float layer in arbitrary mode and couldn't spot any problems (also I don't know why there should be a problem). I assume this is a very old relic from CPU-based rendering (?) which is obsolete by now.

### URL of deployed dev instance (used for testing):
- https://supportfloatinarbitrary.webknossos.xyz

### Steps to test:
- open a dataset with float layer and switch to an arbitrary mode

### Issues:
- fixes #5144

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
