### PR TITLE
Fix tree group ids when splitting unconnected tree in NML upload

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where dataset uploads that contained files larger than 2 GB failed. [#5889](https://github.com/scalableminds/webknossos/pull/5889)
 - Fixed that dataset uploads did not survive back-end restarts. [#5831](https://github.com/scalableminds/webknossos/pull/5831)
+- Fixed a bug where NMLs with unconnected trees and nested tree groups could not be uploaded due to wrong tree group IDs. [#5893](https://github.com/scalableminds/webknossos/pull/5893)
 
 ### Removed
 -

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/MultiComponentTreeSplitter.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/MultiComponentTreeSplitter.scala
@@ -10,7 +10,8 @@ object MultiComponentTreeSplitter {
 
   def splitMulticomponentTrees(trees: Seq[Tree], treeGroups: Seq[TreeGroup]): (Seq[Tree], Seq[TreeGroup]) = {
     var largestTreeId = if (trees.isEmpty) 0 else trees.map(_.treeId).max
-    var largestGroupId = if (treeGroups.isEmpty) 0 else treeGroups.map(_.groupId).max
+    val allGroupIds = TreeUtils.getAllTreeGroupIds(treeGroups)
+    var largestGroupId = if (allGroupIds.isEmpty) 0 else allGroupIds.max
     var treeGroupsMutable: Seq[TreeGroup] = treeGroups
     val treeLists = trees.map { tree =>
       val g = new Multigraph[Int, DefaultEdge](classOf[DefaultEdge])

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
@@ -2,6 +2,7 @@ package com.scalableminds.webknossos.tracingstore.tracings.skeleton
 
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{Tree, TreeGroup}
 
+import scala.annotation.tailrec
 import scala.util.matching.Regex
 import scala.util.matching.Regex.Match
 
@@ -122,4 +123,11 @@ object TreeUtils {
 
     childIter(Seq(rootGroup))
   }
+
+  @tailrec
+  def getAllTreeGroupIds(treeGroups: Seq[TreeGroup], ids: Seq[Int] = Seq[Int]()): Seq[Int] =
+    treeGroups match {
+      case head :: tail => getAllTreeGroupIds(tail ++ head.children, head.groupId +: ids)
+      case _            => ids
+    }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeValidator.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeValidator.scala
@@ -1,10 +1,9 @@
 package com.scalableminds.webknossos.tracingstore.tracings.skeleton
 
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
 import com.scalableminds.util.datastructures.UnionFind
+import com.scalableminds.webknossos.datastore.SkeletonTracing._
 import net.liftweb.common.{Box, Failure, Full}
 
-import scala.annotation.tailrec
 import scala.collection.mutable
 
 object TreeValidator {
@@ -117,7 +116,7 @@ object TreeValidator {
     checkAllNodesUsedExist(trees, branchPoints.map(_.nodeId).distinct, "branchPoints")
 
   def checkNoDuplicateTreeGroupIds(treeGroups: Seq[TreeGroup]): Box[Unit] = {
-    val treeGroupIds = getAllTreeGroupIds(treeGroups, Seq[Int]())
+    val treeGroupIds = TreeUtils.getAllTreeGroupIds(treeGroups)
     val distinctTreeGroupIds = treeGroupIds.distinct
     if (treeGroupIds.size == distinctTreeGroupIds.size) {
       Full(())
@@ -127,7 +126,7 @@ object TreeValidator {
   }
 
   def checkAllTreeGroupIdsUsedExist(trees: Seq[Tree], treeGroups: Seq[TreeGroup]): Box[Unit] = {
-    val existingTreeGroups = getAllTreeGroupIds(treeGroups, Seq[Int]())
+    val existingTreeGroups = TreeUtils.getAllTreeGroupIds(treeGroups)
     val treeGroupsInTrees = trees.flatMap(_.groupId).distinct
 
     val treeGroupsOnlyInTrees = treeGroupsInTrees.diff(existingTreeGroups)
@@ -144,13 +143,6 @@ object TreeValidator {
         block(tree)
       case (f, _) =>
         f
-    }
-
-  @tailrec
-  private def getAllTreeGroupIds(treeGroups: Seq[TreeGroup], ids: Seq[Int]): Seq[Int] =
-    treeGroups match {
-      case head :: tail => getAllTreeGroupIds(tail ++ head.children, head.groupId +: ids)
-      case _            => ids
     }
 
   private def checkAllNodesUsedExist(trees: Seq[Tree], usedNodes: Seq[Int], nodeName: String) = {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Upload NML with nested tree groups and unconnected trees, such as the one linked in https://discuss.webknossos.org/t/cant-upload-nml-duplicate-treegroupids-2/1690
- Should upload correctly, the unconnected trees should be split into connected trees wrapped in a new group.

### Issues:
- fixes #5892

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
