### PR TITLE
Upgrade webknossos-wrap dependency to 1.1.15

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   private val akkaVersion = "2.6.14"
   private val akkaHttpVersion = "10.2.6"
   private val log4jVersion = "2.17.0"
-  private val webknossosWrapVersion = "1.1.13"
+  private val webknossosWrapVersion = "1.1.15"
 
   private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
   private val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion


### PR DESCRIPTION
Upgrades wk-wrap to 1.1.15 which drops the log4j dependency.

------
- [x] Ready for review
