### PR TITLE
Fix dataset upload for >2GB files

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 -
 
 ### Fixed
--
+- Fixed a bug where dataset uploads that contained files larger than 2 GB failed. [#5889](https://github.com/scalableminds/webknossos/pull/5889)
 
 ### Removed
 -


### PR DESCRIPTION
Fixes seek offset integer overflow. All components fit comfortably into Int, but their product did not. We thought the product to be Long already, but there was a lossy conversion after all. Now we just make all the values in the upload service Long. Memory overhead should be negligible.

### Steps to test:
- Upload a dataset as single zip that is >2GB in size
- Should upload correctly.

### Issues:
- fixes #5888 

------
(Please delete unneded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
