### PR TITLE
Invert nux info on new controls, so new users are not bothered

### DIFF
--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -26,3 +26,4 @@ SET recommendedconfiguration = jsonb_set(
 
 ### Postgres Evolutions:
 - [072-jobs-manually-repaired.sql](conf/evolutions/072-jobs-manually-repaired.sql)
+- [073-modern-controls-user-conf.sql](conf/evolutions/073-modern-controls-user-conf.sql)

--- a/conf/evolutions/073-modern-controls-user-conf.sql
+++ b/conf/evolutions/073-modern-controls-user-conf.sql
@@ -1,0 +1,14 @@
+START TRANSACTION;
+
+UPDATE webknossos.multiUsers
+SET novelUserExperienceInfos = jsonb_set(
+        novelUserExperienceInfos,
+        array['shouldSeeModernControlsModal'],
+        to_jsonb('true'::boolean))
+WHERE NOT novelUserExperienceInfos ? 'hasSeenModernControlsModal';
+
+UPDATE webknossos.multiUsers SET  novelUserExperienceInfos = novelUserExperienceInfos - 'hasSeenModernControlsModal';
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 73;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/073-modern-controls-user-conf.sql
+++ b/conf/evolutions/reversions/073-modern-controls-user-conf.sql
@@ -1,0 +1,7 @@
+START TRANSACTION;
+
+UPDATE webknossos.multiUsers SET novelUserExperienceInfos = novelUserExperienceInfos - 'shouldSeeModernControlsModal';
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 73;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/073-modern-controls-user-conf.sql
+++ b/conf/evolutions/reversions/073-modern-controls-user-conf.sql
@@ -2,6 +2,6 @@ START TRANSACTION;
 
 UPDATE webknossos.multiUsers SET novelUserExperienceInfos = novelUserExperienceInfos - 'shouldSeeModernControlsModal';
 
-UPDATE webknossos.releaseInformation SET schemaVersion = 73;
+UPDATE webknossos.releaseInformation SET schemaVersion = 72;
 
 COMMIT TRANSACTION;

--- a/frontend/javascripts/oxalis/view/novel_user_experiences/01-present-modern-controls.js
+++ b/frontend/javascripts/oxalis/view/novel_user_experiences/01-present-modern-controls.js
@@ -10,7 +10,7 @@ export default function PresentModernControls() {
   const dispatch = useDispatch();
   const activeUser = useSelector(state => state.activeUser);
   const [isModalVisible, setIsModalVisible] = React.useState(
-    activeUser != null && !activeUser.novelUserExperienceInfos.shouldSeeModernControlsModal,
+    activeUser != null && activeUser.novelUserExperienceInfos.shouldSeeModernControlsModal,
   );
   if (!isModalVisible) {
     return null;

--- a/frontend/javascripts/oxalis/view/novel_user_experiences/01-present-modern-controls.js
+++ b/frontend/javascripts/oxalis/view/novel_user_experiences/01-present-modern-controls.js
@@ -10,7 +10,7 @@ export default function PresentModernControls() {
   const dispatch = useDispatch();
   const activeUser = useSelector(state => state.activeUser);
   const [isModalVisible, setIsModalVisible] = React.useState(
-    activeUser != null && !activeUser.novelUserExperienceInfos.hasSeenModernControlsModal,
+    activeUser != null && !activeUser.novelUserExperienceInfos.shouldSeeModernControlsModal,
   );
   if (!isModalVisible) {
     return null;
@@ -19,7 +19,7 @@ export default function PresentModernControls() {
   const closeModal = () => {
     setIsModalVisible(false);
     updateNovelUserExperienceInfos(activeUser, {
-      hasSeenModernControlsModal: true,
+      shouldSeeModernControlsModal: false,
     });
   };
 

--- a/frontend/javascripts/types/api_flow_types.js
+++ b/frontend/javascripts/types/api_flow_types.js
@@ -202,7 +202,7 @@ export type APIUserBase = {
 
 export type NovelUserExperienceInfoType = {|
   hasSeenDashboardWelcomeBanner?: boolean,
-  hasSeenModernControlsModal?: boolean,
+  shouldSeeModernControlsModal?: boolean,
 |};
 
 export type APIUserTheme = "auto" | "light" | "dark";

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ START TRANSACTION;
 CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(72);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(73);
 COMMIT TRANSACTION;
 
 


### PR DESCRIPTION
Only existing users should see the NUX dialog presenting the new context menu. New users should just see the new controls without having to choose first.

### URL of deployed dev instance (used for testing):
- https://nuxmoderncontrolsinverse.webknossos.xyz

### Steps to test:
- sign up on dev instance, you should not see the new controls banner

- check out master, sign up, don’t click on the modal
- run the evolution, check out branch, you should see the modal

- refresh db, check out master, sign up, do click on the modal
- run the evolution, check out branch, you should not see the modal again

------
- [x] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Ready for review
