### PR TITLE
Add shortcuts K and L for toggling sidebars

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added a rudimentary version of openAPI docs for some routes. Available at `/swagger.json`. [#5693](https://github.com/scalableminds/webknossos/pull/5693)
+- Added shortcuts K and L for toggling the left and right sidebars. [#5709](https://github.com/scalableminds/webknossos/pull/5709)
 
 ### Changed
 - By default, if data is missing in one magnification, higher magnifications are used for rendering. This setting can be controlled via the left sidebar under "Render Missing Data Black". [#5703](https://github.com/scalableminds/webknossos/pull/5703)

--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -27,6 +27,7 @@ With classic controls, several mouse controls are modifier-driven and may also u
 | G                             | Decrease the Move Value                     |
 | Q                             | Download Screenshot(s) of Viewport(s)       |
 | .                             | Toggle Viewport Maximization                |
+| K, L                          | Toggle Sidebars                             |
 
 ## Skeleton Annotation Mode
 

--- a/frontend/javascripts/oxalis/view/components/border_toggle_button.js
+++ b/frontend/javascripts/oxalis/view/components/border_toggle_button.js
@@ -18,7 +18,9 @@ function BorderToggleButton(props: Props) {
   const { onClick, side, borderOpenStatus, inFooter } = props;
   const placement = side === "left" ? "right" : "left";
   const iconKind = borderOpenStatus[side] ? "hide" : "show";
-  const tooltipTitle = `${borderOpenStatus[side] === false ? "Open" : "Hide"} ${side} sidebar`;
+  const tooltipTitle = `${borderOpenStatus[side] === false ? "Open" : "Hide"} ${side} sidebar (${
+    side === "left" ? "K" : "L"
+  })`;
   const className = `${side}-border-button no-hover-highlighting ${
     inFooter === true ? "footer-button" : "flexlayout__tab_toolbar_button"
   }`;

--- a/frontend/javascripts/oxalis/view/components/border_toggle_button.js
+++ b/frontend/javascripts/oxalis/view/components/border_toggle_button.js
@@ -18,7 +18,7 @@ function BorderToggleButton(props: Props) {
   const { onClick, side, borderOpenStatus, inFooter } = props;
   const placement = side === "left" ? "right" : "left";
   const iconKind = borderOpenStatus[side] ? "hide" : "show";
-  const tooltipTitle = `${borderOpenStatus[side] === false ? "Open" : "Hide"} ${side} sidebar (${
+  const tooltipTitle = `${borderOpenStatus[side] ? "Hide" : "Open"} ${side} sidebar (${
     side === "left" ? "K" : "L"
   })`;
   const className = `${side}-border-button no-hover-highlighting ${

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
@@ -104,8 +104,7 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
         this.toggleBorder(side);
       }),
     );
-    this.unbindListeners.push(this.attachMaximizeListener());
-    this.unbindListeners.push(this.attachToggleBorderListener());
+    this.unbindListeners.push(this.attachKeyboardShortcuts());
   }
 
   unbindAllListeners() {
@@ -136,15 +135,7 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
     setTimeout(this.onLayoutChange, 1);
   }
 
-  attachToggleBorderListener() {
-    const keyboardNoLoop = new InputKeyboardNoLoop(
-      { k: () => this.toggleBorder("left"), l: () => this.toggleBorder("right") },
-      { supportInputElements: false },
-    );
-    return () => keyboardNoLoop.destroy();
-  }
-
-  attachMaximizeListener() {
+  attachKeyboardShortcuts() {
     const toggleMaximize = () => {
       const { model } = this.state;
       const activeNode = model.getActiveTabset();
@@ -157,7 +148,11 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
     };
 
     const keyboardNoLoop = new InputKeyboardNoLoop(
-      { ".": toggleMaximize },
+      {
+        ".": toggleMaximize,
+        k: () => this.toggleBorder("left"),
+        l: () => this.toggleBorder("right"),
+      },
       { supportInputElements: false },
     );
     return () => keyboardNoLoop.destroy();

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
@@ -105,6 +105,7 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
       }),
     );
     this.unbindListeners.push(this.attachMaximizeListener());
+    this.unbindListeners.push(this.attachToggleBorderListener());
   }
 
   unbindAllListeners() {
@@ -133,6 +134,14 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
     this.updateToModelStateAndAdjustIt(model);
     this.setState({ model });
     setTimeout(this.onLayoutChange, 1);
+  }
+
+  attachToggleBorderListener() {
+    const keyboardNoLoop = new InputKeyboardNoLoop(
+      { k: () => this.toggleBorder("left"), l: () => this.toggleBorder("right") },
+      { supportInputElements: false },
+    );
+    return () => keyboardNoLoop.destroy();
   }
 
   attachMaximizeListener() {


### PR DESCRIPTION
The return of K and L :100: This time they toggle the left and right sidebars in the wk tracing view.

### URL of deployed dev instance (used for testing):
- https://klsidebars.webknossos.xyz

### Steps to test:
- Hit k and l in tracing view
- sidebars should be toggled
- Known issue: hitting them in very fast succession, only one may be toggled.

### Issues:
- fixes #5699 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [documentation](../blob/master/docs) if applicable
- [x] Ready for review
