### PR TITLE
Add dataset tags to searchable properties

### DIFF
--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.js
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.js
@@ -102,9 +102,9 @@ class DatasetTable extends React.PureComponent<Props, State> {
       });
 
     const filterByQuery = datasets =>
-      Utils.filterWithSearchQueryAND<APIMaybeUnimportedDataset, "name" | "description">(
+      Utils.filterWithSearchQueryAND<APIMaybeUnimportedDataset, "name" | "description" | "tags">(
         datasets,
-        ["name", "description"],
+        ["name", "description", "tags"],
         this.props.searchQuery,
       );
 


### PR DESCRIPTION
Now that datasets can have tags for better organization they should also be searchable. I add the `tags` property to the search bar to include them in the search results.

### URL of deployed dev instance (used for testing):
- https://searchabletags.webknossos.xyz/dashboard/datasets

### Steps to test:
1. Add one or more unique tag to a dataset
2. Search for the tag
3. The resulting search results should include the datasets with your tags

### Issues:
- No issue

------
(Please delete unneded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
