### PR TITLE
Fix nml upload by providing process browser shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "nanoevents": "^5.1.8",
     "pako": "^0.2.8",
     "pretty-bytes": "^5.1.0",
+    "process": "^0.11.10",
     "protobufjs": "^6.8.6",
     "react": "^16.12.0",
     "react-debounce-render": "^6.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,11 @@ module.exports = function(env = {}) {
       "process.env.BABEL_ENV": process.env.BABEL_ENV,
     }),
     new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
+    new webpack.ProvidePlugin({
+      // Needed for saxophone, i.e. readable-stream, since it is used without importing
+      // Corresponding issue: https://github.com/nodejs/readable-stream/issues/450
+      process: "process/browser",
+    }),
     new MiniCssExtractPlugin({
       filename: "[name].css",
       chunkFilename: "[name].css",
@@ -139,7 +144,10 @@ module.exports = function(env = {}) {
       alias: {
         react: path.resolve("./node_modules/react"),
       },
-      fallback: { url: require.resolve("url/") },
+      fallback: {
+        // Needed for jsonschema
+        url: require.resolve("url/"),
+      },
     },
     optimization: {
       minimize: env.production,


### PR DESCRIPTION
The saxophone library depends on a library that accesses node's process dependency even when in the browser. Related to the webpack upgrade, since webpack no longer auto-provides these node polyfills.

Unfortunately, the nml parsing tests didn't catch this since they are executed in node. Ideally we could configure ava (or babel?) to simulate a browser environment and not include the node globals :thinking: 

### URL of deployed dev instance (used for testing):
- https://fixprocessundefined.webknossos.xyz

### Steps to test:
- Upload an NML in the frontend

------
(Please delete unneeded items, merge only when none are left open)
- [x] Ready for review
