### PR TITLE
Correctly propagate project tracing time as Long instead of Int

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug which made the ad-hoc mesh loading abort too early. [#5696](https://github.com/scalableminds/webknossos/pull/5696)
 - Fixed that viewports turned black when zoomed in very much. [#5797](https://github.com/scalableminds/webknossos/pull/5797)
 - Fixed the bucket loading order in the YZ and XZ viewports. Data in these viewports will be rendered faster than before. [#5798](https://github.com/scalableminds/webknossos/pull/5798)
+- Fixed a bug where projects could not be listed if the tracing time got too large. [#5823](https://github.com/scalableminds/webknossos/pull/5823)
 
 ### Removed
 -

--- a/app/controllers/ProjectController.scala
+++ b/app/controllers/ProjectController.scala
@@ -42,7 +42,7 @@ class ProjectController @Inject()(projectService: ProjectService,
       allCounts <- taskDAO.countOpenInstancesAndTimeByProject
       js <- Fox.serialCombined(projects) { project =>
         for {
-          openInstancesAndTime <- Fox.successful(allCounts.getOrElse(project._id, (0, 0L)))
+          openInstancesAndTime <- Fox.successful(allCounts.getOrElse(project._id, (0L, 0L)))
           r <- projectService.publicWritesWithStatus(project, openInstancesAndTime._1, openInstancesAndTime._2)
         } yield r
       }
@@ -121,7 +121,7 @@ class ProjectController @Inject()(projectService: ProjectService,
       allCounts <- taskDAO.countOpenInstancesAndTimeByProject
       js <- Fox.serialCombined(projects) { project =>
         for {
-          openInstancesAndTime <- Fox.successful(allCounts.getOrElse(project._id, (0, 0L)))
+          openInstancesAndTime <- Fox.successful(allCounts.getOrElse(project._id, (0L, 0L)))
           r <- projectService.publicWritesWithStatus(project, openInstancesAndTime._1, openInstancesAndTime._2)
         } yield r
       }

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -222,7 +222,7 @@ class ProjectService @Inject()(projectDAO: ProjectDAO, teamDAO: TeamDAO, userSer
       )
     }
 
-  def publicWritesWithStatus(project: Project, openTaskInstances: Int, tracingTime: Long)(
+  def publicWritesWithStatus(project: Project, openTaskInstances: Long, tracingTime: Long)(
       implicit ctx: DBAccessContext): Fox[JsObject] =
     for {
       projectJson <- publicWrites(project)

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -223,35 +223,35 @@ class TaskDAO @Inject()(sqlClient: SQLClient, projectDAO: ProjectDAO)(implicit e
     } yield parsed
   }
 
-  def countOpenInstancesForTask(taskId: ObjectId): Fox[Int] =
+  def countOpenInstancesForTask(taskId: ObjectId): Fox[Long] =
     for {
-      result <- run(sql"select openInstances from webknossos.tasks_ where _id = ${taskId.toString}".as[Int])
+      result <- run(sql"select openInstances from webknossos.tasks_ where _id = ${taskId.toString}".as[Long])
       firstResult <- result.headOption.toFox
     } yield firstResult
 
-  def countAllOpenInstancesForOrganization(organizationId: ObjectId): Fox[Int] =
+  def countAllOpenInstancesForOrganization(organizationId: ObjectId): Fox[Long] =
     for {
       result <- run(
         sql"select sum(t.openInstances) from webknossos.tasks_ t join webknossos.projects_ p on t._project = p._id where $organizationId in (select _organization from webknossos.users_ where _id = p._owner)"
-          .as[Int])
+          .as[Long])
       firstResult <- result.headOption
     } yield firstResult
 
-  def countOpenInstancesAndTimeForProject(projectId: ObjectId): Fox[(Int, Int)] =
+  def countOpenInstancesAndTimeForProject(projectId: ObjectId): Fox[(Long, Long)] =
     for {
       result <- run(sql"""select sum(openInstances), sum(tracingtime)
                           from webknossos.tasks_
                           where _project = ${projectId.id}
-                          group by _project""".as[(Int, Option[Int])])
+                          group by _project""".as[(Long, Option[Long])])
       firstResult <- result.headOption
-    } yield (firstResult._1, firstResult._2.getOrElse(0))
+    } yield (firstResult._1, firstResult._2.getOrElse(0L))
 
-  def countOpenInstancesAndTimeByProject: Fox[Map[ObjectId, (Int, Long)]] =
+  def countOpenInstancesAndTimeByProject: Fox[Map[ObjectId, (Long, Long)]] =
     for {
       rowsRaw <- run(sql"""select _project, sum(openInstances), sum(tracingtime)
               from webknossos.tasks_
               group by _project
-           """.as[(String, Int, Option[Long])])
+           """.as[(String, Long, Option[Long])])
     } yield rowsRaw.toList.map(r => (ObjectId(r._1), (r._2, r._3.getOrElse(0L)))).toMap
 
   def listExperienceDomains(organizationId: ObjectId): Fox[List[String]] =


### PR DESCRIPTION
Some project queries summed their task’s tracingTime (ms) values, which is too much for int. In the db, everything is Bigint already, but the scala code previously stored the result in Ints.

In the same query, I also changed sum(openInstances) from int to long, to match the db format, even though we don’t really expect that many instances.

### URL of deployed dev instance (used for testing):
- https://longtracingtime.webknossos.xyz

### Steps to test:
- Create at least one task
- Trace for 1200 hours (or manipulate the db)
- Project list should still be rendered with no error

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
