### PR TITLE
Fix mime type of empty service worker

### DIFF
--- a/app/RequestHandler.scala
+++ b/app/RequestHandler.scala
@@ -38,7 +38,7 @@ class RequestHandler @Inject()(webCommands: WebCommands,
     } else if (request.uri.matches("""^/sitemap.xml$""") && conf.Features.isDemoInstance) {
       Some(sitemapController.getSitemap(conf.Http.uri))
     } else if (request.uri.matches("^/sw\\.(.*)\\.js$") && conf.Features.isDemoInstance) {
-      Some(Action { Ok })
+      Some(Action { Ok("").as("text/javascript") })
     } else if (request.uri == "/favicon.ico") {
       Some(Action { NotFound })
     } else Some(demoProxyController.proxyPageOrMainView)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I enabled isDemoInstance
- I executed `p = navigator.serviceWorker.register('/sw.83b788e368f7296e34a2492b4db8d9b9.js')` in the console. before this PR, this errored due to an incorrect mime type

### Issues:
- follow-up to https://github.com/scalableminds/webknossos/pull/6072[)](https://github.com/scalableminds/webknossos/commit/e2528fff17ddc9446d8459a3650ff0d0bdebf3e6)

------
- [X] Ready for review
