### PR TITLE
Add all csv info to displayed table on successful task creation

### DIFF
--- a/frontend/javascripts/admin/task/task_create_form_view.js
+++ b/frontend/javascripts/admin/task/task_create_form_view.js
@@ -79,11 +79,6 @@ type State = {
   isFetchingData: boolean,
 };
 
-export function taskToShortText(task: APITask) {
-  const { id, creationInfo, editPosition } = task;
-  return `${id},${creationInfo || "null"},(${editPosition.join(",")})`;
-}
-
 export function taskToText(task: APITask) {
   const {
     id,
@@ -113,6 +108,12 @@ export function taskToText(task: APITask) {
   return taskAsString;
 }
 
+function tasksToCSVString(tasks: Array<APITask>) {
+  const allTasksAsStrings = tasks.map(task => taskToText(task)).join("\n");
+  const csv = [TASK_CSV_HEADER, allTasksAsStrings].join("\n");
+  return csv;
+}
+
 export function downloadTasksAsCSV(tasks: Array<APITask>) {
   if (tasks.length < 0) {
     return;
@@ -122,9 +123,12 @@ export function downloadTasksAsCSV(tasks: Array<APITask>) {
   const currentDateAsString = formatDateInLocalTimeZone(lastCreationTime);
   const allTeamNames = _.uniq(tasks.map(task => task.team));
   const teamName = allTeamNames.length > 1 ? "multiple_teams" : allTeamNames[0];
-  const allTasksAsStrings = tasks.map(task => taskToText(task)).join("\n");
-  const csv = [TASK_CSV_HEADER, allTasksAsStrings].join("\n");
-  const filename = `${teamName}-${maybeTaskPlural}-${currentDateAsString}.csv`;
+  const allProjectNames = _.uniq(tasks.map(task => task.projectName));
+  const projectName = allProjectNames.length > 1 ? "multiple_projects" : allProjectNames[0];
+  const taskIds = _.uniq(tasks.map(task => task.id));
+  const taskIdsString = taskIds.length < 4 ? taskIds.join("_") : "multiple_ids";
+  const csv = tasksToCSVString(tasks);
+  const filename = `${teamName}-${maybeTaskPlural}-${taskIdsString}-${projectName}-${currentDateAsString}.csv`;
   const blob = new Blob([csv], { type: "text/plain;charset=utf-8" });
   saveAs(blob, filename);
 }
@@ -159,11 +163,7 @@ export function handleTaskCreationResponse(response: TaskCreationResponseContain
   const failedTasksAsString = failedTasks.join("");
   const successfulTasksContent =
     successfulTasks.length <= maxDisplayedTasksCount ? (
-      <pre>
-        taskId,filename,position
-        <br />
-        {successfulTasks.map(task => taskToShortText(task)).join("\n")}
-      </pre>
+      <pre>{tasksToCSVString(successfulTasks)}</pre>
     ) : (
       "Too many tasks to show, please use CSV download for a full list."
     );

--- a/frontend/javascripts/admin/task/task_create_form_view.js
+++ b/frontend/javascripts/admin/task/task_create_form_view.js
@@ -221,7 +221,7 @@ export function handleTaskCreationResponse(response: TaskCreationResponseContain
         ) : null}
       </div>
     ),
-    width: 600,
+    width: 800,
   });
 }
 


### PR DESCRIPTION
This PR unifies the information that is displayed in the table that is shown upon successful task creating with the information of the CSV.

Imo this change does not make so much sense. Maybe I misunderstood something but to me, the display information in the modal is far too much to be easily understood/is not clearly arranged. Additionally, the file name might get too huge if all IDs (like suggested) are added to the file name. Thus I limited this to a maximum of 3 task ids.

I think some general input on my points is needed before we start a code review :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Got to the admin->task view
- Open the task creation
- Create a task and upon success see new content in the modal.
- Then download the CSV and check the file name.

### Issues:
- fixes #5359

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
