### PR TITLE
Allow node selection in move tool

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fix that active segment and node id were not shown in status bar when being in a non-hybrid annotation. [#5638](https://github.com/scalableminds/webknossos/pull/5638)
 - Fix that "Compute Mesh File" button was enabled in scenarios where it should not be supported (e.g., when no segmentation layer exists). [#5648](https://github.com/scalableminds/webknossos/pull/5648)
 - Fixed a bug where an authentication error was shown when viewing the meshes tab while not logged in. [#5647](https://github.com/scalableminds/webknossos/pull/5647)
+- Fixed that nodes could only be selected via the context menu when an annotation was opened in read-only mode. Shift-Click will now work, too (and if "Classic Controls" are disabled, a simple left click will work, too). [#5661](https://github.com/scalableminds/webknossos/pull/5661)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/controller/combinations/tool_controls.js
+++ b/frontend/javascripts/oxalis/controller/combinations/tool_controls.js
@@ -83,6 +83,13 @@ export class MoveTool {
       over: () => {
         MoveHandlers.handleOverViewport(planeId);
       },
+      leftClick: (pos: Point2, plane: OrthoView, event: MouseEvent, isTouch: boolean) => {
+        const { useLegacyBindings } = Store.getState().userConfiguration;
+
+        if (event.shiftKey || !useLegacyBindings) {
+          SkeletonHandlers.handleSelectNode(planeView, pos, plane, isTouch);
+        }
+      },
       pinch: delta => MoveHandlers.zoom(delta, true),
       mouseMove: (delta: Point2, position: Point2, id, event) => {
         // Always set the correct mouse position. Otherwise, using alt + mouse move and
@@ -117,12 +124,22 @@ export class MoveTool {
 
   static getActionDescriptors(
     _activeTool: AnnotationTool,
-    _useLegacyBindings: boolean,
-    _shiftKey: boolean,
+    useLegacyBindings: boolean,
+    shiftKey: boolean,
     _ctrlKey: boolean,
     _altKey: boolean,
   ): Object {
+    // In legacy mode, don't display a hint for
+    // left click as it would be equal to left drag
+    const leftClickInfo =
+      useLegacyBindings && !shiftKey
+        ? {}
+        : {
+            leftClick: "Select Node",
+          };
+
     return {
+      ...leftClickInfo,
       leftDrag: "Move",
       rightClick: "Context Menu",
     };
@@ -267,7 +284,7 @@ export class SkeletonTool {
     const leftClickInfo = useLegacyBindings
       ? {}
       : {
-          leftClick: "Place Node",
+          leftClick: "Place/Select Node",
         };
 
     return {


### PR DESCRIPTION
...when modern controls are enabled OR when shift is pressed.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a skeleton tracing in read only mode
- enable classic mode
- node selection should work when shift is pressed (also see that the shortcut hint is visible in the status bar as soon as shift is pressed).
- disable classic mode
- node selection should work via a simple left click.

Rationale:
- for classic mode users, this behavior is exactly as before (shift + leftclick in read-only always used to select nodes)
- for modern mode users, this behavior should be a) intuitive (a simple click selects a node) and b) not intrusive, since accidental clicks on a node would only change the current position in the worst case (moving a node is not possible).

### Issues:
- fixes #5649

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
