### PR TITLE
Adapt maximum brush size depending on available magnifications

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Changed a number of API routes from GET to POST to avoid unwanted side effects. [#6023](https://github.com/scalableminds/webknossos/pull/6023)
 - Removed unused datastore route `checkInbox` (use `checkInboxBlocking` instead). [#6023](https://github.com/scalableminds/webknossos/pull/6023)
 - Migrated to Google Analytics 4. [#6031](https://github.com/scalableminds/webknossos/pull/6031)
+- The maximum brush size now depends on the available magnifications. Consequentially, one can use a larger brush size when the magnifications of a volume layer are restricted. [#6066](https://github.com/scalableminds/webknossos/pull/6066)
 
 ### Fixed
 - Fixed volume-related bugs which could corrupt the volume data in certain scenarios. [#5955](https://github.com/scalableminds/webknossos/pull/5955)

--- a/frontend/javascripts/oxalis/constants.js
+++ b/frontend/javascripts/oxalis/constants.js
@@ -262,7 +262,8 @@ const Constants = {
   BUCKET_WIDTH: 32,
   BUCKET_SIZE: 32 ** 3,
   VIEWPORT_WIDTH,
-  // The area of the maximum radius (pi * 300 ^ 2) is 282690.
+  // For reference, the area of a large brush size (let's say, 300px) corresponds to
+  // pi * 300 ^ 2 == 282690.
   // We multiply this with 5, since the labeling is not done
   // during mouse movement, but afterwards. So, a bit of a
   // waiting time should be acceptable.

--- a/frontend/javascripts/oxalis/model/accessors/volumetracing_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/volumetracing_accessor.js
@@ -172,6 +172,16 @@ export function isVolumeAnnotationDisallowedForZoom(tool: AnnotationTool, state:
   return isZoomStepTooHigh;
 }
 
+const MAX_BRUSH_SIZE_FOR_MAG1 = 300;
+export function getMaximumBrushSize(state: OxalisState) {
+  const volumeResolutions = getResolutionInfoOfActiveSegmentationTracingLayer(state);
+  const lowestExistingResolutionIndex = volumeResolutions.getClosestExistingIndex(0);
+
+  // For each leading magnification which does not exist,
+  // we double the maximum brush size.
+  return MAX_BRUSH_SIZE_FOR_MAG1 * 2 ** lowestExistingResolutionIndex;
+}
+
 export function isSegmentationMissingForZoomstep(
   state: OxalisState,
   maxZoomStepForSegmentation: number,

--- a/frontend/javascripts/oxalis/model/accessors/volumetracing_accessor.js
+++ b/frontend/javascripts/oxalis/model/accessors/volumetracing_accessor.js
@@ -175,6 +175,9 @@ export function isVolumeAnnotationDisallowedForZoom(tool: AnnotationTool, state:
 const MAX_BRUSH_SIZE_FOR_MAG1 = 300;
 export function getMaximumBrushSize(state: OxalisState) {
   const volumeResolutions = getResolutionInfoOfActiveSegmentationTracingLayer(state);
+  if (volumeResolutions.resolutions.length === 0) {
+    return MAX_BRUSH_SIZE_FOR_MAG1;
+  }
   const lowestExistingResolutionIndex = volumeResolutions.getClosestExistingIndex(0);
 
   // For each leading magnification which does not exist,

--- a/frontend/javascripts/oxalis/model/reducers/settings_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/settings_reducer.js
@@ -1,16 +1,17 @@
 // @flow
 import type { Action } from "oxalis/model/actions/actions";
+import { MappingStatusEnum } from "oxalis/constants";
 import type { OxalisState, ActiveMappingInfo } from "oxalis/store";
-import { updateKey, updateKey3, type StateShape1 } from "oxalis/model/helpers/deep_update";
 import { clamp } from "libs/utils";
-import { userSettings } from "types/schemas/user_settings.schema";
 import {
   getLayerByName,
   getSegmentationLayers,
   getVisibleSegmentationLayers,
   getMappingInfo,
 } from "oxalis/model/accessors/dataset_accessor";
-import { MappingStatusEnum } from "oxalis/constants";
+import { getMaximumBrushSize } from "oxalis/model/accessors/volumetracing_accessor";
+import { updateKey, updateKey3, type StateShape1 } from "oxalis/model/helpers/deep_update";
+import { userSettings } from "types/schemas/user_settings.schema";
 
 //
 // Update helpers
@@ -91,6 +92,10 @@ function SettingsReducer(state: OxalisState, action: Action): OxalisState {
         const min = settingSpec.minimum != null ? settingSpec.minimum : -Infinity;
         const max = settingSpec.maximum != null ? settingSpec.maximum : Infinity;
         value = clamp(min, value, max);
+        if (settingSpec.dynamicMaximumFn != null) {
+          const dynamicMaximum = settingSpec.dynamicMaximumFn(state);
+          value = Math.min(value, dynamicMaximum);
+        }
       }
 
       // $FlowIssue[invalid-computed-prop] Flow doesn't check that only numbers will be clamped and https://github.com/facebook/flow/issues/8299

--- a/frontend/javascripts/oxalis/model/reducers/settings_reducer.js
+++ b/frontend/javascripts/oxalis/model/reducers/settings_reducer.js
@@ -9,7 +9,6 @@ import {
   getVisibleSegmentationLayers,
   getMappingInfo,
 } from "oxalis/model/accessors/dataset_accessor";
-import { getMaximumBrushSize } from "oxalis/model/accessors/volumetracing_accessor";
 import { updateKey, updateKey3, type StateShape1 } from "oxalis/model/helpers/deep_update";
 import { userSettings } from "types/schemas/user_settings.schema";
 

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.js
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.js
@@ -15,6 +15,7 @@ import { document } from "libs/window";
 import {
   getActiveSegmentationTracing,
   getMappingInfoForVolumeTracing,
+  getMaximumBrushSize,
   getRenderableResolutionForActiveSegmentationTracing,
 } from "oxalis/model/accessors/volumetracing_accessor";
 import { getActiveTree } from "oxalis/model/accessors/skeletontracing_accessor";
@@ -324,6 +325,7 @@ function CreateTreeButton() {
 
 function ChangeBrushSizeButton() {
   const brushSize = useSelector(state => state.userConfiguration.brushSize);
+  const maximumBrushSize = useSelector(state => getMaximumBrushSize(state));
 
   return (
     <Tooltip title="Change the brush size">
@@ -335,7 +337,7 @@ function ChangeBrushSizeButton() {
               label=""
               roundTo={0}
               min={userSettings.brushSize.minimum}
-              max={userSettings.brushSize.maximum}
+              max={maximumBrushSize}
               step={5}
               spans={[0, 14, 10]}
               value={brushSize}

--- a/frontend/javascripts/types/schemas/user_settings.schema.js
+++ b/frontend/javascripts/types/schemas/user_settings.schema.js
@@ -1,6 +1,7 @@
 // @flow
 import { OverwriteModeEnum, FillModeEnum, TDViewDisplayModeEnum } from "oxalis/constants";
 import { baseDatasetViewConfiguration } from "types/schemas/dataset_view_configuration.schema";
+import { getMaximumBrushSize } from "oxalis/model/accessors/volumetracing_accessor";
 
 export const userSettings = {
   clippingDistance: { type: "number", minimum: 1, maximum: 12000 },
@@ -32,7 +33,10 @@ export const userSettings = {
   },
   tdViewDisplayDatasetBorders: { type: "boolean" },
   hideTreeRemovalWarning: { type: "boolean" },
-  brushSize: { type: "number", minimum: 1, maximum: 300 },
+  // Note that the `maximum` limit is a theoretical one. An actual upper limit
+  // is computed depending on the existing magnifications. See
+  // getMaximumBrushSize().
+  brushSize: { type: "number", minimum: 1, maximum: 30000, dynamicMaximumFn: getMaximumBrushSize },
   autoSaveLayouts: { type: "boolean" },
   gpuMemoryFactor: { type: "number" },
   segmentationOpacity: { type: "number", minimum: 0, maximum: 100 },


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a new annotation using the "..." and restrict the available magnifications (e.g., beginning from mag 4)
- adjust the brush size (the old limit was 300; the new limit should be higher; depending on the existing mags)
- add a second volume layer via the left sidebar
- when switching to the second volume layer, the brush size should clamp again to 300 (if mag 1 exists)
- open a dataset in viewmode to ensure that this also works

### Issues:
- fixes #6060

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
