### PR TITLE
Hide unlisted users from more API calls

### DIFF
--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -198,11 +198,9 @@ class DataSetController @Inject()(userService: UserService,
         allowedTeams <- dataSetService.allowedTeamIdsFor(dataSet._id)
         usersByTeams <- userDAO.findAllByTeams(allowedTeams)
         adminsAndDatasetManagers <- userDAO.findAdminsAndDatasetManagersByOrg(organization._id)
-        usersJs <- Fox.serialCombined((usersByTeams ++ adminsAndDatasetManagers).distinct)(u =>
-          userService.compactWrites(u))
-      } yield {
-        Ok(Json.toJson(usersJs))
-      }
+        usersFiltered = (usersByTeams ++ adminsAndDatasetManagers).distinct.filter(!_.isUnlisted)
+        usersJs <- Fox.serialCombined(usersFiltered)(u => userService.compactWrites(u))
+      } yield Ok(Json.toJson(usersJs))
   }
 
   def read(organizationName: String, dataSetName: String, sharingToken: Option[String]): Action[AnyContent] =

--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -143,7 +143,8 @@ class ReportController @Inject()(reportDAO: ReportDAO,
       teamIdValidated <- ObjectId.parse(teamId)
       team <- teamDAO.findOne(teamIdValidated) ?~> "team.notFound" ~> NOT_FOUND
       users <- userDAO.findAllByTeams(List(team._id), includeDeactivated = false)
-      nonAdminUsers <- Fox.filterNot(users)(u => userService.isTeamManagerOrAdminOf(u, teamIdValidated))
+      nonUnlistedUsers = users.filter(!_.isUnlisted)
+      nonAdminUsers <- Fox.filterNot(nonUnlistedUsers)(u => userService.isTeamManagerOrAdminOf(u, teamIdValidated))
       entries: List[OpenTasksEntry] <- getAllAvailableTaskCountsAndProjects(nonAdminUsers)
     } yield Ok(Json.toJson(entries))
   }

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -178,17 +178,17 @@ POST          /projects/:id/transferActiveTasks                                c
 GET           /statistics/webknossos                                           controllers.StatisticsController.webKnossos(interval: String, start: Option[Long], end: Option[Long])
 GET           /statistics/users                                                controllers.StatisticsController.users(interval: String, start: Option[Long], end: Option[Long], limit: Int)
 
-#Organizations
-GET           /organizations                                                    controllers.OrganizationController.list
-GET           /organizations/byInvite/:inviteToken                              controllers.OrganizationController.getByInvite(inviteToken: String)
-GET           /organizations/default                                            controllers.OrganizationController.getDefault
-GET           /organizationsIsEmpty                                             controllers.OrganizationController.organizationsIsEmpty
-GET           /organizations/:organizationName                                  controllers.OrganizationController.get(organizationName: String)
-PATCH         /organizations/:organizationName                                  controllers.OrganizationController.update(organizationName: String)
-DELETE        /organizations/:organizationName                                  controllers.OrganizationController.delete(organizationName: String)
-GET           /operatorData                                                     controllers.OrganizationController.getOperatorData
+# Organizations
+GET           /organizations                                                   controllers.OrganizationController.list
+GET           /organizations/byInvite/:inviteToken                             controllers.OrganizationController.getByInvite(inviteToken: String)
+GET           /organizations/default                                           controllers.OrganizationController.getDefault
+GET           /organizationsIsEmpty                                            controllers.OrganizationController.organizationsIsEmpty
+GET           /organizations/:organizationName                                 controllers.OrganizationController.get(organizationName: String)
+PATCH         /organizations/:organizationName                                 controllers.OrganizationController.update(organizationName: String)
+DELETE        /organizations/:organizationName                                 controllers.OrganizationController.delete(organizationName: String)
+GET           /operatorData                                                    controllers.OrganizationController.getOperatorData
 
-#Timelogging
+# Timelogging
 GET           /time/allusers/:year/:month                                      controllers.TimeController.getWorkingHoursOfAllUsers(year: Int, month: Int, startDay: Option[Int], endDay: Option[Int])
 GET           /time/userlist/:year/:month                                      controllers.TimeController.getWorkingHoursOfUsers(email: String, year: Int, month: Int, startDay: Option[Int], endDay: Option[Int])
 GET           /time/user/:userId                                               controllers.TimeController.getWorkingHoursOfUser(userId: String, startDate: Long, endDate: Long)


### PR DESCRIPTION
### Steps to test:
- sign up as second user, activate
- in local database set that user to isUnlisted = true
- should no longer show in dataset access list (plus sign in dashboard dataset list)

### Issues:
- fixes #5580 

------
- [x] Ready for review
