### PR TITLE
Hide validation icon for file form item in dataset upload

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_upload_view.js
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.js
@@ -557,6 +557,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
               name="zipFile"
               label="Dataset"
               hasFeedback
+              className="hide-valid-form-item-icon"
               rules={[
                 { required: true, message: messages["dataset.import.required.zipFile"] },
                 {

--- a/frontend/stylesheets/_general.less
+++ b/frontend/stylesheets/_general.less
@@ -74,3 +74,9 @@ p {
     display: none;
   }
 }
+
+.hide-valid-form-item-icon {
+  .anticon-check-circle {
+    display: none;
+  }
+}


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the dataset upload view.
- Drop a valid wkw-dataset folder (not zipped) into the file upload via drag & drop.
- There should no longer be a small green checkmark icon indicating, that the upload looks valid.

### Issues:
- fixes #5438

------
- ~~[ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~~
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [ ] Ready for review
