### PR TITLE
Relabel too-high tree ids in backend

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,10 +15,11 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added an icon to the info tab of a tracing that links to the dataset settings. It's located next to the dataset name. [#4772](https://github.com/scalableminds/webknossos/pull/5462)
 
 ### Changed
-- 
+-
 
 ### Fixed
 - Fixed a bug where histograms generation failed for tiny datasets. [#5458](https://github.com/scalableminds/webknossos/pull/5458)
+- Fixed a bug where NMLs with huge tree IDs uploaded via back-end produced broken annotations. [#5484](https://github.com/scalableminds/webknossos/pull/5484)
 
 ### Removed
 - Removed the button to load or refresh the isosurface of the centered cell from the 3D view. Instead, this action can be triggered from the "Meshes" tab. [#5440](https://github.com/scalableminds/webknossos/pull/5440)

--- a/app/models/annotation/TracingStoreRpcClient.scala
+++ b/app/models/annotation/TracingStoreRpcClient.scala
@@ -27,7 +27,7 @@ object TracingStoreRpcClient {
 class TracingStoreRpcClient(tracingStore: TracingStore, dataSet: DataSet, rpc: RPC)(implicit ec: ExecutionContext)
     extends LazyLogging {
 
-  def baseInfo = s"Dataset: ${dataSet.name} Tracingstore: ${tracingStore.url}"
+  def baseInfo = s" Dataset: ${dataSet.name} Tracingstore: ${tracingStore.url}"
 
   def getSkeletonTracing(tracingId: String, version: Option[Long]): Fox[SkeletonTracing] = {
     logger.debug("Called to get SkeletonTracing." + baseInfo)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -38,9 +38,10 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
           AllowRemoteOrigin {
             val tracings: List[Option[SkeletonTracing]] = request.body
             val mergedTracing = tracingService.merge(tracings.flatten)
-            tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist).map { newId =>
-              Ok(Json.toJson(newId))
-            }
+            for {
+              correctedTracing <- tracingService.remapTooLargeTreeIds(mergedTracing)
+              newId <- tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist)
+            } yield Ok(Json.toJson(newId))
           }
         }
       }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -38,9 +38,9 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
           AllowRemoteOrigin {
             val tracings: List[Option[SkeletonTracing]] = request.body
             val mergedTracing = tracingService.merge(tracings.flatten)
+            val processedTracing = tracingService.remapTooLargeTreeIds(mergedTracing)
             for {
-              correctedTracing <- tracingService.remapTooLargeTreeIds(mergedTracing)
-              newId <- tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist)
+              newId <- tracingService.save(processedTracing, None, processedTracing.version, toCache = !persist)
             } yield Ok(Json.toJson(newId))
           }
         }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingService.scala
@@ -172,6 +172,8 @@ trait TracingService[T <: GeneratedMessage with Message[T]]
 
   def merge(tracings: Seq[T]): T
 
+  def remapTooLargeTreeIds(tracing: T): T = tracing
+
   def mergeVolumeData(tracingSelectors: Seq[TracingSelector],
                       tracings: Seq[T],
                       newId: String,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -176,6 +176,13 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
     )
   }
 
+  // Can be removed again when https://github.com/scalableminds/webknossos/issues/5009 is fixed
+  def remapTooLargeTreeIds(skeletonTracing: SkeletonTracing): SkeletonTracing = {
+    if (skeletonTracing.trees.exists(_.treeId > 1048576) {
+
+    } else skeletonTracing
+  }
+
   def mergeVolumeData(tracingSelectors: Seq[TracingSelector],
                       tracings: Seq[SkeletonTracing],
                       newId: String,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -177,11 +177,11 @@ class SkeletonTracingService @Inject()(tracingDataStore: TracingDataStore,
   }
 
   // Can be removed again when https://github.com/scalableminds/webknossos/issues/5009 is fixed
-  def remapTooLargeTreeIds(skeletonTracing: SkeletonTracing): SkeletonTracing = {
-    if (skeletonTracing.trees.exists(_.treeId > 1048576) {
-
+  override def remapTooLargeTreeIds(skeletonTracing: SkeletonTracing): SkeletonTracing =
+    if (skeletonTracing.trees.exists(_.treeId > 1048576)) {
+      val newTrees = for ((tree, index) <- skeletonTracing.trees.zipWithIndex) yield tree.withTreeId(index + 1)
+      skeletonTracing.withTrees(newTrees)
     } else skeletonTracing
-  }
 
   def mergeVolumeData(tracingSelectors: Seq[TracingSelector],
                       tracings: Seq[SkeletonTracing],


### PR DESCRIPTION
Workaround for #5009 

### URL of deployed dev instance (used for testing):
- https://relabeltreeids.webknossos.xyz

### Steps to test:
- upload nml with huge tree ids (>2^20)
- should work (upload should remap the ids)
- upload nml with normal tree ids should not be noticeably slower

### Issues:
- fixes #5478

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
