### PR TITLE
Link to Dataset Settings from Viewer

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added the option to hide the plane borders and crosshairs in the 3D viewport. Also, this setting was moved from the "Other" section of the user settings to the 3D viewport. Additionally, added a setting to hide the dataset bounding box in the 3D view. [#5440](https://github.com/scalableminds/webknossos/pull/5440)
+- Added an icon to the info tab of a tracing that links to the dataset settings. It's located next to the dataset name. [#4772](https://github.com/scalableminds/webknossos/pull/5462)
 
 ### Changed
 - 

--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -3,8 +3,8 @@
  * @flow
  */
 import type { Dispatch } from "redux";
-import { Tooltip } from "antd";
-import { InfoCircleOutlined } from "@ant-design/icons";
+import { Tooltip, Button } from "antd";
+import { EditOutlined, InfoCircleOutlined } from "@ant-design/icons";
 import { connect } from "react-redux";
 import Markdown from "react-remarkable";
 import React from "react";
@@ -221,6 +221,13 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
         >
           {datasetName}
         </Link>
+        <Tooltip title="Edit dataset settings">
+          <Button
+            type="text"
+            icon={<EditOutlined />}
+            href={`/datasets/${owningOrganization}/${datasetName}/edit`}
+          />
+        </Tooltip>
       </p>
     );
   }

--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -192,12 +192,22 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
       description: datasetDescription,
       owningOrganization,
     } = this.props.dataset;
+    const getEditSettingsIcon = () => (
+      <Tooltip title="Edit dataset settings">
+        <Button
+          type="text"
+          icon={<EditOutlined />}
+          href={`/datasets/${owningOrganization}/${datasetName}/edit`}
+        />
+      </Tooltip>
+    );
 
     if (isDatasetViewMode) {
       return (
         <div>
           <p style={{ wordWrap: "break-word" }}>
             <strong>{displayName || datasetName}</strong>
+            {getEditSettingsIcon()}
           </p>
           {datasetDescription ? (
             <div style={{ fontSize: 14 }}>
@@ -221,13 +231,7 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
         >
           {datasetName}
         </Link>
-        <Tooltip title="Edit dataset settings">
-          <Button
-            type="text"
-            icon={<EditOutlined />}
-            href={`/datasets/${owningOrganization}/${datasetName}/edit`}
-          />
-        </Tooltip>
+        {getEditSettingsIcon()}
       </p>
     );
   }

--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -198,6 +198,7 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
           type="text"
           icon={<EditOutlined />}
           href={`/datasets/${owningOrganization}/${datasetName}/edit`}
+          target="_blank"
         />
       </Tooltip>
     );

--- a/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/dataset_info_tab_view.js
@@ -198,6 +198,7 @@ class DatasetInfoTabView extends React.PureComponent<Props> {
           type="text"
           icon={<EditOutlined />}
           href={`/datasets/${owningOrganization}/${datasetName}/edit`}
+          className="transparent-background-on-hover"
           target="_blank"
         />
       </Tooltip>

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -363,3 +363,7 @@ img.keyboard-mouse-icon:first-child {
     border-color: @error-color;
   }
 }
+
+.transparent-background-on-hover:hover {
+  background: transparent;
+}


### PR DESCRIPTION
This PR adds an edit icon next to the dataset name in the info tab that links to the dataset's settings/edit view.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a tracing (annotation or view mode)
- in the info tab next to the dataset's name should be an icon that links to the edit view

### Issues:
- fixes #4772

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] ~~Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- [ ] ~~Updated [documentation](../blob/master/docs) if applicable~~
- [ ] ~~Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- [ ] ~~Needs datastore update after deployment~~
- [x] Ready for review
