### PR TITLE
For empty volume tracings, serve header-only zip

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The front-end API `labelVoxels` returns a promise now which fulfills as soon as the label operation was carried out. [#5955](https://github.com/scalableminds/webknossos/pull/5955)
 - When changing which layers are visible in an annotation, this setting is persisted in the annotation, so when you share it, viewers will see the same visibility configuration. [#5967](https://github.com/scalableminds/webknossos/pull/5967)
 - Downloading public annotations is now also allowed without being authenticated. [#6001](https://github.com/scalableminds/webknossos/pull/6001)
+- Downloaded volume annotation layers no longer produce zero-byte zipfiles but rather a valid header-only zip file with no contents. [#6022](https://github.com/scalableminds/webknossos/pull/6022)
 
 ### Fixed
 - Fixed volume-related bugs which could corrupt the volume data in certain scenarios. [#5955](https://github.com/scalableminds/webknossos/pull/5955)

--- a/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
@@ -93,17 +93,20 @@ object ZipIO extends LazyLogging {
   def zip(sources: List[NamedStream], out: OutputStream)(implicit ec: ExecutionContext): Future[Unit] =
     zip(sources.toIterator, out)
 
-  def zip(sources: Iterator[NamedStream], out: OutputStream)(implicit ec: ExecutionContext): Future[Unit] =
+  def zip(sources: Iterator[NamedStream], out: OutputStream)(implicit ec: ExecutionContext): Future[Unit] = {
+    val zip = startZip(out)
     if (sources.nonEmpty) {
-      val zip = startZip(out)
       for {
         _ <- zipIterator(sources, zip)
         _ = zip.close()
+        _ = out.close()
       } yield ()
     } else {
+      zip.close()
       out.close()
       Future.successful(())
     }
+  }
 
   private def zipIterator(sources: Iterator[NamedStream], zip: OpenZip)(implicit ec: ExecutionContext): Future[Unit] =
     if (!sources.hasNext) {


### PR DESCRIPTION
Before this, empty volume tracings (i.e. never brushed) resulted in zero-bytes data.zip files.
Now we create a 22-byte header-only “empty zip” file.

### URL of deployed dev instance (used for testing):
- https://emptyzip.webknossos.xyz

### Steps to test:
- click “create annotation” for a dataset
- do not brush, select“download”
- resulting zip should contain a data_Volume.zip file that can be opened as a zipfile (but does not have any contents)

### Issues:
- fixes #6015 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
