### PR TITLE
Include ParamFailure values in error chains

### DIFF
--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -35,9 +35,15 @@ trait ResultBox extends I18nSupport with Formatter {
       implicit messages: MessagesProvider): String = chain match {
     case Full(failure) =>
       val serverTimeMsg = if (includeTime) "[Server Time " + formatDate(System.currentTimeMillis()) + "] " else ""
-      serverTimeMsg + " <~ " + Messages(failure.msg) + formatChain(failure.chain, includeTime = false)
+      serverTimeMsg + " <~ " + formatFailure(failure) + formatChain(failure.chain, includeTime = false)
     case _ => ""
   }
+
+  private def formatFailure(failure: Failure)(implicit messages: MessagesProvider): String =
+    failure match {
+      case ParamFailure(msg, _, _, param) => Messages(msg) + " " + param.toString
+      case Failure(msg, _, _)             => Messages(msg)
+    }
 
   def jsonMessages(msgs: JsArray): JsObject =
     Json.obj("messages" -> msgs)


### PR DESCRIPTION
ParamFailure is a subclass of Box/Fox/Failure that contains an additional typed value with information about the error. This information should also be included in the Fox error chain.

Also, it should not be erased in `cleanUpOnFailure` in the UploadService.

This way, uploads with linkedLayers but invalid DataSources should yield readable error messages. We use ParamFailures only very rarely. DataSource validation is one, the other is Task creation (where the error is already appended to the response json manually). This is why this never came up before.

### URL of deployed dev instance (used for testing):
- https://paramfailureformat.webknossos.xyz

- [x] Needs datastore update after deployment
- [x] Ready for review
