### PR TITLE
Remove highlightHoveredCellId property from configuration of existing tasktypes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - By default, if data is missing in one magnification, higher magnifications are used for rendering. This setting can be controlled via the left sidebar under "Render Missing Data Black". [#5703](https://github.com/scalableminds/webknossos/pull/5703)
 
 ### Fixed
--
+- Fixed a bug where existing tasktypes with recommended configurations still had a property that is no longer valid. [#5707](https://github.com/scalableminds/webknossos/pull/5707)
 
 ### Removed
 -

--- a/MIGRATIONS.released.md
+++ b/MIGRATIONS.released.md
@@ -29,6 +29,7 @@ SET recommendedconfiguration = jsonb_set(
         to_jsonb('true'::boolean))
 ```
 - The health check at api/health does not longer include checking data/health and tracings/health if the respective local modules are enabled. Consider monitoring those routes separately.
+- Run as sql: `UPDATE webknossos.tasktypes SET recommendedconfiguration = recommendedconfiguration - 'highlightHoveredCellId';` to avoid invalid recommended configurations in existing task types. This was added later as evolution 75, but should be run already here (note that it is idempotent).
 
 ### Postgres Evolutions:
 - [072-jobs-manually-repaired.sql](conf/evolutions/072-jobs-manually-repaired.sql)

--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -8,3 +8,5 @@ User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 ## Unreleased
 
 ### Postgres Evolutions:
+
+- [075-tasktype-remove-hovered-cell-id.sql](conf/evolutions/075-tasktype-remove-hovered-cell-id.sql)

--- a/conf/evolutions/075-tasktype-remove-hovered-cell-id.sql
+++ b/conf/evolutions/075-tasktype-remove-hovered-cell-id.sql
@@ -1,0 +1,7 @@
+START TRANSACTION;
+
+UPDATE webknossos.tasktypes SET recommendedconfiguration = recommendedconfiguration - 'highlightHoveredCellId';
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 75;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/075-tasktype-remove-hovered-cell-id.sql
+++ b/conf/evolutions/reversions/075-tasktype-remove-hovered-cell-id.sql
@@ -1,0 +1,8 @@
+START TRANSACTION;
+
+# Since we are losing information when removing the property, we cannot set it in the reversion.
+# However, this will not create an invalid state since the object is merged with the user config.
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 74;
+
+COMMIT TRANSACTION;

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ START TRANSACTION;
 CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(74);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(75);
 COMMIT TRANSACTION;
 
 


### PR DESCRIPTION
### Issues:
- fixes #5705 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Ready for review
