### PR TITLE
Increase threshold for slow request slack notifications from 5 to 10s

### DIFF
--- a/util/src/main/scala/com/scalableminds/util/requestlogging/RequestLogging.scala
+++ b/util/src/main/scala/com/scalableminds/util/requestlogging/RequestLogging.scala
@@ -54,7 +54,7 @@ trait RequestLogging extends AbstractRequestLogging {
     for {
       result: Result <- block
       executionTime = System.nanoTime() - start
-      _ = if (executionTime > 5e9) logTimeFormatted(executionTime, request, result)
+      _ = if (executionTime > 1e10) logTimeFormatted(executionTime, request, result)
     } yield result
   }
 


### PR DESCRIPTION
We haven’t been paying much attention to the slow requests recently, and <10s seems acceptable as the front-end can handle it well.

- [x] Ready for review
