### PR TITLE
Fix silent ignoring of superfluous save retries

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Jobs status is no longer polled if jobs are not enabled, avoiding backend logging spam [#5761](https://github.com/scalableminds/webknossos/pull/5761)
 - Fixed a bug that windows user could not open the context menu as it instantly closed after opening. [#5756](https://github.com/scalableminds/webknossos/pull/5756).
 - Fixed a bug where the health check of public datasets failed if no cookie/token was supplied. [#5768](https://github.com/scalableminds/webknossos/pull/5768).
+- Fixed a bug where retried save requests could lead to a 409 CONFLICT error if the first request was already handled by the back-end. [#5779](https://github.com/scalableminds/webknossos/pull/5779).
 
 ### Removed
 -

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -217,7 +217,7 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
     updateGroup.transactionId match {
       case Some(transactionId) =>
         for {
-          _ <- Fox.assertTrue(tracingService.handledGroupIdStoreContains(transactionId, tracingId, updateGroup.version)) ?~> errorMessage ~> CONFLICT
+          _ <- Fox.assertTrue(tracingService.handledGroupIdStoreContains(tracingId, transactionId, updateGroup.version)) ?~> errorMessage ~> CONFLICT
         } yield updateGroup.version
       case None => Fox.failure(errorMessage) ~> CONFLICT
     }


### PR DESCRIPTION
A mistake in #3829 broke the feature introduced in #3767 so users with spotty internet connections could provoke wrong 409 CONFLICT errors.
This PR fixes the lookup of the handled group ids

### Steps to test:
- normal saving should work
- we adapted the front-end code to send “retries” even if the first request succeded, and tested that it can now recover from that agin
- Another way of testing this was described in https://github.com/scalableminds/webknossos/pull/3767#issuecomment-463710421

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
