### PR TITLE
Rename Sample User

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
             wait
       - run:
           name: Refresh datasets
-          command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretScmBoyToken
+          command: curl https://master.webknossos.xyz/data/triggers/checkInboxBlocking?token=secretSampleUserToken
       - run:
           name: Run screenshot-tests
           command: |

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -83,8 +83,8 @@ Samplecountry
     userId,
     multiUserId,
     defaultOrganization._id,
-    "SCM",
-    "Boy",
+    "Sample",
+    "User",
     System.currentTimeMillis(),
     Json.obj(),
     userService.createLoginInfo(userId),
@@ -144,7 +144,7 @@ Samplecountry
             _ <- userExperiencesDAO.updateExperiencesForUser(defaultUser, Map("sampleExp" -> 10))
             _ <- userTeamRolesDAO.insertTeamMembership(defaultUser._id,
                                                        TeamMembership(organizationTeam._id, isTeamManager = true))
-            _ = logger.info("Inserted default user scmboy")
+            _ = logger.info("Inserted default user")
           } yield ()
       }
       .toFox

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,9 +54,9 @@ webKnossos {
   sampleOrganization {
     enabled = true
     user {
-      email = "scmboy@scalableminds.com"
+      email = "sample@scm.io"
       password = "secret"
-      token = "secretScmBoyToken"
+      token = "secretSampleUserToken"
       isSuperUser = true
     }
   }

--- a/frontend/javascripts/test/fixtures/tasktracing_server_objects.js
+++ b/frontend/javascripts/test/fixtures/tasktracing_server_objects.js
@@ -111,9 +111,9 @@ export const annotation: APIAnnotation = {
   user: {
     created: 12345678,
     id: "5b1e45faa00000a900abc2c5",
-    email: "scmboy@scalableminds.com",
-    firstName: "SCM",
-    lastName: "Boy",
+    email: "sample@scm.io",
+    firstName: "Sample",
+    lastName: "User",
     isAnonymous: false,
     teams: [
       { id: "5b1e45f9a00000a000abc2c3", isTeamManager: true, name: "Connectomics department" },

--- a/tools/volume-stress-test/volume-stress-client.sh
+++ b/tools/volume-stress-test/volume-stress-client.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-authtoken=secretScmBoyToken
+authtoken=secretSampleUserToken
 host=http://localhost:9000
 datastorehost=http://localhost:9000
 dataset=sample_organization/e2006-x4y1z1


### PR DESCRIPTION
Renames development mode default user SCM Boy to Sample User < sample @ scm.io >. Hoping that the shorter email address leads to less typing and gender neutrality leads to less exclusion.

### URL of deployed dev instance (used for testing):
- https://sampleuser.webknossos.xyz

### Steps to test:
- Start normally, log in as sample @ scm.io default password »secret« (or the internal dev deployment password)

------
- [x] Ready for review
