### PR TITLE
Upgrade to log4j 2.17.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 object Dependencies {
   private val akkaVersion = "2.6.14"
   private val akkaHttpVersion = "10.2.6"
-  private val log4jVersion = "2.15.0"
+  private val log4jVersion = "2.17.0"
   private val webknossosWrapVersion = "1.1.13"
 
   private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion


### PR DESCRIPTION
Upgrades log4j to the newest version, mitigating more vulnerabilities. Not sure if wk-wrap must also be upgraded so that this has an effect, going to check this in the built container.

- [x] Ready for review

