### PR TITLE
Fix flaky sidebar toggles

### DIFF
--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_helper.js
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_helper.js
@@ -1,7 +1,6 @@
 // @flow
 import { Model, Actions, TabSetNode } from "flexlayout-react";
-import Store, { type BorderOpenStatus } from "oxalis/store";
-import { defaultSplitterSize, borderBarSize } from "./default_layout_configs";
+import { type BorderOpenStatus } from "oxalis/store";
 
 export function getMaximizedItemId(model: typeof Model): ?string {
   const maximizedTabset = model.getMaximizedTabset();
@@ -45,41 +44,32 @@ type NodePositionStatus = {
 
 export function getPositionStatusOf(tabSetNode: typeof TabSetNode): NodePositionStatus {
   // We have to determine whether the current tabset is part of the most upper tabsets directly below the header.
-  const rect = tabSetNode.getRect();
-  const isTopMost = rect.y === 0;
+  const tabSetNodeRect = tabSetNode.getRect();
+  const isTopMost = tabSetNodeRect.y === 0;
   let isLeftMost = false;
   let isRightMost = false;
   if (!isTopMost) {
     // In this case we do not need to calculate the other position booleans.
-    return { isTopMost, isLeftMost, isRightMost };
+    return {
+      isTopMost,
+      isLeftMost,
+      isRightMost,
+    };
   }
-  const borders = { left: null, right: null };
-  tabSetNode
-    .getModel()
-    .getBorderSet()
-    .getBorders()
-    .forEach(border => {
-      const side = border.getLocation().getName();
-      borders[side] = border;
-    });
-  const currentBorderOpenStatus = Store.getState().uiInformation.borderOpenStatus;
 
-  if (borders.left != null) {
-    if (currentBorderOpenStatus.left) {
-      const { x: leftBorderX, width: leftBorderWidth } = borders.left.getContentRect();
-      isLeftMost = rect.x === leftBorderX + leftBorderWidth + defaultSplitterSize;
-    } else {
-      isLeftMost = rect.x === 0 + borderBarSize;
-    }
-  }
-  if (borders.right != null) {
-    if (currentBorderOpenStatus.right) {
-      const { x: rightBorderX } = borders.right.getContentRect();
-      isRightMost = rect.x + rect.width + defaultSplitterSize === rightBorderX;
-    } else {
-      // No need to add defaultSplitterSize as the border is hidden and thus there is no splitter.
-      isRightMost = rect.x + rect.width === window.screen.width - borderBarSize;
-    }
-  }
-  return { isTopMost, isLeftMost, isRightMost };
+  const rootContainerRect = tabSetNode
+    .getModel()
+    .getRoot()
+    .getRect();
+
+  // Comparing the left and right side of the tabSetNode with the left and right side
+  // of the root container that contains everything except for the borders.
+  isLeftMost = tabSetNodeRect.x === rootContainerRect.x;
+  isRightMost =
+    tabSetNodeRect.x + tabSetNodeRect.width === rootContainerRect.x + rootContainerRect.width;
+  return {
+    isTopMost,
+    isLeftMost,
+    isRightMost,
+  };
 }

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
@@ -326,7 +326,6 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
   };
 
   toggleBorder(side: string, toggleInternalState: boolean = true) {
-    this.state.model.doAction(FlexLayout.Actions.selectTab(`${side}-border-tab-container`));
     // The most recent version of borderOpenStatus is needed as two border toggles might be executed directly after another.
     // If borderOpenStatus was passed via props, the first update  of borderOpenStatus will overwritten by the second update.
     const borderOpenStatusCopy = _.cloneDeep(Store.getState().uiInformation.borderOpenStatus);
@@ -336,6 +335,7 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
       // Only adjust the internal state if the toggle is not automated and no tab is maximized.
       this.borderOpenStatusWhenNotMaximized[side] = !this.borderOpenStatusWhenNotMaximized[side];
     }
+    this.state.model.doAction(FlexLayout.Actions.selectTab(`${side}-border-tab-container`));
     this.onLayoutChange();
   }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a new annotation
- Use the upper right sidebar toggle button to close the sidebar
- Use "." to maximize/unmaximize viewports
- The sidebar toggle buttons should always stay visible

### Issues:
- fixes #5411
- while testing, I also noticed another not-ideal behavior for which I created https://github.com/scalableminds/webknossos/issues/5413

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
