### PR TITLE
Fix hideUnmappedIds resetting once placing a node in merger mode

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where an authentication error was shown when viewing the meshes tab while not logged in. [#5647](https://github.com/scalableminds/webknossos/pull/5647)
 - Fixed that nodes could only be selected via the context menu when an annotation was opened in read-only mode. Shift-Click will now work, too (and if "Classic Controls" are disabled, a simple left click will work, too). [#5661](https://github.com/scalableminds/webknossos/pull/5661)
 - Fixed that the copy buttons in the context menu did not work properly. [#5658](https://github.com/scalableminds/webknossos/pull/5658)
+- Fixed that creating a new node in merger mode did always turn of the "Hide unmapped segments" setting. [#5668](https://github.com/scalableminds/webknossos/pull/5668)
 - Fixed that undoing of volume annotations might overwrite the backend data on not loaded magnifications with nothing. [#5608](https://github.com/scalableminds/webknossos/pull/5608)
 - Fixed a bug where volume annotation downloads were occasionally cancelled with “Connection reset by peer” error. [#5660](https://github.com/scalableminds/webknossos/pull/5660)
 

--- a/frontend/javascripts/oxalis/model/reducers/settings_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/settings_reducer.js
@@ -135,22 +135,19 @@ function SettingsReducer(state: OxalisState, action: Action): OxalisState {
       });
     }
     case "SET_MAPPING": {
-      const {
-        mappingName,
-        mapping,
-        mappingKeys,
-        mappingColors,
-        mappingType,
-        hideUnmappedIds,
-      } = action;
+      const { mappingName, mapping, mappingKeys, mappingColors, mappingType } = action;
+      const hideUnmappedIds =
+        action.hideUnmappedIds != null
+          ? action.hideUnmappedIds
+          : state.temporaryConfiguration.activeMapping.hideUnmappedIds;
       return updateActiveMapping(state, {
         mappingName,
         mapping,
         mappingKeys,
         mappingColors,
         mappingType,
+        hideUnmappedIds,
         mappingSize: mappingKeys != null ? mappingKeys.length : 0,
-        hideUnmappedIds: hideUnmappedIds || false,
       });
     }
     default:


### PR DESCRIPTION
This PR fixes that the hideUnmappedIds option reset to false / was turned of each time a node was created when the merger mode was turned on.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
1. open a skeleton or hybrid tracing for a dataset with a segmentation layer
2. enable merger mode
2. enable "hide unmapped ids" in the mapping settings
3. create a new node
4. "hide unmapped ids" should no longer disable automatically

### Issues:
- fixes #5599

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review


Note: There were multiple ways to tackle this issue. One could have been to change the merge mode, to always pass the current setting of `hideUnmappedIds` to the API call "setMapping". Another would be to change the API "setMapping"-method to not passed undefined as  API `hideUnmappedIds`.
But I prefer the implemented version, because it is much shorter and catches the problem at the root. Additionally, I think it makes more sense when the `setMappingAction` called without `hideUnmappedIds` being set, does not change this setting.
