### PR TITLE
Add debug output to failing dataset list requests

### DIFF
--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -234,7 +234,7 @@ class DataSetController @Inject()(userService: UserService,
             dataSetLastUsedTimesDAO.updateForDataSetAndUser(dataSet._id, user._id))
           // Access checked above via dataset. In case of shared dataset/annotation, show datastore even if not otherwise accessible
           dataStore <- dataSetService.dataStoreFor(dataSet)(GlobalAccessContext)
-          js <- dataSetService.publicWrites(dataSet, request.identity, organization, dataStore)
+          js <- dataSetService.publicWrites(dataSet, request.identity, organization, dataStore) ?~> "hi?" ?~> Messages("dataset.list.writesFailed", dataSet.name)
           _ = request.identity.map { user =>
             analyticsService.track(OpenDatasetEvent(user, dataSet))
             if (dataSet.isPublic) {

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -353,7 +353,7 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
       teamsJs <- Fox.serialCombined(teams)(t => teamService.publicWrites(t, Some(organization))) ?~> "dataset.list.teamWritesFailed"
       logoUrl <- logoUrlFor(dataSet, Some(organization)) ?~> "dataset.list.fetchLogoUrlFailed"
       isEditable <- isEditableBy(dataSet, requestingUserOpt, requestingUserTeamManagerMemberships) ?~> "dataset.list.isEditableCheckFailed"
-      lastUsedByUser <- lastUsedTimeFor(dataSet._id, requestingUserOpt) ?~> "dataset.list.isEditableCheckFailed"
+      lastUsedByUser <- lastUsedTimeFor(dataSet._id, requestingUserOpt) ?~> "dataset.list.fetchLastUsedTimeFailed"
       dataStoreJs <- dataStoreService.publicWrites(dataStore) ?~> "dataset.list.dataStoreWritesFailed"
       dataSource <- dataSourceFor(dataSet, Some(organization), skipResolutions) ?~> "dataset.list.fetchDataSourceFailed"
       publicationOpt <- Fox.runOptional(dataSet._publication)(publicationDAO.findOne(_)) ?~> "dataset.list.fetchPublicationFailed"

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -349,15 +349,16 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
                    requestingUserTeamManagerMemberships: Option[List[TeamMembership]] = None)(
       implicit ctx: DBAccessContext): Fox[JsObject] =
     for {
-      teams <- allowedTeamsFor(dataSet._id, requestingUserOpt)
-      teamsJs <- Fox.serialCombined(teams)(t => teamService.publicWrites(t, Some(organization)))
-      logoUrl <- logoUrlFor(dataSet, Some(organization))
-      isEditable <- isEditableBy(dataSet, requestingUserOpt, requestingUserTeamManagerMemberships)
-      lastUsedByUser <- lastUsedTimeFor(dataSet._id, requestingUserOpt)
-      dataStoreJs <- dataStoreService.publicWrites(dataStore)
-      dataSource <- dataSourceFor(dataSet, Some(organization), skipResolutions)
-      publicationOpt <- Fox.runOptional(dataSet._publication)(publicationDAO.findOne(_))
-      publicationJson <- Fox.runOptional(publicationOpt)(publicationService.publicWrites)
+      teams <- allowedTeamsFor(dataSet._id, requestingUserOpt) ?~> "dataset.list.fetchAllowedTeamsFailed"
+      teamsJs <- Fox.serialCombined(teams)(t => teamService.publicWrites(t, Some(organization))) ?~> "dataset.list.teamWritesFailed"
+      logoUrl <- logoUrlFor(dataSet, Some(organization)) ?~> "dataset.list.fetchLogoUrlFailed"
+      _ <- Fox.failure("Nope!")  ?~> "dataset.list.nopeFailed"
+      isEditable <- isEditableBy(dataSet, requestingUserOpt, requestingUserTeamManagerMemberships) ?~> "dataset.list.isEditableCheckFailed"
+      lastUsedByUser <- lastUsedTimeFor(dataSet._id, requestingUserOpt) ?~> "dataset.list.isEditableCheckFailed"
+      dataStoreJs <- dataStoreService.publicWrites(dataStore) ?~> "dataset.list.dataStoreWritesFailed"
+      dataSource <- dataSourceFor(dataSet, Some(organization), skipResolutions) ?~> "dataset.list.fetchDataSourceFailed"
+      publicationOpt <- Fox.runOptional(dataSet._publication)(publicationDAO.findOne(_)) ?~> "dataset.list.fetchPublicationFailed"
+      publicationJson <- Fox.runOptional(publicationOpt)(publicationService.publicWrites) ?~> "dataset.list.publicationWritesFailed"
       worker <- workerDAO.findOneByDataStore(dataStore.name).futureBox
       jobsEnabled = conf.Features.jobsEnabled && worker.nonEmpty
     } yield {

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -352,7 +352,6 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
       teams <- allowedTeamsFor(dataSet._id, requestingUserOpt) ?~> "dataset.list.fetchAllowedTeamsFailed"
       teamsJs <- Fox.serialCombined(teams)(t => teamService.publicWrites(t, Some(organization))) ?~> "dataset.list.teamWritesFailed"
       logoUrl <- logoUrlFor(dataSet, Some(organization)) ?~> "dataset.list.fetchLogoUrlFailed"
-      _ <- Fox.failure("Nope!")  ?~> "dataset.list.nopeFailed"
       isEditable <- isEditableBy(dataSet, requestingUserOpt, requestingUserTeamManagerMemberships) ?~> "dataset.list.isEditableCheckFailed"
       lastUsedByUser <- lastUsedTimeFor(dataSet._id, requestingUserOpt) ?~> "dataset.list.isEditableCheckFailed"
       dataStoreJs <- dataStoreService.publicWrites(dataStore) ?~> "dataset.list.dataStoreWritesFailed"

--- a/conf/messages
+++ b/conf/messages
@@ -115,6 +115,7 @@ dataSet.upload.success=Dataset successfully uploaded. The import is in progress 
 dataSet.create.success=Dataset successfully created
 dataSet.defaultconfiguration.updated=Dataset default configuration updated
 dataSet.list.failed=Failed to retrieve list of data sets.
+dataset.list.writesFailed=Failed to write json for dataset {0}
 dataSet.url.missing=URL missing in the supplied json
 dataSet.dataStore.missing=dataStore missing in the supplied json
 dataSet.dataSet.missing=dataSet missing in the supplied json


### PR DESCRIPTION
We had some failing dataset list requests with no readable error message. To figure out what happened there, I’m adding error messages indicating which dataset caused trouble in which step.