### PR TITLE
Add readable error messages for Project/TaskType unique checks

### DIFF
--- a/app/controllers/ProjectController.scala
+++ b/app/controllers/ProjectController.scala
@@ -71,7 +71,7 @@ class ProjectController @Inject()(projectService: ProjectService,
       for {
         _ <- projectDAO
           .findOneByNameAndOrganization(project.name, request.identity._organization)(GlobalAccessContext)
-          .reverse ?~> "project.name.alreadyTaken"
+          .reverse ?~> Messages("project.name.alreadyTaken", project.name)
         _ <- Fox
           .assertTrue(userService.isTeamManagerOrAdminOf(request.identity, project._team)) ?~> "notAllowed" ~> FORBIDDEN
         _ <- projectDAO.insertOne(project, request.identity._organization) ?~> "project.creation.failed"

--- a/app/models/task/TaskType.scala
+++ b/app/models/task/TaskType.scala
@@ -113,6 +113,15 @@ class TaskTypeDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       parsed <- parseFirst(r, id.toString)
     } yield parsed
 
+  def findOneBySummaryAndOrganization(summary: String, organizationId: ObjectId)(implicit ctx: DBAccessContext): Fox[TaskType] =
+    for {
+      accessQuery <- readAccessQuery
+      r <- run(
+        sql"select #$columns from #$existingCollectionName where summary = '#${sanitize(summary)}' and _organization = $organizationId and #$accessQuery"
+          .as[TasktypesRow])
+      parsed <- parseFirst(r, summary)
+    } yield parsed
+
   override def findAll(implicit ctx: DBAccessContext): Fox[List[TaskType]] =
     for {
       accessQuery <- readAccessQuery

--- a/app/models/task/TaskType.scala
+++ b/app/models/task/TaskType.scala
@@ -113,7 +113,8 @@ class TaskTypeDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       parsed <- parseFirst(r, id.toString)
     } yield parsed
 
-  def findOneBySummaryAndOrganization(summary: String, organizationId: ObjectId)(implicit ctx: DBAccessContext): Fox[TaskType] =
+  def findOneBySummaryAndOrganization(summary: String, organizationId: ObjectId)(
+      implicit ctx: DBAccessContext): Fox[TaskType] =
     for {
       accessQuery <- readAccessQuery
       r <- run(

--- a/conf/messages
+++ b/conf/messages
@@ -188,7 +188,7 @@ priority=Priority
 
 project=Project (optional)
 projectName=Project Name
-project.name.alreadyTaken=Name already used
+project.name.alreadyTaken=The project name “{0}” is already in use.
 project.name.invalidChars=Name contains invalid characters
 project.remove.confirm=Do you really want to delete this project? All annotations and tasks connected to this project will be deleted.
 project.remove.notAllowed=You are not authorized to remove this project. Talk to the owner.
@@ -292,6 +292,7 @@ task.notOneAnnotation=The specified base task does not have exactly one (finishe
 assignment.retrieval.failed=Failed to retrieve any assignment
 
 taskType=Task type
+taskType.summary.alreadyTaken=A task type with summary “{0}” already exists. The summary needs to be unique.
 taskType.editSuccess=Task type successfully edited
 taskType.notFound=Selected task type doesn’t exist
 taskType.deleteSuccess=Task type “{0}” successfully deleted


### PR DESCRIPTION
Adds a readable error message for the tasktype summary unique check, and also improves the respective messages for projects.
I’d say this solves #5593 even though there is no front-end side check. This version should already help the user a lot more than the SQL error.

### URL of deployed dev instance (used for testing):
- https://uniquechecks.webknossos.xyz

### Steps to test:
- Create Project with new name, should work
- Create Project with name that is already in use, should give readable error message
- Create TaskType with new name, should work
- Create TaskType with name that is already in use, should give readable error message

### Issues:
- fixes #5593

------
- [x] Ready for review
