### PR TITLE
Fix that rapid space-presses led to sped up movements

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed bug where volume data downloads would sometimes produce invalid zips due to a race condition. [#5926](https://github.com/scalableminds/webknossos/pull/5926)
+- Fixed a bug which caused that the keyboard delay wasn't respected properly when rapidly pressing a key. [#5947](https://github.com/scalableminds/webknossos/pull/5947)
 
 ### Removed
 

--- a/frontend/javascripts/libs/input.js
+++ b/frontend/javascripts/libs/input.js
@@ -151,6 +151,7 @@ export class InputKeyboard {
   }
 
   attach(key: KeyboardKey, callback: KeyboardLoopHandler) {
+    let delayTimeoutId = null;
     const binding = [
       key,
       event => {
@@ -190,7 +191,7 @@ export class InputKeyboard {
           this.delay +
           (callback.customAdditionalDelayFn != null ? callback.customAdditionalDelayFn() : 0);
         if (totalDelay >= 0) {
-          setTimeout(() => {
+          delayTimeoutId = setTimeout(() => {
             callback.delayed = false;
             callback.lastTime = new Date().getTime();
           }, totalDelay);
@@ -204,6 +205,10 @@ export class InputKeyboard {
         if (this.keyCallbackMap[key] != null) {
           this.keyPressedCount--;
           delete this.keyCallbackMap[key];
+        }
+        if (delayTimeoutId != null) {
+          clearTimeout(delayTimeoutId);
+          delayTimeoutId = null;
         }
       },
     ];


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- set keyboard delay to 500
- set move value to 8000
- press space rapidly in a dataset
- --> on master, this will occasionally jump big values along z
- --> on this branch, z should only increment by one

### Issues:
- fixes #3795

------
(Please delete unneded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
