### PR TITLE
Use bbox topleft instead of 0,0,0 in histogram position sampling

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
@@ -93,7 +93,7 @@ class FindDataService @Inject()(dataServicesHolder: BinaryDataServiceHolder)(imp
       }
     }
 
-    Point3D(0, 0, 0) +: positionCreationIter((1 to iterationCount).toList, List[Point3D]())
+    dataLayer.boundingBox.topLeft +: positionCreationIter((1 to iterationCount).toList, List[Point3D]())
   }
 
   private def checkAllPositionsForData(dataSource: DataSource,


### PR DESCRIPTION
@philippotto rightly pointed out that my previous fix  #5458 works only for the (somewhat standard, but not general) case of the dataset starting at 0,0,0. This PR changes the used position to the dataset bounding box topleft corner.

- [x] Needs datastore update after deployment
- [x] Ready for review
