### PR TITLE
[WIP] Add loaded meshes to sharing link

### DIFF
--- a/frontend/javascripts/admin/user/permissions_and_teams_modal_view.js
+++ b/frontend/javascripts/admin/user/permissions_and_teams_modal_view.js
@@ -8,6 +8,7 @@ import update from "immutability-helper";
 import type { APIUser, APITeam, APITeamMembership } from "types/api_flow_types";
 import { updateUser, getEditableTeams } from "admin/admin_rest_api";
 import messages from "messages";
+import * as Utils from "libs/utils";
 
 const RadioButton = Radio.Button;
 const RadioGroup = Radio.Group;
@@ -129,7 +130,7 @@ class PermissionsAndTeamsModalView extends React.PureComponent<TeamRoleModalProp
   setPermissionsAndTeams = () => {
     const newUserPromises = this.props.users.map(user => {
       if (this.props.selectedUserIds.includes(user.id)) {
-        const newTeams = ((Object.values(this.state.selectedTeams): any): Array<APITeamMembership>);
+        const newTeams = Utils.values(this.state.selectedTeams);
         const newUser = Object.assign({}, user, { teams: newTeams });
         if (this.props.activeUser.isAdmin && this.props.selectedUserIds.length === 1) {
           // If the current user is admin and only one user is edited we also update the permissions.

--- a/frontend/javascripts/libs/utils.js
+++ b/frontend/javascripts/libs/utils.js
@@ -24,6 +24,11 @@ export function mod(x: number, n: number) {
   return ((x % n) + n) % n;
 }
 
+export function values<K, V>(o: { [K]: V }): Array<V> {
+  // $FlowIssue[incompatible-return] remove once https://github.com/facebook/flow/issues/2221 is fixed
+  return Object.values(o);
+}
+
 export function map2<A, B>(fn: (A, number) => B, tuple: [A, A]): [B, B] {
   const [x, y] = tuple;
   return [fn(x, 0), fn(y, 1)];
@@ -514,8 +519,8 @@ export function filterWithSearchQueryOR<T: { +[string]: mixed }, P: $Keys<T>>(
       _.some(properties, fieldName => {
         const value = typeof fieldName === "function" ? fieldName(model) : model[fieldName];
         if (value != null && (typeof value === "string" || value instanceof Object)) {
-          const values = getRecursiveValues(value);
-          return _.some(values, v => v != null && v.toString().match(regexp));
+          const recursiveValues = getRecursiveValues(value);
+          return _.some(recursiveValues, v => v != null && v.toString().match(regexp));
         } else {
           return false;
         }
@@ -545,8 +550,8 @@ export function filterWithSearchQueryAND<T: { +[string]: mixed }, P: $Keys<T>>(
         _.some(properties, fieldName => {
           const value = typeof fieldName === "function" ? fieldName(model) : model[fieldName];
           if (value !== null && (typeof value === "string" || value instanceof Object)) {
-            const values = getRecursiveValues(value);
-            return _.some(values, v => v != null && v.toString().match(pattern));
+            const recursiveValues = getRecursiveValues(value);
+            return _.some(recursiveValues, v => v != null && v.toString().match(pattern));
           } else {
             return false;
           }

--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -140,6 +140,7 @@ import * as Utils from "libs/utils";
 import dimensions from "oxalis/model/dimensions";
 import messages from "messages";
 import window, { location } from "libs/window";
+import DataLayer from "oxalis/model/data_layer";
 
 type OutdatedDatasetConfigurationKeys = "segmentationOpacity" | "isSegmentationDisabled";
 
@@ -1009,9 +1010,7 @@ class DataApi {
    */
   async reloadBuckets(layerName: string): Promise<void> {
     await Promise.all(
-      Object.keys(this.model.dataLayers).map(async currentLayerName => {
-        const dataLayer = this.model.dataLayers[currentLayerName];
-
+      Utils.values(this.model.dataLayers).map(async (dataLayer: DataLayer) => {
         if (dataLayer.name === layerName) {
           if (dataLayer.cube.isSegmentation) {
             await Model.ensureSavedState();
@@ -1030,7 +1029,7 @@ class DataApi {
     if (hasVolumeTracings(Store.getState().tracing)) {
       await Model.ensureSavedState();
     }
-    _.forEach(this.model.dataLayers, dataLayer => {
+    _.forEach(this.model.dataLayers, (dataLayer: DataLayer) => {
       dataLayer.cube.collectAllBuckets();
       dataLayer.layerRenderingManager.refresh();
     });

--- a/frontend/javascripts/oxalis/merger_mode.js
+++ b/frontend/javascripts/oxalis/merger_mode.js
@@ -13,9 +13,9 @@ import api from "oxalis/api/internal_api";
 import messages from "messages";
 
 type MergerModeState = {
-  treeColors: Object,
-  colorMapping: Object,
-  nodesPerSegment: Object,
+  treeColors: { [number]: ?number },
+  colorMapping: { [number]: number },
+  nodesPerSegment: { [number]: number },
   nodes: Array<NodeWithTreeId>,
   // A properly initialized merger mode should always
   // have a segmentationLayerName. However, some edge cases
@@ -41,7 +41,7 @@ function getTreeColor(treeId: number, mergerModeState: MergerModeState) {
   const { treeColors } = mergerModeState;
   let color = treeColors[treeId];
   // Generate a new color if tree was never seen before
-  if (color === undefined) {
+  if (color == null) {
     color = Math.ceil(127 * Math.random());
     treeColors[treeId] = color;
   }
@@ -252,8 +252,8 @@ function shuffleColorOfCurrentTree(mergerModeState: MergerModeState) {
     treeColors[activeTreeId] = undefined;
     // Applies the change of the color to all connected segments
     Object.keys(colorMapping).forEach(key => {
-      if (colorMapping[key] === oldColor) {
-        colorMapping[key] = getTreeColor(activeTreeId, mergerModeState);
+      if (colorMapping[+key] === oldColor) {
+        colorMapping[+key] = getTreeColor(activeTreeId, mergerModeState);
       }
     });
     // Update the segmentation

--- a/frontend/javascripts/oxalis/model.js
+++ b/frontend/javascripts/oxalis/model.js
@@ -88,8 +88,7 @@ export class OxalisModel {
   }
 
   getAllLayers(): Array<DataLayer> {
-    // $FlowIssue[incompatible-return] remove once https://github.com/facebook/flow/issues/2221 is fixed
-    return Object.values(this.dataLayers);
+    return Utils.values(this.dataLayers);
   }
 
   getColorLayers(): Array<DataLayer> {
@@ -100,22 +99,18 @@ export class OxalisModel {
   }
 
   getSegmentationLayers(): Array<DataLayer> {
-    return Object.keys(this.dataLayers)
-      .map(k => this.dataLayers[k])
-      .filter(
-        dataLayer =>
-          getLayerByName(Store.getState().dataset, dataLayer.name).category === "segmentation",
-      );
+    return Utils.values(this.dataLayers).filter(
+      dataLayer =>
+        getLayerByName(Store.getState().dataset, dataLayer.name).category === "segmentation",
+    );
   }
 
   getSegmentationTracingLayers(): Array<DataLayer> {
-    return Object.keys(this.dataLayers)
-      .map(k => this.dataLayers[k])
-      .filter(dataLayer => {
-        const layer = getLayerByName(Store.getState().dataset, dataLayer.name);
+    return Utils.values(this.dataLayers).filter(dataLayer => {
+      const layer = getLayerByName(Store.getState().dataset, dataLayer.name);
 
-        return layer.category === "segmentation" && layer.tracingId != null;
-      });
+      return layer.category === "segmentation" && layer.tracingId != null;
+    });
   }
 
   getSomeSegmentationLayer(): ?DataLayer {

--- a/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
+++ b/frontend/javascripts/oxalis/model/helpers/nml_helpers.js
@@ -27,7 +27,11 @@ import type {
 } from "oxalis/store";
 import { findGroup } from "oxalis/view/right-border-tabs/tree_hierarchy_view_helpers";
 import messages from "messages";
-import { computeArrayFromBoundingBox, computeBoundingBoxFromBoundingBoxObject } from "libs/utils";
+import {
+  computeArrayFromBoundingBox,
+  computeBoundingBoxFromBoundingBoxObject,
+  values,
+} from "libs/utils";
 import type { BoundingBoxType, Vector3 } from "oxalis/constants";
 
 // NML Defaults
@@ -116,10 +120,7 @@ export function serializeToNml(
   buildInfo: APIBuildInfo,
 ): string {
   // Only visible trees will be serialized!
-  // _.filter throws flow errors here, because the type definitions are wrong and I'm not able to fix them
-  const visibleTrees = Object.keys(tracing.trees)
-    .filter(treeId => tracing.trees[Number(treeId)].isVisible)
-    .map(treeId => tracing.trees[Number(treeId)]);
+  const visibleTrees = values(tracing.trees).filter(tree => tree.isVisible);
   return [
     "<things>",
     ...indent(
@@ -793,10 +794,9 @@ export function parseNml(
       })
       .on("finish", () => {
         // Split potentially unconnected trees
-        const originalTreeIds = Object.keys(trees);
+        const originalTrees = values(trees);
         let maxTreeId = getMaximumTreeId(trees);
-        for (const treeId of originalTreeIds) {
-          const tree = trees[Number(treeId)];
+        for (const tree of originalTrees) {
           const newTrees = splitTreeIntoComponents(tree, treeGroups, maxTreeId);
           const newTreesSize = _.size(newTrees);
           if (newTreesSize > 1) {

--- a/frontend/javascripts/oxalis/model/reducers/save_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/save_reducer.js
@@ -3,7 +3,7 @@ import _ from "lodash";
 import update from "immutability-helper";
 
 import type { Action } from "oxalis/model/actions/actions";
-import type { OxalisState, SaveState } from "oxalis/store";
+import type { OxalisState, SaveState, SaveQueueEntry } from "oxalis/store";
 import type { SetVersionNumberAction } from "oxalis/model/actions/save_actions";
 import { getActionLog } from "oxalis/model/helpers/action_logger_middleware";
 import { getStats } from "oxalis/model/accessors/skeletontracing_accessor";
@@ -34,7 +34,11 @@ function updateQueueObj(action, oldQueueObj, newQueue) {
 export function getTotalSaveQueueLength(queueObj: $ElementType<SaveState, "queue">) {
   return (
     queueObj.skeleton.length +
-    _.sum(Object.keys(queueObj.volumes).map(volumeKey => queueObj.volumes[volumeKey].length))
+    _.sum(
+      Utils.values(queueObj.volumes).map(
+        (volumeQueue: Array<SaveQueueEntry>) => volumeQueue.length,
+      ),
+    )
   );
 }
 

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.js
@@ -490,8 +490,7 @@ export function getOrCreateTree(
 
 export function ensureTreeNames(state: OxalisState, trees: MutableTreeMap) {
   // Assign a new tree name for trees without a name
-  // $FlowIssue[incompatible-type] remove once https://github.com/facebook/flow/issues/2221 is fixed
-  for (const tree: MutableTree of Object.values(trees)) {
+  for (const tree of Utils.values(trees)) {
     if (tree.name === "") {
       tree.name = generateTreeName(state, tree.timestamp, tree.treeId);
     }
@@ -594,7 +593,6 @@ export function deleteTree(
   if (_.size(newTrees) > 0) {
     // Setting the tree active whose id is the next highest compared to the id of the deleted tree.
     newActiveTreeId = getNearestTreeId(tree.treeId, newTrees);
-    // Object.keys returns strings and the newActiveNodeId should be an integer
     newActiveNodeId = +_.first(Array.from(newTrees[newActiveTreeId].nodes.keys())) || null;
   }
   const newMaxNodeId = getMaximumNodeId(newTrees);

--- a/frontend/javascripts/oxalis/view/action-bar/save_button.js
+++ b/frontend/javascripts/oxalis/view/action-bar/save_button.js
@@ -17,6 +17,7 @@ import {
   LoadingOutlined,
 } from "@ant-design/icons";
 import ErrorHandling from "libs/error_handling";
+import { values } from "libs/utils";
 
 type OwnProps = {|
   onClick: (SyntheticInputEvent<HTMLButtonElement>) => Promise<*>,
@@ -133,8 +134,7 @@ function getOldestUnsavedTimestamp(saveQueue): ?number {
   if (saveQueue.skeleton.length > 0) {
     oldestUnsavedTimestamp = saveQueue.skeleton[0].timestamp;
   }
-  for (const volumeQueueKey of Object.keys(saveQueue.volumes)) {
-    const volumeQueue = saveQueue.volumes[volumeQueueKey];
+  for (const volumeQueue of values(saveQueue.volumes)) {
     if (volumeQueue.length > 0) {
       const oldestVolumeTimestamp = volumeQueue[0].timestamp;
       oldestUnsavedTimestamp = Math.min(

--- a/frontend/javascripts/test/geometries/skeleton.spec.js
+++ b/frontend/javascripts/test/geometries/skeleton.spec.js
@@ -49,7 +49,7 @@ test.before(t => {
   getSkeletonTracing(Store.getState().tracing).map(skeletonTracing => {
     const trees = skeletonTracing.trees;
     t.is(_.size(trees), 20);
-    for (const tree of Object.values(trees)) {
+    for (const tree of Utils.values(trees)) {
       t.is(tree.nodes.size(), 100);
     }
   });
@@ -75,7 +75,7 @@ test.serial("Skeleton should initialize correctly using the store's state", t =>
     const edgeTreeIds = [];
     let treeColors = [0, 0, 0, 0]; // tree ids start at index 1 so add one bogus RGB value
 
-    for (const tree of Object.values(trees)) {
+    for (const tree of Utils.values(trees)) {
       treeColors = treeColors.concat(skeleton.getTreeRGBA(tree.color, tree.isVisible));
       for (const node of Array.from(tree.nodes.values())) {
         nodePositions = nodePositions.concat(node.position);


### PR DESCRIPTION
- Includes some cleanup (review first commit separately to have an isolated look)
  - I was annoyed that because flow returns mixed for Object.values, we often had to add $FlowIssue comments, or worse, adapted the code to work around that by using Object.keys, converting the key to int and then mapping to get the values. I introduced `Utils.values` which returns the correct type and should be the only spot where the $FlowIssue comment is needed.
  - A couple of times I specified the type if the values were mapped, afterwards, which is a separate issue, since mapping `Array<number>` will lead to flow assuming a type of `number | any` for the mapped value argument :shrug: I did not systematically look for these occurrences, but I assume there are quite a few in our code, leading to less type security.
- 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [ ] Ready for review
