### PR TITLE
Delay opening context menu to support windows again

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Fixed
-- 
+- Fixed a bug that windows user could not open the context menu as it instantly closed after opening. [#5756](https://github.com/scalableminds/webknossos/pull/5756).
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -164,12 +164,20 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
     globalPosition: Vector3,
     viewport: OrthoView,
   ) => {
-    this.setState({
-      contextMenuPosition: [xPos, yPos],
-      clickedNodeId: nodeId,
-      contextMenuGlobalPosition: globalPosition,
-      contextMenuViewport: viewport,
-    });
+    // On Windows the right click to open the context menu is also triggered for the overlay
+    // of the context menu. This causes the context menu to instantly close after opening.
+    // Therefore delay the state update to delay that the context menu is rendered.
+    // Thus the context overlay does not get the right click as an event and therefore does not close.
+    setTimeout(
+      () =>
+        this.setState({
+          contextMenuPosition: [xPos, yPos],
+          clickedNodeId: nodeId,
+          contextMenuGlobalPosition: globalPosition,
+          contextMenuViewport: viewport,
+        }),
+      1,
+    );
   };
 
   hideContextMenu = () => {

--- a/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
+++ b/frontend/javascripts/oxalis/view/layouting/tracing_layout_view.js
@@ -176,7 +176,7 @@ class TracingLayoutView extends React.PureComponent<PropsWithRouter, State> {
           contextMenuGlobalPosition: globalPosition,
           contextMenuViewport: viewport,
         }),
-      1,
+      0,
     );
   };
 


### PR DESCRIPTION
Windows behaves very strangely when it comes to the context menu. The same right-click to open the context menu also somehow reaches the overlay of the context menu, although the context menu isn't even rendered by React at this moment. Additionally, this occurs on all browsers on windows and on no other operating system. The browsers under windows I tested were: Firefox, Chrome, and Opera.

To prevent this weird behaviour I delayed the state change, which causes the context menu to render. This circumvents the behaviour for all tested windows browsers and the code still works on Linux + firefox for me.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a hybrid tracing.
- Play around with the context menu, it should open and close as expected. 
- Once the dev instance is up, please also test on a windows browser.

### Issues:
- none

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- ~~[ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable~~
- ~~[ ] Updated [documentation](../blob/master/docs) if applicable~~
- ~~[ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes~~
- ~~[ ] Needs datastore update after deployment~~
- [x] Ready for review
