### PR TITLE
Make organization name accessible in the UI

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Added
 - Added the possibility to add additional volume layers to an existing annotation via the left sidebar. [#5881](https://github.com/scalableminds/webknossos/pull/5881)
 - Tiff exports are now served from the datastore module to prepare for remote datastores with webknossos-worker. [#5942](https://github.com/scalableminds/webknossos/pull/5942)
+- Added the organization id to the auth token page and organization page. [#5965](https://github.com/scalableminds/webknossos/pull/5965)
 
 ### Changed
 

--- a/frontend/javascripts/admin/auth/auth_token_view.js
+++ b/frontend/javascripts/admin/auth/auth_token_view.js
@@ -3,11 +3,14 @@ import React, { useState, useEffect } from "react";
 import { CopyOutlined, SwapOutlined } from "@ant-design/icons";
 import { Input, Button, Col, Row, Spin, Form } from "antd";
 import { getAuthToken, revokeAuthToken } from "admin/admin_rest_api";
+import { type OxalisState } from "oxalis/store";
 import Toast from "libs/toast";
+import { useSelector } from "react-redux";
 
 const FormItem = Form.Item;
 
 function AuthTokenView() {
+  const activeUser = useSelector((state: OxalisState) => state.activeUser);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [currentToken, setCurrentToken] = useState<string>("");
   const [form] = Form.useForm();
@@ -38,6 +41,13 @@ function AuthTokenView() {
     Toast.success("Token copied to clipboard");
   };
 
+  const copyOrganizationNameToClipboard = async () => {
+    if (activeUser != null) {
+      await navigator.clipboard.writeText(activeUser.organization);
+      Toast.success("Organization ID copied to clipboard");
+    }
+  };
+
   return (
     <div>
       <Row type="flex" justify="center" style={{ padding: 50 }} align="middle">
@@ -60,19 +70,38 @@ function AuthTokenView() {
                 </Button>
               </FormItem>
             </Form>
+            {activeUser != null && (
+              <>
+                <h4>Organization ID</h4>
+                <Form>
+                  <FormItem>
+                    <Input.Group compact>
+                      <Input value={activeUser.organization} style={{ width: "90%" }} readOnly />
+                      <Button
+                        onClick={copyOrganizationNameToClipboard}
+                        icon={<CopyOutlined className="without-icon-margin" />}
+                      />
+                    </Input.Group>
+                  </FormItem>
+                </Form>
+              </>
+            )}
           </Spin>
         </Col>
       </Row>
       <Row type="flex" justify="center" align="middle">
         <Col span={8}>
-          An Auth Token is a series of symbols that serves to authenticate you. It is used in
-          communication with the backend API and sent with every request to verify your identity.
-          <br />
-          You should revoke it if somebody else has acquired your token or you have the suspicion
-          this has happened.{" "}
-          <a href="https://docs.webknossos.org/webknossos/rest_api.html#authentication">
-            Read more
-          </a>
+          <p>
+            An Auth Token is a series of symbols that serves to authenticate you. It is used in
+            communication with the backend API and sent with every request to verify your identity.
+          </p>
+          <p>
+            You should revoke it if somebody else has acquired your token or you have the suspicion
+            this has happened.{" "}
+            <a href="https://docs.webknossos.org/webknossos/rest_api.html#authentication">
+              Read more
+            </a>
+          </p>
         </Col>
       </Row>
     </div>

--- a/frontend/javascripts/admin/organization/organization_edit_view.js
+++ b/frontend/javascripts/admin/organization/organization_edit_view.js
@@ -1,12 +1,13 @@
 // @flow
 import { withRouter } from "react-router-dom";
 import { Form, Button, Card, Input, Row } from "antd";
-import { MailOutlined, TagOutlined } from "@ant-design/icons";
+import { MailOutlined, TagOutlined, CopyOutlined, KeyOutlined } from "@ant-design/icons";
 import React from "react";
 import { FormInstance } from "antd/lib/form";
 
 import { confirmAsync } from "dashboard/dataset/helper_components";
 import { getOrganization, deleteOrganization, updateOrganization } from "admin/admin_rest_api";
+import Toast from "libs/toast";
 import Enum from "Enumjs";
 
 const FormItem = Form.Item;
@@ -106,6 +107,11 @@ class OrganizationEditView extends React.PureComponent<Props, State> {
     }
   };
 
+  handleCopyNameButtonClicked = async (): Promise<void> => {
+    await navigator.clipboard.writeText(this.props.organizationName);
+    Toast.success("Organization name copied to clipboard");
+  };
+
   render() {
     return (
       <div className="container" style={{ paddingTop: 20 }}>
@@ -122,6 +128,20 @@ class OrganizationEditView extends React.PureComponent<Props, State> {
               newUserMailingList: this.state.newUserMailingList,
             }}
           >
+            <FormItem label="ID" readOnly>
+              <Input.Group compact>
+                <Input
+                  prefix={<KeyOutlined />}
+                  value={this.props.organizationName}
+                  style={{ width: "calc(100% - 31px)" }}
+                  readOnly
+                />
+                <Button
+                  onClick={this.handleCopyNameButtonClicked}
+                  icon={<CopyOutlined className="without-icon-margin" />}
+                />
+              </Input.Group>
+            </FormItem>
             <FormItem
               label="Display Name"
               name="displayName"
@@ -140,9 +160,9 @@ class OrganizationEditView extends React.PureComponent<Props, State> {
                 disabled={this.state.isFetchingData}
                 placeholder="Display Name"
               />
-            </FormItem>{" "}
+            </FormItem>
             <FormItem
-              label="Notify About New Users Via:"
+              label="Email Address for New-User Notifications"
               name="newUserMailingList"
               rules={[
                 {


### PR DESCRIPTION
Adds the organization name (debatably presented as "ID") to the UI, so that users can use it for wklibs.
<img width="611" alt="Screenshot 2022-01-18 at 12 03 00" src="https://user-images.githubusercontent.com/335438/149926386-0915a2d6-8357-415b-82c7-83a13e6031fa.png">
<img width="872" alt="Screenshot 2022-01-18 at 12 03 06" src="https://user-images.githubusercontent.com/335438/149926394-5545660a-c16a-48ac-aa26-5bbfd9432491.png">


### Steps to test:
- http://localhost:9000/organizations/sample_organization/edit
- http://localhost:9000/auth/token

### Issues:
- fixes #5962 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- ~[ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change~ see https://github.com/scalableminds/webknossos-libs/issues/558
- [x] Ready for review
