### PR TITLE
Compile tests to different dir to avoid unnecessary recompilations

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,6 +12,7 @@
 <PROJECT_ROOT>/conf/.*
 <PROJECT_ROOT>/lib/.*
 <PROJECT_ROOT>/public/.*
+<PROJECT_ROOT>/public-test/.*
 <PROJECT_ROOT>/tools/.*
 <PROJECT_ROOT>/node_modules/webpack-cli/
 <PROJECT_ROOT>/node_modules/findup/

--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,9 @@ src/main/scala/rebel.xml
 *.zip
 *.skp
 *.mtl
-public/bower_components
 public/bundle
 public/test-bundle
+public-test/test-bundle
 public/docs
 public/commit.txt
 /knowledge

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "ava": {
     "files": [
-      "./public/test-bundle/**/*.{js,jsx}"
+      "./public-test/test-bundle/**/*.{js,jsx}"
     ],
     "ignoredByWatcher": [
       "./binaryData/**/*.*"
@@ -216,7 +216,7 @@
     "sourceMap": false,
     "instrument": false,
     "exclude": [
-      "public/test-bundle/test/**/*.*",
+      "public-test/test-bundle/test/**/*.*",
       "frontend/javascripts/test/**/*.*"
     ]
   }

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-testBundlePath="public/test-bundle"
+testBundlePath="public-test/test-bundle"
 jsPath="frontend/javascripts"
 FIND=find
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Before this PR, I had the problem that the sbt output emited `[info] Slick SQL schema already up to date.` multiple times when I ran `yarn test-prepare-watch` (which meant that it recompiled).
- now, the issue does not exist, anymore
- CI should be enough

### Issues:
- fixes unnecessary recompilations

------
(Please delete unneeded items, merge only when none are left open)
- [X] Ready for review
