### PR TITLE
Blur viewport maximize button after toggling it

### DIFF
--- a/frontend/javascripts/oxalis/view/input_catcher.js
+++ b/frontend/javascripts/oxalis/view/input_catcher.js
@@ -78,10 +78,6 @@ export function recalculateInputCatcherSizes() {
   Store.dispatch(setInputCatcherRects(viewportRects));
 }
 
-export function getHTMLIdForViewportId(viewportID: Viewport) {
-  return `inputcatcher_${viewportID}`;
-}
-
 class InputCatcher extends React.PureComponent<Props, {}> {
   domElement: ?HTMLElement;
 
@@ -103,7 +99,7 @@ class InputCatcher extends React.PureComponent<Props, {}> {
     return (
       <div className="flexlayout-dont-overflow">
         <div
-          id={getHTMLIdForViewportId(viewportID)}
+          id={`inputcatcher_${viewportID}`}
           ref={domElement => {
             this.domElement = domElement;
           }}

--- a/frontend/javascripts/oxalis/view/input_catcher.js
+++ b/frontend/javascripts/oxalis/view/input_catcher.js
@@ -78,6 +78,10 @@ export function recalculateInputCatcherSizes() {
   Store.dispatch(setInputCatcherRects(viewportRects));
 }
 
+export function getHTMLIdForViewportId(viewportID: Viewport) {
+  return `inputcatcher_${viewportID}`;
+}
+
 class InputCatcher extends React.PureComponent<Props, {}> {
   domElement: ?HTMLElement;
 
@@ -99,7 +103,7 @@ class InputCatcher extends React.PureComponent<Props, {}> {
     return (
       <div className="flexlayout-dont-overflow">
         <div
-          id={`inputcatcher_${viewportID}`}
+          id={getHTMLIdForViewportId(viewportID)}
           ref={domElement => {
             this.domElement = domElement;
           }}

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
@@ -15,9 +15,9 @@ import {
   type LayoutKeys,
   resetDefaultLayouts,
 } from "oxalis/view/layouting/default_layout_configs";
-
+import { setViewportAction } from "oxalis/model/actions/view_mode_actions";
 import Statusbar from "oxalis/view/statusbar";
-import { OrthoViews, ArbitraryViews, BorderTabs } from "oxalis/constants";
+import { OrthoViews, ArbitraryViews, BorderTabs, type OrthoView } from "oxalis/constants";
 import AbstractTreeTab from "oxalis/view/right-border-tabs/abstract_tree_tab";
 import CommentTabView from "oxalis/view/right-border-tabs/comment_tab/comment_tab_view";
 import DatasetInfoTabView from "oxalis/view/right-border-tabs/dataset_info_tab_view";
@@ -56,6 +56,7 @@ type OwnProps = {|
 |};
 type DispatchProps = {|
   setBorderOpenStatus: BorderOpenStatus => void,
+  setActiveViewport: OrthoView => void,
 |};
 type Props = {| ...OwnProps, ...StateProps, ...DispatchProps |};
 type State = {
@@ -321,6 +322,11 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
       if (document.activeElement) {
         document.activeElement.blur();
       }
+      const toggledViewportId = this.state.model
+        .getNodeById(data.node)
+        .getChildren()[0]
+        .getId();
+      this.props.setActiveViewport(OrthoViews[toggledViewportId]);
     }
     return action;
   };
@@ -416,6 +422,9 @@ function mapDispatchToProps(dispatch: Dispatch<*>) {
   return {
     setBorderOpenStatus(borderOpenStatus: BorderOpenStatus) {
       dispatch(setBorderOpenStatusAction(borderOpenStatus));
+    },
+    setActiveViewport(viewport: OrthoView) {
+      dispatch(setViewportAction(viewport));
     },
   };
 }

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
@@ -318,6 +318,9 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
         this.maximizedItemId = data.node;
       }
       this.onMaximizeToggle();
+      if (document.activeElement) {
+        document.activeElement.blur();
+      }
     }
     return action;
   };


### PR DESCRIPTION
This PR solves #5609 as suggested by blurring the button to return the focus to the document body. Thus pressing space after toggling the maximize button via a mouse click no longer causes another toggle and instead triggers a movement.
Additionally, it sets the toggled viewport as active so that the third dimension is correct and pressing space moves forth / back.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a dataset in view mode instantly move the cursor over the navbar.
- From there directly move the cursor to the maximize button of the YZ plane and maximize it.
- Then, without moving the mouse (setting the YZ viewport active via hovering with the mouse) try to move with `space` / `shift + space` back and forth. If the direction is correct, both changes should work.

- After that simply toggle the maximize on the other viewports a few times and check whether this still works fine and without any errors occurring. 

### Issues:
- fixes #5609

------
- ~~[ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~~
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
