### PR TITLE
Add default analytics uri

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The toolbar contains two  additional tools: [#5384](https://github.com/scalableminds/webknossos/pull/5384)
   - one for the skeleton mode (similar to the existing move tool).
   - one for erasing volume data (similar to right-dragging with the previous brush/trace tool)
+- Back-end side analytics are now sent to events-relay.webknossos.org by default. You can opt out by setting `backendAnalytics.uri` to empty in your config. [5607](https://github.com/scalableminds/webknossos/pull/5607)
 
 ### Changed
 - Improve error logging for unhandled rejections. [#5575](https://github.com/scalableminds/webknossos/pull/5575)

--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -28,9 +28,9 @@ class AnalyticsService @Inject()(rpc: RPC, wkConf: WkConf, analyticsLookUpServic
   }
 
   private def send(analyticsEventJson: JsObject): Fox[Unit] = {
-    if (wkConf.BackendAnalytics.uri == "" || wkConf.BackendAnalytics.key == "") {
+    if (wkConf.BackendAnalytics.uri == "") {
       if (wkConf.BackendAnalytics.verboseLoggingEnabled) {
-        logger.info(s"Not sending analytics event, since uri/key is not configured. Event was: $analyticsEventJson")
+        logger.info(s"Not sending analytics event, since uri is not configured. Event was: $analyticsEventJson")
       }
     } else {
       if (wkConf.BackendAnalytics.verboseLoggingEnabled) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -244,7 +244,7 @@ slackNotifications {
 
 # Back-end analytics
 backendAnalytics {
-  uri = "TODO Default Relayer URI"
+  uri = "https://events-relay.webknossos.org/events"
   uri = ${?DEV_WK_ANALYTICS_URI}
   key = ""
   verboseLoggingEnabled = false

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -244,7 +244,8 @@ slackNotifications {
 
 # Back-end analytics
 backendAnalytics {
-  uri = ""
+  uri = "TODO Default Relayer URI"
+  uri = ${?DEV_WK_ANALYTICS_URI}
   key = ""
   verboseLoggingEnabled = false
 }


### PR DESCRIPTION
- Log back-end analytics events to the wk event relayer by default.
- Empty `key` is no longer interpreted as opt-out, `uri` needs to be empty for that.

### URL of deployed dev instance (used for testing):
- https://analyticsdefault.webknossos.xyz

### Steps to test:
- Logging should not show failed analytics requests
- if backendAnalytics.verboseLogging = true, the log should show which events are sent
- Specifying the environment variable `DEV_WK_ANALYTICS_URI` with emptystring (or adapting application.conf) should disable the analytics events.
- The event relayer checks the api_key if your webKnossos instance claims to be one of the “known” instances.

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
