### PR TITLE
Fix rendering if 3D viewport is hidden initially

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where the page would scroll up unexpectedly when showing various confirm modals. [#5371](https://github.com/scalableminds/webknossos/pull/5371)
 - Fixed a bug where user changes (email, activation) would show as successful even if they actually failed. [#5392](https://github.com/scalableminds/webknossos/pull/5392)
 - Fixed a bug where dataset uploads were sent to the wrong datastore, and failed [#5404](https://github.com/scalableminds/webknossos/pull/5404)
+- Fixed a rendering bug which occurred when the initial layout had a hidden 3D viewport. [#5429](https://github.com/scalableminds/webknossos/pull/5429)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/controller/td_controller.js
+++ b/frontend/javascripts/oxalis/controller/td_controller.js
@@ -207,6 +207,9 @@ class TDController extends React.PureComponent<Props> {
   }
 
   setTargetAndFixPosition(position?: Vector3): void {
+    if (this.controls == null) {
+      return;
+    }
     position = position || getPosition(this.props.flycam);
     const nmPosition = voxelToNm(this.props.scale, position);
 

--- a/frontend/javascripts/oxalis/controller/td_controller.js
+++ b/frontend/javascripts/oxalis/controller/td_controller.js
@@ -70,7 +70,7 @@ function maybeGetActiveNodeFromProps(props: Props) {
 }
 
 class TDController extends React.PureComponent<Props> {
-  controls: typeof TrackballControls;
+  controls: ?typeof TrackballControls;
   mouseController: InputMouse;
   oldNmPos: Vector3;
   isStarted: boolean;
@@ -148,7 +148,12 @@ class TDController extends React.PureComponent<Props> {
     this.forceUpdate();
   }
 
-  updateControls = () => this.controls.update(true);
+  updateControls = () => {
+    if (!this.controls) {
+      return;
+    }
+    this.controls.update(true);
+  };
 
   getTDViewMouseControls(): Object {
     const skeletonControls =
@@ -207,14 +212,15 @@ class TDController extends React.PureComponent<Props> {
   }
 
   setTargetAndFixPosition(position?: Vector3): void {
-    if (this.controls == null) {
+    const { controls } = this;
+    if (controls == null) {
       return;
     }
     position = position || getPosition(this.props.flycam);
     const nmPosition = voxelToNm(this.props.scale, position);
 
-    this.controls.target.set(...nmPosition);
-    this.controls.update();
+    controls.target.set(...nmPosition);
+    controls.update();
 
     // The following code is a dirty hack. If someone figures out
     // how the trackball control's target can be set without affecting
@@ -263,10 +269,6 @@ class TDController extends React.PureComponent<Props> {
   }
 
   render() {
-    if (!this.controls) {
-      return null;
-    }
-
     return (
       <CameraController
         cameras={this.props.cameras}

--- a/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -134,21 +134,18 @@ class PlaneController extends React.PureComponent<Props> {
     // catchers (only necessary for HammerJS). We should refactor the
     // InputMouse handling so that this is not necessary anymore.
     // See: https://github.com/scalableminds/webknossos/issues/3475
-    const tdId = `inputcatcher_${OrthoViews.TDView}`;
-    Utils.waitForElementWithId(tdId).then(() => {
-      OrthoViewValuesWithoutTDView.forEach(id => {
-        const inputcatcherId = `inputcatcher_${OrthoViews[id]}`;
-        Utils.waitForElementWithId(inputcatcherId).then(el => {
-          if (!document.body.contains(el)) {
-            console.error("el is not attached anymore");
-          }
-          this.input.mouseControllers[id] = new InputMouse(
-            inputcatcherId,
-            this.getPlaneMouseControls(id),
-            id,
-            true,
-          );
-        });
+    OrthoViewValuesWithoutTDView.forEach(id => {
+      const inputcatcherId = `inputcatcher_${OrthoViews[id]}`;
+      Utils.waitForElementWithId(inputcatcherId).then(el => {
+        if (!document.body.contains(el)) {
+          console.error("el is not attached anymore");
+        }
+        this.input.mouseControllers[id] = new InputMouse(
+          inputcatcherId,
+          this.getPlaneMouseControls(id),
+          id,
+          true,
+        );
       });
     });
   }

--- a/frontend/javascripts/oxalis/default_state.js
+++ b/frontend/javascripts/oxalis/default_state.js
@@ -3,7 +3,7 @@
 import type { OxalisState } from "oxalis/store";
 import Constants, { ControlModeEnum, OrthoViews, OverwriteModeEnum } from "oxalis/constants";
 
-const defaultViewportRect = {
+export const defaultViewportRect = {
   top: 0,
   left: 0,
   width: Constants.VIEWPORT_WIDTH,

--- a/frontend/javascripts/oxalis/view/input_catcher.js
+++ b/frontend/javascripts/oxalis/view/input_catcher.js
@@ -8,7 +8,13 @@ import Scalebar from "oxalis/view/scalebar";
 import ViewportStatusIndicator from "oxalis/view/viewport_status_indicator";
 import Store from "oxalis/store";
 import makeRectRelativeToCanvas from "oxalis/view/layouting/layout_canvas_adapter";
-import { defaultViewportRect } from "oxalis/default_state";
+
+const emptyViewportRect = {
+  top: 0,
+  left: 0,
+  width: 0,
+  height: 0,
+};
 
 type Props = {
   viewportID: Viewport,
@@ -50,10 +56,10 @@ const renderedInputCatchers = new Map();
 
 export function recalculateInputCatcherSizes() {
   const viewportRects: Object = {
-    PLANE_XY: defaultViewportRect,
-    PLANE_YZ: defaultViewportRect,
-    PLANE_XZ: defaultViewportRect,
-    TDView: defaultViewportRect,
+    PLANE_XY: emptyViewportRect,
+    PLANE_YZ: emptyViewportRect,
+    PLANE_XZ: emptyViewportRect,
+    TDView: emptyViewportRect,
   };
 
   for (const [viewportID, inputCatcher] of renderedInputCatchers.entries()) {

--- a/frontend/javascripts/oxalis/view/input_catcher.js
+++ b/frontend/javascripts/oxalis/view/input_catcher.js
@@ -8,6 +8,7 @@ import Scalebar from "oxalis/view/scalebar";
 import ViewportStatusIndicator from "oxalis/view/viewport_status_indicator";
 import Store from "oxalis/store";
 import makeRectRelativeToCanvas from "oxalis/view/layouting/layout_canvas_adapter";
+import { defaultViewportRect } from "oxalis/default_state";
 
 type Props = {
   viewportID: Viewport,
@@ -48,7 +49,13 @@ function adaptInputCatcher(inputCatcherDOM: HTMLElement, makeQuadratic: boolean)
 const renderedInputCatchers = new Map();
 
 export function recalculateInputCatcherSizes() {
-  const viewportRects = {};
+  const viewportRects: Object = {
+    PLANE_XY: defaultViewportRect,
+    PLANE_YZ: defaultViewportRect,
+    PLANE_XZ: defaultViewportRect,
+    TDView: defaultViewportRect,
+  };
+
   for (const [viewportID, inputCatcher] of renderedInputCatchers.entries()) {
     const makeQuadratic = viewportID === ArbitraryViewport;
     const rect = adaptInputCatcher(inputCatcher, makeQuadratic);


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a dataset or annotation
- re-arrange the viewports so that the 3d viewport is not visible
- wait a few seconds so the layout is persisted (this is not done via the save button)
- reload the page (previous layout should be visible)
- ensure that all viewports look good (despite the 3d viewport being hidden)
- use "reset layout" and test that all mouse bindings work as expected

### Issues:
- fixes #5430

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
