### PR TITLE
Select mag of segmentation layer for meshfile computation 

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/21.07.0...HEAD)
 
 ### Added
-- 
+- Fixed a bug where non-existing resolutions could be selected for wk-worker-based meshfile computations [#5631](https://github.com/scalableminds/webknossos/pull/5631)
 
 ### Changed
 - 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
@@ -49,7 +49,7 @@ import {
 } from "oxalis/model/accessors/flycam_accessor";
 import {
   getSegmentationLayer,
-  getDatasetResolutionInfo,
+  getResolutionInfoOfSegmentationLayer,
 } from "oxalis/model/accessors/dataset_accessor";
 import { isIsosurfaceStl } from "oxalis/model/sagas/isosurface_saga";
 import { readFileAsArrayBuffer } from "libs/read_file";
@@ -236,7 +236,7 @@ class MeshesView extends React.Component<Props, State> {
     };
 
     const startComputingMeshfile = async () => {
-      const datasetResolutionInfo = getDatasetResolutionInfo(this.props.dataset);
+      const datasetResolutionInfo = getResolutionInfoOfSegmentationLayer(this.props.dataset);
       const defaultOrHigherIndex = datasetResolutionInfo.getIndexOrClosestHigherIndex(
         defaultMeshfileGenerationResolutionIndex,
       );


### PR DESCRIPTION
### Steps to test:
- enable jobs
- on dataset that has more layers in color than in segmentation layer, run meshfile job
- should select resolution present in segmentation layer

### Issues:
- fixes #5629

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
