### PR TITLE
Various fixes and improvements to the tree hierarchy view and NML import

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where dataset uploads of zips with just one file inside failed. [#5534](https://github.com/scalableminds/webknossos/pull/5534)
 - Fixed crashing tree tab which could happen when dragging a node and then switching directly to another tab (e.g., comments) and then back again. [#5573](https://github.com/scalableminds/webknossos/pull/5573)
-- Fixed that the UI allowed mutating trees in the tree tab (dragging/creating/deleting trees and groups). [#5573](https://github.com/scalableminds/webknossos/pull/5573)
+- Fixed that the UI allowed mutating trees in the tree tab (dragging/creating/deleting trees and groups) in read-only tracings. [#5573](https://github.com/scalableminds/webknossos/pull/5573)
 - Fixed "Create a new tree group for this file" setting in front-end import when a group id of 0 was used in the NML. [#5573](https://github.com/scalableminds/webknossos/pull/5573)
 
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,10 +14,14 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Changed
--
+- Improved dragging behavior of trees/groups in the tree tab. [#5573](https://github.com/scalableminds/webknossos/pull/5573)
 
 ### Fixed
 - Fixed a bug where dataset uploads of zips with just one file inside failed. [#5534](https://github.com/scalableminds/webknossos/pull/5534)
+- Fixed crashing tree tab which could happen when dragging a node and then switching directly to another tab (e.g., comments) and then back again. [#5573](https://github.com/scalableminds/webknossos/pull/5573)
+- Fixed that the UI allowed mutating trees in the tree tab (dragging/creating/deleting trees and groups). [#5573](https://github.com/scalableminds/webknossos/pull/5573)
+- Fixed "Create a new tree group for this file" setting in front-end import when a group id of 0 was used in the NML. [#5573](https://github.com/scalableminds/webknossos/pull/5573)
+
 
 ### Removed
 - 

--- a/frontend/javascripts/main.js
+++ b/frontend/javascripts/main.js
@@ -19,8 +19,6 @@ import Store from "oxalis/throttled_store";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
-const dndBackend = HTML5Backend;
-
 async function loadActiveUser() {
   // Try to retreive the currently active user if logged in
   try {
@@ -52,7 +50,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (containerElement) {
     ReactDOM.render(
       <Provider store={Store}>
-        <DndProvider backend={dndBackend}>
+        {/* The DnDProvider is necessary for the TreeHierarchyView. Otherwise, the view may crash in
+        certain conditions. See https://github.com/scalableminds/webknossos/issues/5568 for context.
+        The fix is inspired by:
+        https://github.com/frontend-collective/react-sortable-tree/blob/9aeaf3d38b500d58e2bcc1d9b6febce12f8cc7b4/stories/barebones-no-context.js */}
+        <DndProvider backend={HTML5Backend}>
           <Router />
         </DndProvider>
       </Provider>,

--- a/frontend/javascripts/main.js
+++ b/frontend/javascripts/main.js
@@ -16,6 +16,10 @@ import { setHasOrganizationsAction } from "oxalis/model/actions/ui_actions";
 import ErrorHandling from "libs/error_handling";
 import Router from "router";
 import Store from "oxalis/throttled_store";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+const dndBackend = HTML5Backend;
 
 async function loadActiveUser() {
   // Try to retreive the currently active user if logged in
@@ -48,7 +52,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (containerElement) {
     ReactDOM.render(
       <Provider store={Store}>
-        <Router />
+        <DndProvider backend={dndBackend}>
+          <Router />
+        </DndProvider>
       </Provider>,
       containerElement,
     );

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -531,7 +531,7 @@ export function wrapInNewGroup(
   const trees = _.mapValues(originalTrees, tree => ({
     ...tree,
     // Give parentless trees the new treeGroup as parent
-    groupId: tree.groupId || unusedGroupId,
+    groupId: tree.groupId != null ? tree.groupId : unusedGroupId,
   }));
   const treeGroups = [
     // Create a new tree group which holds the old ones

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -376,13 +376,9 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
     // This method can be used to add props to each node of the SortableTree component
     const { node } = params;
     const nodeProps = {};
-    const isRoot = node.id === MISSING_GROUP_ID;
     if (node.type === TYPE_GROUP) {
       nodeProps.title = this.renderGroupActionsDropdown(node);
-      if (!isRoot) {
-        // Only render the group icon if it's not the root.
-        nodeProps.className = "group-type";
-      }
+      nodeProps.className = "group-type";
     } else {
       const tree = this.props.trees[parseInt(node.id, 10)];
       const rgbColorString = tree.color.map(c => Math.round(c * 255)).join(",");

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -6,7 +6,7 @@ import { DeleteOutlined, PlusOutlined, SettingOutlined, ShrinkOutlined } from "@
 import { connect } from "react-redux";
 import { batchActions } from "redux-batched-actions";
 import * as React from "react";
-import SortableTree from "react-sortable-tree";
+import { SortableTreeWithoutDndContext as SortableTree } from "react-sortable-tree";
 import _ from "lodash";
 import type { Dispatch } from "redux";
 import { type Action } from "oxalis/model/actions/actions";

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -57,6 +57,7 @@ type OwnProps = {|
   onSelectTree: number => void,
   deselectAllTrees: () => void,
   onDeleteGroup: number => void,
+  allowUpdate: boolean,
 |};
 
 type Props = {
@@ -70,7 +71,6 @@ type Props = {
   onToggleTreeGroup: number => void,
   onUpdateTreeGroups: (Array<TreeGroup>) => void,
   onBatchActions: (Array<Action>, string) => void,
-  allowUpdate: boolean,
 };
 
 type State = {

--- a/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/tree_hierarchy_view.js
@@ -70,6 +70,7 @@ type Props = {
   onToggleTreeGroup: number => void,
   onUpdateTreeGroups: (Array<TreeGroup>) => void,
   onBatchActions: (Array<Action>, string) => void,
+  allowUpdate: boolean,
 };
 
 type State = {
@@ -485,14 +486,18 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
     return node.type === TYPE_GROUP ? node.id : -1 - node.id;
   }
 
-  canDrop(params: { nextParent: TreeNode }) {
+  canDrop = (params: { nextParent: TreeNode }) => {
     const { nextParent } = params;
-    return nextParent != null && nextParent.type === TYPE_GROUP;
-  }
+    return this.props.allowUpdate && nextParent != null && nextParent.type === TYPE_GROUP;
+  };
 
-  canDrag(params: { node: TreeNode }) {
+  canDrag = (params: { node: TreeNode }) => {
     const { node } = params;
-    return node.id !== MISSING_GROUP_ID;
+    return this.props.allowUpdate && node.id !== MISSING_GROUP_ID;
+  };
+
+  canNodeHaveChildren(node: TreeNode) {
+    return node.type === TYPE_GROUP;
   }
 
   render() {
@@ -511,6 +516,7 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
               generateNodeProps={this.generateNodeProps}
               canDrop={this.canDrop}
               canDrag={this.canDrag}
+              canNodeHaveChildren={this.canNodeHaveChildren}
               rowHeight={24}
               innerStyle={{ padding: 0 }}
               scaffoldBlockPxWidth={25}

--- a/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-menu/trees_tab_view.js
@@ -125,6 +125,7 @@ type StateProps = {|
   onSetActiveGroup: number => void,
   onDeselectActiveGroup: () => void,
   showDropzoneModal: () => void,
+  allowUpdate: boolean,
 |};
 type Props = {| ...StateProps |};
 
@@ -560,6 +561,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
         treeGroups={this.props.skeletonTracing.treeGroups}
         activeTreeId={this.props.skeletonTracing.activeTreeId}
         activeGroupId={this.props.skeletonTracing.activeGroupId}
+        allowUpdate={this.props.allowUpdate}
         sortBy={sortBy}
         selectedTrees={this.state.selectedTrees}
         onSelectTree={this.onSelectTree}
@@ -705,10 +707,18 @@ class TreesTabView extends React.PureComponent<Props, State> {
                       </ButtonComponent>
                     </Tooltip>
                   </AdvancedSearchPopover>
-                  <ButtonComponent onClick={this.props.onCreateTree} title="Create Tree">
+                  <ButtonComponent
+                    onClick={this.props.onCreateTree}
+                    title="Create Tree"
+                    disabled={!this.props.allowUpdate}
+                  >
                     <i className="fas fa-plus" /> Create
                   </ButtonComponent>
-                  <ButtonComponent onClick={this.handleDelete} title="Delete Tree">
+                  <ButtonComponent
+                    onClick={this.handleDelete}
+                    title="Delete Tree"
+                    disabled={!this.props.allowUpdate}
+                  >
                     <i className="far fa-trash-alt" /> Delete
                   </ButtonComponent>
                   <ButtonComponent
@@ -787,6 +797,7 @@ class TreesTabView extends React.PureComponent<Props, State> {
 
 const mapStateToProps = (state: OxalisState) => ({
   annotation: state.tracing,
+  allowUpdate: state.tracing.restrictions.allowUpdate,
   skeletonTracing: state.tracing.skeleton,
   userConfiguration: state.userConfiguration,
 });

--- a/frontend/stylesheets/react_sortable_tree_overwrites.less
+++ b/frontend/stylesheets/react_sortable_tree_overwrites.less
@@ -19,6 +19,10 @@
     width: 15px;
     background: none;
   }
+
+  .rst__rowContentsDragDisabled {
+    margin-left: 15px;
+  }
 }
 
 // Show a circle icon as the move handle for trees
@@ -50,7 +54,7 @@
 // Show a move icon as the move handle when hovering
 .rst__row.group-type,
 .rst__row.tree-type {
-  &:hover:before {
+  .rst__moveHandle:hover:before {
     color: @text-color;
     content: "\f0b2";
     font-family: "Font Awesome 5 Free";
@@ -59,6 +63,10 @@
     left: 0px;
     position: absolute;
     top: 2px;
+    // Hide the circle/group icon by covering it
+    // with a opaque background
+    background-color: @body-background;
+    padding: 0 1px;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -175,6 +175,8 @@
     "protobufjs": "^6.8.6",
     "react": "^16.12.0",
     "react-debounce-render": "^6.0.0",
+    "react-dnd": "^11.1.3",
+    "react-dnd-html5-backend": "^11.1.3",
     "react-dom": "^16.8.0",
     "react-dropzone": "^11.3.1",
     "react-google-charts": "^2.0.0",


### PR DESCRIPTION
- (1) fixes `Cannot have two HTML5 backends at the same time.` error which could occur when dragging a node and then switching directly to another tab (e.g., comments) and then back again.
- (2) fixes that the UI allowed mutating trees in the tree tab (dragging/creating/deleting trees and groups)
- (3) fixes "Create a new tree group for this file" setting in front-end import when a group id of 0 was used in the NML
- (4) makes use of `canNodeHaveChildren` for `SortableTree` which greatly improves the dragging behavior of trees/groups, since the library doesn't show drag previews where a tree acts as a parent (since this isn't possible, anyway). Previously, one had to carefully move the mouse so that that preview wasn't suggested.

### URL of deployed dev instance (used for testing):
- https://misctreehierarchyfixes.webknossos.xyz

### Steps to test:
(1):
- create an annotation and import an NML with a high tree/group count (you may want to download the NML from here: https://webknossos.brain.mpg.de/annotations/Explorational/60c078080100007000580107#849,1199,978,0,0.424,1615)
- drag a tree from one group to another (ideally, drag the node to the bottom of the view so that the scrolling starts)
- drop the tree and quickly switch to another tab (e.g., comments tab)
- switch back to the trees view
- the tree tab should not crash. this was already a bit hard to reproduce on master, which is why I'm only 90% sure that the fix really works :see_no_evil: 

(2)
- open an annotation with trees and groups and open the share dialog for it
- switch the visibility to public and copy the url
- open the url in an incognito tab --> the annotation is read only
- ensure that trees and groups cannot be created/deleted/dragged via the trees tab (also check the dropdown menu)

(3)
- import an NML which uses the group id 0 for one of its groups
- check "Create a new tree group for this file" and click import
- the NML should properly be wrapped with a new group and have its origin hierarchy

(4)
- in general, play around with the drag and drop behavior of the trees and groups. i think, that the dnd behavior feels way better now, since invalid drag previews are less frequent.
- also pay attention to details such as the drag-icon which appears on hover, since I had to change the implementation a bit, because I didn't want the drag preview to appear in read-only tracings


### Issues:
- fixes #5569 
- fixes #5568
- part of #5495 (only the frontend part)

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
