### PR TITLE
Poll jobs in meshes tab only if jobs are enabled

### DIFF
--- a/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
@@ -156,7 +156,9 @@ class MeshesView extends React.Component<Props, State> {
 
   componentDidMount() {
     maybeFetchMeshFiles(this.props.segmentationLayer, this.props.dataset, false);
-    this.pollJobData();
+    if (features().jobsEnabled) {
+      this.pollJobData();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Since the job request can only be sent (and served) if jobs are enabled on that webKnossos instance, the polling is unnecessary otherwise as well. 
It creates a lot of error logging in the back-end if jobs are not enabled, this PR gets rid of that

- [x] Ready for review
