### PR TITLE
Fix isMappingEnabled api method

### DIFF
--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -1126,8 +1126,10 @@ class DataApi {
     if (!effectiveLayerName) {
       return false;
     }
-    return getMappingInfo(Store.getState().temporaryConfiguration.activeMappingByLayer, layerName)
-      .isMappingEnabled;
+    return getMappingInfo(
+      Store.getState().temporaryConfiguration.activeMappingByLayer,
+      effectiveLayerName,
+    ).isMappingEnabled;
   }
 
   refreshIsosurfaces() {


### PR DESCRIPTION
I checked the api methods for other occurrences of this kind of bug but this seemed to be the only one :)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the `ROI2017_wkw` dataset
  - Execute `webknossos.apiReady().then(async api => api.data.activateMapping("astrocyte"))` and wait for activation
  - Then execute `webknossos.apiReady().then(async api => api.data.isMappingEnabled())` which should return true

------
- [x] Ready for review
