### PR TITLE
Use disabled list in wk module detection

### DIFF
--- a/app/utils/StoreModules.scala
+++ b/app/utils/StoreModules.scala
@@ -3,9 +3,13 @@ package utils
 import javax.inject._
 
 class StoreModules @Inject()(conf: WkConf) {
-  def localTracingStoreEnabled: Boolean =
-    conf.Play.Modules.enabled.contains("com.scalableminds.webknossos.tracingstore.TracingStoreModule")
+  def localTracingStoreEnabled: Boolean = {
+    val key = "com.scalableminds.webknossos.tracingstore.TracingStoreModule"
+    conf.Play.Modules.enabled.contains(key) && !conf.Play.Modules.disabled.contains(key)
+  }
 
-  def localDataStoreEnabled: Boolean =
-    conf.Play.Modules.enabled.contains("com.scalableminds.webknossos.datastore.DataStoreModule")
+  def localDataStoreEnabled: Boolean = {
+    val key = "com.scalableminds.webknossos.datastore.DataStoreModule"
+    conf.Play.Modules.enabled.contains(key) && !conf.Play.Modules.disabled.contains(key)
+  }
 }

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -18,6 +18,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
   object Play {
     object Modules {
       val enabled: Seq[String] = getList[String]("play.modules.enabled")
+      val disabled: Seq[String] = getList[String]("play.modules.disabled")
     }
   }
 


### PR DESCRIPTION
Our kube setup does not disable play modules by removing them from the “enabled” list but from adding them to the “disabled” list. This must be reflected in the detection used in our health checks.

Hotfix following up #5208 

- [x] Ready for review
