### PR TITLE
Clean up sbt build definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val protocolBufferSettings = Seq(
-  Compile / PB.protoSources := Seq(new java.io.File("webknossos-datastore/proto")),
+  Compile / PB.protoSources := Seq(baseDirectory.value / "proto"),
   Compile / PB.targets := Seq(
     scalapb.gen() -> (Compile / sourceManaged).value / "proto"
   )

--- a/project/BuildInfoSettings.scala
+++ b/project/BuildInfoSettings.scala
@@ -1,6 +1,7 @@
 import scala.sys.process._
 import sbt.Keys.{name, sbtVersion, scalaVersion}
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
+import scala.language.postfixOps
 
 object BuildInfoSettings {
 
@@ -29,7 +30,7 @@ object BuildInfoSettings {
       "ciTag" -> ciTag,
       "gitTag" -> gitTag,
       "version" -> webKnossosVersion,
-      "datastoreApiVersion" -> "1.0",
+      "datastoreApiVersion" -> "1.0"
     ),
     buildInfoPackage := "webknossos",
     buildInfoOptions := Seq(BuildInfoOption.ToJson)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,52 +2,52 @@ import play.sbt.PlayImport._
 import sbt._
 
 object Dependencies {
-  val akkaVersion = "2.6.14"
-  val log4jVersion = "2.13.3"
-  val webknossosWrapVersion = "1.1.10"
+  private val akkaVersion = "2.6.14"
+  private val log4jVersion = "2.13.3"
+  private val webknossosWrapVersion = "1.1.10"
 
-  val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
-  val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
-  val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
-  val commonsEmail = "org.apache.commons" % "commons-email" % "1.5"
-  val commonsIo = "commons-io" % "commons-io" % "2.9.0"
-  val commonsLang = "org.apache.commons" % "commons-lang3" % "3.1"
-  val gson = "com.google.code.gson" % "gson" % "1.7.1"
-  val grpc = "io.grpc" % "grpc-netty-shaded" % scalapb.compiler.Version.grpcJavaVersion
-  val grpcServices = "io.grpc" % "grpc-services" % scalapb.compiler.Version.grpcJavaVersion
-  val scalapbRuntime = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
-  val scalapbRuntimeGrpc = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
-  val liftCommon = "net.liftweb" %% "lift-common" % "3.0.2"
-  val liftUtil = "net.liftweb" %% "lift-util" % "3.0.2"
-  val log4jApi = "org.apache.logging.log4j" % "log4j-core" % log4jVersion % Provided
-  val log4jCore = "org.apache.logging.log4j" % "log4j-api" % log4jVersion % Provided
-  val playFramework = "com.typesafe.play" %% "play" % "2.8.8"
-  val playJson = "com.typesafe.play" %% "play-json" % "2.8.1"
-  val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val playIterateesStreams = "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1"
-  val reactiveBson = "org.reactivemongo" %% "reactivemongo-bson" % "0.12.7"
-  val scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.7"
-  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
-  val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test"
-  val silhouette = "com.mohiva" %% "play-silhouette" % "6.0.0"
-  val silhouetteTestkit = "com.mohiva" %% "play-silhouette-testkit" % "5.0.7" % "test"
-  val trireme = "io.apigee.trireme" % "trireme-core" % "0.9.3"
-  val triremeNode = "io.apigee.trireme" % "trireme-node12src" % "0.9.3"
-  val webknossosWrap = "com.scalableminds" %% "webknossos-wrap" % webknossosWrapVersion
-  val xmlWriter = "org.glassfish.jaxb" % "txw2" % "2.2.11"
-  val woodstoxXml = "org.codehaus.woodstox" % "wstx-asl" % "3.2.3"
-  val redis = "net.debasishg" %% "redisclient" % "3.9"
-  val spire = "org.typelevel" %% "spire" % "0.14.1"
-  val jgrapht = "org.jgrapht" % "jgrapht-core" % "1.4.0"
+  private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
+  private val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
+  private val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
+  private val commonsEmail = "org.apache.commons" % "commons-email" % "1.5"
+  private val commonsIo = "commons-io" % "commons-io" % "2.9.0"
+  private val commonsLang = "org.apache.commons" % "commons-lang3" % "3.1"
+  private val gson = "com.google.code.gson" % "gson" % "1.7.1"
+  private val grpc = "io.grpc" % "grpc-netty-shaded" % scalapb.compiler.Version.grpcJavaVersion
+  private val grpcServices = "io.grpc" % "grpc-services" % scalapb.compiler.Version.grpcJavaVersion
+  private val scalapbRuntime = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
+  private val scalapbRuntimeGrpc = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
+  private val liftCommon = "net.liftweb" %% "lift-common" % "3.0.2"
+  private val liftUtil = "net.liftweb" %% "lift-util" % "3.0.2"
+  private val log4jApi = "org.apache.logging.log4j" % "log4j-core" % log4jVersion % Provided
+  private val log4jCore = "org.apache.logging.log4j" % "log4j-api" % log4jVersion % Provided
+  private val playFramework = "com.typesafe.play" %% "play" % "2.8.8"
+  private val playJson = "com.typesafe.play" %% "play-json" % "2.8.1"
+  private val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
+  private val playIterateesStreams = "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1"
+  private val reactiveBson = "org.reactivemongo" %% "reactivemongo-bson" % "0.12.7"
+  private val scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.7"
+  private val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
+  private val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test"
+  private val silhouette = "com.mohiva" %% "play-silhouette" % "6.0.0"
+  private val silhouetteTestkit = "com.mohiva" %% "play-silhouette-testkit" % "5.0.7" % "test"
+  private val trireme = "io.apigee.trireme" % "trireme-core" % "0.9.3"
+  private val triremeNode = "io.apigee.trireme" % "trireme-node12src" % "0.9.3"
+  private val webknossosWrap = "com.scalableminds" %% "webknossos-wrap" % webknossosWrapVersion
+  private val xmlWriter = "org.glassfish.jaxb" % "txw2" % "2.2.11"
+  private val woodstoxXml = "org.codehaus.woodstox" % "wstx-asl" % "3.2.3"
+  private val redis = "net.debasishg" %% "redisclient" % "3.9"
+  private val spire = "org.typelevel" %% "spire" % "0.14.1"
+  private val jgrapht = "org.jgrapht" % "jgrapht-core" % "1.4.0"
 
-  val sql = Seq(
+  private val sql = Seq(
     "com.typesafe.slick" %% "slick" % "3.2.3",
     "com.typesafe.slick" %% "slick-hikaricp" % "3.2.3",
     "com.typesafe.slick" %% "slick-codegen" % "3.2.3",
     "org.postgresql" % "postgresql" % "42.2.20"
   )
 
-  val utilDependencies = Seq(
+  val utilDependencies: Seq[ModuleID] = Seq(
     commonsEmail,
     commonsIo,
     commonsLang,
@@ -63,7 +63,7 @@ object Dependencies {
     scalaLogging
   )
 
-  val webknossosDatastoreDependencies = Seq(
+  val webknossosDatastoreDependencies: Seq[ModuleID] = Seq(
     grpc,
     grpcServices,
     scalapbRuntimeGrpc,
@@ -78,12 +78,12 @@ object Dependencies {
     spire
   )
 
-  val webknossosTracingstoreDependencies = Seq(
+  val webknossosTracingstoreDependencies: Seq[ModuleID] = Seq(
     redis,
     jgrapht
   )
 
-  val webknossosDependencies = Seq(
+  val webknossosDependencies: Seq[ModuleID] = Seq(
     akkaTest,
     commonsCodec,
     scalaAsync,

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,1 @@
+scalacOptions := Seq("-feature", "-deprecation")

--- a/tools/proxy/proxy.js
+++ b/tools/proxy/proxy.js
@@ -28,7 +28,7 @@ function makeEnv(port, host) {
 const processes = {
   backend: spawnIfNotSpecified(
     "noBackend",
-    'sbt "~run 9001" -jvm-debug 5005 -J-XX:MaxMetaspaceSize=2048m -J-Xmx8g -Dlogger.file=conf/logback-dev.xml',
+    'sbt "run 9001" -jvm-debug 5005 -J-XX:MaxMetaspaceSize=2048m -J-Xmx8g -Dlogger.file=conf/logback-dev.xml',
     [],
     {
       cwd: ROOT,


### PR DESCRIPTION
 - make proto path absolute (fixing relative glob warning)
 - clean up build/project files as suggested by intellij
 - enable verbose feature + deprecation warnings also for project files
 - explicitly enable postfix operators for buildinfo (fixing a feature warning)
 - remove tilde from sbt command in proxy (this was previously necessary for sbt not to close again immediately, but it now works also without it)

### Steps to test:
- `./clean` + `yarn install` + `yarn start` should print fewer warnings than on master
- should give a working webKnossos, not close immediately

### Issues:
- fixes #5533 

------
- [x] Ready for review
