### PR TITLE
Fix race condition in volume data download

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that dataset uploads did not survive back-end restarts. [#5831](https://github.com/scalableminds/webknossos/pull/5831)
 - Fixed a bug where NMLs with unconnected trees and nested tree groups could not be uploaded due to wrong tree group IDs. [#5893](https://github.com/scalableminds/webknossos/pull/5893)
 - Fixed a security vulnerability by upgrading log4j to newest version. [#5900](https://github.com/scalableminds/webknossos/pull/5900)
+- Fixed bug where volume data downloads would sometimes produce invalid zips due to a race condition. [#5926](https://github.com/scalableminds/webknossos/pull/5926)
 
 ### Removed
 -

--- a/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
@@ -92,11 +92,10 @@ object ZipIO extends LazyLogging {
   def zip(sources: Iterator[NamedStream], out: OutputStream)(implicit ec: ExecutionContext): Future[Unit] =
     if (sources.nonEmpty) {
       val zip = startZip(out)
-      val zipWrittenFuture = zipIterator(sources, zip)
-      zipWrittenFuture.onComplete { _ =>
-        zip.close()
-      }
-      zipWrittenFuture
+      for {
+        _ <- zipIterator(sources, zip)
+        _ = zip.close()
+      } yield ()
     } else {
       out.close()
       Future.successful(())

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -124,7 +124,6 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
             for {
               tracing <- tracingService.find(tracingId, version) ?~> Messages("tracing.notFound")
               data <- tracingService.allDataFile(tracingId, tracing)
-              _ = Thread.sleep(5)
             } yield Ok.sendFile(data)
           }
         }


### PR DESCRIPTION
Fixing a bug I presumably introduced in 2018, when I did not understand that the onComplete block of a Future is not guaranteed to be performed immediately after the Future is complete. This lead to the zip writing not being flushed at the time when sendFile started. Because of this, sendFile determined (and sent) a wrong contentLength, which broke the transfer, as the file was flushed and closed later, creating a file size mismatch.

This means we can remove the Thread.sleep from allDataBlocking. 

It _may_ be a fix for #5684 though I am not super confident there (since that one also sometimes happened when allDataBlocking itself worked ok)

### Steps to test:
- Create a farly large volume annotation (i.e. brush around the dataset in mag2, creating lots of mag1 data)
- Download that volume annotation
- Should contain an intact data.zip
- To ensure the error is fixed, check out master _remove the Thread.sleep_ , see that that the data.zip is broken
- To make testing easier, I queried the allDataBlocking route directly via curl

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
