### PR TITLE
Add hint to application.conf changes for context to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,14 +21,17 @@ assignees: ''
 <!-- If the bug is hard to reproduce check the following: -->
 - [ ] Cannot reproduce the bug anymore / needs deeper investigation.
 <!--- If you can reproduce the bug, provide a list of actions to reproduce the bug. -->
+
 1.
 2.
 3.
 4.
 
-
 ## Your Environment for bug
 <!--- In what environment did the bug occur? -->
-* Browser name and version: e.g. Chrome 39
-* Operating System and version: e.g. Windows 10
-* Version of WebKnossos (Release or Commit):
+- Browser name and version: e.g. Chrome 39
+- Operating System and version: e.g. Windows 10
+- Version of WebKnossos (Release or Commit):
+- Needed `application.conf` changes:
+  - [ ] Set `jobsEnabled` to true
+  - [ ] Set `isDemoInstance` to true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,5 +33,5 @@ assignees: ''
 - Operating System and version: e.g. Windows 10
 - Version of WebKnossos (Release or Commit):
 - Needed `application.conf` changes:
-  - [ ] Set `jobsEnabled` to true
-  - [ ] Set `isDemoInstance` to true
+  - [ ] Specific to long-running jobs (`jobsEnabled=true`)
+  - [ ] Specific to webKnossos.org (`isDemoInstance=true`)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,6 +32,5 @@ assignees: ''
 - Browser name and version: e.g. Chrome 39
 - Operating System and version: e.g. Windows 10
 - Version of WebKnossos (Release or Commit):
-- Needed `application.conf` changes:
-  - [ ] Specific to long-running jobs (`jobsEnabled=true`)
-  - [ ] Specific to webKnossos.org (`isDemoInstance=true`)
+- [ ] Specific to long-running jobs (set `jobsEnabled=true` in `application.conf`)
+- [ ] Specific to webKnossos.org (set `isDemoInstance=true` in `application.conf`)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,3 +12,6 @@ assignees: ''
 
 ## Context
 <!--- Why is this change / new feature important ? What are its use cases? -->
+* For the context the following changes to the `application.conf` are needed:
+  * [ ] Set `jobsEnabled` to true
+  * [ ] Set `isDemoInstance` to true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,5 +13,5 @@ assignees: ''
 ## Context
 <!--- Why is this change / new feature important ? What are its use cases? -->
 * For the context the following changes to the `application.conf` are needed:
-  * [ ] Set `jobsEnabled` to true
-  * [ ] Set `isDemoInstance` to true
+  * [ ] Specific to long-running jobs (`jobsEnabled=true`)
+  * [ ] Specific to webKnossos.org (`isDemoInstance=true`)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,6 +12,5 @@ assignees: ''
 
 ## Context
 <!--- Why is this change / new feature important ? What are its use cases? -->
-* For the context the following changes to the `application.conf` are needed:
-  * [ ] Specific to long-running jobs (`jobsEnabled=true`)
-  * [ ] Specific to webKnossos.org (`isDemoInstance=true`)
+* [ ] Specific to long-running jobs (set `jobsEnabled=true` in `application.conf`)
+* [ ] Specific to webKnossos.org (set `isDemoInstance=true` in `application.conf`)


### PR DESCRIPTION
This PR simply adds hints to changes needed in the `application.conf` to get the local dev-webknossos instance running in a context / with specific features needed for this issue.

Note that I also made the files linter compliant.