### PR TITLE
Send Slack notification if bucket loading requests are too slow

### DIFF
--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -9,6 +9,7 @@ User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 
 - The docker files now place the webKnossos installation under `/webknossos` instead of `/srv/webknossos`. All mounts, most importantly `/srv/webknossos/binaryData`, need to be changed accordingly.
 - The entrypoint of the docker files have changed. Therefore, any existing `docker-compose.yml` setups need to be adapted. In most cases, only the `entrypoint: bin/webknossos` lines need to be removed (if existant).
+- To receive Slack notifications about slow bucket requests, overwrite `slackNotifications.uri` in the webknossos-datastore config.
 
 ### Postgres Evolutions:
 

--- a/app/oxalis/telemetry/SlackNotificationService.scala
+++ b/app/oxalis/telemetry/SlackNotificationService.scala
@@ -1,7 +1,7 @@
 package oxalis.telemetry
 
 import com.scalableminds.webknossos.datastore.rpc.RPC
-import com.scalableminds.webknossos.tracingstore.slacknotification.SlackClient
+import com.scalableminds.webknossos.datastore.slacknotification.SlackClient
 import com.typesafe.scalalogging.LazyLogging
 import javax.inject.Inject
 import utils.WkConf

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -50,5 +50,10 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
     val children = List(WebKnossos, WatchFileSystem, Cache, Isosurface)
   }
 
-  val children = List(Http, Datastore)
+  object SlackNotifications {
+    val uri: String = get[String]("slackNotifications.uri")
+    val verboseLoggingEnabled: Boolean = get[Boolean]("slackNotifications.verboseLoggingEnabled")
+  }
+
+  val children = List(Http, Datastore, SlackNotifications)
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
@@ -38,4 +38,5 @@ trait BucketProvider extends FoxImplicits with LazyLogging {
 
   def bucketStream(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte])] =
     Iterator.empty
+
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/slacknotification/DSSlackNotificationService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/slacknotification/DSSlackNotificationService.scala
@@ -1,0 +1,20 @@
+package com.scalableminds.webknossos.datastore.slacknotification
+
+import com.scalableminds.webknossos.datastore.DataStoreConfig
+import com.scalableminds.webknossos.datastore.rpc.RPC
+import com.typesafe.scalalogging.LazyLogging
+import javax.inject.Inject
+
+class DSSlackNotificationService @Inject()(rpc: RPC, config: DataStoreConfig) extends LazyLogging {
+  private lazy val slackClient = new SlackClient(rpc,
+    config.SlackNotifications.uri,
+    name = s"webKnossos-datastore at ${config.Http.uri}",
+    config.SlackNotifications.verboseLoggingEnabled)
+
+  def noticeSlowRequest(msg: String): Unit =
+    slackClient.info(
+      title = s"Slow request",
+      msg = msg
+    )
+
+}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/slacknotification/DSSlackNotificationService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/slacknotification/DSSlackNotificationService.scala
@@ -7,9 +7,9 @@ import javax.inject.Inject
 
 class DSSlackNotificationService @Inject()(rpc: RPC, config: DataStoreConfig) extends LazyLogging {
   private lazy val slackClient = new SlackClient(rpc,
-    config.SlackNotifications.uri,
-    name = s"webKnossos-datastore at ${config.Http.uri}",
-    config.SlackNotifications.verboseLoggingEnabled)
+                                                 config.SlackNotifications.uri,
+                                                 name = s"webKnossos-datastore at ${config.Http.uri}",
+                                                 config.SlackNotifications.verboseLoggingEnabled)
 
   def noticeSlowRequest(msg: String): Unit =
     slackClient.info(

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/slacknotification/SlackClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/slacknotification/SlackClient.scala
@@ -1,4 +1,4 @@
-package com.scalableminds.webknossos.tracingstore.slacknotification
+package com.scalableminds.webknossos.datastore.slacknotification
 
 import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.scalalogging.LazyLogging

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -55,4 +55,9 @@ datastore {
   agglomerateSkeleton.maxEdges = 10000
 }
 
+slackNotifications {
+  uri = ""
+  verboseLoggingEnabled = false # log all slack messages also to stdout
+}
+
 pidfile.path = "/dev/null" # Avoid the creation of a pid file

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreConfig.scala
@@ -32,5 +32,6 @@ class TracingStoreConfig @Inject()(configuration: Configuration) extends ConfigR
     val uri: String = get[String]("slackNotifications.uri")
     val verboseLoggingEnabled: Boolean = get[Boolean]("slackNotifications.verboseLoggingEnabled")
   }
+
   val children = List(Http, Tracingstore, SlackNotifications)
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreModule.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreModule.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.tracingstore
 import akka.actor.ActorSystem
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
-import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
+import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.scalableminds.webknossos.tracingstore.tracings.TracingDataStore
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.SkeletonTracingService
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeTracingService
@@ -19,6 +19,6 @@ class TracingStoreModule extends AbstractModule {
     bind(classOf[VolumeTracingService]).asEagerSingleton()
     bind(classOf[TracingStoreAccessTokenService]).asEagerSingleton()
     bind(classOf[TSRemoteWebKnossosClient]).asEagerSingleton()
-    bind(classOf[SlackNotificationService]).asEagerSingleton()
+    bind(classOf[TSSlackNotificationService]).asEagerSingleton()
   }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.tracingstore.controllers
 import com.google.inject.Inject
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, SkeletonTracingOpt, SkeletonTracings}
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
-import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
+import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton._
 import com.scalableminds.webknossos.tracingstore.{TracingStoreAccessTokenService, TSRemoteWebKnossosClient}
 import play.api.i18n.Messages
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext
 class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingService,
                                           val remoteWebKnossosClient: TSRemoteWebKnossosClient,
                                           val accessTokenService: TracingStoreAccessTokenService,
-                                          val slackNotificationService: SlackNotificationService)(
+                                          val slackNotificationService: TSSlackNotificationService)(
     implicit val ec: ExecutionContext,
     val bodyParsers: PlayBodyParsers)
     extends TracingController[SkeletonTracing, SkeletonTracings] {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.JsonHelper.{boxFormat, optionFormat}
 import com.scalableminds.webknossos.datastore.controllers.Controller
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
-import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
+import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.scalableminds.webknossos.tracingstore.tracings.{
   TracingSelector,
   TracingService,
@@ -32,7 +32,7 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
 
   def accessTokenService: TracingStoreAccessTokenService
 
-  def slackNotificationService: SlackNotificationService
+  def slackNotificationService: TSSlackNotificationService
 
   implicit val tracingCompanion: GeneratedMessageCompanion[T] = tracingService.tracingCompanion
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -12,7 +12,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.DataSourceLike
 import com.scalableminds.webknossos.datastore.models.{WebKnossosDataRequest, WebKnossosIsosurfaceRequest}
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
 import com.scalableminds.webknossos.datastore.VolumeTracing.{VolumeTracing, VolumeTracingOpt, VolumeTracings}
-import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
+import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.scalableminds.webknossos.tracingstore.tracings.volume.{ResolutionRestrictions, VolumeTracingService}
 import com.scalableminds.webknossos.tracingstore.{TracingStoreAccessTokenService, TSRemoteWebKnossosClient}
 import play.api.i18n.Messages
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
 class VolumeTracingController @Inject()(val tracingService: VolumeTracingService,
                                         val remoteWebKnossosClient: TSRemoteWebKnossosClient,
                                         val accessTokenService: TracingStoreAccessTokenService,
-                                        val slackNotificationService: SlackNotificationService)(
+                                        val slackNotificationService: TSSlackNotificationService)(
     implicit val ec: ExecutionContext,
     val bodyParsers: PlayBodyParsers)
     extends TracingController[VolumeTracing, VolumeTracings] {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/slacknotification/TSSlackNotificationService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/slacknotification/TSSlackNotificationService.scala
@@ -1,11 +1,12 @@
 package com.scalableminds.webknossos.tracingstore.slacknotification
 
 import com.scalableminds.webknossos.datastore.rpc.RPC
+import com.scalableminds.webknossos.datastore.slacknotification.SlackClient
 import com.scalableminds.webknossos.tracingstore.TracingStoreConfig
 import com.typesafe.scalalogging.LazyLogging
 import javax.inject.Inject
 
-class SlackNotificationService @Inject()(rpc: RPC, config: TracingStoreConfig) extends LazyLogging {
+class TSSlackNotificationService @Inject()(rpc: RPC, config: TracingStoreConfig) extends LazyLogging {
   private lazy val slackClient = new SlackClient(rpc,
                                                  config.SlackNotifications.uri,
                                                  name = s"webKnossos-tracingstore at ${config.Http.uri}",

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -4,7 +4,7 @@ import com.google.protobuf.ByteString
 import com.scalableminds.fossildb.proto.fossildbapi._
 import com.scalableminds.util.tools.{BoxImplicits, Fox, FoxImplicits}
 import com.scalableminds.webknossos.tracingstore.TracingStoreConfig
-import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
+import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.typesafe.scalalogging.LazyLogging
 import io.grpc.health.v1._
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
@@ -41,7 +41,7 @@ case class VersionedKeyValuePair[T](versionedKey: VersionedKey, value: T) {
   def version: Long = versionedKey.version
 }
 
-class FossilDBClient(collection: String, config: TracingStoreConfig, slackNotificationService: SlackNotificationService)
+class FossilDBClient(collection: String, config: TracingStoreConfig, slackNotificationService: TSSlackNotificationService)
     extends FoxImplicits
     with LazyLogging {
   private val address = config.Tracingstore.Fossildb.address

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -41,7 +41,9 @@ case class VersionedKeyValuePair[T](versionedKey: VersionedKey, value: T) {
   def version: Long = versionedKey.version
 }
 
-class FossilDBClient(collection: String, config: TracingStoreConfig, slackNotificationService: TSSlackNotificationService)
+class FossilDBClient(collection: String,
+                     config: TracingStoreConfig,
+                     slackNotificationService: TSSlackNotificationService)
     extends FoxImplicits
     with LazyLogging {
   private val address = config.Tracingstore.Fossildb.address

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.tracingstore.tracings
 
 import com.google.inject.Inject
 import com.scalableminds.webknossos.tracingstore.TracingStoreConfig
-import com.scalableminds.webknossos.tracingstore.slacknotification.SlackNotificationService
+import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.typesafe.scalalogging.LazyLogging
 import play.api.inject.ApplicationLifecycle
 
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 
 class TracingDataStore @Inject()(config: TracingStoreConfig,
                                  lifecycle: ApplicationLifecycle,
-                                 slackNotificationService: SlackNotificationService)
+                                 slackNotificationService: TSSlackNotificationService)
     extends LazyLogging {
 
   val healthClient = new FossilDBClient("healthCheckOnly", config, slackNotificationService)


### PR DESCRIPTION
### Steps to test that I used:
- Enter valid slack token (or set verboseLoggingEnabled=true in application.conf and monitor backend logging)
- Add sleep to bucket loading
- slack notification should be sent/logged

### Issues:
- fixes #5856 

------
- [x] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Needs datastore update after deployment
- [x] Ready for review
