### PR TITLE
Add tags to mailchimp for some user interactions

### DIFF
--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -18,7 +18,7 @@ import models.user._
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import org.apache.commons.codec.binary.Base64
 import org.apache.commons.codec.digest.HmacUtils
-import oxalis.mail.{DefaultMails, MailchimpClient, Send}
+import oxalis.mail.{DefaultMails, MailchimpClient, MailchimpTag, Send}
 import oxalis.security._
 import oxalis.thirdparty.BrainTracing
 import play.api.data.Form
@@ -104,7 +104,7 @@ class AuthenticationController @Inject()(
                 brainDBResult <- brainTracing.registerIfNeeded(user, signUpData.password).toFox
               } yield {
                 if (conf.Features.isDemoInstance) {
-                  mailchimpClient.registerUser(user, multiUser, tag = "registered_as_user")
+                  mailchimpClient.registerUser(user, multiUser, tag = MailchimpTag.RegisteredAsUser)
                 } else {
                   Mailer ! Send(defaultMails.newUserMail(user.name, email, brainDBResult, autoActivate))
                 }
@@ -206,6 +206,7 @@ class AuthenticationController @Inject()(
         _ <- Fox.serialCombined(request.body.recipients)(recipient =>
           inviteService.inviteOneRecipient(recipient, request.identity, request.body.autoActivate))
         _ = analyticsService.track(InviteEvent(request.identity, request.body.recipients.length))
+        _ = mailchimpClient.tagUser(request.identity, MailchimpTag.HasInvitedTeam)
       } yield Ok
   }
 
@@ -400,7 +401,7 @@ class AuthenticationController @Inject()(
                                                        email.toLowerCase,
                                                        request.headers.get("Host").getOrElse("")))
                     if (conf.Features.isDemoInstance) {
-                      mailchimpClient.registerUser(user, multiUser, tag = "registered_as_admin")
+                      mailchimpClient.registerUser(user, multiUser, MailchimpTag.RegisteredAsAdmin)
                     }
                     Ok
                   }

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -222,7 +222,7 @@ class DataSetController @Inject()(userService: UserService,
           js <- dataSetService.publicWrites(dataSet, request.identity, organization, dataStore)
           _ = request.identity.map { user =>
             analyticsService.track(OpenDatasetEvent(user, dataSet))
-            if (dataSet.isPublic && dataSet._organization != user._organization) {
+            if (dataSet.isPublic) {
               mailchimpClient.tagUser(user, MailchimpTag.HasViewedPublishedDataset)
             }
           }

--- a/app/controllers/WKDataStoreController.scala
+++ b/app/controllers/WKDataStoreController.scala
@@ -11,6 +11,7 @@ import models.analytics.{AnalyticsService, UploadDatasetEvent}
 import models.binary._
 import models.organization.OrganizationDAO
 import net.liftweb.common.Full
+import oxalis.mail.{MailchimpClient, MailchimpTag}
 import oxalis.security.{WebknossosBearerTokenAuthenticatorService, WkSilhouetteEnvironment}
 import play.api.i18n.Messages
 import play.api.libs.json.{JsError, JsSuccess, JsValue}
@@ -24,6 +25,7 @@ class WKDataStoreController @Inject()(dataSetService: DataSetService,
                                       analyticsService: AnalyticsService,
                                       organizationDAO: OrganizationDAO,
                                       dataSetDAO: DataSetDAO,
+                                      mailchimpClient: MailchimpClient,
                                       wkSilhouetteEnvironment: WkSilhouetteEnvironment)(implicit ec: ExecutionContext)
     extends Controller
     with LazyLogging {
@@ -55,6 +57,7 @@ class WKDataStoreController @Inject()(dataSetService: DataSetService,
               "dataSet.notFound",
               dataSetName) ~> NOT_FOUND
             _ = analyticsService.track(UploadDatasetEvent(user, dataSet, dataStore, dataSetSizeBytes))
+            _ = mailchimpClient.tagUser(user, MailchimpTag.HasUploadedOwnDataset)
             _ <- dataSetService.addInitialTeams(dataSet, teams)(AuthorizedAccessContext(user), request.messages)
             _ <- dataSetService.addUploader(dataSet, user._id)(AuthorizedAccessContext(user))
           } yield Ok

--- a/app/oxalis/mail/MailchimpClient.scala
+++ b/app/oxalis/mail/MailchimpClient.scala
@@ -1,29 +1,30 @@
 package oxalis.mail
 
+import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.security.SCrypt
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.scalalogging.LazyLogging
 import javax.inject.Inject
-import models.user.{MultiUser, User}
+import models.user.{MultiUser, MultiUserDAO, User}
+import oxalis.mail.MailchimpTag.MailchimpTag
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
 import utils.WkConf
 
-import scala.concurrent.ExecutionContext
-
-class MailchimpClient @Inject()(wkConf: WkConf, rpc: RPC)(implicit ec: ExecutionContext) extends LazyLogging {
+class MailchimpClient @Inject()(wkConf: WkConf, rpc: RPC, multiUserDAO: MultiUserDAO) extends LazyLogging {
 
   private lazy val conf = wkConf.Mail.Mailchimp
 
-  def registerUser(user: User, multiUser: MultiUser, tag: String): Fox[Unit] = {
-    if (conf.host.isEmpty) return Fox.successful(())
+  def registerUser(user: User, multiUser: MultiUser, tag: MailchimpTag): Unit = {
+    if (conf.host.isEmpty) return
     val emailMd5 = SCrypt.md5(multiUser.email)
-    logger.info(s"Registering user ${user._id} for Mailchimp, tag=$tag")
+    logger.info(s"Registering user ${user._id} for Mailchimp, tag=${MailchimpTag.format(tag)}")
     for {
       _ <- registerUser(user.firstName, user.lastName, multiUser.email, emailMd5)
       _ <- tagUser(emailMd5, tag)
     } yield ()
+    ()
   }
 
   private def registerUser(firstName: String, lastName: String, email: String, emailMd5: String): Fox[WSResponse] = {
@@ -39,10 +40,20 @@ class MailchimpClient @Inject()(wkConf: WkConf, rpc: RPC)(implicit ec: Execution
     rpc(uri).silent.withBasicAuth(conf.user, conf.password).put(userBody)
   }
 
-  private def tagUser(emailMd5: String, tag: String): Fox[WSResponse] = {
+  def tagUser(user: User, tag: MailchimpTag): Unit = {
+    if (conf.host.isEmpty) return
+    for {
+      multiUser <- multiUserDAO.findOne(user._multiUser)(GlobalAccessContext)
+      emailMd5 = SCrypt.md5(multiUser.email)
+      _ <- tagUser(emailMd5, tag)
+    } yield ()
+    ()
+  }
+
+  private def tagUser(emailMd5: String, tag: MailchimpTag): Fox[WSResponse] = {
     val uri = s"${conf.host}/lists/${conf.listId}/members/$emailMd5/tags"
     val tagBody = Json.obj(
-      "tags" -> List(Json.obj("name" -> tag, "status" -> "active"))
+      "tags" -> List(Json.obj("name" -> MailchimpTag.format(tag), "status" -> "active"))
     )
     rpc(uri).silent.withBasicAuth(conf.user, conf.password).post(tagBody)
   }

--- a/app/oxalis/mail/MailchimpTag.scala
+++ b/app/oxalis/mail/MailchimpTag.scala
@@ -9,7 +9,9 @@ object MailchimpTag extends ExtendedEnumeration {
   HasViewedPublishedDataset = Value
 
   def format(tag: MailchimpTag): String =
-    "[A-Z]".r.replaceAllIn(tag.toString, { m =>
-      "_" + m.group(0).toLowerCase()
-    })
+    "[A-Z]".r
+      .replaceAllIn(tag.toString, { m =>
+        "_" + m.group(0).toLowerCase()
+      })
+      .drop(1)
 }

--- a/app/oxalis/mail/MailchimpTag.scala
+++ b/app/oxalis/mail/MailchimpTag.scala
@@ -1,0 +1,15 @@
+package oxalis.mail
+
+import com.scalableminds.util.enumeration.ExtendedEnumeration
+
+object MailchimpTag extends ExtendedEnumeration {
+  type MailchimpTag = Value
+
+  val RegisteredAsUser, RegisteredAsAdmin, HasAnnotated, HasInvitedTeam, HasUploadedOwnDataset,
+  HasViewedPublishedDataset = Value
+
+  def format(tag: MailchimpTag): String =
+    "[A-Z]".r.replaceAllIn(tag.toString, { m =>
+      "_" + m.group(0).toLowerCase()
+    })
+}


### PR DESCRIPTION
Adds mailchimp tags to users in the audience. These calls are non-blocking so the normal wk operation is not impeded.
The new tags are `has_annotated`, `has_invited_team`, `has_uploaded_own_dataset`, `has_viewed_published_dataset`.

### Steps to test:
- fill in valid credentials in `application.conf` key block `mailchimp`
- create annotation, view public dataset of other organization, upload dataset, send invites
- corresponding mailchimp user should get those tags.
- to test without credentials, add logging to `MailchimpClient.scala` L54 instead

### Issues:
- fixes #5450 

------
- [x] Ready for review
