### PR TITLE
Re-enable ad-hoc mesh computation for volume annotations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,6 +39,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that creating a new node in merger mode did always turn of the "Hide unmapped segments" setting. [#5668](https://github.com/scalableminds/webknossos/pull/5668)
 - Fixed that undoing of volume annotations might overwrite the backend data on not loaded magnifications with nothing. [#5608](https://github.com/scalableminds/webknossos/pull/5608)
 - Fixed a bug where volume annotation downloads were occasionally cancelled with “Connection reset by peer” error. [#5660](https://github.com/scalableminds/webknossos/pull/5660)
+- Fixed that the ad-hoc mesh computation was disabled for volume annotations. [#5689](https://github.com/scalableminds/webknossos/pull/5689)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/meshes_view.js
@@ -263,12 +263,7 @@ class MeshesView extends React.Component<Props, State> {
   getComputeMeshAdHocTooltipInfo = () => {
     let title = "";
     let disabled = true;
-    if (this.props.hasVolume) {
-      title =
-        this.props.segmentationLayer != null && this.props.segmentationLayer.fallbackLayer
-          ? "Meshes cannot be computed for volume annotations. However, you can open this dataset in view mode to compute meshes for the dataset's segmentation layer."
-          : "Meshes cannot be computed for volume annotations.";
-    } else if (this.props.segmentationLayer == null) {
+    if (this.props.segmentationLayer == null) {
       title = "There is no segmentation layer for which a mesh could be computed.";
     } else {
       title = "Compute mesh for the centered segment.";


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a volume annotation and brush (cell should be at least 4vx wide in each dimension)
- click "compute mesh (ad-hoc)" in mesh tab
- see isosurface in 3D viewport

will look like this:
![image](https://user-images.githubusercontent.com/2486553/130772397-0c848543-e75d-4c04-b892-83496c8929df.png)


### Issues:
- follow-up for #5648 (see https://github.com/scalableminds/webknossos/pull/5648#discussion_r695586540)

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
