### PR TITLE
Serve empty service worker js for Demo Instance

### DIFF
--- a/app/RequestHandler.scala
+++ b/app/RequestHandler.scala
@@ -37,6 +37,8 @@ class RequestHandler @Inject()(webCommands: WebCommands,
       Some(assets.at(path = "/public", file = path))
     } else if (request.uri.matches("""^/sitemap.xml$""") && conf.Features.isDemoInstance) {
       Some(sitemapController.getSitemap(conf.Http.uri))
+    } else if (request.uri.matches("^/sw\\.(.*)\\.js$") && conf.Features.isDemoInstance) {
+      Some(Action { Ok })
     } else if (request.uri == "/favicon.ico") {
       Some(Action { NotFound })
     } else Some(demoProxyController.proxyPageOrMainView)


### PR DESCRIPTION
As an attempt to make the proxied weblium page load faster, serve the requested service worker as empty file.

### Steps to test:
- enable isDemoInstance in conf
- navigate to http://localhost:9000/sw.asdf.js
- should answer 200 with empty body, not wk 404 site
---
- [x] Ready for review
