### PR TITLE
Only poll api/jobs from meshes tab while logged in

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fix that active segment and node id were not shown in status bar when being in a non-hybrid annotation. [#5638](https://github.com/scalableminds/webknossos/pull/5638)
+- Fixed a bug where an authentication error was shown when viewing the meshes tab while not logged in. [#5647](https://github.com/scalableminds/webknossos/pull/5647)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
@@ -92,6 +92,7 @@ const mapStateToProps = (state: OxalisState): * => ({
   datasetName: state.dataset.name,
   availableMeshFiles: state.availableMeshFiles,
   currentMeshFile: state.currentMeshFile,
+  activeUser: state.activeUser,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<*>): * => ({
@@ -168,7 +169,8 @@ class MeshesView extends React.Component<Props, State> {
   }
 
   async pollJobData(): Promise<void> {
-    const jobs = await getJobs();
+    const jobs = this.props.activeUser != null ? await getJobs() : [];
+
     const oldActiveJobId = this.state.activeMeshJobId;
 
     const meshJobsForDataset = jobs.filter(


### PR DESCRIPTION
### Steps to test:
- set up jobsEnabled
- set a dataset with a segmentation layer to public
- open that dataset while logged out
- no request to api/jobs should be sent

### Issues:
- fixes #5646

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
