### PR TITLE
Bump backend logging dependency log4j to 2.15.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
   private val akkaVersion = "2.6.14"
   private val akkaHttpVersion = "10.2.6"
-  private val log4jVersion = "2.13.3"
+  private val log4jVersion = "2.15.0"
   private val webknossosWrapVersion = "1.1.11"
 
   private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion


### PR DESCRIPTION
… to mitigate security vulnerabilities in the older version.

Note that as a follow-up, https://github.com/scalableminds/webknossos-wrap/pull/71 also needs to be merged, released, and integrated into webKnossos.

- [x] Needs datastore update after deployment
- [x] Ready for review
