### PR TITLE
Fix crashes related to maximizing/minimizing

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that segment IDs could not be copied to the clipboard. [#5709](https://github.com/scalableminds/webknossos/pull/5709)
 - Fixed a bug where volume annotation version restore skipped buckets that were not yet touched in the version to be restored. [#5717](https://github.com/scalableminds/webknossos/pull/5717)
 - Fixed a rendering bug showing non-existant or wrongly-colored edges that sometimes occurred after deleting edges, nodes, or trees. [#5724](https://github.com/scalableminds/webknossos/pull/5724)
+- Fixed an error during viewport maximization in flight mode. Also, fixed a crash during minimization of the 3D-View for datasets with lots of magnnifications. [#5746](https://github.com/scalableminds/webknossos/pull/5746)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/bucket_picker_strategies/orthogonal_bucket_picker.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/bucket_picker_strategies/orthogonal_bucket_picker.js
@@ -89,6 +89,11 @@ function addNecessaryBucketsToPriorityQueueOrthogonal(
     bottomRightVector[v] = areas[planeId].bottom;
     bottomRightVector[u] = areas[planeId].right;
 
+    const width = bottomRightVector[u] - topLeftVector[u];
+    const height = bottomRightVector[v] - topLeftVector[v];
+    // If the viewport is not visible, no buckets need to be added
+    if (width === 0 || height === 0) continue;
+
     const scaledTopLeftVector = zoomedAddressToAnotherZoomStep(
       topLeftVector,
       resolutions,

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/texture_bucket_manager.js
@@ -380,7 +380,11 @@ export default class TextureBucketManager {
           this.lookUpBuffer[posInBuffer + 1] = bucketZoomStep;
         }
       } else if (address !== -1) {
-        const baseBucketAddresses = this._getBaseBucketAddresses(bucket, zoomStepDifference);
+        const baseBucketAddresses = this._getBaseBucketAddresses(
+          bucket,
+          zoomStepDifference,
+          maxZoomStepDiff,
+        );
         for (const baseBucketAddress of baseBucketAddresses) {
           const lookUpIdx = this._getBucketIndex(baseBucketAddress);
           const posInBuffer = channelCountForLookupBuffer * lookUpIdx;
@@ -431,7 +435,13 @@ export default class TextureBucketManager {
     );
   }
 
-  _getBaseBucketAddresses(bucket: DataBucket, zoomStepDifference: number): Array<Vector4> {
+  _getBaseBucketAddresses(
+    bucket: DataBucket,
+    zoomStepDifference: number,
+    maxZoomStepDifference: number,
+  ): Array<Vector4> {
+    if (zoomStepDifference > maxZoomStepDifference) return [];
+
     const resolutions = getResolutions(Store.getState().dataset);
     return getBaseBucketsForFallbackBucket(bucket.zoomedAddress, zoomStepDifference, resolutions);
   }

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_wrapper.js
@@ -330,7 +330,9 @@ class FlexLayoutWrapper extends React.PureComponent<Props, State> {
         .getNodeById(data.node)
         .getChildren()[0]
         .getId();
-      this.props.setActiveViewport(OrthoViews[toggledViewportId]);
+      if (OrthoViews[toggledViewportId] != null) {
+        this.props.setActiveViewport(OrthoViews[toggledViewportId]);
+      }
     }
     return action;
   };


### PR DESCRIPTION
- Fix a crash when maximizing in flight mode (not part of the issue, but encountered while I was at it)
  - In-depth explanation: When maximizing the flight mode, the `activeViewport` was set to `undefined` leading to an error when calculating the global position later. `activeViewport` is assumed to always be defined.
- Fix a crash when minimizing the 3D-View in datasets with lots of magnifications (10+)
  - In-depth explanation: When the 3D-View was maximized, the bucket picking still tried to select buckets. However, due to an area of 0, the results was only a single bucket for each viewport. Its position was 0, 0, 0 and its magnification was the lowest available one, for example 10. Then when the 3D-View was minimized again, the `getBaseBucketsForFallbackBucket` function is called to compute `all bucket addresses for which the fallback bucket is the provided bucket.` The fallback bucket in question is the one in mag 10 whereas the current mag is 1, leading to way too many bucket addresses being computed and usually an OOM error.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- To reproduce the flight mode maximizing crash: Open a tracing, switch to flight mode and then maximize the viewport. The page should not crash.
- Reproducing the other crash is only possible for datasets with lots of mags (see for example https://webknossos.org/datasets/scalable_minds/l4dense_motta_et_al_demo_v2/view#2598,4693,1792,0,1).
  - Open the dataset in view mode and maximize the 3D-View, then minimize it again (on master wK freezes and eventually OOMs).
  - I checked that the 0, 0, 0 bucket in the lowest resolution is no longer selected during bucket picking (thus avoiding the OOM) by setting a breakpoint in `layer_rendering_manager` line 238 checking the result of `consumeBucketsFromArrayBuffer`.

### Issues:
- fixes #5714 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [x] Ready for review
