### PR TITLE
Explorative Resolutions Followup: Fix nightly, add padding

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.js
+++ b/frontend/javascripts/admin/admin_rest_api.js
@@ -671,7 +671,7 @@ export function createExplorational(
   datasetId: APIDatasetId,
   typ: TracingType,
   withFallback: boolean,
-  resolutionRestrictions?: APIResolutionRestrictions,
+  resolutionRestrictions: ?APIResolutionRestrictions,
   options?: RequestOptions = {},
 ): Promise<APIAnnotation> {
   const url = `/api/datasets/${datasetId.owningOrganization}/${datasetId.name}/createExplorational`;

--- a/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.js
@@ -109,7 +109,7 @@ const CreateExplorativeModal = ({ datasetId, onClose }: Props) => {
             value={[lowResolutionIndex, highResolutionIndex]}
             style={{ flexGrow: 1 }}
           />
-          <div style={{ width: "5.5em", textAlign: "right" }}>
+          <div style={{ width: "6.5em", textAlign: "right" }}>
             {datasetResolutionInfo.getResolutionByIndexOrThrow(highResolutionIndex).join("-")}
           </div>
         </div>

--- a/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
@@ -39,7 +39,7 @@ export async function screenshotDataset(
   optionalDatasetConfigOverride: ?DatasetConfiguration,
 ): Promise<Screenshot> {
   const options = getDefaultRequestOptions(baseUrl);
-  const createdExplorational = await createExplorational(datasetId, "skeleton", false, options);
+  const createdExplorational = await createExplorational(datasetId, "skeleton", false, null, options);
   if (optionalDatasetConfigOverride != null) {
     await updateDatasetConfiguration(datasetId, optionalDatasetConfigOverride, options);
   }
@@ -54,7 +54,7 @@ export async function screenshotDatasetWithMapping(
   mappingName: string,
 ): Promise<Screenshot> {
   const options = getDefaultRequestOptions(baseUrl);
-  const createdExplorational = await createExplorational(datasetId, "skeleton", false, options);
+  const createdExplorational = await createExplorational(datasetId, "skeleton", false, null, options);
   await openTracingView(page, baseUrl, createdExplorational.id);
   await page.evaluate(
     `webknossos.apiReady().then(async api => api.data.activateMapping("${mappingName}"))`,

--- a/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.js
@@ -39,7 +39,13 @@ export async function screenshotDataset(
   optionalDatasetConfigOverride: ?DatasetConfiguration,
 ): Promise<Screenshot> {
   const options = getDefaultRequestOptions(baseUrl);
-  const createdExplorational = await createExplorational(datasetId, "skeleton", false, null, options);
+  const createdExplorational = await createExplorational(
+    datasetId,
+    "skeleton",
+    false,
+    null,
+    options,
+  );
   if (optionalDatasetConfigOverride != null) {
     await updateDatasetConfiguration(datasetId, optionalDatasetConfigOverride, options);
   }
@@ -54,7 +60,13 @@ export async function screenshotDatasetWithMapping(
   mappingName: string,
 ): Promise<Screenshot> {
   const options = getDefaultRequestOptions(baseUrl);
-  const createdExplorational = await createExplorational(datasetId, "skeleton", false, null, options);
+  const createdExplorational = await createExplorational(
+    datasetId,
+    "skeleton",
+    false,
+    null,
+    options,
+  );
   await openTracingView(page, baseUrl, createdExplorational.id);
   await page.evaluate(
     `webknossos.apiReady().then(async api => api.data.activateMapping("${mappingName}"))`,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://explorativeresolutionsfollowup.webknossos.xyz

### Steps to test:
- In Create Explorative Modal, highly downsampled resolutions (e.g. 512-512-512 or 1024-1024-1) should still be rendered without line-break
- Nightly/Screenshot tests should run through


----
- [x] Ready for review
