### PR TITLE
Add loadAgglomerateSkeletonForSegmentId to frontend api

### DIFF
--- a/.importjs.js
+++ b/.importjs.js
@@ -1,5 +1,5 @@
 module.exports = {
-  excludes: ["./target/**", "./public/**"],
+  excludes: ["./target/**", "./public/**", "./public-test/**"],
   useRelativePaths: false,
   environments: ["browser"],
   aliases: {

--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -491,7 +491,7 @@ class TracingApi {
    * a segmentation layer is visible for which an agglomerate mapping is enabled.
    *
    * @example
-   * api.tracing.getTreeName();
+   * api.tracing.loadAgglomerateSkeletonForSegmentId(3);
    */
   loadAgglomerateSkeletonForSegmentId(segmentId: number) {
     loadAgglomerateSkeletonForSegmentId(segmentId);

--- a/frontend/javascripts/oxalis/api/api_latest.js
+++ b/frontend/javascripts/oxalis/api/api_latest.js
@@ -37,10 +37,6 @@ import {
 } from "oxalis/model/helpers/position_converter";
 import { callDeep } from "oxalis/view/right-border-tabs/tree_hierarchy_view_helpers";
 import { centerTDViewAction } from "oxalis/model/actions/view_mode_actions";
-import {
-  loadAdHocMeshAction,
-  loadPrecomputedMeshAction,
-} from "oxalis/model/actions/segmentation_actions";
 import { discardSaveQueuesAction } from "oxalis/model/actions/save_actions";
 import {
   doWithToken,
@@ -70,6 +66,7 @@ import {
   getVolumeTracings,
   hasVolumeTracings,
 } from "oxalis/model/accessors/volumetracing_accessor";
+import { getHalfViewportExtentsFromState } from "oxalis/model/sagas/automatic_brush_saga";
 import {
   getLayerBoundaries,
   getLayerByName,
@@ -82,6 +79,11 @@ import {
   getRotation,
   getRequestLogZoomStep,
 } from "oxalis/model/accessors/flycam_accessor";
+import {
+  loadAdHocMeshAction,
+  loadPrecomputedMeshAction,
+} from "oxalis/model/actions/segmentation_actions";
+import { loadAgglomerateSkeletonForSegmentId } from "oxalis/controller/combinations/segmentation_handlers";
 import { maybeFetchMeshFiles } from "oxalis/view/right-border-tabs/segments_tab/segments_view_helper";
 import { overwriteAction } from "oxalis/model/helpers/overwrite_action_middleware";
 import { parseNml } from "oxalis/model/helpers/nml_helpers";
@@ -116,6 +118,7 @@ import Constants, {
   TDViewDisplayModeEnum,
   MappingStatusEnum,
 } from "oxalis/constants";
+import DataLayer from "oxalis/model/data_layer";
 import Model, { type OxalisModel } from "oxalis/model";
 import Request from "libs/request";
 import Store, {
@@ -132,7 +135,6 @@ import Store, {
   type VolumeTracing,
   type OxalisState,
 } from "oxalis/store";
-import { getHalfViewportExtentsFromState } from "oxalis/model/sagas/automatic_brush_saga";
 import Toast, { type ToastStyle } from "libs/toast";
 import UrlManager from "oxalis/controller/url_manager";
 import UserLocalStorage from "libs/user_local_storage";
@@ -140,7 +142,6 @@ import * as Utils from "libs/utils";
 import dimensions from "oxalis/model/dimensions";
 import messages from "messages";
 import window, { location } from "libs/window";
-import DataLayer from "oxalis/model/data_layer";
 
 type OutdatedDatasetConfigurationKeys = "segmentationOpacity" | "isSegmentationDisabled";
 
@@ -483,6 +484,17 @@ class TracingApi {
     return getTree(tracing, treeId)
       .map(activeTree => activeTree.name)
       .get();
+  }
+
+  /**
+   * Loads the agglomerate skeleton for the given segment id. Only possible if
+   * a segmentation layer is visible for which an agglomerate mapping is enabled.
+   *
+   * @example
+   * api.tracing.getTreeName();
+   */
+  loadAgglomerateSkeletonForSegmentId(segmentId: number) {
+    loadAgglomerateSkeletonForSegmentId(segmentId);
   }
 
   /**

--- a/frontend/javascripts/oxalis/controller/combinations/segmentation_handlers.js
+++ b/frontend/javascripts/oxalis/controller/combinations/segmentation_handlers.js
@@ -48,7 +48,18 @@ export async function handleAgglomerateSkeletonAtClick(clickPosition: Point2) {
   loadAgglomerateSkeletonAtPosition(globalPosition);
 }
 
-export async function loadAgglomerateSkeletonAtPosition(position: Vector3) {
+export function loadAgglomerateSkeletonAtPosition(position: Vector3): void {
+  const segmentation = Model.getVisibleSegmentationLayer();
+  if (!segmentation) {
+    return;
+  }
+  const renderedZoomStep = api.data.getRenderedZoomStepAtPosition(segmentation.name, position);
+  const segmentId = segmentation.cube.getMappedDataValue(position, renderedZoomStep);
+
+  loadAgglomerateSkeletonForSegmentId(segmentId);
+}
+
+export function loadAgglomerateSkeletonForSegmentId(segmentId: number): void {
   const state = Store.getState();
   const segmentation = Model.getVisibleSegmentationLayer();
   if (!segmentation) {
@@ -62,11 +73,7 @@ export async function loadAgglomerateSkeletonAtPosition(position: Vector3) {
   const isAgglomerateMappingEnabled = hasAgglomerateMapping(state);
 
   if (mappingName && isAgglomerateMappingEnabled.value) {
-    const renderedZoomStep = api.data.getRenderedZoomStepAtPosition(segmentation.name, position);
-
-    const cellId = segmentation.cube.getMappedDataValue(position, renderedZoomStep);
-
-    Store.dispatch(loadAgglomerateSkeletonAction(segmentation.name, mappingName, cellId));
+    Store.dispatch(loadAgglomerateSkeletonAction(segmentation.name, mappingName, segmentId));
   } else {
     Toast.error(isAgglomerateMappingEnabled.reason);
   }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a dataset with an agglomerate mapping
- set some nodes in segments
- run the following
```
window.webknossos.apiReady(3).then(async (api) => {
	const treesInGroup = Object.values(api.tracing.getAllTrees());
	const layerName = api.data.getVisibleSegmentationLayerName();

	const promises = [];
	for (const tree of treesInGroup) {
		for (const node of tree.nodes.values()) {
			promises.push(api.data.getDataValue(layerName, node.position));
		}
	}

	const agglomerateIds =  await Promise.all(promises)
	for (const id of agglomerateIds) {
		api.tracing.loadAgglomerateSkeletonForSegmentId(id);
	}
	console.log("agglomerateIds: ", agglomerateIds);
})
```

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
