### PR TITLE
Allow uploading multi-layer volume annotations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added the option to make a segment's ID active via the right-click context menu in the segments list. [#5935](https://github.com/scalableminds/webknossos/pull/6006)
 - Added a button next to the histogram which adapts the contrast and brightness to the currently visible data. [#5961](https://github.com/scalableminds/webknossos/pull/5961)
 - Running uploads can now be cancelled. [#5958](https://github.com/scalableminds/webknossos/pull/5958)
-- Annotations with multiple volume layers can now be uploaded. [#6028](https://github.com/scalableminds/webknossos/pull/6028)
+- Annotations with multiple volume layers can now be uploaded. (Note that merging multiple annotations with multiple volume layers each is not supported.) [#6028](https://github.com/scalableminds/webknossos/pull/6028)
 
 ### Changed
 - Upgraded webpack build tool to v5 and all other webpack related dependencies to their latest version. Enabled persistent caching which speeds up server restarts during development as well as production builds. [#5969](https://github.com/scalableminds/webknossos/pull/5969)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added the option to make a segment's ID active via the right-click context menu in the segments list. [#5935](https://github.com/scalableminds/webknossos/pull/6006)
 - Added a button next to the histogram which adapts the contrast and brightness to the currently visible data. [#5961](https://github.com/scalableminds/webknossos/pull/5961)
 - Running uploads can now be cancelled. [#5958](https://github.com/scalableminds/webknossos/pull/5958)
+- Annotations with multiple volume layers can now be uploaded. [#6028](https://github.com/scalableminds/webknossos/pull/6028)
 
 ### Changed
 - Upgraded webpack build tool to v5 and all other webpack related dependencies to their latest version. Enabled persistent caching which speeds up server restarts during development as well as production builds. [#5969](https://github.com/scalableminds/webknossos/pull/5969)
@@ -30,6 +31,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed the placeholder resolution computation for anisotropic layers with missing base resolutions. [#5983](https://github.com/scalableminds/webknossos/pull/5983)
 - Fixed a bug where ad-hoc meshes were computed for a mapping, although it was disabled. [#5982](https://github.com/scalableminds/webknossos/pull/5982)
 - Fixed a bug where volume annotation downloads would sometimes contain truncated zips. [#6009](https://github.com/scalableminds/webknossos/pull/6009)
+- Fixed a bug where downloaded multi-layer volume annotations would have the wrong data.zip filenames. [#6028](https://github.com/scalableminds/webknossos/pull/6028)
 
 
 ### Removed

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -69,7 +69,10 @@ class AnnotationIOController @Inject()(
     value =
       """Upload NML(s) or ZIP(s) of NML(s) to create a new explorative annotation.
 Expects:
- - As file attachment: any number of NML files or ZIP files containing NMLs, optionally with volume data ZIPs referenced from an NML in a ZIP
+ - As file attachment:
+    - Any number of NML files or ZIP files containing NMLs, optionally with volume data ZIPs referenced from an NML in a ZIP
+    - If multiple annotations are uploaded, they are merged into one.
+       - This is not supported if any of the annotations has multiple volume layers.
  - As form parameter: createGroupForEachFile [String] should be one of "true" or "false"
    - If "true": in merged annotation, create tree group wrapping the trees of each file
    - If "false": in merged annotation, rename trees with the respective file name as prefix""",
@@ -106,6 +109,8 @@ Expects:
             description = descriptionForNMLs(parseResultsFiltered.map(_.description))
             _ <- assertNonEmpty(parseSuccesses)
             skeletonTracings = parseSuccesses.flatMap(_.skeletonTracing)
+            // Create a list of volume layers for each uploaded (non-skeleton-only) annotation.
+            // This is what determines the merging strategy for volume layers
             volumeLayersGroupedRaw = parseSuccesses.map(_.volumeLayers).filter(_.nonEmpty)
             dataSet <- findDataSetForUploadedAnnotations(skeletonTracings,
                                                          volumeLayersGroupedRaw.flatten.map(_.tracing))

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -11,7 +11,11 @@ import com.scalableminds.util.tools.{Fox, FoxImplicits, TextUtils}
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, SkeletonTracingOpt, SkeletonTracings}
 import com.scalableminds.webknossos.datastore.VolumeTracing.{VolumeTracing, VolumeTracingOpt, VolumeTracings}
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryImplicits
-import com.scalableminds.webknossos.datastore.models.datasource.{AbstractSegmentationLayer, SegmentationLayer}
+import com.scalableminds.webknossos.datastore.models.datasource.{
+  AbstractSegmentationLayer,
+  GenericDataSource,
+  SegmentationLayer
+}
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeTracingDefaults
 import com.typesafe.scalalogging.LazyLogging
@@ -20,8 +24,8 @@ import javax.inject.Inject
 import models.analytics.{AnalyticsService, DownloadAnnotationEvent, UploadAnnotationEvent}
 import models.annotation.AnnotationState._
 import models.annotation._
-import models.annotation.nml.NmlResults.NmlParseResult
-import models.annotation.nml.{NmlResults, NmlService, NmlWriter}
+import models.annotation.nml.NmlResults.{NmlParseResult, NmlParseSuccess}
+import models.annotation.nml.{NmlResults, NmlWriter}
 import models.binary.{DataSet, DataSetDAO, DataSetService}
 import models.organization.OrganizationDAO
 import models.project.ProjectDAO
@@ -53,7 +57,7 @@ class AnnotationIOController @Inject()(
     analyticsService: AnalyticsService,
     sil: Silhouette[WkEnv],
     provider: AnnotationInformationProvider,
-    nmlService: NmlService)(implicit ec: ExecutionContext, val materializer: Materializer)
+    annotationUploadService: AnnotationUploadService)(implicit ec: ExecutionContext, val materializer: Materializer)
     extends Controller
     with FoxImplicits
     with ProtoGeometryImplicits
@@ -64,7 +68,7 @@ class AnnotationIOController @Inject()(
     value =
       """Upload NML(s) or ZIP(s) of NML(s) to create a new explorative annotation.
 Expects:
- - As file attachment: any number of NML files or ZIP files containing NMLs, optionally with at most one volume data ZIP referenced from an NML in a ZIP
+ - As file attachment: any number of NML files or ZIP files containing NMLs, optionally with volume data ZIPs referenced from an NML in a ZIP
  - As form parameter: createGroupForEachFile [String] should be one of "true" or "false"
    - If "true": in merged annotation, create tree group wrapping the trees of each file
    - If "false": in merged annotation, rename trees with the respective file name as prefix""",
@@ -86,42 +90,33 @@ Expects:
         val overwritingDataSetName: Option[String] =
           request.body.dataParts.get("datasetName").flatMap(_.headOption)
         val attachedFiles = request.body.files.map(f => (f.ref.path.toFile, f.filename))
-        val parsedFiles = nmlService.extractFromFiles(attachedFiles, useZipName = true, overwritingDataSetName)
-        val tracingsProcessed = nmlService.wrapOrPrefixTrees(parsedFiles.parseResults, shouldCreateGroupForEachFile)
+        val parsedFiles =
+          annotationUploadService.extractFromFiles(attachedFiles, useZipName = true, overwritingDataSetName)
+        val parsedFilesWraped =
+          annotationUploadService.wrapOrPrefixTrees(parsedFiles.parseResults, shouldCreateGroupForEachFile)
+        val parseResultsFiltered: List[NmlParseResult] = parsedFilesWraped.filter(_.succeeded)
 
-        val parseSuccesses: List[NmlParseResult] = tracingsProcessed.filter(_.succeeded)
-
-        if (parseSuccesses.isEmpty) {
+        if (parseResultsFiltered.isEmpty) {
           returnError(parsedFiles)
         } else {
-          val (skeletonTracings, volumeTracingsWithDataLocations) = extractTracings(parseSuccesses)
-          val name = nameForUploaded(parseSuccesses.map(_.fileName))
-          val description = descriptionForNMLs(parseSuccesses.map(_.description))
-
           for {
-            _ <- bool2Fox(skeletonTracings.nonEmpty || volumeTracingsWithDataLocations.nonEmpty) ?~> "nml.file.noFile"
-            dataSet <- findDataSetForUploadedAnnotations(skeletonTracings, volumeTracingsWithDataLocations.map(_._1))
+            parseSuccesses <- Fox.serialCombined(parseResultsFiltered)(r => r.toSuccessBox)
+            name = nameForUploaded(parseResultsFiltered.map(_.fileName))
+            description = descriptionForNMLs(parseResultsFiltered.map(_.description))
+            _ <- assertNonEmpty(parseSuccesses)
+            skeletonTracings = parseSuccesses.flatMap(_.skeletonTracing)
+            volumeLayersGroupedRaw = parseSuccesses.map(_.volumeLayers).filter(_.nonEmpty)
+            dataSet <- findDataSetForUploadedAnnotations(skeletonTracings,
+                                                         volumeLayersGroupedRaw.flatten.map(_.tracing))
+            volumeLayersGrouped <- adaptVolumeTracingsToFallbackLayer(volumeLayersGroupedRaw, dataSet)
             tracingStoreClient <- tracingStoreService.clientFor(dataSet)
-            mergedVolumeTracingIdOpt <- Fox.runOptional(volumeTracingsWithDataLocations.headOption) { _ =>
-              for {
-                volumeTracingsAdapted <- Fox.serialCombined(volumeTracingsWithDataLocations)(v =>
-                  adaptPropertiesToFallbackLayer(v._1, dataSet))
-                mergedIdOpt <- tracingStoreClient.mergeVolumeTracingsByContents(
-                  VolumeTracings(volumeTracingsAdapted.map(v => VolumeTracingOpt(Some(v)))),
-                  volumeTracingsWithDataLocations.map(t => parsedFiles.otherFiles.get(t._2).map(_.path.toFile)),
-                  persistTracing = true
-                )
-              } yield mergedIdOpt
-            }
-            mergedSkeletonTracingIdOpt <- Fox.runOptional(skeletonTracings.headOption) { _ =>
-              tracingStoreClient.mergeSkeletonTracingsByContents(
-                SkeletonTracings(skeletonTracings.map(t => SkeletonTracingOpt(Some(t)))),
-                persistTracing = true)
-            }
-            annotationLayers <- AnnotationLayer.layersFromIds(mergedSkeletonTracingIdOpt, mergedVolumeTracingIdOpt)
+            mergedVolumeLayers <- mergeAndSaveVolumeLayers(volumeLayersGrouped,
+                                                           tracingStoreClient,
+                                                           parsedFiles.otherFiles)
+            mergedSkeletonLayers <- mergeAndSaveSkeletonLayers(skeletonTracings, tracingStoreClient)
             annotation <- annotationService.createFrom(request.identity,
                                                        dataSet,
-                                                       annotationLayers,
+                                                       mergedSkeletonLayers ::: mergedVolumeLayers,
                                                        AnnotationType.Explorational,
                                                        name,
                                                        description)
@@ -134,6 +129,56 @@ Expects:
         }
       }
   }
+
+  private def mergeAndSaveVolumeLayers(volumeLayersGrouped: Seq[List[UploadedVolumeLayer]],
+                                       client: WKRemoteTracingStoreClient,
+                                       otherFiles: Map[String, TemporaryFile]): Fox[List[AnnotationLayer]] = {
+    if (volumeLayersGrouped.isEmpty) return Fox.successful(List())
+    if (volumeLayersGrouped.length > 1 && volumeLayersGrouped.exists(_.length > 1))
+      return Fox.failure("Cannot merge multiple annotations that each have multiple volume layers.")
+    if (volumeLayersGrouped.length == 1) { // Just one annotation was uploaded, keep its layers separate
+      Fox.serialCombined(volumeLayersGrouped.toList.flatten) { uploadedVolumeLayer =>
+        val dataZipFile = otherFiles.get(uploadedVolumeLayer.dataZipLocation).map(_.path.toFile)
+        for {
+          savedTracingId <- client.saveVolumeTracing(uploadedVolumeLayer.tracing,
+                                                     uploadedVolumeLayer.getDataZipFrom(otherFiles))
+        } yield
+          AnnotationLayer(
+            savedTracingId,
+            AnnotationLayerType.Volume,
+            uploadedVolumeLayer.name
+          )
+      }
+    } else { // Multiple annotations with volume layers (but at most one each) was uploaded merge those volume layers into one
+      val uploadedVolumeLayersFlat = volumeLayersGrouped.toList.flatten
+      for {
+        mergedTracingId <- client.mergeVolumeTracingsByContents(
+          VolumeTracings(uploadedVolumeLayersFlat.map(v => VolumeTracingOpt(Some(v.tracing)))),
+          uploadedVolumeLayersFlat.map(v => v.getDataZipFrom(otherFiles)),
+          persistTracing = true
+        )
+      } yield
+        List(
+          AnnotationLayer(
+            mergedTracingId,
+            AnnotationLayerType.Volume,
+            None
+          ))
+    }
+  }
+
+  private def mergeAndSaveSkeletonLayers(skeletonTracings: List[SkeletonTracing],
+                                         tracingStoreClient: WKRemoteTracingStoreClient): Fox[List[AnnotationLayer]] = {
+    if (skeletonTracings.isEmpty) return Fox.successful(List())
+    for {
+      mergedTracingId <- tracingStoreClient.mergeSkeletonTracingsByContents(
+        SkeletonTracings(skeletonTracings.map(t => SkeletonTracingOpt(Some(t)))),
+        persistTracing = true)
+    } yield List(AnnotationLayer(mergedTracingId, AnnotationLayerType.Skeleton, None))
+  }
+
+  private def assertNonEmpty(parseSuccesses: List[NmlParseSuccess]) =
+    bool2Fox(parseSuccesses.exists(p => p.skeletonTracing.nonEmpty || p.volumeLayers.nonEmpty)) ?~> "nml.file.noFile"
 
   private def findDataSetForUploadedAnnotations(
       skeletonTracings: List[SkeletonTracing],
@@ -173,14 +218,6 @@ Expects:
       Future.successful(JsonBadRequest(Messages("nml.file.noFile")))
     }
 
-  private def extractTracings(
-      parseSuccesses: List[NmlParseResult]): (List[SkeletonTracing], List[(VolumeTracing, String)]) = {
-    val tracings = parseSuccesses.flatMap(_.bothTracingOpts)
-    val skeletons = tracings.flatMap(_._1)
-    val volumes = tracings.flatMap(_._2)
-    (skeletons, volumes)
-  }
-
   private def assertAllOnSameDataSet(skeletons: List[SkeletonTracing], volumes: List[VolumeTracing]): Fox[String] =
     for {
       dataSetName <- volumes.headOption.map(_.dataSetName).orElse(skeletons.headOption.map(_.dataSetName)).toFox
@@ -197,9 +234,23 @@ Expects:
     } yield organizationNames.headOption
   }
 
-  private def adaptPropertiesToFallbackLayer(volumeTracing: VolumeTracing, dataSet: DataSet): Fox[VolumeTracing] =
+  private def adaptVolumeTracingsToFallbackLayer(volumeLayersGrouped: List[List[UploadedVolumeLayer]],
+                                                 dataSet: DataSet): Fox[List[List[UploadedVolumeLayer]]] =
     for {
       dataSource <- dataSetService.dataSourceFor(dataSet).flatMap(_.toUsable)
+      allAdapted <- Fox.serialCombined(volumeLayersGrouped) { volumeLayers =>
+        Fox.serialCombined(volumeLayers) { volumeLayer =>
+          for {
+            tracingAdapted <- adaptPropertiesToFallbackLayer(volumeLayer.tracing, dataSource)
+          } yield volumeLayer.copy(tracing = tracingAdapted)
+        }
+      }
+    } yield allAdapted
+
+  private def adaptPropertiesToFallbackLayer[T](volumeTracing: VolumeTracing,
+                                                dataSource: GenericDataSource[T]): Fox[VolumeTracing] =
+    for {
+      _ <- Fox.successful(())
       fallbackLayer = dataSource.dataLayers.flatMap {
         case layer: SegmentationLayer if volumeTracing.fallbackLayer contains layer.name         => Some(layer)
         case layer: AbstractSegmentationLayer if volumeTracing.fallbackLayer contains layer.name => Some(layer)

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -19,9 +19,8 @@ import io.swagger.annotations.{
   ApiResponses
 }
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.{AnnotationUploadService, _}
 import models.annotation.nml.NmlResults.TracingBoxContainer
-import models.annotation.nml.NmlService
 import models.project.ProjectDAO
 import models.task._
 import models.user._
@@ -42,7 +41,7 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
                                userService: UserService,
                                taskDAO: TaskDAO,
                                taskService: TaskService,
-                               nmlService: NmlService,
+                               nmlService: AnnotationUploadService,
                                sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller
     with ResultBox

--- a/app/models/annotation/AnnotationUploadService.scala
+++ b/app/models/annotation/AnnotationUploadService.scala
@@ -38,8 +38,8 @@ class AnnotationUploadService @Inject()(temporaryFileCreator: TemporaryFileCreat
                      isTaskUpload: Boolean,
                      basePath: Option[String] = None)(implicit m: MessagesProvider): NmlParseResult =
     NmlParser.parse(name, inputStream, overwritingDataSetName, isTaskUpload, basePath) match {
-      case Full((skeletonTracing, volumeTracingsWithDataLocations, description)) =>
-        NmlParseSuccess(name, skeletonTracing, volumeTracingsWithDataLocations, description)
+      case Full((skeletonTracing, uploadedVolumeLayers, description)) =>
+        NmlParseSuccess(name, skeletonTracing, uploadedVolumeLayers, description)
       case Failure(msg, _, chain) => NmlParseFailure(name, msg + chain.map(_ => formatChain(chain)).getOrElse(""))
       case Empty                  => NmlParseEmpty(name)
     }
@@ -82,8 +82,8 @@ class AnnotationUploadService @Inject()(temporaryFileCreator: TemporaryFileCreat
 
     if (parseResults.length > 1) {
       parseResults.map {
-        case NmlParseSuccess(name, Some(skeletonTracing), volumeTracingsWithDataLocations, description) =>
-          NmlParseSuccess(name, Some(renameTrees(name, skeletonTracing)), volumeTracingsWithDataLocations, description)
+        case NmlParseSuccess(name, Some(skeletonTracing), uploadedVolumeLayers, description) =>
+          NmlParseSuccess(name, Some(renameTrees(name, skeletonTracing)), uploadedVolumeLayers, description)
         case r => r
       }
     } else {
@@ -104,11 +104,8 @@ class AnnotationUploadService @Inject()(temporaryFileCreator: TemporaryFileCreat
     }
 
     parseResults.map {
-      case NmlParseSuccess(name, Some(skeletonTracing), volumeTracingsWithDataLocations, description) =>
-        NmlParseSuccess(name,
-                        Some(wrapTreesInGroup(name, skeletonTracing)),
-                        volumeTracingsWithDataLocations,
-                        description)
+      case NmlParseSuccess(name, Some(skeletonTracing), uploadedVolumeLayers, description) =>
+        NmlParseSuccess(name, Some(wrapTreesInGroup(name, skeletonTracing)), uploadedVolumeLayers, description)
       case r => r
     }
   }

--- a/app/models/annotation/nml/NmlVolumeTag.scala
+++ b/app/models/annotation/nml/NmlVolumeTag.scala
@@ -1,0 +1,3 @@
+package models.annotation.nml
+
+case class NmlVolumeTag(dataZipPath: String, fallbackLayerName: Option[String], name: Option[String]) {}

--- a/test/backend/NMLUnitTestSuite.scala
+++ b/test/backend/NMLUnitTestSuite.scala
@@ -3,9 +3,8 @@ package backend
 import java.io.ByteArrayInputStream
 
 import com.scalableminds.webknossos.datastore.SkeletonTracing._
-import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
-import models.annotation.FetchedAnnotationLayer
 import models.annotation.nml.{NmlParser, NmlWriter}
+import models.annotation.{FetchedAnnotationLayer, UploadedVolumeLayer}
 import net.liftweb.common.{Box, Full}
 import org.scalatestplus.play.PlaySpec
 import play.api.i18n.{DefaultMessagesApi, Messages, MessagesProvider}
@@ -23,7 +22,7 @@ class NMLUnitTestSuite extends PlaySpec {
   }
 
   def writeAndParseTracing(skeletonTracing: SkeletonTracing)
-    : Box[(Option[SkeletonTracing], Option[(VolumeTracing, String)], String)] = {
+    : Box[(Option[SkeletonTracing], List[UploadedVolumeLayer], String)] = {
     val annotationLayers = List(FetchedAnnotationLayer("dummySkeletonTracingId", None, Left(skeletonTracing), None))
     val nmlEnumarator =
       new NmlWriter().toNmlStream(annotationLayers, None, None, None, "testOrganization", None, None)
@@ -33,7 +32,7 @@ class NMLUnitTestSuite extends PlaySpec {
   }
 
   def isParseSuccessful(
-      parsedTracing: Box[(Option[SkeletonTracing], Option[(VolumeTracing, String)], String)]): Boolean =
+      parsedTracing: Box[(Option[SkeletonTracing], List[UploadedVolumeLayer], String)]): Boolean =
     parsedTracing match {
       case Full(tuple) =>
         tuple match {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Volume.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Volume.scala
@@ -1,3 +1,0 @@
-package com.scalableminds.webknossos.tracingstore.tracings.volume
-
-case class Volume(location: String, fallbackLayer: Option[String])


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://uploadmultilayervolumes.webknossos.xyz

### Steps to test:
- Create volume annotation, add second layer in left sidebar, name the layers, brush different content
- download the annotation, reupload, should look the same
- with/without fallback layer information should also still be propagated
- uploading multiple such annotations is not supported
- uploading multiple volumes with *at most one* volume layer each is still supported in this case the volume content should all be merged into a single layer
- uploading multiple skeletons should yield one merged skeleton (with or without additional group hierarchy depending on checkbox)

### Issues:
- fixes #6020

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs tracingstore update after deployment
- [x] Ready for review
