### PR TITLE
Pass through URL Params in Proxy

### DIFF
--- a/app/controllers/DemoProxyController.scala
+++ b/app/controllers/DemoProxyController.scala
@@ -31,7 +31,7 @@ class DemoProxyController @Inject()(ws: WSClient, conf: WkConf, sil: Silhouette[
 
   private def matchesProxyPage(request: UserAwareRequest[WkEnv, AnyContent]): Boolean =
     conf.Features.isDemoInstance && conf.Proxy.routes
-      .exists(route => matchesPageWithWildcard(route, request.uri)) && (request.identity.isEmpty || request.uri != "/")
+      .exists(route => matchesPageWithWildcard(route, request.path)) && (request.identity.isEmpty || request.uri != "/")
 
   private def matchesPageWithWildcard(routeWithWildcard: String, actualRequest: String): Boolean = {
     val wildcardRegex = "^" + Regex.quote(routeWithWildcard).replace("*", "\\E.*\\Q") + "$"


### PR DESCRIPTION
### Steps to test:
- in application.conf set isDemoInstance=true, add a proxy.prefix and a proxy.routes entry (e.g. `"/test"`)
- Visit that url with and without url params
- wK should send the proxy requests regardless of the url params, if the path matches the routes list

### Issues:
- fixes #5493 

------
- [x] Ready for review
