### PR TITLE
Finetune discoverability of user scripts modal code input

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
@@ -115,7 +115,7 @@ class UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps
             placeholder="Select an existing user script"
             options={this.state.scripts.map(script => ({ value: script.id, label: script.name }))}
           />
-          <TextArea rows={15} onChange={this.handleCodeChange} value={this.state.code} />
+          <TextArea rows={15} onChange={this.handleCodeChange} value={this.state.code} placeholder="Add wK frondent script code here"/>
         </Spin>
       </Modal>
     );

--- a/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
@@ -115,7 +115,12 @@ class UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps
             placeholder="Select an existing user script"
             options={this.state.scripts.map(script => ({ value: script.id, label: script.name }))}
           />
-          <TextArea rows={15} onChange={this.handleCodeChange} value={this.state.code} placeholder="Choose an existing user script from the dropdown above or add wK frondent script code here"/>
+          <TextArea
+            rows={15}
+            onChange={this.handleCodeChange}
+            value={this.state.code}
+            placeholder="Choose an existing user script from the dropdown above or add wK frondent script code here"
+          />
         </Spin>
       </Modal>
     );

--- a/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
@@ -119,7 +119,7 @@ class UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps
             rows={15}
             onChange={this.handleCodeChange}
             value={this.state.code}
-            placeholder="Choose an existing user script from the dropdown above or add wK frondent script code here"
+            placeholder="Choose an existing user script from the dropdown above or add webKnossos frontend script code here"
           />
         </Spin>
       </Modal>

--- a/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.js
@@ -115,7 +115,7 @@ class UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps
             placeholder="Select an existing user script"
             options={this.state.scripts.map(script => ({ value: script.id, label: script.name }))}
           />
-          <TextArea rows={15} onChange={this.handleCodeChange} value={this.state.code} placeholder="Add wK frondent script code here"/>
+          <TextArea rows={15} onChange={this.handleCodeChange} value={this.state.code} placeholder="Choose an existing user script from the dropdown above or add wK frondent script code here"/>
         </Spin>
       </Modal>
     );


### PR DESCRIPTION
Added a small placeholder text to the user script modal to make the usage more obivous/easier to understand.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Issues:
- No issue

------
(Please delete unneded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
