### PR TITLE
Schedule fetching job status updates

### DIFF
--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -120,7 +120,8 @@ class JobService @Inject()(wkConf: WkConf,
     with LazyLogging {
 
   override protected lazy val enabled: Boolean = wkConf.Features.jobsEnabled
-  protected lazy val tickerInterval: FiniteDuration = 5 minutes // note that user requests can trigger more frequent checking
+  protected lazy val tickerInterval
+    : FiniteDuration = 5 minutes // note that user requests can trigger more frequent checking
 
   def tick(): Unit = {
     updateCeleryInfos()

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -307,13 +307,12 @@ class UserService @Inject()(conf: WkConf,
       teamMemberships <- teamMembershipsFor(user._id)
       multiUser <- multiUserDAO.findOne(user._multiUser)(GlobalAccessContext)
       novelUserExperienceInfos = multiUser.novelUserExperienceInfos
-      email <- emailFor(user)
       teamMembershipsJs <- Fox.serialCombined(teamMemberships)(tm => teamMembershipService.publicWrites(tm))
       experiences <- experiencesFor(user._id)
     } yield {
       Json.obj(
         "id" -> user._id.toString,
-        "email" -> email,
+        "email" -> multiUser.email,
         "firstName" -> user.firstName,
         "lastName" -> user.lastName,
         "isAdmin" -> user.isAdmin,


### PR DESCRIPTION
Checks celery job status list every 5 minutes.
Note that user requests can trigger this in a higher frequency, this is just added in case users don’t list their jobs for a long time.

### Steps to test:
- enable jobs, see in logging that update runs every 5 minutes even if the user does not open jobs overview page

### Issues:
- fixes #5331

------
- [x] Ready for review
