### PR TITLE
fix dataset edit button shown to users who cant edit

### DIFF
--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.js
@@ -4,7 +4,7 @@
  */
 import type { Dispatch } from "redux";
 import { Tooltip, Button, Dropdown, Menu } from "antd";
-import { EditOutlined, InfoCircleOutlined, StarOutlined } from "@ant-design/icons";
+import { SettingOutlined, InfoCircleOutlined, StarOutlined } from "@ant-design/icons";
 import { connect } from "react-redux";
 import Markdown from "react-remarkable";
 import React from "react";
@@ -248,17 +248,21 @@ class DatasetInfoTabView extends React.PureComponent<Props, State> {
       description: datasetDescription,
       owningOrganization,
     } = this.props.dataset;
-    const getEditSettingsIcon = () => (
-      <Tooltip title="Edit dataset settings">
-        <Button
-          type="text"
-          icon={<EditOutlined />}
-          href={`/datasets/${owningOrganization}/${datasetName}/edit`}
-          className="transparent-background-on-hover"
-          target="_blank"
-        />
-      </Tooltip>
-    );
+    const { activeUser } = this.props;
+    const getEditSettingsIcon = () =>
+      activeUser != null &&
+      activeUser.organization === owningOrganization &&
+      (activeUser.isAdmin || activeUser.isDatasetManager) ? (
+        <Tooltip title="Edit dataset settings">
+          <Button
+            type="text"
+            icon={<SettingOutlined />}
+            href={`/datasets/${owningOrganization}/${datasetName}/edit`}
+            className="transparent-background-on-hover"
+            target="_blank"
+          />
+        </Tooltip>
+      ) : null;
 
     if (isDatasetViewMode) {
       return (


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):

### Steps to test:
1. open dataset and use the changed edit icon in the info tab, next to the dataset name
2. share the current dataset to a secondary account
3. verify that the icon does not appear in read-only mode

### Issues:
- fixes #5791 

------
- [✓] Ready for review
