### PR TITLE
Update backend protobuf dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import play.routes.compiler.InjectedRoutesGenerator
-import play.sbt.routes.RoutesKeys.{routesGenerator, routesImport}
+import play.sbt.routes.RoutesKeys.routesGenerator
 import sbt._
 
 ThisBuild / version := "wk"
@@ -18,7 +18,7 @@ ThisBuild / scalacOptions ++= Seq(
   "-P:silencer:pathFilters=(.*target/.*/routes/.*/(ReverseRoutes\\.scala|Routes\\.scala|routes\\.java|JavaScriptReverseRoutes.scala)|.*target/.*\\.template\\.scala)"
 )
 
-ThisBuild / routesImport := Seq.empty
+ThisBuild / dependencyCheckAssemblyAnalyzerEnabled := Some(false)
 
 ThisBuild / libraryDependencies ++= Seq(
   compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.0" cross CrossVersion.full),
@@ -41,10 +41,10 @@ lazy val commonSettings = Seq(
 )
 
 lazy val protocolBufferSettings = Seq(
-  ProtocPlugin.autoImport.PB.targets in Compile := Seq(
-    scalapb.gen() -> new java.io.File((sourceManaged in Compile).value + "/proto")
-  ),
-  ProtocPlugin.autoImport.PB.protoSources := Seq(new java.io.File("webknossos-datastore/proto"))
+  Compile / PB.protoSources := Seq(new java.io.File("webknossos-datastore/proto")),
+  Compile / PB.targets := Seq(
+    scalapb.gen() -> (Compile / sourceManaged).value / "proto"
+  )
 )
 
 lazy val copyConfFilesSetting = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
   val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
   val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
-  val commonsEmail = "org.apache.commons" % "commons-email" % "1.3.1"
+  val commonsEmail = "org.apache.commons" % "commons-email" % "1.5"
   val commonsIo = "commons-io" % "commons-io" % "2.4"
   val commonsLang = "org.apache.commons" % "commons-lang3" % "3.1"
   val gson = "com.google.code.gson" % "gson" % "1.7.1"

--- a/project/DependencyResolvers.scala
+++ b/project/DependencyResolvers.scala
@@ -1,7 +1,6 @@
 import sbt._
 
 object DependencyResolvers {
-  val teamon = "teamon.eu repo" at "http://repo.teamon.eu"
   val atlassian = "Atlassian Releases" at "https://maven.atlassian.com/public/"
 
   val dependencyResolvers = Seq(
@@ -9,7 +8,6 @@ object DependencyResolvers {
     Resolver.sonatypeRepo("snapshots"),
     Resolver.typesafeRepo("releases"),
     Resolver.bintrayRepo("scalaz", "releases"),
-    teamon,
     atlassian
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.23")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
@@ -10,4 +10,6 @@ addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.0"
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "3.1.3")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
@@ -1,5 +1,7 @@
 package com.scalableminds.webknossos.datastore.controllers
 
+import java.io.FileInputStream
+
 import com.google.protobuf.CodedInputStream
 import com.scalableminds.util.mvc.ExtendedController
 import com.scalableminds.util.requestlogging.RequestLogging
@@ -9,9 +11,8 @@ import net.liftweb.util.Helpers.tryo
 import play.api.libs.json.{JsError, Reads}
 import play.api.mvc.Results._
 import play.api.mvc._
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
-import java.io.FileInputStream
 import scala.concurrent.{ExecutionContext, Future}
 
 trait Controller
@@ -42,7 +43,7 @@ trait ValidationHelpers {
       _.validate[A].asEither.left.map(e => BadRequest(JsError.toJson(e)))
     )
 
-  def validateProto[A <: GeneratedMessage with Message[A]](implicit bodyParsers: PlayBodyParsers,
+  def validateProto[A <: GeneratedMessage](implicit bodyParsers: PlayBodyParsers,
                                                            companion: GeneratedMessageCompanion[A],
                                                            ec: ExecutionContext): BodyParser[A] =
     bodyParsers.raw.validate { raw =>

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
@@ -44,8 +44,8 @@ trait ValidationHelpers {
     )
 
   def validateProto[A <: GeneratedMessage](implicit bodyParsers: PlayBodyParsers,
-                                                           companion: GeneratedMessageCompanion[A],
-                                                           ec: ExecutionContext): BodyParser[A] =
+                                           companion: GeneratedMessageCompanion[A],
+                                           ec: ExecutionContext): BodyParser[A] =
     bodyParsers.raw.validate { raw =>
       if (raw.size < raw.memoryThreshold) {
         Box(raw.asBytes())

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
@@ -10,7 +10,7 @@ import net.liftweb.common.{Failure, Full}
 import play.api.http.{HeaderNames, Status}
 import play.api.libs.json._
 import play.api.libs.ws._
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -53,7 +53,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
     parseJsonResponse(performRequest)
   }
 
-  def getWithProtoResponse[T <: GeneratedMessage with Message[T]](companion: GeneratedMessageCompanion[T]): Fox[T] = {
+  def getWithProtoResponse[T <: GeneratedMessage](companion: GeneratedMessageCompanion[T]): Fox[T] = {
     request = request.withMethod("GET")
     parseProtoResponse(performRequest)(companion)
   }
@@ -73,7 +73,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
     parseJsonResponse(performRequest)
   }
 
-  def postWithProtoResponse[T <: GeneratedMessage with Message[T]](file: File)(
+  def postWithProtoResponse[T <: GeneratedMessage](file: File)(
       companion: GeneratedMessageCompanion[T]): Fox[T] = {
     request = request.withBody(file).withMethod("POST")
     parseProtoResponse(performRequest)(companion)
@@ -111,7 +111,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
     parseJsonResponse(performRequest)
   }
 
-  def postJsonWithProtoResponse[J: Writes, T <: GeneratedMessage with Message[T]](body: J = Json.obj())(
+  def postJsonWithProtoResponse[J: Writes, T <: GeneratedMessage](body: J = Json.obj())(
       companion: GeneratedMessageCompanion[T]): Fox[T] = {
     request = request
       .addHttpHeaders(HeaderNames.CONTENT_TYPE -> "application/json")
@@ -128,7 +128,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
     performRequest
   }
 
-  def postProtoWithJsonResponse[T <: GeneratedMessage with Message[T], J: Reads](body: T): Fox[J] = {
+  def postProtoWithJsonResponse[T <: GeneratedMessage, J: Reads](body: T): Fox[J] = {
     request = request
       .addHttpHeaders(HeaderNames.CONTENT_TYPE -> "application/x-protobuf")
       .withBody(body.toByteArray)
@@ -226,7 +226,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
       }
     }
 
-  private def parseProtoResponse[T <: GeneratedMessage with Message[T]](r: Fox[WSResponse])(
+  private def parseProtoResponse[T <: GeneratedMessage](r: Fox[WSResponse])(
       companion: GeneratedMessageCompanion[T]) =
     r.flatMap { response =>
       if (Status.isSuccessful(response.status)) {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
@@ -73,8 +73,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
     parseJsonResponse(performRequest)
   }
 
-  def postWithProtoResponse[T <: GeneratedMessage](file: File)(
-      companion: GeneratedMessageCompanion[T]): Fox[T] = {
+  def postWithProtoResponse[T <: GeneratedMessage](file: File)(companion: GeneratedMessageCompanion[T]): Fox[T] = {
     request = request.withBody(file).withMethod("POST")
     parseProtoResponse(performRequest)(companion)
   }
@@ -226,8 +225,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
       }
     }
 
-  private def parseProtoResponse[T <: GeneratedMessage](r: Fox[WSResponse])(
-      companion: GeneratedMessageCompanion[T]) =
+  private def parseProtoResponse[T <: GeneratedMessage](r: Fox[WSResponse])(companion: GeneratedMessageCompanion[T]) =
     r.flatMap { response =>
       if (Status.isSuccessful(response.status)) {
         if (verbose) {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -5,26 +5,17 @@ import com.scalableminds.util.tools.JsonHelper.{boxFormat, optionFormat}
 import com.scalableminds.webknossos.datastore.controllers.Controller
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
 import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
-import com.scalableminds.webknossos.tracingstore.tracings.{
-  TracingSelector,
-  TracingService,
-  UpdateAction,
-  UpdateActionGroup
-}
-import com.scalableminds.webknossos.tracingstore.{
-  TracingStoreAccessTokenService,
-  TracingStoreWkRpcClient,
-  TracingUpdatesReport
-}
+import com.scalableminds.webknossos.tracingstore.tracings.{TracingSelector, TracingService, UpdateAction, UpdateActionGroup}
+import com.scalableminds.webknossos.tracingstore.{TracingStoreAccessTokenService, TracingStoreWkRpcClient, TracingUpdatesReport}
 import play.api.i18n.Messages
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-trait TracingController[T <: GeneratedMessage with Message[T], Ts <: GeneratedMessage with Message[Ts]]
+trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage]
     extends Controller {
 
   def tracingService: TracingService[T]

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -5,8 +5,17 @@ import com.scalableminds.util.tools.JsonHelper.{boxFormat, optionFormat}
 import com.scalableminds.webknossos.datastore.controllers.Controller
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
 import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
-import com.scalableminds.webknossos.tracingstore.tracings.{TracingSelector, TracingService, UpdateAction, UpdateActionGroup}
-import com.scalableminds.webknossos.tracingstore.{TracingStoreAccessTokenService, TracingStoreWkRpcClient, TracingUpdatesReport}
+import com.scalableminds.webknossos.tracingstore.tracings.{
+  TracingSelector,
+  TracingService,
+  UpdateAction,
+  UpdateActionGroup
+}
+import com.scalableminds.webknossos.tracingstore.{
+  TracingStoreAccessTokenService,
+  TracingStoreWkRpcClient,
+  TracingUpdatesReport
+}
 import play.api.i18n.Messages
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
@@ -15,8 +24,7 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage]
-    extends Controller {
+trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends Controller {
 
   def tracingService: TracingService[T]
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -12,7 +12,7 @@ import io.grpc.{Status, StatusRuntimeException}
 import net.liftweb.common.{Box, Empty, Full}
 import net.liftweb.util.Helpers.tryo
 import play.api.libs.json.{Json, Reads, Writes}
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -28,7 +28,7 @@ trait KeyValueStoreImplicits extends BoxImplicits {
 
   implicit def asProto[T <: GeneratedMessage](o: T): Array[Byte] = o.toByteArray
 
-  implicit def fromProto[T <: GeneratedMessage with Message[T]](a: Array[Byte])(
+  implicit def fromProto[T <: GeneratedMessage](a: Array[Byte])(
       implicit companion: GeneratedMessageCompanion[T]): Box[T] = tryo(companion.parseFrom(a))
 }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingMigrationService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingMigrationService.scala
@@ -5,7 +5,7 @@ import com.scalableminds.webknossos.datastore.SkeletonTracing.SkeletonTracing
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
 import com.scalableminds.webknossos.datastore.geometry.{Color, NamedBoundingBox => ProtoBox}
 import net.liftweb.common.Full
-import scalapb.{GeneratedMessage, Message}
+import scalapb.GeneratedMessage
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -17,7 +17,7 @@ trait ColorGenerator {
     Color(getRandomComponent, getRandomComponent, getRandomComponent, 1.0)
 }
 
-trait TracingMigrationService[T <: GeneratedMessage with Message[T]] extends FoxImplicits {
+trait TracingMigrationService[T <: GeneratedMessage] extends FoxImplicits {
   // Each migration transforms a tracing and additionally returns whether the tracing was modified
   def migrations: List[T => Fox[(T, Boolean)]]
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingService.scala
@@ -1,18 +1,18 @@
 package com.scalableminds.webknossos.tracingstore.tracings
 
-import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
-import com.scalableminds.webknossos.tracingstore.RedisTemporaryStore
-import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.json._
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 import java.util.UUID
 
+import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
+import com.scalableminds.webknossos.tracingstore.RedisTemporaryStore
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType.TracingType
+import com.typesafe.scalalogging.LazyLogging
+import play.api.libs.json._
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-trait TracingService[T <: GeneratedMessage with Message[T]]
+trait TracingService[T <: GeneratedMessage]
     extends KeyValueStoreImplicits
     with FoxImplicits
     with LazyLogging

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/UpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/UpdateActions.scala
@@ -2,10 +2,10 @@ package com.scalableminds.webknossos.tracingstore.tracings
 
 import com.scalableminds.webknossos.datastore.SkeletonTracing.SkeletonTracing
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
-import scalapb.{GeneratedMessage, Message}
 import play.api.libs.json._
+import scalapb.GeneratedMessage
 
-trait UpdateAction[T <: GeneratedMessage with Message[T]] {
+trait UpdateAction[T <: GeneratedMessage] {
 
   def actionTimestamp: Option[Long]
 
@@ -27,7 +27,7 @@ object UpdateAction {
   type VolumeUpdateAction = UpdateAction[VolumeTracing]
 }
 
-case class UpdateActionGroup[T <: GeneratedMessage with Message[T]](
+case class UpdateActionGroup[T <: GeneratedMessage](
     version: Long,
     timestamp: Long,
     actions: List[UpdateAction[T]],
@@ -43,7 +43,7 @@ case class UpdateActionGroup[T <: GeneratedMessage with Message[T]](
 
 object UpdateActionGroup {
 
-  implicit def updateActionGroupReads[T <: GeneratedMessage with Message[T]](
+  implicit def updateActionGroupReads[T <: GeneratedMessage](
       implicit fmt: Reads[UpdateAction[T]]): Reads[UpdateActionGroup[T]] =
     (json: JsValue) =>
       for {
@@ -66,7 +66,7 @@ object UpdateActionGroup {
                              transactionGroupIndex)
     }
 
-  implicit def updateActionGroupWrites[T <: GeneratedMessage with Message[T]](
+  implicit def updateActionGroupWrites[T <: GeneratedMessage](
       implicit fmt: Writes[UpdateAction[T]]): Writes[UpdateActionGroup[T]] =
     (value: UpdateActionGroup[T]) =>
       Json.obj(


### PR DESCRIPTION
Update some backend dependencies to fix security vulnerabilities.
 - `scalapb`, `protoc`, `grpc`, `commons-mail`.

Remove unused line from build.sbt and unused dependency resolver

Added dependency-check plugin to analyze vulnerabilities. I will try to do more dependency updates in the coming days and weeks.

### URL of deployed dev instance (used for testing):
- https://updateproto.webknossos.xyz

### Steps to test:
- should still be able to trace / load old tracings from fossildb
- should still be able to send mail (I tested that)

------
- [x] Needs datastore update after deployment
- [x] Ready for review
