### PR TITLE
Fix unsafe integer usage by using string keys instead

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where existing tasktypes with recommended configurations still had a property that is no longer valid. [#5707](https://github.com/scalableminds/webknossos/pull/5707)
 - Fixed that segment IDs could not be copied to the clipboard. [#5709](https://github.com/scalableminds/webknossos/pull/5709)
 - Fixed a bug where volume annotation version restore skipped buckets that were not yet touched in the version to be restored. [#5717](https://github.com/scalableminds/webknossos/pull/5717)
+- Fixed a rendering bug showing non-existant or wrongly-colored edges that sometimes occurred after deleting edges, nodes, or trees. [#5724](https://github.com/scalableminds/webknossos/pull/5724)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/geometries/skeleton.js
+++ b/frontend/javascripts/oxalis/geometries/skeleton.js
@@ -428,7 +428,7 @@ class Skeleton {
   // ######### API ###############
 
   /**
-   * Combined node/edge id and a treeId to a single unique id using recursive cantor pairings.
+   * Combine node, edge and tree ids to a single unique id.
    * @param numbers - Array of node/edge id and treeId
    */
   combineIds(...numbers: Array<number>): string {

--- a/frontend/javascripts/oxalis/geometries/skeleton.js
+++ b/frontend/javascripts/oxalis/geometries/skeleton.js
@@ -38,7 +38,7 @@ type BufferPosition = {
 
 type BufferCollection = {
   buffers: Array<Buffer>,
-  idToBufferPosition: Map<number, BufferPosition>,
+  idToBufferPosition: Map<string, BufferPosition>,
   freeList: Array<BufferPosition>,
   helper: BufferHelper,
   material: typeof THREE.Material,
@@ -218,7 +218,7 @@ class Skeleton {
    * @param updateBoundingSphere - toggle to update ThreeJS's internals
    * @param createFunc - callback(buffer, index) that actually creates a node / edge
    */
-  create(id: number, collection: BufferCollection, createFunc: BufferOperation) {
+  create(id: string, collection: BufferCollection, createFunc: BufferOperation) {
     let currentBuffer = collection.buffers[0];
     if (collection.freeList.length === 0 && currentBuffer.nextIndex >= currentBuffer.capacity) {
       currentBuffer = this.initializeBuffer(MAX_CAPACITY, collection.material, collection.helper);
@@ -242,7 +242,7 @@ class Skeleton {
    * @param collection - collection of all buffers
    * @param deleteFunc - callback(buffer, index) that actually deletes/invalidates a node / edge
    */
-  delete(id: number, collection: BufferCollection, deleteFunc: BufferOperation) {
+  delete(id: string, collection: BufferCollection, deleteFunc: BufferOperation) {
     const bufferPosition = collection.idToBufferPosition.get(id);
     if (bufferPosition != null) {
       const changedAttributes = deleteFunc(bufferPosition);
@@ -262,7 +262,7 @@ class Skeleton {
    * @param collection - collection of all buffers
    * @param deleteFunc - callback(buffer, index) that actually updates a node / edge
    */
-  update(id: number, collection: BufferCollection, updateFunc: BufferOperation) {
+  update(id: string, collection: BufferCollection, updateFunc: BufferOperation) {
     const bufferPosition = collection.idToBufferPosition.get(id);
     if (bufferPosition != null) {
       const changedAttributes = updateFunc(bufferPosition);
@@ -431,8 +431,8 @@ class Skeleton {
    * Combined node/edge id and a treeId to a single unique id using recursive cantor pairings.
    * @param numbers - Array of node/edge id and treeId
    */
-  combineIds(...numbers: Array<number>) {
-    return numbers.reduce((acc, value) => 0.5 * (acc + value) * (acc + value + 1) + value);
+  combineIds(...numbers: Array<number>): string {
+    return numbers.join(",");
   }
 
   /**
@@ -513,7 +513,7 @@ class Skeleton {
 
     const edgePositionUpdater = (edge: Edge, isIngoingEdge: boolean) => {
       // The changed node is the target node of the edge which is saved
-      // after the source node in the buffer. THus we need an offset.
+      // after the source node in the buffer. Thus we need an offset.
       const indexOffset = isIngoingEdge ? 3 : 0;
       const bufferEdgeId = this.combineIds(treeId, edge.source, edge.target);
       this.update(bufferEdgeId, this.edges, ({ buffer, index }) => {


### PR DESCRIPTION
In skeleton.js a recursive cantor pairing was used to combine three integers into a unique single integer which is used as a Map key. However, these numbers quickly become very large, exceeding javascript's `Number.MAX_SAFE_INTEGER`. In that case, the Map access to delete edges will fail sometimes resulting in wrongly colored or left over edges.
I switched to a simple string concatenation approach to create the unique keys. According to a quick search this shouldn't be much slower and I didn't notice any slow-downs.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open an empty tracing and drag-and-drop this NML into it
[orphan-nodes.zip](https://github.com/scalableminds/webknossos/files/7137619/orphan-nodes.zip)
  - Make sure the tracing is empty so that the IDs are not relabeled!
- Jump to position 198722, 346458, 5801 and reload the page to fix an issue with the 3D view if annotations are far outside of the dataset
- Remove the node there, then delete the smaller of the two agglomerates that were created by the split
  - On master you'll see some left over edges without nodes and warnings in the console (`[Skeleton] Unable to find buffer position for id 78519564543334160`, ...)
  - On this branch the agglomerate should be correctly deleted without any left over edges

### Issues:
- fixes #5158 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
