### PR TITLE
More logging for long-running jobs

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -56,7 +56,7 @@ class AnnotationController @Inject()(
 
   def info(typ: String, id: String, timestamp: Long): Action[AnyContent] = sil.UserAwareAction.async {
     implicit request =>
-      log {
+      log() {
         val notFoundMessage =
           if (request.identity.isEmpty) "annotation.notFound.considerLoggingIn" else "annotation.notFound"
         for {
@@ -211,7 +211,7 @@ class AnnotationController @Inject()(
 
   def finish(typ: String, id: String, timestamp: Long): Action[AnyContent] = sil.SecuredAction.async {
     implicit request =>
-      log {
+      log() {
         for {
           (updated, message) <- finishAnnotation(typ, id, request.identity, timestamp) ?~> "annotation.finish.failed"
           restrictions <- provider.restrictionsFor(typ, id)
@@ -222,7 +222,7 @@ class AnnotationController @Inject()(
 
   def finishAll(typ: String, timestamp: Long): Action[JsValue] = sil.SecuredAction.async(parse.json) {
     implicit request =>
-      log {
+      log() {
         withJsonAs[JsArray](request.body \ "annotations") { annotationIds =>
           val results = Fox.serialSequence(annotationIds.value.toList) { jsValue =>
             jsValue.asOpt[String].toFox.flatMap(id => finishAnnotation(typ, id, request.identity, timestamp))

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -63,7 +63,7 @@ class AnnotationIOController @Inject()(nmlWriter: NmlWriter,
 
   def upload: Action[MultipartFormData[TemporaryFile]] = sil.SecuredAction.async(parse.multipartFormData) {
     implicit request =>
-      log {
+      log() {
         val shouldCreateGroupForEachFile: Boolean =
           request.body.dataParts("createGroupForEachFile").headOption.contains("true")
         val overwritingDataSetName: Option[String] =

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -93,7 +93,7 @@ class Application @Inject()(multiUserDAO: MultiUserDAO,
       val after = System.currentTimeMillis()
       logger.info(s"Answering ok for wK health check, took ${after - before} ms$localStoresLabelWrapped")
     }
-    log {
+    log() {
       for {
         before <- Fox.successful(System.currentTimeMillis())
         dataStoreDuration <- checkDatastoreHealthIfEnabled ?~> "dataStore.unavailable"

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -205,7 +205,7 @@ class DataSetController @Inject()(userService: UserService,
 
   def read(organizationName: String, dataSetName: String, sharingToken: Option[String]): Action[AnyContent] =
     sil.UserAwareAction.async { implicit request =>
-      log {
+      log() {
         val ctx = URLSharing.fallbackTokenAccessContext(sharingToken)
         for {
           organization <- organizationDAO.findOneByName(organizationName)(GlobalAccessContext) ?~> Messages(

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -147,7 +147,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
   }
 
   def request: Action[AnyContent] = sil.SecuredAction.async { implicit request =>
-    log {
+    log() {
       val user = request.identity
       for {
         teams <- taskService.getAllowedTeamsForNextTask(user)

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -36,7 +36,7 @@ class UserController @Inject()(userService: UserService,
   private val DefaultAnnotationListLimit = 1000
 
   def current: Action[AnyContent] = sil.SecuredAction.async { implicit request =>
-    log {
+    log() {
       for {
         userJs <- userService.publicWrites(request.identity, request.identity)
       } yield Ok(userJs)
@@ -44,7 +44,7 @@ class UserController @Inject()(userService: UserService,
   }
 
   def user(userId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
-    log {
+    log() {
       for {
         userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
         user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND

--- a/app/oxalis/security/UserAwareRequestLogging.scala
+++ b/app/oxalis/security/UserAwareRequestLogging.scala
@@ -11,8 +11,8 @@ trait UserAwareRequestLogging extends AbstractRequestLogging {
   case class RequesterIdOpt(id: Option[String]) //forcing implicit conversion
 
   def log(notifier: Option[String => Unit] = None)(block: => Future[Result])(implicit request: Request[_],
-                                    requesterIdOpt: RequesterIdOpt,
-                                    ec: ExecutionContext): Future[Result] =
+                                                                             requesterIdOpt: RequesterIdOpt,
+                                                                             ec: ExecutionContext): Future[Result] =
     for {
       result: Result <- block
       _ = logRequestFormatted(request, result, notifier, requesterIdOpt.id)

--- a/app/oxalis/security/UserAwareRequestLogging.scala
+++ b/app/oxalis/security/UserAwareRequestLogging.scala
@@ -10,18 +10,12 @@ trait UserAwareRequestLogging extends AbstractRequestLogging {
 
   case class RequesterIdOpt(id: Option[String]) //forcing implicit conversion
 
-  def log(block: => Result)(implicit request: Request[_], requesterIdOpt: RequesterIdOpt): Result = {
-    val result: Result = block
-    logRequestFormatted(request, result, requesterIdOpt.id)
-    result
-  }
-
-  def log(block: => Future[Result])(implicit request: Request[_],
-                                    userIdOpt: RequesterIdOpt,
+  def log(notifier: Option[String => Unit] = None)(block: => Future[Result])(implicit request: Request[_],
+                                    requesterIdOpt: RequesterIdOpt,
                                     ec: ExecutionContext): Future[Result] =
     for {
       result: Result <- block
-      _ = logRequestFormatted(request, result, userIdOpt.id)
+      _ = logRequestFormatted(request, result, notifier, requesterIdOpt.id)
     } yield result
 
   implicit def userAwareRequestToRequesterIdOpt(implicit request: UserAwareRequest[WkEnv, _]): RequesterIdOpt =

--- a/app/oxalis/telemetry/SlackNotificationService.scala
+++ b/app/oxalis/telemetry/SlackNotificationService.scala
@@ -25,6 +25,12 @@ class SlackNotificationService @Inject()(rpc: RPC, config: WkConf) extends LazyL
       msg = msg
     )
 
+  def info(title: String, msg: String): Unit =
+    slackClient.info(
+      title = title,
+      msg = msg
+    )
+
   def noticeFailedJobRequest(msg: String): Unit =
     slackClient.warn(
       title = "Failed job request",

--- a/app/oxalis/telemetry/SlackNotificationService.scala
+++ b/app/oxalis/telemetry/SlackNotificationService.scala
@@ -25,6 +25,12 @@ class SlackNotificationService @Inject()(rpc: RPC, config: WkConf) extends LazyL
       msg = msg
     )
 
+  def noticeFailedJobRequest(msg: String): Unit =
+    slackClient.warn(
+      title = "Failed job request",
+      msg = msg
+    )
+
   def noticeBaseAnnotationTaskCreation(taskType: List[String], numberOfTasks: Int): Unit =
     slackClient.info(
       title = "Task creation with base",

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -91,7 +91,6 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
       val user: String = get[String]("mail.smtp.user")
       val pass: String = get[String]("mail.smtp.pass")
     }
-    val demoSender: String = get[String]("mail.demoSender")
     val defaultSender: String = get[String]("mail.defaultSender")
     object Mailchimp {
       val host: String = get[String]("mail.mailchimp.host")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,7 +153,6 @@ mail {
     pass = ""
   }
   defaultSender = "webKnossos <no-reply@webknossos.org>"
-  demoSender = ""
   reply = "webKnossos <no-reply@webknossos.org>"
   mailchimp {
     host = ""

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,7 +76,7 @@ features {
   autoBrushReadyDatasets = []
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
-  jobsEnabled = false
+  jobsEnabled = true
   # For new users, the dashboard will show a banner which encourages the user to check out the following dataset.
   # If isDemoInstance == true, `/createExplorative/hybrid/true` is appended to the URL so that a new tracing is opened.
   # If isDemoInstance == false, `/view` is appended to the URL so that it's opened in view mode (since the user might not
@@ -239,7 +239,7 @@ googleAnalytics.trackingId = ""
 # Back-end analytics
 slackNotifications {
   uri = ""
-  verboseLoggingEnabled = false # log all slack messages also to stdout
+  verboseLoggingEnabled = true # log all slack messages also to stdout
 }
 
 # Back-end analytics

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,7 +76,7 @@ features {
   autoBrushReadyDatasets = []
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
-  jobsEnabled = true
+  jobsEnabled = false
   # For new users, the dashboard will show a banner which encourages the user to check out the following dataset.
   # If isDemoInstance == true, `/createExplorative/hybrid/true` is appended to the URL so that a new tracing is opened.
   # If isDemoInstance == false, `/view` is appended to the URL so that it's opened in view mode (since the user might not
@@ -239,7 +239,7 @@ googleAnalytics.trackingId = ""
 # Back-end analytics
 slackNotifications {
   uri = ""
-  verboseLoggingEnabled = true # log all slack messages also to stdout
+  verboseLoggingEnabled = false # log all slack messages also to stdout
 }
 
 # Back-end analytics

--- a/util/src/main/scala/com/scalableminds/util/requestlogging/RequestLogging.scala
+++ b/util/src/main/scala/com/scalableminds/util/requestlogging/RequestLogging.scala
@@ -25,15 +25,16 @@ trait AbstractRequestLogging extends LazyLogging {
   private def resultBody(result: Result): String =
     result.body match {
       case HttpEntity.Strict(byteString, _) => byteString.take(20000).decodeString("utf-8")
-      case _ => ""
-  }
+      case _                                => ""
+    }
 
 }
 
 trait RequestLogging extends AbstractRequestLogging {
   // Hint: within webKnossos itself, UserAwareRequestLogging is available, which additionally logs the requester user id
 
-  def log(notifier: Option[String => Unit] = None)(block: => Future[Result])(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
+  def log(notifier: Option[String => Unit] = None)(block: => Future[Result])(implicit request: Request[_],
+                                                                             ec: ExecutionContext): Future[Result] =
     for {
       result: Result <- block
       _ = logRequestFormatted(request, result, notifier)

--- a/util/src/main/scala/com/scalableminds/util/requestlogging/RequestLogging.scala
+++ b/util/src/main/scala/com/scalableminds/util/requestlogging/RequestLogging.scala
@@ -1,21 +1,31 @@
 package com.scalableminds.util.requestlogging
 
 import com.typesafe.scalalogging.LazyLogging
-import play.api.http.HttpEntity
+import play.api.http.{HttpEntity, Status}
 import play.api.mvc.{Request, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait AbstractRequestLogging extends LazyLogging {
 
-  def logRequestFormatted(request: Request[_], result: Result, userId: Option[String] = None): Unit = {
-    val userIdMsg = userId.map(id => s" for user $id").getOrElse("")
+  def logRequestFormatted(request: Request[_],
+                          result: Result,
+                          notifier: Option[String => Unit],
+                          requesterId: Option[String] = None): Unit = {
+
+    if (Status.isSuccessful(result.header.status)) return
+
+    val userIdMsg = requesterId.map(id => s" for user $id").getOrElse("")
+    val resultMsg = s": ${resultBody(result)}"
+    val msg = s"Answering ${result.header.status} at ${request.uri}$userIdMsg$resultMsg"
+    logger.warn(msg)
+    notifier.foreach(_(msg))
+  }
+
+  private def resultBody(result: Result): String =
     result.body match {
-      case HttpEntity.Strict(byteString, _) if result.header.status != 200 =>
-        logger.warn(
-          s"Answering ${result.header.status} at ${request.uri}$userIdMsg – ${byteString.take(20000).decodeString("utf-8")}")
-      case _ => ()
-    }
+      case HttpEntity.Strict(byteString, _) => byteString.take(20000).decodeString("utf-8")
+      case _ => ""
   }
 
 }
@@ -23,10 +33,10 @@ trait AbstractRequestLogging extends LazyLogging {
 trait RequestLogging extends AbstractRequestLogging {
   // Hint: within webKnossos itself, UserAwareRequestLogging is available, which additionally logs the requester user id
 
-  def log(block: => Future[Result])(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
+  def log(notifier: Option[String => Unit] = None)(block: => Future[Result])(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
     for {
       result: Result <- block
-      _ = logRequestFormatted(request, result)
+      _ = logRequestFormatted(request, result, notifier)
     } yield result
 
   def logTime(notifier: String => Unit)(block: => Future[Result])(implicit request: Request[_],
@@ -43,14 +53,8 @@ trait RequestLogging extends AbstractRequestLogging {
     for {
       result: Result <- block
       executionTime = System.nanoTime() - start
-      _ = if (request.uri.contains("volume") && executionTime > 3e9) logTimeFormatted(executionTime, request, result)
+      _ = if (executionTime > 5e9) logTimeFormatted(executionTime, request, result)
     } yield result
-  }
-
-  def log(block: => Result)(implicit request: Request[_]): Result = {
-    val result: Result = block
-    logRequestFormatted(request, result)
-    result
   }
 
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -50,5 +50,10 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
     val children = List(WebKnossos, WatchFileSystem, Cache, Isosurface)
   }
 
-  val children = List(Http, Datastore)
+  object SlackNotifications {
+    val uri: String = get[String]("slackNotifications.uri")
+    val verboseLoggingEnabled: Boolean = get[Boolean]("slackNotifications.verboseLoggingEnabled")
+  }
+
+  val children = List(Http, Datastore, SlackNotifications)
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -50,10 +50,5 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
     val children = List(WebKnossos, WatchFileSystem, Cache, Isosurface)
   }
 
-  object SlackNotifications {
-    val uri: String = get[String]("slackNotifications.uri")
-    val verboseLoggingEnabled: Boolean = get[Boolean]("slackNotifications.verboseLoggingEnabled")
-  }
-
-  val children = List(Http, Datastore, SlackNotifications)
+  val children = List(Http, Datastore)
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
@@ -32,5 +32,5 @@ class TracingStoreConfig @Inject()(configuration: Configuration) extends ConfigR
     val uri: String = get[String]("slackNotifications.uri")
     val verboseLoggingEnabled: Boolean = get[Boolean]("slackNotifications.verboseLoggingEnabled")
   }
-  val children = List(Http, Tracingstore)
+  val children = List(Http, Tracingstore, SlackNotifications)
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
@@ -14,7 +14,7 @@ class Application @Inject()(tracingDataStore: TracingDataStore, redisClient: Red
     extends Controller {
 
   def health: Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       AllowRemoteOrigin {
         for {
           before <- Fox.successful(System.currentTimeMillis())

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -33,7 +33,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
 
   def mergedFromContents(persist: Boolean): Action[SkeletonTracings] = Action.async(validateProto[SkeletonTracings]) {
     implicit request =>
-      log {
+      log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
             val tracings: List[Option[SkeletonTracing]] = request.body
@@ -48,7 +48,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
 
   def duplicate(tracingId: String, version: Option[Long], fromTask: Option[Boolean]): Action[AnyContent] =
     Action.async { implicit request =>
-      log {
+      log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
             for {
@@ -63,7 +63,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
     }
 
   def updateActionLog(tracingId: String): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
           for {
@@ -77,7 +77,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
   }
 
   def updateActionStatistics(tracingId: String): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
           for {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -52,7 +52,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
   implicit val bodyParsers: PlayBodyParsers
 
   def save: Action[T] = Action.async(validateProto[T]) { implicit request =>
-    log {
+    log() {
       logTime(slackNotificationService.noticeSlowRequest) {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
@@ -67,7 +67,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
   }
 
   def saveMultiple: Action[Ts] = Action.async(validateProto[Ts]) { implicit request =>
-    log {
+    log() {
       logTime(slackNotificationService.noticeSlowRequest) {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
@@ -85,7 +85,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
   }
 
   def get(tracingId: String, version: Option[Long]): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
           for {
@@ -100,7 +100,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
 
   def getMultiple: Action[List[Option[TracingSelector]]] = Action.async(validateJson[List[Option[TracingSelector]]]) {
     implicit request =>
-      log {
+      log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
             for {
@@ -115,7 +115,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
 
   def update(tracingId: String): Action[List[UpdateActionGroup[T]]] =
     Action.async(validateJson[List[UpdateActionGroup[T]]]) { implicit request =>
-      log {
+      log() {
         logTime(slackNotificationService.noticeSlowRequest) {
           accessTokenService.validateAccess(UserAccessRequest.writeTracing(tracingId)) {
             AllowRemoteOrigin {
@@ -226,7 +226,7 @@ trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMe
 
   def mergedFromIds(persist: Boolean): Action[List[Option[TracingSelector]]] =
     Action.async(validateJson[List[Option[TracingSelector]]]) { implicit request =>
-      log {
+      log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
             for {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -45,7 +45,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
 
   def initialData(tracingId: String, minResolution: Option[Int], maxResolution: Option[Int]): Action[AnyContent] =
     Action.async { implicit request =>
-      log {
+      log() {
         logTime(slackNotificationService.noticeSlowRequest) {
           accessTokenService.validateAccess(UserAccessRequest.webknossos) {
             AllowRemoteOrigin {
@@ -66,7 +66,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
 
   def mergedFromContents(persist: Boolean): Action[VolumeTracings] = Action.async(validateProto[VolumeTracings]) {
     implicit request =>
-      log {
+      log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
             val tracings: List[Option[VolumeTracing]] = request.body
@@ -80,7 +80,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
   }
 
   def initialDataMultiple(tracingId: String): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       logTime(slackNotificationService.noticeSlowRequest) {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
@@ -97,7 +97,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
   }
 
   def allData(tracingId: String, version: Option[Long]): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
           for {
@@ -112,7 +112,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
   }
 
   def allDataBlocking(tracingId: String, version: Option[Long]): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
           for {
@@ -127,7 +127,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
 
   def data(tracingId: String): Action[List[WebKnossosDataRequest]] =
     Action.async(validateJson[List[WebKnossosDataRequest]]) { implicit request =>
-      log {
+      log() {
         accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
           AllowRemoteOrigin {
             for {
@@ -150,7 +150,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
                 minResolution: Option[Int],
                 maxResolution: Option[Int],
                 downsample: Option[Boolean]): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       logTime(slackNotificationService.noticeSlowRequest) {
         accessTokenService.validateAccess(UserAccessRequest.webknossos) {
           AllowRemoteOrigin {
@@ -173,7 +173,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
 
   def unlinkFallback(tracingId: String): Action[DataSourceLike] = Action.async(validateJson[DataSourceLike]) {
     implicit request =>
-      log {
+      log() {
         logTime(slackNotificationService.noticeSlowRequest) {
           accessTokenService.validateAccess(UserAccessRequest.webknossos) {
             AllowRemoteOrigin {
@@ -190,7 +190,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
 
   def importVolumeData(tracingId: String): Action[MultipartFormData[TemporaryFile]] =
     Action.async(parse.multipartFormData) { implicit request =>
-      log {
+      log() {
         accessTokenService.validateAccess(UserAccessRequest.writeTracing(tracingId)) {
           AllowRemoteOrigin {
             for {
@@ -205,7 +205,7 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
     }
 
   def updateActionLog(tracingId: String): Action[AnyContent] = Action.async { implicit request =>
-    log {
+    log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId)) {
         AllowRemoteOrigin {
           for {


### PR DESCRIPTION
- Send slack notification for successful jobs (additionally to the previously existing notification for failed ones)
- Send slack notification + log to console if the run job request itself fails

### Steps to test:
- set `jobsEnabled = true` and `slackNotifications.verboseLoggingEnabled = true`
- upload dataset that needs conversion (but do not run webknossos-worker), slack notification for the failed request should be logged to backend logging
- do run webknossos-worker upload valid and invalid dataset (that needs conversion), both success and failure should be logged as slack notification to the backend logging

- [x] Ready for review
