### PR TITLE
add segment name to STL file name when downloading ad-hoc meshes

### DIFF
--- a/frontend/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/annotation_actions.js
@@ -113,10 +113,6 @@ export type CreateMeshFromBufferAction = {
   name: string,
 };
 
-export type TriggerActiveIsosurfaceDownloadAction = {
-  type: "TRIGGER_ACTIVE_ISOSURFACE_DOWNLOAD",
-};
-
 export type TriggerIsosurfaceDownloadAction = {
   type: "TRIGGER_ISOSURFACE_DOWNLOAD",
   cellName: string,
@@ -196,7 +192,6 @@ export type AnnotationActionTypes =
   | CreateMeshFromBufferAction
   | UpdateLocalMeshMetaDataAction
   | UpdateIsosurfaceVisibilityAction
-  | TriggerActiveIsosurfaceDownloadAction
   | TriggerIsosurfaceDownloadAction
   | RefreshIsosurfacesAction
   | FinishedRefreshingIsosurfacesAction
@@ -356,10 +351,6 @@ export const createMeshFromBufferAction = (
   type: "CREATE_MESH_FROM_BUFFER",
   buffer,
   name,
-});
-
-export const triggerActiveIsosurfaceDownloadAction = (): TriggerActiveIsosurfaceDownloadAction => ({
-  type: "TRIGGER_ACTIVE_ISOSURFACE_DOWNLOAD",
 });
 
 export const triggerIsosurfaceDownloadAction = (

--- a/frontend/javascripts/oxalis/model/actions/annotation_actions.js
+++ b/frontend/javascripts/oxalis/model/actions/annotation_actions.js
@@ -119,6 +119,7 @@ export type TriggerActiveIsosurfaceDownloadAction = {
 
 export type TriggerIsosurfaceDownloadAction = {
   type: "TRIGGER_ISOSURFACE_DOWNLOAD",
+  cellName: string,
   cellId: number,
 };
 
@@ -362,9 +363,11 @@ export const triggerActiveIsosurfaceDownloadAction = (): TriggerActiveIsosurface
 });
 
 export const triggerIsosurfaceDownloadAction = (
+  cellName: string,
   cellId: number,
 ): TriggerIsosurfaceDownloadAction => ({
   type: "TRIGGER_ISOSURFACE_DOWNLOAD",
+  cellName,
   cellId,
 });
 

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -369,7 +369,7 @@ function* maybeLoadIsosurface(
   return [];
 }
 
-function* downloadIsosurfaceCellById(cellId: number): Saga<void> {
+function* downloadIsosurfaceCellById(cellName: string, cellId: number): Saga<void> {
   const sceneController = getSceneController();
   const geometry = sceneController.getIsosurfaceGeometry(cellId);
   if (geometry == null) {
@@ -387,11 +387,11 @@ function* downloadIsosurfaceCellById(cellId: number): Saga<void> {
   stl.setUint32(cellIdIndex, cellId, true);
 
   const blob = new Blob([stl]);
-  yield* call(saveAs, blob, `mesh-${cellId}.stl`);
+  yield* call(saveAs, blob, `${cellName}-${cellId}.stl`);
 }
 
 function* downloadIsosurfaceCell(action: TriggerIsosurfaceDownloadAction): Saga<void> {
-  yield* call(downloadIsosurfaceCellById, action.cellId);
+  yield* call(downloadIsosurfaceCellById, action.cellName, action.cellId);
 }
 
 function* downloadActiveIsosurfaceCell(): Saga<void> {

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.js
@@ -394,11 +394,6 @@ function* downloadIsosurfaceCell(action: TriggerIsosurfaceDownloadAction): Saga<
   yield* call(downloadIsosurfaceCellById, action.cellName, action.cellId);
 }
 
-function* downloadActiveIsosurfaceCell(): Saga<void> {
-  const currentId = yield* call(getCurrentCellId);
-  yield* call(downloadIsosurfaceCellById, currentId);
-}
-
 function* importIsosurfaceFromStl(action: ImportIsosurfaceFromStlAction): Saga<void> {
   const { layerName, buffer } = action;
   const dataView = new DataView(buffer);
@@ -513,7 +508,6 @@ export default function* isosurfaceSaga(): Saga<void> {
   yield* take("WK_READY");
   yield _takeEvery(FlycamActions, ensureSuitableIsosurface);
   yield _takeEvery("CHANGE_ACTIVE_ISOSURFACE_CELL", changeActiveIsosurfaceCell);
-  yield _takeEvery("TRIGGER_ACTIVE_ISOSURFACE_DOWNLOAD", downloadActiveIsosurfaceCell);
   yield _takeEvery("TRIGGER_ISOSURFACE_DOWNLOAD", downloadIsosurfaceCell);
   yield _takeEvery("IMPORT_ISOSURFACE_FROM_STL", importIsosurfaceFromStl);
   yield _takeEvery("REMOVE_ISOSURFACE", removeIsosurface);

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
@@ -311,7 +311,11 @@ function _MeshInfoItem(props: {
     <Tooltip title="Download Mesh">
       <VerticalAlignBottomOutlined
         key="download-button"
-        onClick={() => Store.dispatch(triggerIsosurfaceDownloadAction(segment.name ? segment.name : "mesh", segment.id))}
+        onClick={() =>
+          Store.dispatch(
+            triggerIsosurfaceDownloadAction(segment.name ? segment.name : "mesh", segment.id),
+          )
+        }
       />
     </Tooltip>
   );

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
@@ -311,7 +311,7 @@ function _MeshInfoItem(props: {
     <Tooltip title="Download Mesh">
       <VerticalAlignBottomOutlined
         key="download-button"
-        onClick={() => Store.dispatch(triggerIsosurfaceDownloadAction(segment.id))}
+        onClick={() => Store.dispatch(triggerIsosurfaceDownloadAction(segment.name ? segment.name : "mesh", segment.id))}
       />
     </Tooltip>
   );

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.js
@@ -15,7 +15,6 @@ import {
   createMeshFromBufferAction,
   deleteMeshAction,
   importIsosurfaceFromStlAction,
-  triggerActiveIsosurfaceDownloadAction,
   updateCurrentMeshFileAction,
 } from "oxalis/model/actions/annotation_actions";
 import {
@@ -157,9 +156,6 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): * => ({
       trackAction("Import STL");
       dispatch(createMeshFromBufferAction(info.file.name, buffer));
     }
-  },
-  downloadIsosurface() {
-    dispatch(triggerActiveIsosurfaceDownloadAction());
   },
   changeActiveIsosurfaceId(cellId: ?number, seedPosition: Vector3, shouldReload: boolean) {
     if (cellId == null) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):

### Steps to test:
1. create a new segment
2. rename in segments tab
3. try download "name-123"
4. removing name downloads "mesh-123"

### Issues:
- fixes #5841 

------
- [✓] Ready for review
