### PR TITLE
Only upload to datastores that allow upload

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed artifacts in screenshots near the dataset border. [#5324](https://github.com/scalableminds/webknossos/pull/5324)
 - Fixed a bug where the page would scroll up unexpectedly when showing various confirm modals. [#5371](https://github.com/scalableminds/webknossos/pull/5371)
 - Fixed a bug where user changes (email, activation) would show as successful even if they actually failed. [#5392](https://github.com/scalableminds/webknossos/pull/5392)
+- Fixed a bug where dataset uploads were sent to the wrong datastore, and failed [#5404](https://github.com/scalableminds/webknossos/pull/5404)
 
 ### Removed
 -

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.js
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.js
@@ -69,13 +69,14 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
   formRef = React.createRef<typeof FormInstance>();
 
   componentDidUpdate(prevProps: PropsWithFormAndRouter) {
+    const uploadableDatastores = this.props.datastores.filter(datastore => datastore.allowsUpload);
     if (this.formRef.current != null) {
       if (
         prevProps.datastores.length === 0 &&
-        this.props.datastores.length > 0 &&
-        this.formRef.current.getFieldValue("datastore") !== this.props.datastores[0].url
+        uploadableDatastores.length > 0 &&
+        this.formRef.current.getFieldValue("datastore") !== uploadableDatastores[0].url
       ) {
-        this.formRef.current.setFieldsValue({ datastore: this.props.datastores[0].url });
+        this.formRef.current.setFieldsValue({ datastore: uploadableDatastores[0].url });
       }
     }
   }


### PR DESCRIPTION
Fixed a bug where dataset uploads were sent to the wrong datastore (first in list, regardless of allowsUpload), and thus failed.

~I’m a bit confused why this bug didn’t occur before. The datastore list from the server is ordered by name, so the “correct” one, webknossos.org is sent last, but the old code took the first.~ regression introduced in #5350 (for explanation see comment below)

### Steps to test:
- set up external datastore, insert into db with allowsUpload = false
- upload dataset, should go to local datastore
- toggle allowsUpload for both datastes
- reload upload page, upload should now go to the other datastore.

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
