### PR TITLE
Fix non-32-aligned bucket requests

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -106,12 +106,12 @@ class BinaryDataController @Inject()(
       @ApiParam(value = "Name of the dataset’s organization", required = true) organizationName: String,
       @ApiParam(value = "Dataset name", required = true) dataSetName: String,
       @ApiParam(value = "Layer name of the dataset", required = true) dataLayerName: String,
-      @ApiParam(value = "x coordinate of the top-left corner of the bounding box", required = true) x: Int,
-      @ApiParam(value = "y coordinate of the top-left corner of the bounding box", required = true) y: Int,
-      @ApiParam(value = "z coordinate of the top-left corner of the bounding box", required = true) z: Int,
-      @ApiParam(value = "width of the bounding box", required = true) width: Int,
-      @ApiParam(value = "height of the bounding box", required = true) height: Int,
-      @ApiParam(value = "depth of the bounding box", required = true) depth: Int,
+      @ApiParam(value = "Mag1 x coordinate of the top-left corner of the bounding box", required = true) x: Int,
+      @ApiParam(value = "Mag1 y coordinate of the top-left corner of the bounding box", required = true) y: Int,
+      @ApiParam(value = "Mag1 z coordinate of the top-left corner of the bounding box", required = true) z: Int,
+      @ApiParam(value = "Target-mag width of the bounding box", required = true) width: Int,
+      @ApiParam(value = "Target-mag height of the bounding box", required = true) height: Int,
+      @ApiParam(value = "Target-mag depth of the bounding box", required = true) depth: Int,
       @ApiParam(value = "Exponent of the dataset mag (e.g. 4 for mag 16-16-8)", required = true) resolution: Int,
       @ApiParam(value = "If true, use lossy compression by sending only half-bytes of the data") halfByte: Boolean
   ): Action[AnyContent] = Action.async { implicit request =>

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/Positions.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/Positions.scala
@@ -78,10 +78,12 @@ case class BucketPosition(
     BucketPosition(globalX, globalY, globalZ + (bucketLength * resolution.z), resolution)
 
   def toHighestResBoundingBox: BoundingBox =
-    new BoundingBox(Point3D(globalX, globalY, globalZ),
-                    bucketLength * resolution.x,
-                    bucketLength * resolution.y,
-                    bucketLength * resolution.z)
+    new BoundingBox(
+      Point3D(topLeft.x * resolution.x, topLeft.y * resolution.y, topLeft.z * resolution.z),
+      bucketLength * resolution.x,
+      bucketLength * resolution.y,
+      bucketLength * resolution.z
+    )
 
   override def toString: String =
     s"BucketPosition($globalX, $globalY, $globalZ, mag$resolution)"

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/DataServiceRequests.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/DataServiceRequests.scala
@@ -19,7 +19,7 @@ case class DataServiceDataRequest(
     dataLayerMapping: Option[String],
     cuboid: Cuboid,
     settings: DataServiceRequestSettings,
-    voxelDimensions: Vector3I = Vector3I(1, 1, 1)
+    voxelDimensions: Vector3I = Vector3I(1, 1, 1) // if != 1, skip voxels when loading (used for isosurface generation)
 )
 
 case class DataReadInstruction(


### PR DESCRIPTION
`toHighestResBoundingBox` method of `BucketPosition` needs to use the bucket-length aligned topleft as its topleft.

This error resulted in buckets not being selected for a cuboid request if they touched the bottomright faces of the layer bounding box.

### URL of deployed dev instance (used for testing):
- https://rawcuboidfix.webknossos.xyz

### Steps to test:
- request non-32-aligned cuboid that borders the boundingbox (bottomright)
- should not skip buckets

----
- [x] Needs datastore update after deployment
- [x] Ready for review
