### PR TITLE
In find data, sample topleft last

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
@@ -93,7 +93,7 @@ class FindDataService @Inject()(dataServicesHolder: BinaryDataServiceHolder)(imp
       }
     }
 
-    dataLayer.boundingBox.topLeft +: positionCreationIter((1 to iterationCount).toList, List[Point3D]())
+    positionCreationIter((1 to iterationCount).toList, List[Point3D]()) :+ dataLayer.boundingBox.topLeft
   }
 
   private def checkAllPositionsForData(dataSource: DataSource,


### PR DESCRIPTION
We added topleft to the position sampling to provide a simple solution for the histogram for tiny datasets.
However, it had the effect that the find data functionality now tends to jump to topleft rather than the center. So the topleft should be appended rather than prepended.
This is slightly slower as the list append has to copy the list, but I’d say the impact is negligible as this is not a very long list and this is not a very frequent operation.

### URL of deployed dev instance (used for testing):
- https://finddatatopleftlast.webknossos.xyz

### Steps to test:
- click find data on a layer that extends to the topleft of the bounding box
- should jump to center
- histogram for tiny datasets should still be computed

### Issues:
- fixes #5543 

- [x] Needs datastore update after deployment
- [x] Ready for review
