### PR TITLE
Swagger: annotate body of dataset upload reserve/finish

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -108,9 +108,12 @@ Expects:
 """,
     nickname = "datasetReserveUpload"
   )
-  @ApiImplicitParams({
-    @ApiImplicitParam(name = "ReserveUploadInformation", required = true, dataTypeClass = classOf[ReserveUploadInformation], paramType = "body")
-  })
+  @ApiImplicitParams(
+    Array(
+      new ApiImplicitParam(name = "ReserveUploadInformation",
+                           required = true,
+                           dataTypeClass = classOf[ReserveUploadInformation],
+                           paramType = "body")))
   def reserveUpload(token: String): Action[ReserveUploadInformation] =
     Action.async(validateJson[ReserveUploadInformation]) { implicit request =>
       accessTokenService.validateAccess(UserAccessRequest.administrateDataSources, Some(token)) {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -110,7 +110,7 @@ Expects:
   )
   @ApiImplicitParams(
     Array(
-      new ApiImplicitParam(name = "ReserveUploadInformation",
+      new ApiImplicitParam(name = "reserveUploadInformation",
                            required = true,
                            dataTypeClass = classOf[ReserveUploadInformation],
                            paramType = "body")))
@@ -205,6 +205,12 @@ Expects:
 """,
     nickname = "datasetFinishUpload"
   )
+  @ApiImplicitParams(
+    Array(
+      new ApiImplicitParam(name = "uploadInformation",
+                           required = true,
+                           dataTypeClass = classOf[UploadInformation],
+                           paramType = "body")))
   @ApiResponses(
     Array(
       new ApiResponse(code = 200, message = "Empty body, chunk was saved on the server"),

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -16,7 +16,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MultipartFormData, PlayBodyParsers}
 import java.io.File
 
-import io.swagger.annotations.{Api, ApiOperation, ApiResponse, ApiResponses}
+import io.swagger.annotations.{Api, ApiImplicitParam, ApiImplicitParams, ApiOperation, ApiResponse, ApiResponses}
 import play.api.libs.Files
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -108,6 +108,9 @@ Expects:
 """,
     nickname = "datasetReserveUpload"
   )
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "ReserveUploadInformation", required = true, dataTypeClass = classOf[ReserveUploadInformation], paramType = "body")
+  })
   def reserveUpload(token: String): Action[ReserveUploadInformation] =
     Action.async(validateJson[ReserveUploadInformation]) { implicit request =>
       accessTokenService.validateAccess(UserAccessRequest.administrateDataSources, Some(token)) {


### PR DESCRIPTION
Adds swagger annotations for the json-body payload of the reserve & finish dataset-upload routes. The type of the json is not annotated correctly, but simply having string is good enough for now.

------
- [x] Ready for review
