### PR TITLE
Open invite dialog if #invite is in url hash

### DIFF
--- a/frontend/javascripts/admin/user/user_list_view.js
+++ b/frontend/javascripts/admin/user/user_list_view.js
@@ -19,6 +19,7 @@ import * as React from "react";
 import _ from "lodash";
 import moment from "moment";
 
+import { location } from "libs/window";
 import type { APIUser, APITeamMembership, ExperienceMap } from "types/api_flow_types";
 import { InviteUsersModal } from "admin/onboarding";
 import type { OxalisState } from "oxalis/store";
@@ -89,6 +90,10 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
 
   componentDidMount() {
     this.fetchData();
+
+    if (location.hash === "#invite") {
+      this.setState({ isInviteModalVisible: true });
+    }
   }
 
   componentWillUpdate(nextProps, nextState) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open `/users#invite` directly in the browser. the invite-user dialog should open.

### Issues:
- fixes #5500

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
