### PR TITLE
Release 21.05.1

### DIFF
--- a/CHANGELOG.released.md
+++ b/CHANGELOG.released.md
@@ -7,13 +7,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 For upgrade instructions, please check the [migration guide](MIGRATIONS.released.md).
 
+## [21.05.1](https://github.com/scalableminds/webknossos/releases/tag/21.05.1) - 2021-05-05
+[Commits](https://github.com/scalableminds/webknossos/compare/21.05.0...21.05.1)
+
+### Highlights
+- Added a dark theme for webKnossos. [#5407](https://github.com/scalableminds/webknossos/pull/5407)
+
+### Changed
+- The deployment configuration of webKnossos was cleaned up. If you host your own webKnossos instance, be sure to update your config according to the migration guide. [#5208](https://github.com/scalableminds/webknossos/pull/5208)
+
+### Fixed
+- Fixed a bug where users could see long-running jobs listing of other users [#5435](https://github.com/scalableminds/webknossos/pull/5435)
+- Fixed a rendering bug which occurred when the initial layout had a hidden 3D viewport. [#5429](https://github.com/scalableminds/webknossos/pull/5429)
+- Fixed an incorrect initial camera rotation in the 3D viewport and an incorrect initial zoom value. [#5453](https://github.com/scalableminds/webknossos/pull/5453)
+- Fixed a bug where the task search showed duplicates if a user had multiple instances of a task (as made possible by the transfer functionality). [#5456](https://github.com/scalableminds/webknossos/pull/5456)
+- Fixed a bug where showing active users of a project, and transferring their tasks was broken. [#5456](https://github.com/scalableminds/webknossos/pull/5456)
+
 ## [21.05.0](https://github.com/scalableminds/webknossos/releases/tag/21.05.0) - 2021-04-22
 [Commits](https://github.com/scalableminds/webknossos/compare/21.04.0...21.05.0)
 
 ### Highlights
 - The layout of the tracing view was revamped. Most notably, the layout now has two well-behaved sidebars (left and right) which can be collapsed and expanded while the remaining space is used for the main data view. Additionally, a status bar was added which shows important information, such as the currently rendered magnification and useful mouse controls. [#5279](https://github.com/scalableminds/webknossos/pull/5279)
 - Added a screenshot of the 3D view when using the screenshot functionality in the tracing view. [#5324](https://github.com/scalableminds/webknossos/pull/5324)
-
 
 ### Added
 - The names of Task Types and Projects no longer need to be globally unique, instead only within their respective organization.  [#5334](https://github.com/scalableminds/webknossos/pull/5334)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,34 +8,15 @@ and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MIC
 For upgrade instructions, please check the [migration guide](MIGRATIONS.released.md).
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos/compare/21.04.0...HEAD)
+[Commits](https://github.com/scalableminds/webknossos/compare/21.05.0...HEAD)
 
 ### Added
-- The names of Task Types and Projects no longer need to be globally unique, instead only within their respective organization.  [#5334](https://github.com/scalableminds/webknossos/pull/5334)
-- Upgraded UI library antd to version 4, creating a slightly more modern look and behavior of many UI elements. [#5350](https://github.com/scalableminds/webknossos/pull/5350)
-- Added a screenshot of the 3D view when using the screenshot functionality in the tracing view. [#5324](https://github.com/scalableminds/webknossos/pull/5324)
-- Tiff export jobs of volume annotations now show the link back to the annotation in the jobs list. [#5378](https://github.com/scalableminds/webknossos/pull/5378)
-- Added support for flight- and oblique-mode when having non-uint8 dataset layers. [#5396](https://github.com/scalableminds/webknossos/pull/5396)
 - Added a dark theme for webKnossos. [#5407](https://github.com/scalableminds/webknossos/pull/5407)
 
 ### Changed
-- webKnossos is now part of the [image.sc support community](https://forum.image.sc/tag/webknossos). [#5332](https://github.com/scalableminds/webknossos/pull/5332)
-- Meshes that are imported by the user in the meshes tab are now rendered the same way as generated isosurface meshes. [#5326](https://github.com/scalableminds/webknossos/pull/5326)
-- In the new REST API version 4, projects are no longer referenced by name, but instead by id. [#5334](https://github.com/scalableminds/webknossos/pull/5334)
-- The layout of the tracing view was revamped. Most notably, the layout now has two well-behaved sidebars (left and right) which can be collapsed and expanded while the remaining space is used for the main data view. Additionally, a status bar was added which shows important information, such as the currently rendered magnification and useful mouse controls. [#5279](https://github.com/scalableminds/webknossos/pull/5279)
 - The deployment configuration of webKnossos was cleaned up. If you host your own webKnossos instance, be sure to update your config according to the migration guide. [#5208](https://github.com/scalableminds/webknossos/pull/5208)
 
 ### Fixed
-- Fixed a bug where some values in the project list were displayed incorrectly after pausing/unpausing the project. [#5339](https://github.com/scalableminds/webknossos/pull/5339)
-- Fixed that editing a task type would always re-add the default values to the recommended configuration (if enabled). [#5341](https://github.com/scalableminds/webknossos/pull/5341)
-- Fixed a bug where tasks created from existing volume annotations that did not have a specified bounding box were broken. [#5362](https://github.com/scalableminds/webknossos/pull/5361)
-- Fixed broken search functionality in select components. [#5394](https://github.com/scalableminds/webknossos/pull/5394)
-- Fixed a bug which could cause corrupted trees when CTRL+Rightclick was used in an empty tree. [#5385](https://github.com/scalableminds/webknossos/pull/5385)
-- Fixed a bug in Safari which could cause an error message (which is safe to ignore). [#5373](https://github.com/scalableminds/webknossos/pull/5373)
-- Fixed artifacts in screenshots near the dataset border. [#5324](https://github.com/scalableminds/webknossos/pull/5324)
-- Fixed a bug where the page would scroll up unexpectedly when showing various confirm modals. [#5371](https://github.com/scalableminds/webknossos/pull/5371)
-- Fixed a bug where user changes (email, activation) would show as successful even if they actually failed. [#5392](https://github.com/scalableminds/webknossos/pull/5392)
-- Fixed a bug where dataset uploads were sent to the wrong datastore, and failed [#5404](https://github.com/scalableminds/webknossos/pull/5404)
 - Fixed a bug where users could see long-running jobs listing of other users [#5435](https://github.com/scalableminds/webknossos/pull/5435)
 - Fixed a rendering bug which occurred when the initial layout had a hidden 3D viewport. [#5429](https://github.com/scalableminds/webknossos/pull/5429)
 - Fixed an incorrect initial camera rotation in the 3D viewport and an incorrect initial zoom value. [#5453](https://github.com/scalableminds/webknossos/pull/5453)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,20 +8,16 @@ and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MIC
 For upgrade instructions, please check the [migration guide](MIGRATIONS.released.md).
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos/compare/21.05.0...HEAD)
+[Commits](https://github.com/scalableminds/webknossos/compare/21.05.1...HEAD)
 
 ### Added
-- Added a dark theme for webKnossos. [#5407](https://github.com/scalableminds/webknossos/pull/5407)
+- 
 
 ### Changed
-- The deployment configuration of webKnossos was cleaned up. If you host your own webKnossos instance, be sure to update your config according to the migration guide. [#5208](https://github.com/scalableminds/webknossos/pull/5208)
+- 
 
 ### Fixed
-- Fixed a bug where users could see long-running jobs listing of other users [#5435](https://github.com/scalableminds/webknossos/pull/5435)
-- Fixed a rendering bug which occurred when the initial layout had a hidden 3D viewport. [#5429](https://github.com/scalableminds/webknossos/pull/5429)
-- Fixed an incorrect initial camera rotation in the 3D viewport and an incorrect initial zoom value. [#5453](https://github.com/scalableminds/webknossos/pull/5453)
-- Fixed a bug where the task search showed duplicates if a user had multiple instances of a task (as made possible by the transfer functionality). [#5456](https://github.com/scalableminds/webknossos/pull/5456)
-- Fixed a bug where showing active users of a project, and transferring their tasks was broken. [#5456](https://github.com/scalableminds/webknossos/pull/5456)
+- 
 
 ### Removed
 -

--- a/MIGRATIONS.released.md
+++ b/MIGRATIONS.released.md
@@ -5,6 +5,63 @@ See `MIGRATIONS.unreleased.md` for the changes which are not yet part of an offi
 This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 
+## [21.05.1](https://github.com/scalableminds/webknossos/releases/tag/21.05.1) - 2021-05-05
+- The config keys in application.conf were restructured. If you overwrite any of them for your config, please adapt to the new structure, according to the table below. If you run any stand-alone datastores or tracingstores, make sure to update their config files as well.
+
+old key | new key | notes
+--------|--------|-------
+`http.address` | removed | used by play, default is 0.0.0.0, you can still overwrite it if necessary
+`actor.defaultTimeout` | removed | was already unused
+`js.defaultTimeout` | removed | was already unused
+`akka.loggers` | removed | was already unused
+`application.name` | removed | was already unused
+`application.branch` | removed | was already unused
+`application.version` | removed | was already unused
+`application.title` | `webKnossos.tabTitle` |
+`application.insertInitialData` | `webKnossos.sampleOrganization.enabled` |
+`application.insertLocalConnectDatastore` | removed | feature removed, insert manually instead
+`application.authentication.defaultuser.email` | `webKnossos.sampleOrganization.user.email` |
+`application.authentication.defaultUser.password` | `webKnossos.sampleOrganization.user.password` |
+`application.authentication.defaultUser.token` | `webKnossos.sampleOrganization.user.token` |
+`application.authentication.defaultUser.isSuperUser` | `webKnossos.sampleOrganization.user.isSuperUser` |
+`application.authentication.ssoKey` | `webKnossos.user.ssoKey` |
+`application.authentication.inviteExpiry` | `webKnossos.user.inviteExpiry` |
+`webKnossos.user.time.tracingPauseInSeconds` | `webKnossos.user.time.tracingPause` | **type changed from Int to FiniteDuration, add ` seconds`**
+`webKnossos.query.maxResults` | removed | was already unused
+`user.cacheTimeoutInMinutes` | `webKnossos.cache.user.timeout` | **type changed from Int to FiniteDuration, add ` minutes`**
+`tracingstore.enabled` | removed | info contained in `play.modules.enabled`
+`datastore.enabled` | removed | info contained in `play.modules.enabled`
+`datastore.webKnossos.pingIntervalMinutes` | `datastore.webKnossos.pingInterval` | **type changed from Int to FiniteDuration, add ` minutes`**
+`braingames.binary.cacheMaxSize` | `datastore.cache.dataCube.maxEntries` |
+`braingames.binary.mappingCacheMaxSize` | `datastore.cache.mapping.maxEntries` |
+`braingames.binary.agglomerateFileCacheMaxSize` | `datastore.cache.agglomerateFile.maxFileHandleEntries` |
+`braingames.binary.agglomerateCacheMaxSize` | `datastore.cache.agglomerateFile.maxSegmentIdEntries` |
+`braingames.binary.agglomerateStandardBlockSize` | `datastore.cache.agglomerateFile.blockSize` |
+`braingames.binary.agglomerateMaxReaderRange` | `datastore.cache.agglomerateFile.cumsumMaxReaderRange` |
+`braingames.binary.loadTimeout` | removed | was already unused
+`braingames.binary.saveTimeout` | removed | was already unused
+`braingames.binary.isosurfaceTimeout` | `datastore.isosurface.timeout` |  **type changed from Int to FiniteDuration, add ` seconds`**
+`braingames.binary.isosurfaceActorPoolSize` | `datastore.isosurface.actorPoolSize` |
+`braingames.binary.baseFolder` | `datastore.baseFolder`
+`braingames.binary.agglomerateSkeletonEdgeLimit` | `datastore.agglomerateSkeleton.maxEdges`
+`braingames.binary.changeHandler.enabled` | `datastore.watchFileSystem.enabled`
+`braingames.binary.tickerInterval` | `datastore.watchFileSystem.interval` |  **type changed from Int to FiniteDuration, add ` minutes`**
+`mail.enabled` | removed | now enabled if `mail.host` is non-empty
+`jobs.username` | `jobs.user` |
+`braintracing.active` | `braintracing.enabled`
+`braintracing.url` | `braintracing.uri`
+`airbrake.apiKey` | removed | was already unused
+`airbrake.ssl` | removed | was already unused
+`airbrake.enabled` | removed | was already unused
+`airbrake.endpoint` | removed | was already unused
+`slackNotifications.url` | `slackNotifications.uri` |
+`google.analytics.trackingId` | `googleAnalytics.trackingId` |
+`operatorData` | `webKnossos.operatorData`
+
+### Postgres Evolutions:
+- [070-dark-theme.sql](conf/evolutions/070-dark-theme.sql)
+
+
 ## [21.05.0](https://github.com/scalableminds/webknossos/releases/tag/21.05.0) - 2021-04-22
 - Instances with long-running jobs only: the `tiff_cubing` job was renamed to `convert_to_wkw`. For old jobs to be listed properly, execute sql `update webknossos.jobs set command = 'convert_to_wkw' where command = 'tiff_cubing';`
 

--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -6,57 +6,7 @@ This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 
 ## Unreleased
-- The config keys in application.conf were restructured. If you overwrite any of them for your config, please adapt to the new structure, according to the table below. If you run any stand-alone datastores or tracingstores, make sure to update their config files as well.
-
-old key | new key | notes
---------|--------|-------
-`http.address` | removed | used by play, default is 0.0.0.0, you can still overwrite it if necessary
-`actor.defaultTimeout` | removed | was already unused
-`js.defaultTimeout` | removed | was already unused
-`akka.loggers` | removed | was already unused
-`application.name` | removed | was already unused
-`application.branch` | removed | was already unused
-`application.version` | removed | was already unused
-`application.title` | `webKnossos.tabTitle` |
-`application.insertInitialData` | `webKnossos.sampleOrganization.enabled` |
-`application.insertLocalConnectDatastore` | removed | feature removed, insert manually instead
-`application.authentication.defaultuser.email` | `webKnossos.sampleOrganization.user.email` |
-`application.authentication.defaultUser.password` | `webKnossos.sampleOrganization.user.password` |
-`application.authentication.defaultUser.token` | `webKnossos.sampleOrganization.user.token` |
-`application.authentication.defaultUser.isSuperUser` | `webKnossos.sampleOrganization.user.isSuperUser` |
-`application.authentication.ssoKey` | `webKnossos.user.ssoKey` |
-`application.authentication.inviteExpiry` | `webKnossos.user.inviteExpiry` |
-`webKnossos.user.time.tracingPauseInSeconds` | `webKnossos.user.time.tracingPause` | **type changed from Int to FiniteDuration, add ` seconds`**
-`webKnossos.query.maxResults` | removed | was already unused
-`user.cacheTimeoutInMinutes` | `webKnossos.cache.user.timeout` | **type changed from Int to FiniteDuration, add ` minutes`**
-`tracingstore.enabled` | removed | info contained in `play.modules.enabled`
-`datastore.enabled` | removed | info contained in `play.modules.enabled`
-`datastore.webKnossos.pingIntervalMinutes` | `datastore.webKnossos.pingInterval` | **type changed from Int to FiniteDuration, add ` minutes`**
-`braingames.binary.cacheMaxSize` | `datastore.cache.dataCube.maxEntries` |
-`braingames.binary.mappingCacheMaxSize` | `datastore.cache.mapping.maxEntries` |
-`braingames.binary.agglomerateFileCacheMaxSize` | `datastore.cache.agglomerateFile.maxFileHandleEntries` |
-`braingames.binary.agglomerateCacheMaxSize` | `datastore.cache.agglomerateFile.maxSegmentIdEntries` |
-`braingames.binary.agglomerateStandardBlockSize` | `datastore.cache.agglomerateFile.blockSize` |
-`braingames.binary.agglomerateMaxReaderRange` | `datastore.cache.agglomerateFile.cumsumMaxReaderRange` |
-`braingames.binary.loadTimeout` | removed | was already unused
-`braingames.binary.saveTimeout` | removed | was already unused
-`braingames.binary.isosurfaceTimeout` | `datastore.isosurface.timeout` |  **type changed from Int to FiniteDuration, add ` seconds`**
-`braingames.binary.isosurfaceActorPoolSize` | `datastore.isosurface.actorPoolSize` |
-`braingames.binary.baseFolder` | `datastore.baseFolder`
-`braingames.binary.agglomerateSkeletonEdgeLimit` | `datastore.agglomerateSkeleton.maxEdges`
-`braingames.binary.changeHandler.enabled` | `datastore.watchFileSystem.enabled`
-`braingames.binary.tickerInterval` | `datastore.watchFileSystem.interval` |  **type changed from Int to FiniteDuration, add ` minutes`**
-`mail.enabled` | removed | now enabled if `mail.host` is non-empty
-`jobs.username` | `jobs.user` |
-`braintracing.active` | `braintracing.enabled`
-`braintracing.url` | `braintracing.uri`
-`airbrake.apiKey` | removed | was already unused
-`airbrake.ssl` | removed | was already unused
-`airbrake.enabled` | removed | was already unused
-`airbrake.endpoint` | removed | was already unused
-`slackNotifications.url` | `slackNotifications.uri` |
-`google.analytics.trackingId` | `googleAnalytics.trackingId` |
-`operatorData` | `webKnossos.operatorData`
+-
 
 ### Postgres Evolutions:
-- [070-dark-theme.sql](conf/evolutions/070-dark-theme.sql)
+-


### PR DESCRIPTION
Necessary because of the fixes related to the initial rendering of the 3D viewport. Also, I had to clean up the changelog as I didn't clear it on the last release..

------
- [X] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [X] Ready for review
