### PR TITLE
Fix desync of td view camera and store state

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Fixed
--
+- Fixed a bug that caused a distortion when moving or zooming in the maximized 3d viewport. [#5550](https://github.com/scalableminds/webknossos/pull/5550)
 
 ### Removed
 - 

--- a/frontend/javascripts/oxalis/controller/camera_controller.js
+++ b/frontend/javascripts/oxalis/controller/camera_controller.js
@@ -36,6 +36,7 @@ import api from "oxalis/api/internal_api";
 type Props = {
   cameras: OrthoViewMap<typeof THREE.OrthographicCamera>,
   onCameraPositionChanged: () => void,
+  onTDCameraChanged: () => void,
   setTargetAndFixPosition: () => void,
 };
 
@@ -164,6 +165,8 @@ class CameraController extends React.PureComponent<Props> {
       tdCamera.left = oldMid - newWidth / 2;
       tdCamera.right = oldMid + newWidth / 2;
       tdCamera.updateProjectionMatrix();
+
+      this.props.onTDCameraChanged();
     }
   }
 

--- a/frontend/javascripts/oxalis/controller/td_controller.js
+++ b/frontend/javascripts/oxalis/controller/td_controller.js
@@ -128,13 +128,7 @@ class TDController extends React.PureComponent<Props> {
       tdCamera,
       view,
       new THREE.Vector3(...pos),
-      (userTriggered: boolean = true) => {
-        const setCameraAction = userTriggered
-          ? setTDCameraAction
-          : setTDCameraWithoutTimeTrackingAction;
-        // write threeJS camera into store
-        Store.dispatch(setCameraAction(threeCameraToCameraData(tdCamera)));
-      },
+      this.onTDCameraChanged,
     );
 
     this.controls.noZoom = true;
@@ -267,12 +261,22 @@ class TDController extends React.PureComponent<Props> {
     Store.dispatch(moveTDViewYAction((delta.y / scaleY) * -1));
   }
 
+  onTDCameraChanged = (userTriggered: boolean = true) => {
+    const tdCamera = this.props.cameras[OrthoViews.TDView];
+    const setCameraAction = userTriggered
+      ? setTDCameraAction
+      : setTDCameraWithoutTimeTrackingAction;
+    // Write threeJS camera into store
+    Store.dispatch(setCameraAction(threeCameraToCameraData(tdCamera)));
+  };
+
   render() {
     return (
       <CameraController
         cameras={this.props.cameras}
         onCameraPositionChanged={this.updateControls}
         setTargetAndFixPosition={this.setTargetAndFixPosition}
+        onTDCameraChanged={this.onTDCameraChanged}
       />
     );
   }


### PR DESCRIPTION
This bug led to a distortion of the 3d viewport when moving/zooming after maximizing it (could happen after minimizing it as well). The cause of the bug was a desynchronization of the 3d view camera internal state and its store state. The 3d view camera was adjusted when maximizing the 3d viewport without updating the store state. This led to distortion errors, afterwards.

I scanned the code but didn't find other occurrences where the 3d view camera is updated without updating the store state.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create some skeletons so that you see something in the 3d view
- Maximize the 3d view using `.`
- Then, without moving the mouse out of the 3d view or clicking, either zoom or move the 3d view -> No distortion should happen.
  - The repro can be a bit tricky. I would propose you to test this on master as well, to check whether the reproduction instructions work for you! For me the distortion doesn't always happen when zooming for some reason, but moving triggers it. If you cannot observe the distortion zoom a bit when not maximized and try again.

### Issues:
- fixes #5520 
- fixes #5448 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
