### PR TITLE
minor Swagger Schema updates

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -73,7 +73,7 @@ class AnnotationController @Inject()(
         value =
           "For Task and Explorational annotations, id is an annotation id. For CompoundTask, id is a task id. For CompoundProject, id is a project id. For CompoundTaskType, id is a task type id")
       id: String,
-      @ApiParam(value = "Timestamp in milliseconds (time at which the request is sent)") timestamp: Long, required = true)
+      @ApiParam(value = "Timestamp in milliseconds (time at which the request is sent)", required = true) timestamp: Long)
     : Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     log() {
       val notFoundMessage =

--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -73,7 +73,7 @@ class AnnotationController @Inject()(
         value =
           "For Task and Explorational annotations, id is an annotation id. For CompoundTask, id is a task id. For CompoundProject, id is a project id. For CompoundTaskType, id is a task type id")
       id: String,
-      @ApiParam(value = "Timestamp in milliseconds (time at which the request is sent)") timestamp: Long)
+      @ApiParam(value = "Timestamp in milliseconds (time at which the request is sent)") timestamp: Long, required = true)
     : Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     log() {
       val notFoundMessage =

--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -61,7 +61,7 @@ class AnnotationController @Inject()(
   implicit val timeout: Timeout = Timeout(5 seconds)
   private val taskReopenAllowed = (conf.Features.taskReopenAllowed + (10 seconds)).toMillis
 
-  @ApiOperation(value = "Information about an annotation")
+  @ApiOperation(value = "Information about an annotation", nickname = "annotationInfo")
   @ApiResponses(
     Array(new ApiResponse(code = 200, message = "JSON object containing information about this annotation."),
           new ApiResponse(code = 400, message = badRequestLabel)))

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -71,7 +71,8 @@ Expects:
  - As form parameter: createGroupForEachFile [String] should be one of "true" or "false"
    - If "true": in merged annotation, create tree group wrapping the trees of each file
    - If "false": in merged annotation, rename trees with the respective file name as prefix""",
-    nickname = "annotationUpload")
+    nickname = "annotationUpload"
+  )
   @ApiResponses(
     Array(
       new ApiResponse(

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -70,7 +70,8 @@ Expects:
  - As file attachment: any number of NML files or ZIP files containing NMLs, optionally with at most one volume data ZIP referenced from an NML in a ZIP
  - As form parameter: createGroupForEachFile [String] should be one of "true" or "false"
    - If "true": in merged annotation, create tree group wrapping the trees of each file
-   - If "false": in merged annotation, rename trees with the respective file name as prefix""")
+   - If "false": in merged annotation, rename trees with the respective file name as prefix""",
+    nickname = "annotationUpload")
   @ApiResponses(
     Array(
       new ApiResponse(
@@ -219,7 +220,7 @@ Expects:
       )
     }
 
-  @ApiOperation(value = "Download an annotation as NML/ZIP")
+  @ApiOperation(value = "Download an annotation as NML/ZIP", nickname = "annotationDownload")
   @ApiResponses(
     Array(
       new ApiResponse(code = 200,

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -210,7 +210,7 @@ class DataSetController @Inject()(userService: UserService,
       } yield Ok(Json.toJson(usersJs))
   }
 
-  @ApiOperation(value = "Get information about this dataset")
+  @ApiOperation(value = "Get information about this dataset", nickname = "datasetInfo")
   @ApiResponses(
     Array(new ApiResponse(code = 200, message = "JSON object containing dataset information"),
           new ApiResponse(code = 400, message = badRequestLabel)))

--- a/app/controllers/DataStoreController.scala
+++ b/app/controllers/DataStoreController.scala
@@ -39,7 +39,7 @@ class DataStoreController @Inject()(dataStoreDAO: DataStoreDAO,
       (__ \ 'isForeign).readNullable[Boolean] and
       (__ \ 'isConnector).readNullable[Boolean] and
       (__ \ 'allowsUpload).readNullable[Boolean])(DataStore.fromUpdateForm _)
-  @ApiOperation(value = "List all available datastores")
+  @ApiOperation(value = "List all available datastores", nickname = "datastoreList")
   @ApiResponses(
     Array(new ApiResponse(code = 200, message = "JSON list of objects containing datastore information"),
           new ApiResponse(code = 400, message = badRequestLabel)))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -88,7 +88,7 @@ class BinaryDataController @Inject()(
   /**
     * Handles requests for raw binary data via HTTP GET.
     */
-  @ApiOperation(value = "Get raw binary data from a bounding box in a dataset layer", nickname="datasetDownload")
+  @ApiOperation(value = "Get raw binary data from a bounding box in a dataset layer", nickname = "datasetDownload")
   @ApiResponses(
     Array(
       new ApiResponse(code = 200, message = "Raw bytes from the dataset"),

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -34,7 +34,7 @@ import play.api.mvc.{Action, AnyContent, PlayBodyParsers, RawBuffer, ResponseHea
 
 import scala.concurrent.ExecutionContext
 
-@Api
+@Api(tags = Array("datastore"))
 class BinaryDataController @Inject()(
     dataSourceRepository: DataSourceRepository,
     config: DataStoreConfig,
@@ -88,7 +88,7 @@ class BinaryDataController @Inject()(
   /**
     * Handles requests for raw binary data via HTTP GET.
     */
-  @ApiOperation(value = "Get raw binary data from a bounding box in a dataset layer")
+  @ApiOperation(value = "Get raw binary data from a bounding box in a dataset layer", nickname="datasetDownload")
   @ApiResponses(
     Array(
       new ApiResponse(code = 200, message = "Raw bytes from the dataset"),

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -21,7 +21,7 @@ import play.api.libs.Files
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-@Api
+@Api(tags = Array("datastore"))
 class DataSourceController @Inject()(
     dataSourceRepository: DataSourceRepository,
     dataSourceService: DataSourceService,
@@ -101,7 +101,8 @@ Expects:
   - resumableTotalChunks (string): total chunk count of the upload
   - totalFileCount (string): total file count of the upload
   - resumableIdentifier (string): identifier of the resumable upload and file ("{uploadId}/{filepath}")
-""")
+""",
+    nickname = "datasetUploadChunk")
   @ApiResponses(
     Array(
       new ApiResponse(code = 200, message = "Empty body, chunk was saved on the server"),
@@ -160,7 +161,8 @@ Expects:
   - name (string): dataset name
   - initialTeams (list of string): names of the webknossos teams dataset should be accessible for
   - needsConversion (boolean): mark as true for non-wkw datasets. They are stored differently and a conversion job can later be run.
-""")
+""",
+    nickname = "datasetFinishUpload")
   @ApiResponses(
     Array(
       new ApiResponse(code = 200, message = "Empty body, chunk was saved on the server"),

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -102,7 +102,8 @@ Expects:
   - totalFileCount (string): total file count of the upload
   - resumableIdentifier (string): identifier of the resumable upload and file ("{uploadId}/{filepath}")
 """,
-    nickname = "datasetUploadChunk")
+    nickname = "datasetUploadChunk"
+  )
   @ApiResponses(
     Array(
       new ApiResponse(code = 200, message = "Empty body, chunk was saved on the server"),
@@ -162,7 +163,8 @@ Expects:
   - initialTeams (list of string): names of the webknossos teams dataset should be accessible for
   - needsConversion (boolean): mark as true for non-wkw datasets. They are stored differently and a conversion job can later be run.
 """,
-    nickname = "datasetFinishUpload")
+    nickname = "datasetFinishUpload"
+  )
   @ApiResponses(
     Array(
       new ApiResponse(code = 200, message = "Empty body, chunk was saved on the server"),


### PR DESCRIPTION
Sets nicknames for the `operationId`, as well as a `datastore` tag and marking the timestamp param as required for the annotation info request.
