### PR TITLE
Fix that 3d view broke if it had no width

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed "Create a new tree group for this file" setting in front-end import when a group id of 0 was used in the NML. [#5573](https://github.com/scalableminds/webknossos/pull/5573)
 - Fixed a bug that caused a distortion when moving or zooming in the maximized 3d viewport. [#5550](https://github.com/scalableminds/webknossos/pull/5550)
 - Fixed a bug that prevented focusing the login fields when being prompted to login after trying to view a dataset without being logged in.[#5521](https://github.com/scalableminds/webknossos/pull/5577)
+- Fixed that the 3d view content disappeared permanently if the 3d view was resized to not be visible. [#5588](https://github.com/scalableminds/webknossos/pull/5588)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/controller/camera_controller.js
+++ b/frontend/javascripts/oxalis/controller/camera_controller.js
@@ -153,13 +153,13 @@ class CameraController extends React.PureComponent<Props> {
       const oldWidth = tdCamera.right - tdCamera.left;
       const oldHeight = tdCamera.top - tdCamera.bottom;
 
-      const oldAspectRatio = oldWidth / oldHeight;
       const tdRect = inputCatcherRects[OrthoViews.TDView];
+
+      // Do not update the tdCamera if the tdView is not visible
+      if (tdRect.height === 0 || tdRect.width === 0) return;
+
+      const oldAspectRatio = oldWidth / oldHeight;
       const newAspectRatio = tdRect.width / tdRect.height;
-
-      // Do not update the tdCamera if the tdView is not visible (height === 0)
-      if (Number.isNaN(newAspectRatio)) return;
-
       const newWidth = (oldWidth * newAspectRatio) / oldAspectRatio;
 
       tdCamera.left = oldMid - newWidth / 2;


### PR DESCRIPTION
The condition that checked whether the 3d view was not visible, to avoid updating the camera state in that case, was too unspecific. It only checked whether the 3d view had 0 height (and not straightforward, but only by checking whether the result of a division was NaN), but not whether it had 0 width. I changed the condition to be more explicit and complete.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Easier reproduction instructions than in the issue
- Move the vertical splitter (from between the viewports) all the way to the right so that the 3d view is no longer visible.
- Move it back -> the 3d view content should be visible again (on master it is not)

### Issues:
- fixes #5472 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
