### PR TITLE
Omit parent release name from wk version string

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 - "Center new Nodes" option was renamed to "Auto-center Nodes" and changed to also influence the centering-behavior when deleting a node. [#5538](https://github.com/scalableminds/webknossos/pull/5538)
+- The displayed webKnossos version now omits the parent release name for intermediate builds. [#5565](https://github.com/scalableminds/webknossos/pull/5565)
 
 ### Fixed
 - Fixed that a disabled "Center new Nodes" option didn't work correctly in merger mode. [#5538](https://github.com/scalableminds/webknossos/pull/5538)

--- a/project/BuildInfoSettings.scala
+++ b/project/BuildInfoSettings.scala
@@ -18,9 +18,8 @@ object BuildInfoSettings {
 
   def commitHash: String = getStdoutFromCommand("git rev-parse HEAD", "<getting commit hash failed>")
   def commitDate: String = getStdoutFromCommand("git log -1 --format=%cd ", "<getting git date failed>")
-  def gitTag: String = getStdoutFromCommand("git describe --abbrev=0 --tags", "<getting git tag failed>")
 
-  def webKnossosVersion: String = if (ciTag != "") ciTag else gitTag + "-" + (if (ciBuild != "") ciBuild else "dev")
+  def webKnossosVersion: String = if (ciTag != "") ciTag else (if (ciBuild != "") ciBuild else "dev")
 
   lazy val webknossosBuildInfoSettings = Seq(
     buildInfoKeys := Seq[BuildInfoKey](name, scalaVersion, sbtVersion,
@@ -28,7 +27,6 @@ object BuildInfoSettings {
       "commitDate" -> commitDate,
       "ciBuild" -> ciBuild,
       "ciTag" -> ciTag,
-      "gitTag" -> gitTag,
       "version" -> webKnossosVersion,
       "datastoreApiVersion" -> "1.0"
     ),
@@ -42,7 +40,6 @@ object BuildInfoSettings {
       "commitDate" -> commitDate,
       "ciBuild" -> ciBuild,
       "ciTag" -> ciTag,
-      "gitTag" -> gitTag,
       "version" -> webKnossosVersion,
       "datastoreApiVersion" -> "1.0"
     ),
@@ -56,7 +53,6 @@ object BuildInfoSettings {
       "commitDate" -> commitDate,
       "ciBuild" -> ciBuild,
       "ciTag" -> ciTag,
-      "gitTag" -> gitTag,
       "version" -> webKnossosVersion
     ),
     buildInfoPackage := "webknossosTracingstore",


### PR DESCRIPTION
The parent release as obtained by `git describe --tags` only yields the latest release if that tag happened in master. However, our release process means that often the tags do not land as direct ancestors to newer commits. Thus, this version string is often more confusing than helpful.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- visit `api/buildinfo` both locally and on dev deployment
- should show "dev" or ci tag

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
