### PR TITLE
Allow zip download of (small) datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,7 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/21.08.0...HEAD)
 
 ### Added
--
+- Added the possibility to download small datasets as zip from the datastore. [#5691](https://github.com/scalableminds/webknossos/pull/5691)
 
 ### Changed
 -

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,6 +119,7 @@ datastore {
     enabled = true
     interval = 1 minute
   }
+  dataSourceDownload.sizeLimitBytes = 1000000000 # 1GB
   cache {
     dataCube.maxEntries = 40
     mapping.maxEntries = 5

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -25,6 +25,9 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
       val enabled: Boolean = get[Boolean]("datastore.watchFileSystem.enabled")
       val interval: FiniteDuration = get[FiniteDuration]("datastore.watchFileSystem.interval")
     }
+    object DataSourceDownload {
+      val sizeLimitBytes: Long = get[Long]("datastore.dataSourceDownload.sizeLimitBytes")
+    }
     object Cache {
       object DataCube {
         val maxEntries: Int = get[Int]("datastore.cache.dataCube.maxEntries")

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -349,4 +349,17 @@ class DataSourceController @Inject()(
         }
   }
 
+  def downloadZip(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async {
+    implicit request =>
+      //accessTokenService
+      //.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
+      AllowRemoteOrigin {
+        for {
+          data <- dataSourceService.downloadZip(organizationName, dataSetName)
+        } yield
+          Ok.sendFile(data, fileName = _ => Some(dataSetName + ".zip")).withHeaders(("content-type", "application/zip"))
+      }
+      //      }
+  }
+
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -351,15 +351,16 @@ class DataSourceController @Inject()(
 
   def downloadZip(organizationName: String, dataSetName: String): Action[AnyContent] = Action.async {
     implicit request =>
-      //accessTokenService
-      //.validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
-      AllowRemoteOrigin {
-        for {
-          data <- dataSourceService.downloadZip(organizationName, dataSetName)
-        } yield
-          Ok.sendFile(data, fileName = _ => Some(dataSetName + ".zip")).withHeaders(("content-type", "application/zip"))
-      }
-      //      }
+      accessTokenService
+        .validateAccess(UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName))) {
+          AllowRemoteOrigin {
+            for {
+              data <- dataSourceService.downloadZip(organizationName, dataSetName)
+            } yield
+              Ok.sendFile(data, fileName = _ => Some(dataSetName + ".zip"))
+                .withHeaders(("content-type", "application/zip"))
+          }
+        }
   }
 
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -1,10 +1,13 @@
 package com.scalableminds.webknossos.datastore.services
 
+import java.io.{BufferedOutputStream, File, FileOutputStream}
 import java.nio.file.Path
 
 import com.scalableminds.util.geometry.{Point3D, Vector3I}
+import com.scalableminds.util.io.{NamedStream, ZipIO}
 import com.scalableminds.util.tools.ExtendedTypes.ExtendedArraySeq
-import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import com.scalableminds.util.tools.{Fox, FoxImplicits, TextUtils}
+import com.scalableminds.webknossos.datastore.dataformats.wkw.WKWBucketStreamSink
 import com.scalableminds.webknossos.datastore.helpers.DataSetDeleter
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.{Category, DataLayer, ElementClass}

--- a/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
+++ b/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
@@ -47,6 +47,7 @@ POST        /datasets/sample/:organizationName/:dataSetName/download            
 POST        /datasets/:organizationName/:dataSetName                                                                              @com.scalableminds.webknossos.datastore.controllers.DataSourceController.update(organizationName: String, dataSetName: String)
 GET         /datasets/:organizationName/:dataSetName                                                                              @com.scalableminds.webknossos.datastore.controllers.DataSourceController.explore(organizationName: String, dataSetName: String)
 DELETE      /datasets/:organizationName/:dataSetName/deleteOnDisk                                                                 @com.scalableminds.webknossos.datastore.controllers.DataSourceController.deleteOnDisk(organizationName: String, dataSetName: String)
+GET         /datasets/:organizationName/:dataSetName/download                                                                     @com.scalableminds.webknossos.datastore.controllers.DataSourceController.downloadZip(organizationName: String, dataSetName: String)
 
 # Actions
 GET         /triggers/checkInbox                                                                                                  @com.scalableminds.webknossos.datastore.controllers.DataSourceController.triggerInboxCheck()

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -53,7 +53,7 @@ datastore {
     actorPoolSize = 1
   }
   agglomerateSkeleton.maxEdges = 10000
-  dataSourceDownload.sizeLimitBytes = 2 * 1000 * 1000 * 1000 // 2GB
+  dataSourceDownload.sizeLimitBytes = 1000000000 # 1GB
 }
 
 pidfile.path = "/dev/null" # Avoid the creation of a pid file

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -53,6 +53,7 @@ datastore {
     actorPoolSize = 1
   }
   agglomerateSkeleton.maxEdges = 10000
+  dataSourceDownload.sizeLimitBytes = 2 * 1000 * 1000 * 1000 // 2GB
 }
 
 pidfile.path = "/dev/null" # Avoid the creation of a pid file


### PR DESCRIPTION
New route `GET /data/datasets/:organizationName/:dataSetName/download?token=validDatastoreToken`

### URL of deployed dev instance (used for testing):
- https://downloaddataset.webknossos.xyz

### Steps to test:
- Take the token from /api/buildinfo (if you are superuser)
- Download a dataset, should result in zipfile with correct name and content
- Try downloading a dataset >1GB, should yield readable error

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
