### PR TITLE
Multi-NML Upload: allow for only some to have Orga Attribute

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,10 +15,11 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added an icon to the info tab of a tracing that links to the dataset settings. It's located next to the dataset name. [#4772](https://github.com/scalableminds/webknossos/pull/5462)
 
 ### Changed
-- 
+-
 
 ### Fixed
 - Fixed a bug where histograms generation failed for tiny datasets. [#5458](https://github.com/scalableminds/webknossos/pull/5458)
+- Fixed a bug where the upload of multiple NMLs failed if some of them have an organization attribute and others don’t. [#5483](https://github.com/scalableminds/webknossos/pull/5483)
 
 ### Removed
 - Removed the button to load or refresh the isosurface of the centered cell from the 3D view. Instead, this action can be triggered from the "Meshes" tab. [#5440](https://github.com/scalableminds/webknossos/pull/5440)

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -173,14 +173,12 @@ class AnnotationIOController @Inject()(nmlWriter: NmlWriter,
 
   private def assertAllOnSameOrganization(skeletons: List[SkeletonTracing],
                                           volumes: List[VolumeTracing]): Fox[Option[String]] =
+    // Note that organizationNames are optional. Tracings with no organization attribute are ignored here
     for {
-      organizationName: Option[String] <- volumes.headOption
-        .map(_.organizationName)
-        .orElse(skeletons.headOption.map(_.organizationName))
-        .toFox
-      _ <- bool2Fox(skeletons.forall(_.organizationName == organizationName))
-      _ <- bool2Fox(volumes.forall(_.organizationName == organizationName))
-    } yield organizationName
+      _ <- Fox.successful(())
+      organizationNames = skeletons.flatMap(_.organizationName) ::: volumes.flatMap(_.organizationName)
+      _ <- bool2Fox(organizationNames.forall(_ == organizationNames.head))
+    } yield organizationNames.headOption
 
   private def adaptPropertiesToFallbackLayer(volumeTracing: VolumeTracing, dataSet: DataSet): Fox[VolumeTracing] =
     for {

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -172,13 +172,13 @@ class AnnotationIOController @Inject()(nmlWriter: NmlWriter,
     } yield dataSetName
 
   private def assertAllOnSameOrganization(skeletons: List[SkeletonTracing],
-                                          volumes: List[VolumeTracing]): Fox[Option[String]] =
+                                          volumes: List[VolumeTracing]): Fox[Option[String]] = {
     // Note that organizationNames are optional. Tracings with no organization attribute are ignored here
+    val organizationNames = skeletons.flatMap(_.organizationName) ::: volumes.flatMap(_.organizationName)
     for {
-      _ <- Fox.successful(())
-      organizationNames = skeletons.flatMap(_.organizationName) ::: volumes.flatMap(_.organizationName)
-      _ <- bool2Fox(organizationNames.forall(_ == organizationNames.head))
+      _ <- Fox.runOptional(organizationNames.headOption)(name => bool2Fox(organizationNames.forall(_ == name)))
     } yield organizationNames.headOption
+  }
 
   private def adaptPropertiesToFallbackLayer(volumeTracing: VolumeTracing, dataSet: DataSet): Fox[VolumeTracing] =
     for {


### PR DESCRIPTION
Changes the assertion so that it looks only at tracings that _do have_ an organization attribute. If all have one, or none, the behavior is unchanged. If only some have one, only they are compared and this organization name is returned and used for the disambiguation.

e.g. `<experiment name="myDataset" organization="sample_organization" description="" />`

### URL of deployed dev instance (used for testing):
- https://nmlorgaoptional.webknossos.xyz

### Steps to test:
- create nmls with different combinations: in the `experiment` tag 
- same orga → should work
- both no orga → should work
- only one with orga tag → should work (this is the new part)
- different orga → should be rejected

### Issues:
- fixes bug reported in https://discuss.webknossos.org/t/upload-nml-failed/1666/5

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
