### PR TITLE
Fix copy-buttons in context menu and change out-of-context-menu-click behavior

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,11 +17,13 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 - Improved context menu for interactions with segmentation data which wasn't loaded completely, yet. [#5637](https://github.com/scalableminds/webknossos/pull/5637)
+- Clicking outside of the context menu closes it without performing any other action (e.g., previously, a node could be created when clicking outside of the context menu, when the skeleton tool was active). Also, a repeated rightclick doesn't open the context menu again. [#5658](https://github.com/scalableminds/webknossos/pull/5658)
 
 ### Fixed
 - Fix that active segment and node id were not shown in status bar when being in a non-hybrid annotation. [#5638](https://github.com/scalableminds/webknossos/pull/5638)
 - Fix that "Compute Mesh File" button was enabled in scenarios where it should not be supported (e.g., when no segmentation layer exists). [#5648](https://github.com/scalableminds/webknossos/pull/5648)
 - Fixed a bug where an authentication error was shown when viewing the meshes tab while not logged in. [#5647](https://github.com/scalableminds/webknossos/pull/5647)
+- Fixed that the copy buttons in the context menu did not work properly. [#5658](https://github.com/scalableminds/webknossos/pull/5658)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/context_menu.js
+++ b/frontend/javascripts/oxalis/view/context_menu.js
@@ -445,6 +445,14 @@ function ContextMenu(props: Props) {
   return (
     <React.Fragment>
       <div
+        className="node-context-menu-overlay"
+        onClick={hideContextMenu}
+        onContextMenu={evt => {
+          evt.preventDefault();
+          hideContextMenu();
+        }}
+      />
+      <div
         style={{
           position: "absolute",
           left: contextMenuPosition[0],
@@ -452,7 +460,6 @@ function ContextMenu(props: Props) {
         }}
         className="node-context-menu"
         tabIndex={-1}
-        onBlur={hideContextMenu}
         ref={inputRef}
       >
         <Shortcut supportInputElements keys="escape" onTrigger={hideContextMenu} />

--- a/frontend/javascripts/oxalis/view/context_menu.js
+++ b/frontend/javascripts/oxalis/view/context_menu.js
@@ -454,7 +454,6 @@ function ContextMenu(props: Props) {
       />
       <div
         style={{
-          position: "absolute",
           left: contextMenuPosition[0],
           top: contextMenuPosition[1],
         }}

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -515,3 +515,10 @@ img.keyboard-mouse-icon:first-child {
 .hide-if-last:last-child {
   display: none;
 }
+
+.node-context-menu-overlay {
+  width: 100%;
+  height: calc(100% - @navbar-height);
+  position: absolute;
+  z-index: 99;
+}


### PR DESCRIPTION
With this PR:
- the copy buttons in the context menu are fixed (before the PR, the `blur()` event was triggered directly and the menu was closed immediately)
- clicking outside of the context menu closes it (and doesn't do anything else, such as creating a node)
- the only downside: a repeated rightclick doesn't open the context menu again. technically, this should be possible, but the effort to implement this is several times higher than the current pr. Also, I think, it's not that important (right now, at least).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a tracing (disable classic mode)
- open a context menu via right click
- use the copy buttons (e.g., copy position) and ensure that the position is copied.
- the context menu will stay open (I find that okay)
- left click outside of the context menu --> the menu should close, but no node or similar should be created
- right click outside of the context menu --> the menu should close and nothing else will happen. ideally, the context menu would open again, but as explained above, this "feature" got dropped with this PR for now.

### Issues:
- fixes #5606
- fixes #5657

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
