### PR TITLE
Fix: Add path to schema diffing

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
   },
   "scripts": {
     "start": "node tools/proxy/proxy.js",
-    "stop": "killall java && killall node",
     "build": "node --max-old-space-size=4096 node_modules/.bin/webpack --env.production",
     "build-dev": "node_modules/.bin/webpack",
     "build-watch": "node_modules/.bin/webpack -w",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "scripts": {
     "start": "node tools/proxy/proxy.js",
+    "stop": "killall java && killall node",
     "build": "node --max-old-space-size=4096 node_modules/.bin/webpack --env.production",
     "build-dev": "node_modules/.bin/webpack",
     "build-watch": "node_modules/.bin/webpack -w",


### PR DESCRIPTION
The schema diffing uses `execSync` and for some commands sets the environment variables. As this replaces the environment variables the `$PATH` is also reset which caused it no not find psql anymore on my machine. Therefore I added the envs of the process (including the PATH variable) to the envs of the process. This fixed the issue for me.

Note that the spread operator is not supported because the node version that is used by the backend is `0.12`.

Additionally, I propose a yarn command as a short command to kill all running nodejs and java processes if some of the ports are still occupied when the server did not get shutdown properly. But this is only optionally.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Starting the server locally and opening a first webpage causes the backend to perform the schema diffing. If this works out fine (which can be seen in the console via the absence of an error) the fix should work.

### Issues:
- The is no issue for that

------
- [x] Ready for review
