### PR TITLE
Make w shortcut non-looping

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,13 +16,14 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 - The docker setup has been restructured, which requires changes to existing docker-compose setups. See the migration guide for details. [#5843](https://github.com/scalableminds/webknossos/pull/5843)
 - By default, if data is missing in one magnification, higher magnifications are used for rendering. This setting can be controlled via the left sidebar under "Render Missing Data Black". [#5862](https://github.com/scalableminds/webknossos/pull/5862)
+- Made the `w` shortcut to cycle through the tools non-looping. [#5865](https://github.com/scalableminds/webknossos/pull/5865)
 
 ### Fixed
 - Fixed a bug that the displayed value range of a histogram of a color layer wasn't applied until the slider was dragged a bit. [#5853](https://github.com/scalableminds/webknossos/pull/5853)
 - Fixed a bug where admins could not share annotations with teams they were not explicitly a member of. [#5845](https://github.com/scalableminds/webknossos/pull/5845)
 
 ### Removed
--
+- Removed `1` shortcut which allowed to cycle through the tools but only if some of the tools were active. Use `w` instead. [#5865](https://github.com/scalableminds/webknossos/pull/5865)
 
 ### Breaking Change
 -

--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -104,7 +104,7 @@ Note that you can enable *Classic Controls* which will behave slightly different
 | CTRL + SHIFT + Left Mouse Drag    | Remove Voxels From Cell                                     |
 | Alt + Mouse Move                  | Move                                                        |
 | C                                 | Create New Cell                                             |
-| W, 1                              | Toggle Modes (Move / Trace / Brush)                         |
+| W                                 | Toggle Modes (Move / Skeleton / Trace / Brush / ...)        |
 | SHIFT + Mousewheel or SHIFT + I, O | Change Brush Size (Brush Mode)                             |
 | V                                 | Copy Segmentation of Current Cell From Previous Slice       |
 | SHIFT + V                         | Copy Segmentation of Current Cell From Next Slice           |

--- a/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
+++ b/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.js
@@ -133,7 +133,6 @@ class VolumeKeybindings {
   static getKeyboardControls() {
     return {
       c: () => Store.dispatch(createCellAction()),
-      "1": cycleTools,
       v: () => {
         Store.dispatch(copySegmentationLayerAction());
       },
@@ -378,7 +377,6 @@ class PlaneController extends React.PureComponent<Props> {
         h: () => this.changeMoveValue(25),
         g: () => this.changeMoveValue(-25),
 
-        w: cycleTools,
         ...loopedKeyboardControls,
       },
       {
@@ -427,16 +425,17 @@ class PlaneController extends React.PureComponent<Props> {
         }
       },
       q: downloadScreenshot,
+      w: cycleTools,
     };
 
     // TODO: Find a nicer way to express this, while satisfying flow
-    const emptyDefaultHandler = { c: null, "1": null };
-    const { c: skeletonCHandler, "1": skeletonOneHandler, ...skeletonControls } =
+    const emptyDefaultHandler = { c: null };
+    const { c: skeletonCHandler, ...skeletonControls } =
       this.props.tracing.skeleton != null
         ? SkeletonKeybindings.getKeyboardControls()
         : emptyDefaultHandler;
 
-    const { c: volumeCHandler, "1": volumeOneHandler, ...volumeControls } =
+    const { c: volumeCHandler, ...volumeControls } =
       this.props.tracing.volume != null
         ? VolumeKeybindings.getKeyboardControls()
         : emptyDefaultHandler;
@@ -455,7 +454,6 @@ class PlaneController extends React.PureComponent<Props> {
         volumeCHandler,
         boundingBoxCHandler,
       ),
-      "1": this.createToolDependentKeyboardHandler(skeletonOneHandler, volumeOneHandler),
     };
   }
 


### PR DESCRIPTION
See the linked issues/reports.
While I was at it, I removed an old keyboard shortcut which allowed to cycle between tools using `1` but only if a volume tool was active. Very confusing and inferior to the `w` shortcut imo.

The toggling is a little bit weird, because the "Eraser" appears twice (once for brushing, once for tracing) and the one for tracing is hidden by default unless the "Trace" tool is active. However, that has been the case before as well.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Use w in an annotation to toggle through the tools. This should work reliably without jumping

### Issues:
- fixes https://forum.image.sc/t/bug-w-shortcut-debouncing-in-volume-annotation-mode-not-working-correctly/59787
- fixes https://discuss.webknossos.org/t/toggling-modes-with-w-does-not-work-reliably/1676/2

------
(Please delete unneded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [documentation](../blob/master/docs) if applicable
- [x] Ready for review
