### PR TITLE
Fix volume version restore for untouched buckets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where existing tasktypes with recommended configurations still had a property that is no longer valid. [#5707](https://github.com/scalableminds/webknossos/pull/5707)
 - Fixed that segment IDs could not be copied to the clipboard. [#5709](https://github.com/scalableminds/webknossos/pull/5709)
+- Fixed a bug where volume annotation version restore skipped buckets that were not yet touched in the version to be restored. [#5717](https://github.com/scalableminds/webknossos/pull/5717)
 
 ### Removed
 -

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -75,7 +75,11 @@ class FossilDBClient(collection: String, config: TracingStoreConfig, slackNotifi
       case statusRuntimeException: StatusRuntimeException =>
         if (statusRuntimeException.getStatus == Status.UNAVAILABLE) Fox.failure("FossilDB is unavailable") ~> 500
         else Fox.failure("Could not get from FossilDB: " + statusRuntimeException.getMessage)
-      case e: Exception => Fox.failure("Could not get from FossilDB: " + e.getMessage)
+      case e: Exception => {
+        if (e.getMessage == "No such element") { Fox.empty } else {
+          Fox.failure("Could not get from FossilDB: " + e.getMessage)
+        }
+      }
     }
 
   def getVersion(key: String,


### PR DESCRIPTION
`VolumeTracingService.revertToVolumeVersion` checked against “Empty” to select which buckets need to be restored to empty. However, the fossildb client gave Failure instead of Empty for missing buckets. This is why the version restore skipped those buckets.

### URL of deployed dev instance (used for testing):
- https://volumerestore.webknossos.xyz

### Steps to test:
- Create volume annotation, brush some, save, then restore version 0, reload page, should still look like version 0

### Issues:
- fixes #5717 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
