### PR TITLE
Add option to change active segement

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/22.02.0...HEAD)
 
 ### Added
+- Added the option to make a segment's ID active via the right-click context menu in the segments list. [#5935](https://github.com/scalableminds/webknossos/pull/6006)
 - Added a button next to the histogram which adapts the contrast and brightness to the currently visible data. [#5961](https://github.com/scalableminds/webknossos/pull/5961)
 - Running uploads can now be cancelled. [#5958](https://github.com/scalableminds/webknossos/pull/5958)
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
@@ -105,15 +105,14 @@ const getMakeSegmentActiveMenuItem = (
   setActiveCell,
   activeCellId,
   andCloseContextMenu,
-) => { 
+) => {
   const disabled = segment.id === activeCellId;
-  const title = disabled ? "This segment ID is already active."
-   : "Make this the active segment ID.";
+  const title = disabled
+    ? "This segment ID is already active."
+    : "Make this the active segment ID.";
   return (
     <Menu.Item
-      onClick={() =>
-        andCloseContextMenu(setActiveCell(segment.id, segment.somePosition))
-      }
+      onClick={() => andCloseContextMenu(setActiveCell(segment.id, segment.somePosition))}
       disabled={disabled}
     >
       <Tooltip title={title}>Make Segment Active</Tooltip>
@@ -198,12 +197,7 @@ function _SegmentListItem({
         visibleSegmentationLayer != null,
         andCloseContextMenu,
       )}
-      {getMakeSegmentActiveMenuItem(
-        segment,
-        setActiveCell,
-        activeCellId,
-        andCloseContextMenu,
-      )}
+      {getMakeSegmentActiveMenuItem(segment, setActiveCell, activeCellId, andCloseContextMenu)}
     </Menu>
   );
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
@@ -100,6 +100,27 @@ const getComputeMeshAdHocMenuItem = (
   );
 };
 
+const getMakeSegmentActiveMenuItem = (
+  segment,
+  setActiveCell,
+  activeCellId,
+  andCloseContextMenu,
+) => { 
+  const disabled = segment.id === activeCellId;
+  const title = disabled ? "This segment ID is already active."
+   : "Make this the active segment ID.";
+  return (
+    <Menu.Item
+      onClick={() =>
+        andCloseContextMenu(setActiveCell(segment.id, segment.somePosition))
+      }
+      disabled={disabled}
+    >
+      <Tooltip title={title}>Make Segment Active</Tooltip>
+    </Menu.Item>
+  );
+};
+
 type Props = {
   segment: Segment,
   mapId: number => number,
@@ -117,6 +138,7 @@ type Props = {
   onSelectSegment: Segment => void,
   visibleSegmentationLayer: ?APISegmentationLayer,
   changeActiveIsosurfaceId: (?number, Vector3, boolean) => void,
+  setActiveCell: (number, somePosition?: Vector3) => void,
   isosurface: ?IsosurfaceInformation,
   setPosition: (Vector3, boolean) => void,
   loadPrecomputedMeshForSegment: Segment => Promise<void>,
@@ -149,6 +171,7 @@ function _SegmentListItem({
   onSelectSegment,
   visibleSegmentationLayer,
   changeActiveIsosurfaceId,
+  setActiveCell,
   isosurface,
   setPosition,
   loadPrecomputedMeshForSegment,
@@ -173,6 +196,12 @@ function _SegmentListItem({
         segment,
         changeActiveIsosurfaceId,
         visibleSegmentationLayer != null,
+        andCloseContextMenu,
+      )}
+      {getMakeSegmentActiveMenuItem(
+        segment,
+        setActiveCell,
+        activeCellId,
         andCloseContextMenu,
       )}
     </Menu>

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.js
@@ -115,7 +115,7 @@ const getMakeSegmentActiveMenuItem = (
       onClick={() => andCloseContextMenu(setActiveCell(segment.id, segment.somePosition))}
       disabled={disabled}
     >
-      <Tooltip title={title}>Make Segment Active</Tooltip>
+      <Tooltip title={title}>Activate Segment ID</Tooltip>
     </Menu.Item>
   );
 };

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.js
@@ -44,7 +44,7 @@ import {
   updateDatasetSettingAction,
   updateTemporarySettingAction,
 } from "oxalis/model/actions/settings_actions";
-import { updateSegmentAction } from "oxalis/model/actions/volumetracing_actions";
+import { updateSegmentAction, setActiveCellAction } from "oxalis/model/actions/volumetracing_actions";
 import DataLayer from "oxalis/model/data_layer";
 import DomVisibilityObserver from "oxalis/view/components/dom_visibility_observer";
 import Model from "oxalis/model";
@@ -163,6 +163,9 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): * => ({
       return;
     }
     dispatch(changeActiveIsosurfaceCellAction(cellId, seedPosition, shouldReload));
+  },
+  setActiveCell(segmentId: number, somePosition?: Vector3) {
+    dispatch(setActiveCellAction(segmentId, somePosition));
   },
   setCurrentMeshFile(layerName: string, fileName: string) {
     dispatch(updateCurrentMeshFileAction(layerName, fileName));

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.js
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.js
@@ -44,7 +44,10 @@ import {
   updateDatasetSettingAction,
   updateTemporarySettingAction,
 } from "oxalis/model/actions/settings_actions";
-import { updateSegmentAction, setActiveCellAction } from "oxalis/model/actions/volumetracing_actions";
+import {
+  updateSegmentAction,
+  setActiveCellAction,
+} from "oxalis/model/actions/volumetracing_actions";
 import DataLayer from "oxalis/model/data_layer";
 import DomVisibilityObserver from "oxalis/view/components/dom_visibility_observer";
 import Model from "oxalis/model";


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- use brush tool
- create multiple segments
- open the segments tab
- the right-click context menu for each segment now gives an option to make the segment ID active
- the context menu item should be disabled if the segment ID is already acive (has the brush icon)

### Issues:
- fixes #5935 

------
(Please delete unneeded items, merge only when none are left open)
- [✓] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [✓] Ready for review
