### PR TITLE
Serve exported files from datastore

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added the possibility to add additional volume layers to an existing annotation via the left sidebar. [#5881](https://github.com/scalableminds/webknossos/pull/5881)
+- Tiff exports are now served from the datastore module to prepare for remote datastores with webknossos-worker. [#5942](https://github.com/scalableminds/webknossos/pull/5942)
 
 ### Changed
 

--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -1,6 +1,5 @@
 package controllers
 
-import java.nio.file.{Files, Paths}
 import java.util.Date
 
 import com.mohiva.play.silhouette.api.Silhouette
@@ -177,18 +176,6 @@ class JobsController @Inject()(jobDAO: JobDAO,
           js <- jobService.publicWrites(job)
         } yield Ok(js)
       }
-    }
-
-  def downloadExport(jobId: String, exportFileName: String): Action[AnyContent] =
-    sil.SecuredAction.async { implicit request =>
-      for {
-        jobIdValidated <- ObjectId.parse(jobId)
-        job <- jobDAO.findOne(jobIdValidated)
-        latestRunId <- job.latestRunId.toFox
-        organization <- organizationDAO.findOne(request.identity._organization)
-        filePath = Paths.get("binaryData", organization.name, ".export", latestRunId, exportFileName)
-        _ <- bool2Fox(Files.exists(filePath)) ?~> "job.export.fileNotFound"
-      } yield Ok.sendPath(filePath, inline = false)
     }
 
 }

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -66,7 +66,8 @@ case class Job(
           }
         case "export_tiff" =>
           (commandArgs \ "export_file_name").toOption.flatMap(_.asOpt[String]).map { exportFileName =>
-            s"/api/jobs/${_id.id}/downloadExport/$exportFileName"
+            val exportFilePath = s"$organizationName/.export/$exportFileName"
+            s"DATASTORE_URL/exports/${_id.id}/download?filePath=$exportFilePath"
           }
         case "infer_nuclei" =>
           returnValue.map { resultDatasetName =>

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -11,6 +11,7 @@ import com.scalableminds.webknossos.schema.Tables._
 import com.typesafe.scalalogging.LazyLogging
 import javax.inject.Inject
 import models.analytics.{AnalyticsService, FailedJobEvent, RunJobEvent}
+import models.binary.DataStoreDAO
 import models.job.JobState.JobState
 import models.organization.OrganizationDAO
 import models.user.{MultiUserDAO, User, UserDAO}
@@ -24,7 +25,6 @@ import utils.{ObjectId, SQLClient, SQLDAO, WkConf}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
-
 import scala.concurrent.duration._
 
 case class Job(
@@ -56,19 +56,22 @@ case class Job(
 
   def effectiveState: JobState = manualState.getOrElse(state)
 
-  def resultLink(organizationName: String): Option[String] =
+  def exportFileName: Option[String] = argAsStringOpt("export_file_name")
+
+  def datasetName: Option[String] = argAsStringOpt("dataset_name")
+
+  private def argAsStringOpt(key: String) = (commandArgs \ key).toOption.flatMap(_.asOpt[String])
+
+  def resultLink(organizationName: String, dataStorePublicUrl: String): Option[String] =
     if (effectiveState != JobState.SUCCESS) None
     else {
       command match {
         case "convert_to_wkw" =>
-          (commandArgs \ "dataset_name").toOption.flatMap(_.asOpt[String]).map { dataSetName =>
-            s"/datasets/$organizationName/$dataSetName/view"
+          datasetName.map { dsName =>
+            s"/datasets/$organizationName/$dsName/view"
           }
         case "export_tiff" =>
-          (commandArgs \ "export_file_name").toOption.flatMap(_.asOpt[String]).map { exportFileName =>
-            val exportFilePath = s"$organizationName/.export/$exportFileName"
-            s"DATASTORE_URL/exports/${_id.id}/download?filePath=$exportFilePath"
-          }
+          Some(s"$dataStorePublicUrl/data/exports/${_id.id}/download")
         case "infer_nuclei" =>
           returnValue.map { resultDatasetName =>
             s"/datasets/$organizationName/$resultDatasetName/view"
@@ -93,7 +96,7 @@ class JobDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       Job(
         ObjectId(r._Id),
         ObjectId(r._Owner),
-        r._Datastore,
+        r._Datastore.trim,
         r.command,
         Json.parse(r.commandargs).as[JsObject],
         state,
@@ -116,6 +119,13 @@ class JobDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       accessQuery <- readAccessQuery
       r <- run(sql"select #$columns from #$existingCollectionName where #$accessQuery order by created".as[JobsRow])
       parsed <- parseAll(r)
+    } yield parsed
+
+  override def findOne(jobId: ObjectId)(implicit ctx: DBAccessContext): Fox[Job] =
+    for {
+      accessQuery <- readAccessQuery
+      r <- run(sql"select #$columns from #$existingCollectionName where #$accessQuery and _id = $jobId".as[JobsRow])
+      parsed <- parseFirst(r, jobId)
     } yield parsed
 
   def countUnassignedPendingForDataStore(_dataStore: String): Fox[Int] =
@@ -222,6 +232,7 @@ class JobService @Inject()(wkConf: WkConf,
                            userDAO: UserDAO,
                            multiUserDAO: MultiUserDAO,
                            jobDAO: JobDAO,
+                           dataStoreDAO: DataStoreDAO,
                            organizationDAO: OrganizationDAO,
                            analyticsService: AnalyticsService,
                            slackNotificationService: SlackNotificationService,
@@ -259,7 +270,8 @@ class JobService @Inject()(wkConf: WkConf,
     for {
       user <- userDAO.findOne(jobBeforeChange._owner)(GlobalAccessContext)
       organization <- organizationDAO.findOne(user._organization)(GlobalAccessContext)
-      resultLink = jobAfterChange.resultLink(organization.name)
+      dataStore <- dataStoreDAO.findOneByName(jobBeforeChange._dataStore)(GlobalAccessContext)
+      resultLink = jobAfterChange.resultLink(organization.name, dataStore.publicUrl)
       resultLinkMrkdwn = resultLink.map(l => s" <${wkConf.Http.uri}$l|Result>").getOrElse("")
       multiUser <- multiUserDAO.findOne(user._multiUser)(GlobalAccessContext)
       superUserLabel = if (multiUser.isSuperUser) " (for superuser)" else ""
@@ -278,7 +290,8 @@ class JobService @Inject()(wkConf: WkConf,
     for {
       owner <- userDAO.findOne(job._owner) ?~> "user.notFound"
       organization <- organizationDAO.findOne(owner._organization) ?~> "organization.notFound"
-      resultLink = job.resultLink(organization.name)
+      dataStore <- dataStoreDAO.findOneByName(job._dataStore) ?~> "dataStore.notFound"
+      resultLink = job.resultLink(organization.name, dataStore.publicUrl)
     } yield {
       Json.obj(
         "id" -> job._id.id,

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -88,6 +88,7 @@ PATCH         /datastores/:name/status                                         c
 POST          /datastores/:name/verifyUpload                                   controllers.WKRemoteDataStoreController.validateDataSetUpload(name: String, key: String, token: String)
 POST          /datastores/:name/reportDatasetUpload                            controllers.WKRemoteDataStoreController.reportDatasetUpload(name: String, key: String, token: String, dataSetName: String, dataSetSizeBytes: Long)
 POST          /datastores/:name/deleteErroneous                                controllers.WKRemoteDataStoreController.deleteErroneous(name: String, key: String)
+GET           /datastores/:name/jobExportProperties                            controllers.WKRemoteDataStoreController.jobExportProperties(name: String, key: String, jobId: String)
 POST          /datastores/:name/validateUserAccess                             controllers.UserTokenController.validateAccessViaDatastore(name: String, key: String, token: Option[String])
 POST          /datastores                                                      controllers.DataStoreController.create
 DELETE        /datastores/:name                                                controllers.DataStoreController.delete(name: String)

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -207,5 +207,4 @@ GET           /jobs/run/computeMeshFile/:organizationName/:dataSetName         c
 GET           /jobs/run/exportTiff/:organizationName/:dataSetName              controllers.JobsController.runExportTiffJob(organizationName: String, dataSetName: String, bbox: String, layerName: Option[String], tracingId: Option[String], tracingVersion: Option[String], annotationId: Option[String], annotationType: Option[String], hideUnmappedIds: Option[Boolean], mappingName: Option[String], mappingType: Option[String])
 GET           /jobs/run/inferNuclei/:organizationName/:dataSetName             controllers.JobsController.runInferNucleiJob(organizationName: String, dataSetName: String, layerName: Option[String])
 GET           /jobs/:id                                                        controllers.JobsController.get(id: String)
-GET           /jobs/:id/downloadExport/:exportFileName                         controllers.JobsController.downloadExport(id: String, exportFileName: String)
 POST          /jobs/:id/status                                                 controllers.WKRemoteWorkerController.updateJobStatus(key: String, id: String)

--- a/frontend/javascripts/admin/job/job_list_view.js
+++ b/frontend/javascripts/admin/job/job_list_view.js
@@ -17,7 +17,7 @@ import {
 import * as React from "react";
 
 import type { APIJob } from "types/api_flow_types";
-import { getJobs } from "admin/admin_rest_api";
+import { getJobs, doWithToken } from "admin/admin_rest_api";
 import Persistence from "libs/persistence";
 import * as Utils from "libs/utils";
 import FormattedDate from "components/formatted_date";
@@ -64,6 +64,7 @@ type State = {
   isLoading: boolean,
   jobs: Array<APIJob>,
   searchQuery: string,
+  token: string,
 };
 
 const persistence: Persistence<State> = new Persistence(
@@ -78,6 +79,7 @@ class JobListView extends React.PureComponent<Props, State> {
     isLoading: true,
     jobs: [],
     searchQuery: "",
+    token: "",
   };
 
   componentWillMount() {
@@ -100,10 +102,12 @@ class JobListView extends React.PureComponent<Props, State> {
 
   async fetchData(): Promise<void> {
     const jobs = await getJobs();
+    const token = await doWithToken(async t => t);
     this.setState(
       {
         isLoading: false,
         jobs,
+        token,
       },
       // refresh jobs according to the refresh interval
       () => {
@@ -182,7 +186,7 @@ class JobListView extends React.PureComponent<Props, State> {
       return (
         <span>
           {job.resultLink && (
-            <a href={job.resultLink} title="Download">
+            <a href={`${job.resultLink}?token=${this.state.token}`} title="Download">
               <DownOutlined />
               Download
             </a>

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
@@ -1,0 +1,27 @@
+package com.scalableminds.webknossos.datastore.controllers
+
+import java.nio.file.Paths
+
+import com.google.inject.Inject
+import com.scalableminds.util.tools.FoxImplicits
+import com.scalableminds.webknossos.datastore.DataStoreConfig
+import com.scalableminds.webknossos.datastore.services.{DataStoreAccessTokenService, UserAccessRequest}
+import play.api.mvc.{Action, AnyContent}
+
+import scala.concurrent.ExecutionContext
+
+class ExportsController @Inject()(
+                                   accessTokenService: DataStoreAccessTokenService, config: DataStoreConfig)(implicit ec: ExecutionContext)
+extends Controller
+with FoxImplicits {
+
+  private val dataBaseDir = Paths.get(config.Datastore.baseFolder)
+
+  def download(token: Option[String]): Action[AnyContent] = Action.async { implicit request =>
+    accessTokenService.validateAccessForSyncBlock(UserAccessRequest.listDataSources, token) {
+      AllowRemoteOrigin {
+        Ok(dataBaseDir.toString)
+      }
+    }
+  }
+}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
@@ -1,27 +1,32 @@
 package com.scalableminds.webknossos.datastore.controllers
 
-import java.nio.file.Paths
+import java.nio.file.{Files, Paths}
 
 import com.google.inject.Inject
 import com.scalableminds.util.tools.FoxImplicits
 import com.scalableminds.webknossos.datastore.DataStoreConfig
-import com.scalableminds.webknossos.datastore.services.{DataStoreAccessTokenService, UserAccessRequest}
+import com.scalableminds.webknossos.datastore.services.{DataStoreAccessTokenService, JobExportId, UserAccessRequest}
 import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.ExecutionContext
 
-class ExportsController @Inject()(
-                                   accessTokenService: DataStoreAccessTokenService, config: DataStoreConfig)(implicit ec: ExecutionContext)
-extends Controller
-with FoxImplicits {
+class ExportsController @Inject()(accessTokenService: DataStoreAccessTokenService, config: DataStoreConfig)(
+    implicit ec: ExecutionContext)
+    extends Controller
+    with FoxImplicits {
 
   private val dataBaseDir = Paths.get(config.Datastore.baseFolder)
 
-  def download(token: Option[String]): Action[AnyContent] = Action.async { implicit request =>
-    accessTokenService.validateAccessForSyncBlock(UserAccessRequest.listDataSources, token) {
-      AllowRemoteOrigin {
-        Ok(dataBaseDir.toString)
+  def download(token: Option[String], jobId: String, filePath: String): Action[AnyContent] = Action.async {
+    implicit request =>
+      accessTokenService.validateAccess(UserAccessRequest.downloadJobExport(jobId, filePath), token) {
+        AllowRemoteOrigin {
+          val fullPath = dataBaseDir.resolve(filePath)
+          for {
+            _ <- bool2Fox(Files.exists(fullPath)) ?~> "job.export.fileNotFound"
+          } yield Ok.sendPath(fullPath, inline = false)
+        }
       }
-    }
   }
+
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
@@ -1,32 +1,49 @@
 package com.scalableminds.webknossos.datastore.controllers
 
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 import com.google.inject.Inject
 import com.scalableminds.util.tools.FoxImplicits
 import com.scalableminds.webknossos.datastore.DataStoreConfig
-import com.scalableminds.webknossos.datastore.services.{DataStoreAccessTokenService, JobExportId, UserAccessRequest}
+import com.scalableminds.webknossos.datastore.services.{
+  DSRemoteWebKnossosClient,
+  DataStoreAccessTokenService,
+  UserAccessRequest
+}
+import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.ExecutionContext
 
-class ExportsController @Inject()(accessTokenService: DataStoreAccessTokenService, config: DataStoreConfig)(
-    implicit ec: ExecutionContext)
+case class JobExportProperties(jobId: String, runId: String, organizationName: String, exportFileName: String) {
+
+  def fullPathIn(baseDir: Path): Path =
+    baseDir.resolve(organizationName).resolve(".export").resolve(runId).resolve(exportFileName)
+}
+
+object JobExportProperties {
+  implicit val jsonFormat: OFormat[JobExportProperties] = Json.format[JobExportProperties]
+}
+
+class ExportsController @Inject()(webKnossosClient: DSRemoteWebKnossosClient,
+                                  accessTokenService: DataStoreAccessTokenService,
+                                  config: DataStoreConfig)(implicit ec: ExecutionContext)
     extends Controller
     with FoxImplicits {
 
-  private val dataBaseDir = Paths.get(config.Datastore.baseFolder)
+  private val dataBaseDir: Path = Paths.get(config.Datastore.baseFolder)
 
-  def download(token: Option[String], jobId: String, filePath: String): Action[AnyContent] = Action.async {
-    implicit request =>
-      accessTokenService.validateAccess(UserAccessRequest.downloadJobExport(jobId, filePath), token) {
-        AllowRemoteOrigin {
-          val fullPath = dataBaseDir.resolve(filePath)
-          for {
-            _ <- bool2Fox(Files.exists(fullPath)) ?~> "job.export.fileNotFound"
-          } yield Ok.sendPath(fullPath, inline = false)
-        }
+  def download(token: Option[String], jobId: String): Action[AnyContent] = Action.async { implicit request =>
+    accessTokenService.validateAccess(UserAccessRequest.downloadJobExport(jobId), token) {
+      AllowRemoteOrigin {
+        for {
+          exportProperties <- webKnossosClient.getJobExportProperties(jobId)
+          fullPath = exportProperties.fullPathIn(dataBaseDir)
+          _ <- bool2Fox(Files.exists(fullPath)) ?~> "job.export.fileNotFound"
+        } yield Ok.sendPath(fullPath, inline = false)
       }
+    }
+
   }
 
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
@@ -4,11 +4,12 @@ import com.github.ghik.silencer.silent
 import com.scalableminds.util.geometry.{BoundingBox, Point3D, Scale}
 import com.scalableminds.webknossos.datastore.models.datasource.DataSetViewConfiguration.DataSetViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.GenericInboxDataSource
+import com.scalableminds.webknossos.datastore.services.AccessResourceId
 import play.api.libs.json._
 
 package object datasource {
 
-  case class DataSourceId(name: String, team: String) // here team is not (yet) renamed to organization to avoid migrating all jsons
+  case class DataSourceId(name: String, team: String) extends AccessResourceId // here team is not (yet) renamed to organization to avoid migrating all jsons
 
   object DataSourceId {
     implicit val dataSourceIdFormat: Format[DataSourceId] = Json.format[DataSourceId]

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
@@ -4,12 +4,11 @@ import com.github.ghik.silencer.silent
 import com.scalableminds.util.geometry.{BoundingBox, Point3D, Scale}
 import com.scalableminds.webknossos.datastore.models.datasource.DataSetViewConfiguration.DataSetViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.GenericInboxDataSource
-import com.scalableminds.webknossos.datastore.services.AccessResourceId
 import play.api.libs.json._
 
 package object datasource {
 
-  case class DataSourceId(name: String, team: String) extends AccessResourceId // here team is not (yet) renamed to organization to avoid migrating all jsons
+  case class DataSourceId(name: String, team: String) // here team is not (yet) renamed to organization to avoid migrating all jsons
 
   object DataSourceId {
     implicit val dataSourceIdFormat: Format[DataSourceId] = Json.format[DataSourceId]

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
@@ -19,10 +19,17 @@ object AccessMode extends ExtendedEnumeration {
 
 object AccessResourceType extends ExtendedEnumeration {
   type AccessResourceType = Value
-  val datasource, tracing, webknossos = Value
+  val datasource, tracing, webknossos, jobExport = Value
 }
 
-case class UserAccessRequest(resourceId: DataSourceId, resourceType: AccessResourceType.Value, mode: AccessMode.Value) {
+trait AccessResourceId {}
+
+case class JobExportId(jobId: String, filePath: String) extends AccessResourceId
+case class TracingAccessId(tracingId: String) extends AccessResourceId
+
+case class UserAccessRequest(resourceId: AccessResourceId,
+                             resourceType: AccessResourceType.Value,
+                             mode: AccessMode.Value) {
   def toCacheKey(token: Option[String]) = s"$token#$resourceId#$resourceType#$mode"
 }
 
@@ -43,10 +50,13 @@ object UserAccessRequest {
   def writeDataSource(dataSourceId: DataSourceId): UserAccessRequest =
     UserAccessRequest(dataSourceId, AccessResourceType.datasource, AccessMode.write)
 
+  def downloadJobExport(jobId: String, filePath: String): UserAccessRequest =
+    UserAccessRequest(JobExportId(jobId, filePath), AccessResourceType.jobExport, AccessMode.read)
+
   def readTracing(tracingId: String): UserAccessRequest =
-    UserAccessRequest(DataSourceId(tracingId, ""), AccessResourceType.tracing, AccessMode.read)
+    UserAccessRequest(TracingAccessId(tracingId), AccessResourceType.tracing, AccessMode.read)
   def writeTracing(tracingId: String): UserAccessRequest =
-    UserAccessRequest(DataSourceId(tracingId, ""), AccessResourceType.tracing, AccessMode.write)
+    UserAccessRequest(TracingAccessId(tracingId), AccessResourceType.tracing, AccessMode.write)
 
   def webknossos: UserAccessRequest =
     UserAccessRequest(DataSourceId("webknossos", ""), AccessResourceType.webknossos, AccessMode.administrate)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
@@ -22,14 +22,7 @@ object AccessResourceType extends ExtendedEnumeration {
   val datasource, tracing, webknossos, jobExport = Value
 }
 
-trait AccessResourceId {}
-
-case class JobExportId(jobId: String, filePath: String) extends AccessResourceId
-case class TracingAccessId(tracingId: String) extends AccessResourceId
-
-case class UserAccessRequest(resourceId: AccessResourceId,
-                             resourceType: AccessResourceType.Value,
-                             mode: AccessMode.Value) {
+case class UserAccessRequest(resourceId: DataSourceId, resourceType: AccessResourceType.Value, mode: AccessMode.Value) {
   def toCacheKey(token: Option[String]) = s"$token#$resourceId#$resourceType#$mode"
 }
 
@@ -50,13 +43,13 @@ object UserAccessRequest {
   def writeDataSource(dataSourceId: DataSourceId): UserAccessRequest =
     UserAccessRequest(dataSourceId, AccessResourceType.datasource, AccessMode.write)
 
-  def downloadJobExport(jobId: String, filePath: String): UserAccessRequest =
-    UserAccessRequest(JobExportId(jobId, filePath), AccessResourceType.jobExport, AccessMode.read)
-
   def readTracing(tracingId: String): UserAccessRequest =
-    UserAccessRequest(TracingAccessId(tracingId), AccessResourceType.tracing, AccessMode.read)
+    UserAccessRequest(DataSourceId(tracingId, ""), AccessResourceType.tracing, AccessMode.read)
   def writeTracing(tracingId: String): UserAccessRequest =
-    UserAccessRequest(TracingAccessId(tracingId), AccessResourceType.tracing, AccessMode.write)
+    UserAccessRequest(DataSourceId(tracingId, ""), AccessResourceType.tracing, AccessMode.write)
+
+  def downloadJobExport(jobId: String): UserAccessRequest =
+    UserAccessRequest(DataSourceId(jobId, ""), AccessResourceType.jobExport, AccessMode.read)
 
   def webknossos: UserAccessRequest =
     UserAccessRequest(DataSourceId("webknossos", ""), AccessResourceType.webknossos, AccessMode.administrate)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebKnossosClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebKnossosClient.scala
@@ -5,6 +5,7 @@ import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.DataStoreConfig
+import com.scalableminds.webknossos.datastore.controllers.JobExportProperties
 import com.scalableminds.webknossos.datastore.helpers.IntervalScheduler
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.InboxDataSourceLike
@@ -90,6 +91,12 @@ class DSRemoteWebKnossosClient @Inject()(
 
   def deleteErroneousDataSource(id: DataSourceId): Fox[_] =
     rpc(s"$webKnossosUri/api/datastores/$dataStoreName/deleteErroneous").addQueryString("key" -> dataStoreKey).post(id)
+
+  def getJobExportProperties(jobId: String): Fox[JobExportProperties] =
+    rpc(s"$webKnossosUri/api/datastores/$dataStoreName/jobExportProperties")
+      .addQueryString("jobId" -> jobId)
+      .addQueryString("key" -> dataStoreKey)
+      .getWithJsonResponse[JobExportProperties]
 
   override def requestUserAccess(token: Option[String], accessRequest: UserAccessRequest): Fox[UserAccessAnswer] =
     rpc(s"$webKnossosUri/api/datastores/$dataStoreName/validateUserAccess")

--- a/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
+++ b/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
@@ -54,3 +54,6 @@ GET         /triggers/checkInbox                                                
 GET         /triggers/checkInboxBlocking                                                                                          @com.scalableminds.webknossos.datastore.controllers.DataSourceController.triggerInboxCheckBlocking(token: Option[String])
 GET         /triggers/newOrganizationFolder                                                                                       @com.scalableminds.webknossos.datastore.controllers.DataSourceController.createOrganizationDirectory(token: Option[String], organizationName: String)
 GET         /triggers/reload/:organizationName/:dataSetName                                                                       @com.scalableminds.webknossos.datastore.controllers.DataSourceController.reload(token: Option[String], organizationName: String, dataSetName: String, layerName: Option[String])
+
+# Exports
+GET         /exports/:jobId/download                                                                                              @com.scalableminds.webknossos.datastore.controllers.ExportsController.download(token: Option[String], jobId: String, filePath: String)

--- a/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
+++ b/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
@@ -56,4 +56,4 @@ GET         /triggers/newOrganizationFolder                                     
 GET         /triggers/reload/:organizationName/:dataSetName                                                                       @com.scalableminds.webknossos.datastore.controllers.DataSourceController.reload(token: Option[String], organizationName: String, dataSetName: String, layerName: Option[String])
 
 # Exports
-GET         /exports/:jobId/download                                                                                              @com.scalableminds.webknossos.datastore.controllers.ExportsController.download(token: Option[String], jobId: String, filePath: String)
+GET         /exports/:jobId/download                                                                                              @com.scalableminds.webknossos.datastore.controllers.ExportsController.download(token: Option[String], jobId: String)


### PR DESCRIPTION
Serve exported files from the datastore (which naturally has read access to the data root dir (”binaryData”) where the exports are stored by the webknossos-worker.

New protocol:
 - job result link (generated by backend) now points to datastore download route
 - frontend appends a valid user token
 - when the user clicks that link, the datastore
   - checks that the user may access the job export
   - fetches the job export properties
   - constructs the full file path from those
   - serves the file

### TODO Frontend:
 - [x] Add datastore user token to link in list

### Steps to test:
- Set up wk-worker locally
- Run a tif export job (create bbox in dataset view mode, click export icon, select layer)
- Download link in jobs list should work when job is finished, should point to datastore route (/data/* instead of /api)

### Issues:
- fixes #5842 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
