### PR TITLE
Fix analytics event for dataset-upload-page

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where NMLs with huge tree IDs uploaded via back-end produced broken annotations. [#5484](https://github.com/scalableminds/webknossos/pull/5484)
 - Fixed a bug where the upload of multiple NMLs failed if some of them have an organization attribute and others don’t. [#5483](https://github.com/scalableminds/webknossos/pull/5483)
 - Fixed a bug in the application of agglomerate files where the `cumsum.json` was not used correctly. [#5499](https://github.com/scalableminds/webknossos/pull/5499)
+- Fixed an innocuous error toast when opening the dataset import view. [#5526](https://github.com/scalableminds/webknossos/pull/5526)
 
 ### Removed
 - Removed the button to load or refresh the isosurface of the centered cell from the 3D view. Instead, this action can be triggered from the "Meshes" tab. [#5440](https://github.com/scalableminds/webknossos/pull/5440)

--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -126,19 +126,20 @@ export function doWithToken<T>(fn: (token: string) => Promise<T>, tries: number 
   });
 }
 
-export function sendAnalyticsEvent(eventType: string, eventProperties: Object): void {
+export function sendAnalyticsEvent(eventType: string, eventProperties: {} = {}): void {
   // Note that the Promise from sendJSONReceiveJSON is not awaited or returned here,
   // since failing analytics events should not have an impact on the application logic.
   Request.sendJSONReceiveJSON(`/api/analytics/${eventType}`, {
     method: "POST",
     data: eventProperties,
+    showErrorToast: false,
   });
 }
 
 export function sendFailedRequestAnalyticsEvent(
   requestType: string,
   error: Object,
-  requestProperties: Object,
+  requestProperties: {},
 ): void {
   const eventProperties = {
     request_type: requestType,
@@ -1035,10 +1036,7 @@ export function createResumableUpload(
   );
 }
 
-export function finishDatasetUpload(
-  datastoreHost: string,
-  uploadInformation: Object,
-): Promise<void> {
+export function finishDatasetUpload(datastoreHost: string, uploadInformation: {}): Promise<void> {
   return doWithToken(token =>
     Request.sendJSONReceiveJSON(`/data/datasets/finishUpload?token=${token}`, {
       data: uploadInformation,


### PR DESCRIPTION
…and never show error for failed analytics requests

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open dataset upload page
- analytics request should succeed and no error toast should be shown
- break analytics route (or use ublock origin)
- request should fail but it should not raise an error toast

### Issues:
- follow-up to #5490

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
