### PR TITLE
Fix collapse/expand sidebars on touchscreens

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug which made the ad-hoc mesh loading abort too early. [#5696](https://github.com/scalableminds/webknossos/pull/5696)
 - Fixed that viewports turned black when zoomed in very much. [#5797](https://github.com/scalableminds/webknossos/pull/5797)
 - Fixed the bucket loading order in the YZ and XZ viewports. Data in these viewports will be rendered faster than before. [#5798](https://github.com/scalableminds/webknossos/pull/5798)
+- Fixed that collapsing/expanding the sidebars did not work for touchscreens. [#5825](https://github.com/scalableminds/webknossos/pull/5825)
 
 ### Removed
 -

--- a/frontend/javascripts/oxalis/view/components/border_toggle_button.js
+++ b/frontend/javascripts/oxalis/view/components/border_toggle_button.js
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Button, Tooltip } from "antd";
 import { connect } from "react-redux";
 import type { OxalisState, BorderOpenStatus } from "oxalis/store";
+import { V2 } from "libs/mjs";
 
 type OwnProps = {|
   onClick: () => void,
@@ -13,6 +14,8 @@ type StateProps = {|
   borderOpenStatus: BorderOpenStatus,
 |};
 type Props = {| ...OwnProps, ...StateProps |};
+
+const DRAG_THRESHOLD = 5;
 
 function BorderToggleButton(props: Props) {
   const { onClick, side, borderOpenStatus, inFooter } = props;
@@ -27,20 +30,44 @@ function BorderToggleButton(props: Props) {
   const imageClass = `center-item-using-flex icon-sidebar-toggle icon-sidebar-${iconKind}-${side}-${
     inFooter ? "dark" : "bright"
   }`;
+  const [lastTouchPosition, setLastTouchPosition] = React.useState([0, 0]);
 
   return (
     <Tooltip title={tooltipTitle} placement={placement}>
       <Button
         className={className}
+        size="small"
+        /*
+        Normally, a simple onClick handler would be enough for this button
+        to support both desktops as mobile devices with touchscreens.
+        However, since the button is placed in the FlexLayout's panels,
+        its presence interferes with the existing mouse drag / touch drag
+        behavior to move tabs around.
+        For this reason, we have to call stopPropagation and preventDefault.
+        Additionally, we need to detect whether the user has dragged a tap
+        across screen (to move a tab). In that case, onTouchEnd does nothing.
+        */
         onClick={event => {
           if (event != null) {
             event.target.blur();
           }
           onClick();
         }}
-        size="small"
-        onMouseDown={evt => evt.stopPropagation()}
-        onTouchStart={evt => evt.preventDefault()}
+        onMouseDown={evt => {
+          evt.stopPropagation();
+        }}
+        onTouchStart={evt => {
+          evt.preventDefault();
+          setLastTouchPosition([evt.touches[0].pageX, evt.touches[0].pageY]);
+        }}
+        onTouchEnd={evt => {
+          const currentTouchPos = [evt.changedTouches[0].pageX, evt.changedTouches[0].pageY];
+
+          const delta = V2.length(V2.sub(lastTouchPosition, currentTouchPos));
+          if (delta < DRAG_THRESHOLD) {
+            onClick();
+          }
+        }}
       >
         <div className={imageClass} />
       </Button>

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -436,7 +436,12 @@ img.keyboard-mouse-icon:first-child {
 .left-border-button,
 .right-border-button {
   border: none;
-  padding: 0px 5px 0px 0px;
+  margin: 0px 5px 0px 0px;
+  padding: 0;
+  // If the z-index is wrong, tapping the collapse/expand buttons
+  // on mobile does not work or the icon bleeds some white background
+  // into the top navbar.
+  z-index: 999;
   color: @text-color-secondary;
   i {
     font-size: 15px !important;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixsidebarfortouch.webknossos.xyz

### Steps to test:
- open a dataset and try to move tabs around as well as use the collapse/expand sidebar buttons for both sidebars
- enable the devtools' mobile device feature and repeat the above steps

before this pr, expanding/collapsing the sidebars wasn't possible on touch.

### Issues:
- fixes #5822

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Needs datastore update after deployment
- [X] Ready for review
