### PR TITLE
Send Session ID With Back-End Analytics

### DIFF
--- a/app/WebKnossosModule.scala
+++ b/app/WebKnossosModule.scala
@@ -1,5 +1,6 @@
 import com.google.inject.AbstractModule
 import controllers.InitialDataService
+import models.analytics.AnalyticsSessionService
 import models.job.JobService
 import models.annotation.AnnotationStore
 import models.binary.DataSetService
@@ -26,5 +27,6 @@ class WebKnossosModule extends AbstractModule {
     bind(classOf[TimeSpanService]).asEagerSingleton()
     bind(classOf[JobService]).asEagerSingleton()
     bind(classOf[SlackNotificationService]).asEagerSingleton()
+    bind(classOf[AnalyticsSessionService]).asEagerSingleton()
   }
 }

--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -64,12 +64,12 @@ class AnalyticsLookUpService @Inject()(userDAO: UserDAO, multiUserDAO: MultiUser
   def webknossos_uri: String = wkConf.Http.uri
 }
 
-class AnalyticsSessionService @Inject()() extends LazyLogging {
+class AnalyticsSessionService @Inject()(wkConf: WkConf) extends LazyLogging {
   // Maintains session IDs per multiUser. The value is the start time of the session.
   // After an inactivity pause a new session id is assigned.
 
   // After this duration of inactivity, a new session ID is generated for a user
-  private lazy val pause: FiniteDuration = 30 seconds
+  private lazy val pause: FiniteDuration = wkConf.BackendAnalytics.sessionPause
 
   // format: userId → (lastRefreshTimestamp, sessionId)
   private lazy val sessionIdStore: scala.collection.mutable.Map[ObjectId, (Long, Long)] = scala.collection.mutable.Map()

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -157,6 +157,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
   object BackendAnalytics {
     val uri: String = get[String]("backendAnalytics.uri")
     val key: String = get[String]("backendAnalytics.key")
+    val sessionPause: FiniteDuration = get[FiniteDuration]("backendAnalytics.sessionPause")
     val verboseLoggingEnabled: Boolean = get[Boolean]("backendAnalytics.verboseLoggingEnabled")
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -246,6 +246,7 @@ slackNotifications {
 backendAnalytics {
   uri = ""
   key = ""
+  sessionPause = 30 minutes
   verboseLoggingEnabled = false
 }
 


### PR DESCRIPTION
Use session_id field for backend analytics, as described in https://developers.amplitude.com/docs/http-api-v2

### Steps to test:
- set backendAnalytics.verboseLoggingEnabled = true
- set backendAnalytics.sessionPause down to 30 seconds
- create annotation, trace some, save, should all show same session id in logging
- wait for duration “sessionPause”
- save again, new session id should show in analytics logging

### Issues:
- fixes #5280 

------
- [x] Ready for review
