### PR TITLE
Fix copying of segment ids

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed a bug where existing tasktypes with recommended configurations still had a property that is no longer valid. [#5707](https://github.com/scalableminds/webknossos/pull/5707)
+- Fixed that segment IDs could not be copied to the clipboard. [#5709](https://github.com/scalableminds/webknossos/pull/5709)
 
 ### Removed
 -

--- a/frontend/javascripts/admin/auth/auth_token_view.js
+++ b/frontend/javascripts/admin/auth/auth_token_view.js
@@ -2,7 +2,6 @@
 import React, { useState, useEffect } from "react";
 import { CopyOutlined, SwapOutlined } from "@ant-design/icons";
 import { Input, Button, Col, Row, Spin, Form } from "antd";
-import Clipboard from "clipboard-js";
 import { getAuthToken, revokeAuthToken } from "admin/admin_rest_api";
 import Toast from "libs/toast";
 
@@ -35,7 +34,7 @@ function AuthTokenView() {
   };
 
   const copyTokenToClipboard = async () => {
-    await Clipboard.copy(currentToken);
+    await navigator.clipboard.writeText(currentToken);
     Toast.success("Token copied to clipboard");
   };
 

--- a/frontend/javascripts/admin/task/task_list_view.js
+++ b/frontend/javascripts/admin/task/task_list_view.js
@@ -13,7 +13,6 @@ import {
   PlayCircleOutlined,
   PlusOutlined,
 } from "@ant-design/icons";
-import Clipboard from "clipboard-js";
 import React from "react";
 import _ from "lodash";
 
@@ -159,7 +158,9 @@ class TaskListView extends React.PureComponent<Props, State> {
         title={`Anonymous Task Links for Task ${anonymousTaskId}`}
         visible={this.state.isAnonymousTaskLinkModalVisible}
         onOk={() => {
-          Clipboard.copy(tasksString).then(() => Toast.success("Links copied to clipboard"));
+          navigator.clipboard
+            .writeText(tasksString)
+            .then(() => Toast.success("Links copied to clipboard"));
           this.setState({ isAnonymousTaskLinkModalVisible: false });
         }}
         onCancel={() => this.setState({ isAnonymousTaskLinkModalVisible: false })}

--- a/frontend/javascripts/admin/user/user_list_view.js
+++ b/frontend/javascripts/admin/user/user_list_view.js
@@ -14,7 +14,6 @@ import {
   UserOutlined,
 } from "@ant-design/icons";
 import { connect } from "react-redux";
-import Clipboard from "clipboard-js";
 import * as React from "react";
 import _ from "lodash";
 import moment from "moment";
@@ -441,7 +440,7 @@ class UserListView extends React.PureComponent<PropsWithRouter, State> {
                     <CopyOutlined
                       style={{ margin: "0 0 0 5px" }}
                       onClick={async () => {
-                        await Clipboard.copy(domain);
+                        await navigator.clipboard.writeText(domain);
                         Toast.success(`"${domain}" copied to clipboard`);
                       }}
                     />

--- a/frontend/javascripts/dashboard/dataset/import_sharing_component.js
+++ b/frontend/javascripts/dashboard/dataset/import_sharing_component.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { Button, Input, Checkbox, Tooltip } from "antd";
-import Clipboard from "clipboard-js";
 import React, { useState, useEffect } from "react";
 
 import type { APIDataset, APIDatasetId } from "types/api_flow_types";
@@ -61,7 +60,11 @@ export default function ImportSharingComponent({ form, datasetId, hasNoAllowedTe
   }
 
   async function handleCopySharingLink(): Promise<void> {
-    await Clipboard.copy(getSharingLink());
+    const link = getSharingLink();
+    if (!link) {
+      return;
+    }
+    await navigator.clipboard.writeText(link);
     Toast.success("Sharing Link copied to clipboard");
   }
 
@@ -72,7 +75,7 @@ export default function ImportSharingComponent({ form, datasetId, hasNoAllowedTe
   }
 
   async function handleCopyAllowUsageCode(): Promise<void> {
-    await Clipboard.copy(getAllowUsageCode());
+    await navigator.clipboard.writeText(getAllowUsageCode());
     Toast.success("Code copied to clipboard");
   }
 

--- a/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -5,7 +5,6 @@
 
 import { connect } from "react-redux";
 import BackboneEvents from "backbone-events-standalone";
-import Clipboard from "clipboard-js";
 import * as React from "react";
 import _ from "lodash";
 import api from "oxalis/api/internal_api";
@@ -353,9 +352,9 @@ class PlaneController extends React.PureComponent<Props> {
             mapping,
             getRequestLogZoomStep(Store.getState()),
           );
-          Clipboard.copy(String(hoveredId)).then(() =>
-            Toast.success(`Segment id ${hoveredId} copied to clipboard.`),
-          );
+          navigator.clipboard
+            .writeText(String(hoveredId))
+            .then(() => Toast.success(`Segment id ${hoveredId} copied to clipboard.`));
         } else {
           Toast.warning("No segment under cursor.");
         }

--- a/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.js
@@ -2,7 +2,6 @@
 import { Input, Tooltip } from "antd";
 import { PushpinOutlined, ReloadOutlined } from "@ant-design/icons";
 import { connect } from "react-redux";
-import Clipboard from "clipboard-js";
 import React, { PureComponent } from "react";
 import type { APIDataset } from "types/api_flow_types";
 import { V3 } from "libs/mjs";
@@ -39,13 +38,13 @@ const positionInputErrorStyle = {
 class DatasetPositionView extends PureComponent<Props> {
   copyPositionToClipboard = async () => {
     const position = V3.floor(getPosition(this.props.flycam)).join(", ");
-    await Clipboard.copy(position);
+    await navigator.clipboard.writeText(position);
     Toast.success("Position copied to clipboard");
   };
 
   copyRotationToClipboard = async () => {
     const rotation = V3.round(getRotation(this.props.flycam)).join(", ");
-    await Clipboard.copy(rotation);
+    await navigator.clipboard.writeText(rotation);
     Toast.success("Rotation copied to clipboard");
   };
 

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.js
@@ -2,7 +2,6 @@
 import { Alert, Divider, Radio, Modal, Input, Button, Row, Col } from "antd";
 import { CopyOutlined, ShareAltOutlined } from "@ant-design/icons";
 import { useSelector } from "react-redux";
-import Clipboard from "clipboard-js";
 import React, { useState, useEffect } from "react";
 import type { APIDataset, APIAnnotationVisibility, APIAnnotationType } from "types/api_flow_types";
 import {
@@ -68,7 +67,7 @@ export function getUrl(sharingToken: string, includeToken: boolean) {
 }
 
 export async function copyUrlToClipboard(url: string) {
-  await Clipboard.copy(url);
+  await navigator.clipboard.writeText(url);
   Toast.success("URL copied to clipboard.");
 }
 

--- a/frontend/javascripts/oxalis/view/context_menu.js
+++ b/frontend/javascripts/oxalis/view/context_menu.js
@@ -36,7 +36,6 @@ import {
 import Model from "oxalis/model";
 import api from "oxalis/api/internal_api";
 import Toast from "libs/toast";
-import Clipboard from "clipboard-js";
 import messages from "messages";
 import { getSegmentationLayer } from "oxalis/model/accessors/dataset_accessor";
 import { getNodeAndTree, findTreeByNodeId } from "oxalis/model/accessors/skeletontracing_accessor";
@@ -94,7 +93,7 @@ function copyIconWithTooltip(value: string | number, title: string) {
       <CopyOutlined
         style={{ margin: "0 0 0 5px" }}
         onClick={async () => {
-          await Clipboard.copy(value);
+          await navigator.clipboard.writeText(value.toString());
           Toast.success(`"${value}" copied to clipboard`);
         }}
       />

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "base64-js": "^1.2.1",
     "beautiful-react-hooks": "^0.30.5",
     "classnames": "^2.2.5",
-    "clipboard-js": "^0.2.0",
     "comlink": "^4.3.0",
     "copy-webpack-plugin": "^4.6.0",
     "cross-fetch": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3204,11 +3204,6 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-clipboard-js@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/clipboard-js/-/clipboard-js-0.2.0.tgz#ba1a6092ccbce43ccc9817407737692e432f409b"
-  integrity sha1-uhpgksy85DzMmBdAdzdpLkMvQJs=
-
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"


### PR DESCRIPTION
- the clipboard-js library we used was quite old. I removed in favor of the native navigator clipboard interface (see https://caniuse.com/mdn-api_clipboard_writetext)
- the old and new clipboard api don't accept numbers as inputs which is why I added the `toString` invocation where necessary

### URL of deployed dev instance (used for testing):
- https://fixcopyingnumbers.webknossos.xyz

### Steps to test:
- open a dataset with a segmentation
- rightclick on a segment and click the "copy segment id" icon
- the clipboard should update with the id (note that the toast itself is not enough as a success indicator, as the buggy version also showed the toast without copying anything)

### Issues:
- fixes https://github.com/scalableminds/webknossos/issues/5708

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
