### PR TITLE
Prepare datastore for JRE 11+, fat jar assembly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,10 @@ jobs:
           name: Build webknossos-tracingstore (sbt)
           command: docker-compose run base sbt -no-colors "project webknossosTracingstore" copyMessages compile stage
 
+      - run:
+          name: Assemble webknossos-datastore fat-jar (sbt)
+          command: docker-compose run base sbt -no-colors "project webknossosDatastore" assembly
+
       - save_cache:
           name: Save target cache
           key: target-cache-{{ checksum ".circleci/cache_version" }}-{{ .Branch }}-{{ .Revision }}

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added the possibility for admins to set long-running jobs to a “manually repaired” state. [#5530](https://github.com/scalableminds/webknossos/pull/5530)
+- Added compatibility with newer JREs, tested with 8, 11 and 14. [#5558](https://github.com/scalableminds/webknossos/pull/5558)
 
 ### Changed
 - "Center new Nodes" option was renamed to "Auto-center Nodes" and changed to also influence the centering-behavior when deleting a node. [#5538](https://github.com/scalableminds/webknossos/pull/5538)

--- a/build.sbt
+++ b/build.sbt
@@ -68,20 +68,6 @@ lazy val webknossosDatastore = (project in file("webknossos-datastore"))
   .settings(
     name := "webknossos-datastore",
     commonSettings,
-    assembly / assemblyMergeStrategy := {
-      case PathList(ps @ _*) if ps.last endsWith ".class"                 => MergeStrategy.last
-      case PathList(ps @ _*) if ps.last endsWith ".proto"                 => MergeStrategy.last
-      case PathList(ps @ _*) if ps.last == "reference-overrides.conf"     => MergeStrategy.concat
-      case PathList(ps @ _*) if ps.last == "io.netty.versions.properties" => MergeStrategy.last
-      case PathList(ps @ _*) if ps.last == "mailcap.default"              => MergeStrategy.last
-      case PathList(ps @ _*) if ps.last == "mimetypes.default"            => MergeStrategy.last
-      case PathList(ps @ _*) if ps.last == "native-image.properties"      => MergeStrategy.last
-      case PathList(ps @ _*) if ps.last == "application.conf"             => MergeStrategy.concat
-      case x =>
-        val oldStrategy = (assembly / assemblyMergeStrategy).value
-        oldStrategy(x)
-    },
-    assembly / test := {},
     BuildInfoSettings.webknossosDatastoreBuildInfoSettings,
     libraryDependencies ++= Dependencies.webknossosDatastoreDependencies,
     routesGenerator := InjectedRoutesGenerator,
@@ -94,7 +80,19 @@ lazy val webknossosDatastore = (project in file("webknossos-datastore"))
       }
       ((libs +++ subs +++ targets) ** "*.jar").classpath
     },
-    copyConfFilesSetting
+    copyConfFilesSetting,
+    assembly / assemblyMergeStrategy := {
+      case PathList(ps @ _*) if ps.last endsWith ".class" => MergeStrategy.last
+      case PathList(ps @ _*) if ps.last endsWith ".proto" => MergeStrategy.last
+      case PathList(ps @ _*) if List("io.netty.versions.properties", "mailcap.default",
+        "mimetypes.default", "native-image.properties").contains(ps.last) => MergeStrategy.last
+      case PathList(ps @ _*) if List("application.conf", "reference-overrides.conf").contains(ps.last) => MergeStrategy.concat
+      case x =>
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
+        oldStrategy(x)
+    },
+    assembly / test := {},
+    assembly / assemblyJarName := s"webknossos-datastore-${BuildInfoSettings.webKnossosVersion}.jar"
   )
 
 lazy val webknossosTracingstore = (project in file("webknossos-tracingstore"))

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,8 @@ ThisBuild / libraryDependencies ++= Seq(
   "com.github.ghik" % "silencer-lib" % "1.7.0" % Provided cross CrossVersion.full
 )
 
+ThisBuild / assemblyMergeStrategy := (_ => MergeStrategy.first)
+
 PlayKeys.devSettings := Seq("play.server.akka.requestTimeout" -> "10000s", "play.server.http.idleTimeout" -> "10000s")
 
 scapegoatIgnoredFiles := Seq(".*/Tables.scala",
@@ -68,6 +70,7 @@ lazy val webknossosDatastore = (project in file("webknossos-datastore"))
   .settings(
     name := "webknossos-datastore",
     commonSettings,
+    assembly / assemblyMergeStrategy := (_ => MergeStrategy.first),
     BuildInfoSettings.webknossosDatastoreBuildInfoSettings,
     libraryDependencies ++= Dependencies.webknossosDatastoreDependencies,
     routesGenerator := InjectedRoutesGenerator,

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,6 @@ ThisBuild / libraryDependencies ++= Seq(
   "com.github.ghik" % "silencer-lib" % "1.7.0" % Provided cross CrossVersion.full
 )
 
-ThisBuild / assemblyMergeStrategy := (_ => MergeStrategy.first)
-
 PlayKeys.devSettings := Seq("play.server.akka.requestTimeout" -> "10000s", "play.server.http.idleTimeout" -> "10000s")
 
 scapegoatIgnoredFiles := Seq(".*/Tables.scala",
@@ -70,7 +68,20 @@ lazy val webknossosDatastore = (project in file("webknossos-datastore"))
   .settings(
     name := "webknossos-datastore",
     commonSettings,
-    assembly / assemblyMergeStrategy := (_ => MergeStrategy.first),
+    assembly / assemblyMergeStrategy := {
+      case PathList(ps @ _*) if ps.last endsWith ".class"                 => MergeStrategy.last
+      case PathList(ps @ _*) if ps.last endsWith ".proto"                 => MergeStrategy.last
+      case PathList(ps @ _*) if ps.last == "reference-overrides.conf"     => MergeStrategy.concat
+      case PathList(ps @ _*) if ps.last == "io.netty.versions.properties" => MergeStrategy.last
+      case PathList(ps @ _*) if ps.last == "mailcap.default"              => MergeStrategy.last
+      case PathList(ps @ _*) if ps.last == "mimetypes.default"            => MergeStrategy.last
+      case PathList(ps @ _*) if ps.last == "native-image.properties"      => MergeStrategy.last
+      case PathList(ps @ _*) if ps.last == "application.conf"             => MergeStrategy.concat
+      case x =>
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
+        oldStrategy(x)
+    },
+    assembly / test := {},
     BuildInfoSettings.webknossosDatastoreBuildInfoSettings,
     libraryDependencies ++= Dependencies.webknossosDatastoreDependencies,
     routesGenerator := InjectedRoutesGenerator,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
   private val akkaVersion = "2.6.14"
   private val log4jVersion = "2.13.3"
-  private val webknossosWrapVersion = "1.1.11-SNAPSHOT"
+  private val webknossosWrapVersion = "1.1.11"
 
   private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
   private val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
   private val akkaVersion = "2.6.14"
   private val log4jVersion = "2.13.3"
-  private val webknossosWrapVersion = "1.1.10"
+  private val webknossosWrapVersion = "1.1.11-SNAPSHOT"
 
   private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
   private val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,6 @@ addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")
 
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "3.1.3")
 
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"


### PR DESCRIPTION
Depends on https://github.com/scalableminds/webknossos-wrap/pull/67

- Use the new wk-wrap version that allows compatibility with JRE 11+
- add assembly sbt plugin to build fat jar for datastore
  - call `sbt "project webknossosDatastore" assembly`
  - that outputs a jar in `webknossos-datastore/target/scala-2.12`, which can then be run via `java -Dconfig.file=my-datastore.conf -jar webknossos-datastore-assembly-wk.jar`
  - the config.file should begin with the line `include "standalone-datastore.conf"` and can then overwrite keys (probably `http.uri`, `http.port`, `play.http.secret.key`, `datastore.key`, `datastore.name`, `datastore.webKnossos.uri`, `datastore.baseFolder`)

### Steps to test:
- run standard wK with JRE 11 (see `openjdk-11-jdk` and `sudo update-alternatives --config java`), should load data, read/write to  fossil normally
- I also tested with openjdk 14 (had to add PPA for that)
- build fat jar and execute it as described above, should be able to connect it to webKnossos and load data, also compare https://github.com/scalableminds/webknossos/wiki/Set-up-a-standalone-datastore-locally

### Issues:
- fixes #4429 
- fixes #5545 
- fixes #5544 

### Note:
I created follow-up issue #5567 to track the discussion on how to publish and distribute the Jar file.


### TODO

- [x] use wkw release once https://github.com/scalableminds/webknossos-wrap/pull/67 is merged
- [x] refactor assembly command in build.sbt (function can be compacted?)
- [x] rename jar (buildinfo?)
- [x] build jar in CI?

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
