### PR TITLE
Fix condition for active segment and node id in status bar

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Improved context menu for interactions with segmentation data which wasn't loaded completely, yet. [#5637](https://github.com/scalableminds/webknossos/pull/5637)
 
 ### Fixed
--
+- Fix that active segment and node id were not shown in status bar when being in a non-hybrid annotation. [#5638](https://github.com/scalableminds/webknossos/pull/5638)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/statusbar.js
+++ b/frontend/javascripts/oxalis/view/statusbar.js
@@ -301,7 +301,7 @@ function Infos() {
       ) : null}
       {isPlaneMode ? getCellInfo(globalMousePosition) : null}
 
-      {isSkeletonAnnotation ? (
+      {isVolumeAnnotation ? (
         <span className="info-element">
           <NumberInputPopoverSetting
             value={activeCellId}
@@ -314,7 +314,7 @@ function Infos() {
           />
         </span>
       ) : null}
-      {isVolumeAnnotation ? (
+      {isSkeletonAnnotation ? (
         <span className="info-element">
           <NumberInputPopoverSetting
             value={activeNodeId}


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open skeleton-only annotation and check that active node id is displayed in status bar
- open volume-only annotation and check that active segment id is displayed in status bar

### Issues:
- follow up to #5231 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
