### PR TITLE
use allDataBlocking and temporary files for explorative download

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed volume-related bugs which could corrupt the volume data in certain scenarios. [#5955](https://github.com/scalableminds/webknossos/pull/5955)
 - Fixed the placeholder resolution computation for anisotropic layers with missing base resolutions. [#5983](https://github.com/scalableminds/webknossos/pull/5983)
 - Fixed a bug where ad-hoc meshes were computed for a mapping, although it was disabled. [#5982](https://github.com/scalableminds/webknossos/pull/5982)
+- Fixed a bug where volume annotation downloads would sometimes contain truncated zips. [#6009](https://github.com/scalableminds/webknossos/pull/6009)
 
 
 ### Removed

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -275,7 +275,6 @@ Expects:
           tracingStoreClient.getSkeletonTracing(_, skeletonVersion))
         user <- userService.findOneById(annotation._user, useCache = true)
         taskOpt <- Fox.runOptional(annotation._task)(taskDAO.findOne)
-        nmlTemporaryFile = temporaryFileCreator.create()
         nmlStream = nmlWriter.toNmlStream(fetchedAnnotationLayers,
                                           Some(annotation),
                                           dataSet.scale,
@@ -283,6 +282,7 @@ Expects:
                                           organizationName,
                                           Some(user),
                                           taskOpt)
+        nmlTemporaryFile = temporaryFileCreator.create()
         temporaryFileStream = new BufferedOutputStream(new FileOutputStream(nmlTemporaryFile))
         _ <- NamedEnumeratorStream("", nmlStream).writeTo(temporaryFileStream)
         _ = temporaryFileStream.close()

--- a/app/models/annotation/WKRemoteTracingStoreClient.scala
+++ b/app/models/annotation/WKRemoteTracingStoreClient.scala
@@ -176,10 +176,10 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
         .addQueryStringOptional("version", version.map(_.toString))
         .getWithProtoResponse[VolumeTracing](VolumeTracing)
       data <- Fox.runIf(!skipVolumeData) {
-        rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allData")
+        rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataBlocking")
           .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
           .addQueryStringOptional("version", version.map(_.toString))
-          .getStream
+          .getWithBytesResponse
       }
       fetchedAnnotationLayer <- FetchedAnnotationLayer.fromAnnotationLayer(annotationLayer, Right(tracing), data)
     } yield fetchedAnnotationLayer

--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -197,6 +197,7 @@ class NmlWriter @Inject()(implicit ec: ExecutionContext) extends FoxImplicits {
     Xml.withinElementSync("volume") {
       writer.writeAttribute("id", index.toString)
       writer.writeAttribute("location", volumeFilename.getOrElse(volumeLayer.volumeDataZipName(index, isSingle)))
+      volumeLayer.name.foreach(_ => writer.writeAttribute("name", _))
       volumeLayer.tracing match {
         case Right(volumeTracing) => volumeTracing.fallbackLayer.foreach(writer.writeAttribute("fallbackLayer", _))
         case _                    => ()

--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -197,7 +197,7 @@ class NmlWriter @Inject()(implicit ec: ExecutionContext) extends FoxImplicits {
     Xml.withinElementSync("volume") {
       writer.writeAttribute("id", index.toString)
       writer.writeAttribute("location", volumeFilename.getOrElse(volumeLayer.volumeDataZipName(index, isSingle)))
-      volumeLayer.name.foreach(_ => writer.writeAttribute("name", _))
+      volumeLayer.name.foreach(n => writer.writeAttribute("name", n))
       volumeLayer.tracing match {
         case Right(volumeTracing) => volumeTracing.fallbackLayer.foreach(writer.writeAttribute("fallbackLayer", _))
         case _                    => ()

--- a/util/src/main/scala/com/scalableminds/util/io/FileIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/FileIO.scala
@@ -24,11 +24,11 @@ trait NamedStream {
 }
 
 case class NamedFunctionStream(name: String, writer: OutputStream => Future[Unit]) extends NamedStream {
-  def writeTo(out: OutputStream)(implicit ec: ExecutionContext) = writer(out)
+  def writeTo(out: OutputStream)(implicit ec: ExecutionContext): Future[Unit] = writer(out)
 }
 
 case class NamedEnumeratorStream(name: String, enumerator: Enumerator[Array[Byte]]) extends NamedStream {
-  def writeTo(out: OutputStream)(implicit ec: ExecutionContext) = {
+  def writeTo(out: OutputStream)(implicit ec: ExecutionContext): Future[Unit] = {
     val iteratee = Iteratee.foreach[Array[Byte]] { bytes =>
       out.write(bytes)
     }

--- a/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
@@ -59,9 +59,13 @@ object ZipIO extends LazyLogging {
     }
 
     def addFileFromEnumerator(name: String, data: Enumerator[Array[Byte]])(
+        implicit ec: ExecutionContext): Future[Unit] =
+      addFileFromNamedEnumerator(NamedEnumeratorStream(name, data))
+
+    def addFileFromNamedEnumerator(namedEnumerator: NamedEnumeratorStream)(
         implicit ec: ExecutionContext): Future[Unit] = {
-      stream.putNextEntry(new ZipEntry(name))
-      NamedEnumeratorStream("", data).writeTo(stream).map(_ => stream.closeEntry())
+      stream.putNextEntry(new ZipEntry(namedEnumerator.name))
+      namedEnumerator.writeTo(stream).map(_ => stream.closeEntry())
     }
 
     /**


### PR DESCRIPTION
Changing the wk-backend-side handling of downloading single annotations (tasks + exploratives, not compound): ditching the stream forwarding in favor of what has proven stable for compound annotations already (see #3959). A negative side effect could be slightly longer response times, since the file is only served after it is completely written. Though if prevents the dataloss we sometimes saw previously, I think it is worth it.

### URL of deployed dev instance (used for testing):
- https://volumedownloadblocking.webknossos.xyz

### Steps to test:
- create annotations + download them, check for expected content
  - skeleton-only
  - hybrid with one volume layer
  - hybrid with multiple volume layers

### Issues:
- possible fix for #5684 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
