### PR TITLE
Guard against empty saves

### DIFF
--- a/frontend/javascripts/oxalis/model/sagas/save_saga.js
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.js
@@ -678,12 +678,15 @@ export function* pushTracingTypeAsync(
         }
       }
     } else {
-      // Saving the tracing automatically (via timeout) only saves the current state.
-      // It does not require to reach an empty saveQueue. This is especially
-      // important when the auto-saving happens during continuous movements.
-      // Always draining the save queue completely would mean that save
-      // requests are sent as long as the user moves.
-      yield* call(sendRequestToServer, tracingType, tracingId);
+      saveQueue = yield* select(state => selectQueue(state, tracingType, tracingId));
+      if (saveQueue.length > 0) {
+        // Saving the tracing automatically (via timeout) only saves the current state.
+        // It does not require to reach an empty saveQueue. This is especially
+        // important when the auto-saving happens during continuous movements.
+        // Always draining the save queue completely would mean that save
+        // requests are sent as long as the user moves.
+        yield* call(sendRequestToServer, tracingType, tracingId);
+      }
     }
     yield* put(setSaveBusyAction(false, tracingType));
   }


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/scalableminds/webknossos/pull/5999.
See these line changes: https://github.com/scalableminds/webknossos/commit/3831806188f218aea876a1e76181b462bc652a44#diff-acc1d929544bdde3687f0e79f303c4f23b61ca97fafe5e4579202972d2e37acaR673

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### Issues:
- follow-up for #5999 (also see https://github.com/scalableminds/webknossos/pull/6051 which fixes the symptom in the back-end)


------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
