### PR TITLE
Fix sync between simple and advanced datasource view in dataset settings.

### DIFF
--- a/frontend/javascripts/dashboard/dataset/dataset_import_view.js
+++ b/frontend/javascripts/dashboard/dataset/dataset_import_view.js
@@ -511,11 +511,16 @@ class DatasetImportView extends React.PureComponent<Props, State> {
       return;
     }
 
-    // Trigger validation manually, because fields may have been updated
-    form
-      .validateFields()
-      .then(formValues => this.submit(formValues))
-      .catch(errorInfo => this.handleValidationFailed(errorInfo));
+    const afterForceUpdateCallback = () =>
+      // Trigger validation manually, because fields may have been updated
+      form
+        .validateFields()
+        .then(formValues => this.submit(formValues))
+        .catch(errorInfo => this.handleValidationFailed(errorInfo));
+    // Need to force update of the SimpleAdvancedDataForm as removing a layer in the advanced tab does not update
+    // the form items in the simple tab (only the values are updated). The form items automatically update once
+    // the simple tab renders, but this is not the case when the user directly submits the changes.
+    this.forceUpdate(afterForceUpdateCallback);
   };
 
   submit = async (formValues: FormData) => {


### PR DESCRIPTION
This PR tries to solve the bug of #5465 where users could not submit the updated dataset settings, when their last step was removing a dataset layer from the datasource json setting.

The reason for this bug is, that once the user removes a layer in the advanced tab and then submits the form without changing back to the simple version, the form values are updated but not the form items of the simple view. As these form items were last rendered with outdated values, there are still the form items for the removed layer. They are not rendered and thus not updated by the value change. But they are still used to validate the currently edited settings. As the form items of the removed layer still existed, the validation does not succeed.
This problem is simply tackled by forcing a re-render of the form component from the parent, directly after syncing the field between the advanced and simple tab once the submit button is pressed. Luckily, the `forceRender` function called by the parent is enough as I could not get a `forceRender` solely for the `SimpleAdvancedDataForm`working. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
1. First do the following on the master:
2. Prepare a dataset with more than one layer. I tested with 3 layers.
3. Got to the settings of that dataset and except any inferred changes in the simple view of the data settings.
4. Switch to the advanced settings and then remove the first layer.  Then open the console and directly submit the changes without switching back to the simple view. The submit should fail and there should be errors in the console. (If this did not happen, try to redo the steps and this time remove another layer)
5. Once you could reproduce this, try the same on this branch. The error should no longer exist and the update of the data settings should succeed smoothly.

### Issues:
- fixes  #5465

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
