### PR TITLE
Separate api/health from data/health and tracings/health 

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
     - The "Mapping" setting was moved to the segmentation layer in the left sidebar.
   - The status bar contains additional elements for (editable) information, such as the active tree id (previously positioned in the left sidebar).
   - Some UI elements were less spacious by favoring icons instead of labels. Hover these elements to get an helpful tooltip.
+- The health check at api/health does not longer include checking data/health and tracings/health if the respective local modules are enabled. Consider monitoring those routes separately.
 
 ### Fixed
 - Fixed that a disabled "Center new Nodes" option didn't work correctly in merger mode. [#5538](https://github.com/scalableminds/webknossos/pull/5538)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
     - The "Mapping" setting was moved to the segmentation layer in the left sidebar.
   - The status bar contains additional elements for (editable) information, such as the active tree id (previously positioned in the left sidebar).
   - Some UI elements were less spacious by favoring icons instead of labels. Hover these elements to get an helpful tooltip.
-- The health check at api/health does not longer include checking data/health and tracings/health if the respective local modules are enabled. Consider monitoring those routes separately.
+- The health check at api/health does not longer include checking data/health and tracings/health if the respective local modules are enabled. Consider monitoring those routes separately. [#5601](https://github.com/scalableminds/webknossos/pull/5601)
 
 ### Fixed
 - Fixed that a disabled "Center new Nodes" option didn't work correctly in merger mode. [#5538](https://github.com/scalableminds/webknossos/pull/5538)

--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -23,6 +23,7 @@ SET recommendedconfiguration = jsonb_set(
         array['useLegacyBindings'],
         to_jsonb('true'::boolean))
 ```
+- The health check at api/health does not longer include checking data/health and tracings/health if the respective local modules are enabled. Consider monitoring those routes separately.
 
 ### Postgres Evolutions:
 - [072-jobs-manually-repaired.sql](conf/evolutions/072-jobs-manually-repaired.sql)


### PR DESCRIPTION
The check at `api/health` is used by liveliness probes for auto-restart. It should be as fast as possible. `data/health` occasionally becomes slow if the datastore module is very busy. It should not trigger auto-restarts then, but rather be monitored separately.

### Steps to test:
- ping `api/health`, it should stay fast even during I/O intensive operations

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Ready for review
