### PR TITLE
Add remote origin headers also in error case

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where toggling between not archived and archived annotations in the "My Annotation" of the dashboard led to inconsistent states and duplicates of annotations. [#6058](https://github.com/scalableminds/webknossos/pull/6058)
 - Fixed a bug where deactivated users would still be listed as allowed to access the datasets of their team. [#6070](https://github.com/scalableminds/webknossos/pull/6070)
 - Fix occasionally "disappearing" data. [#6055](https://github.com/scalableminds/webknossos/pull/6055)
+- Fixed a bug where remote-origin headers were omitted in error case. [#6098](https://github.com/scalableminds/webknossos/pull/6098)
 
 ### Removed
 - The previously disabled Import Skeleton Button has been removed. The functionality is available via the context menu for datasets with active ID mappings. [#6073](https://github.com/scalableminds/webknossos/pull/6073)

--- a/app/controllers/Controller.scala
+++ b/app/controllers/Controller.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.mohiva.play.silhouette.api.actions.{SecuredRequest, UserAwareRequest}
 import com.scalableminds.util.accesscontext.{AuthorizedAccessContext, DBAccessContext}
-import com.scalableminds.util.mvc.{ExtendedController, ValidationHelpers}
+import com.scalableminds.util.mvc.ExtendedController
 import com.scalableminds.util.tools.Fox
 import com.typesafe.scalalogging.LazyLogging
 import models.user.User
@@ -16,7 +16,6 @@ import scala.concurrent.ExecutionContext
 trait Controller
     extends InjectedController
     with ExtendedController
-    with ValidationHelpers
     with UserAwareRequestLogging
     with I18nSupport
     with LazyLogging {

--- a/app/controllers/Controller.scala
+++ b/app/controllers/Controller.scala
@@ -2,9 +2,8 @@ package controllers
 
 import com.mohiva.play.silhouette.api.actions.{SecuredRequest, UserAwareRequest}
 import com.scalableminds.util.accesscontext.{AuthorizedAccessContext, DBAccessContext}
-import com.scalableminds.util.mvc.ExtendedController
+import com.scalableminds.util.mvc.{ExtendedController, ValidationHelpers}
 import com.scalableminds.util.tools.Fox
-import com.scalableminds.webknossos.datastore.controllers.ValidationHelpers
 import com.typesafe.scalalogging.LazyLogging
 import models.user.User
 import oxalis.security.{UserAwareRequestLogging, WkEnv}

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -75,49 +75,49 @@ class DataSetController @Inject()(userService: UserService,
                 w: Option[Int],
                 h: Option[Int]): Action[AnyContent] =
     sil.UserAwareAction.async { implicit request =>
-        def imageFromCacheIfPossible(dataSet: DataSet): Fox[Array[Byte]] = {
-          val width = Math.clamp(w.getOrElse(DefaultThumbnailWidth), 1, MaxThumbnailWidth)
-          val height = Math.clamp(h.getOrElse(DefaultThumbnailHeight), 1, MaxThumbnailHeight)
-          dataSetService.thumbnailCache.find(
-            thumbnailCacheKey(organizationName, dataSetName, dataLayerName, width, height)) match {
-            case Some(a) =>
-              Fox.successful(a)
-            case _ =>
-              val defaultCenterOpt = dataSet.adminViewConfiguration.flatMap(c =>
-                c.get("position").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Vec3Int])))
-              val defaultZoomOpt = dataSet.adminViewConfiguration.flatMap(c =>
-                c.get("zoom").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Double])))
-              dataSetService
-                .clientFor(dataSet)(GlobalAccessContext)
-                .flatMap(
-                  _.requestDataLayerThumbnail(organizationName,
-                    dataLayerName,
-                    width,
-                    height,
-                    defaultZoomOpt,
-                    defaultCenterOpt))
-                .map { result =>
-                  // We don't want all images to expire at the same time. Therefore, we add some random variation
-                  dataSetService.thumbnailCache.insert(
-                    thumbnailCacheKey(organizationName, dataSetName, dataLayerName, width, height),
-                    result,
-                    Some((ThumbnailCacheDuration.toSeconds + math.random * 2.hours.toSeconds) seconds)
-                  )
-                  result
-                }
-          }
+      def imageFromCacheIfPossible(dataSet: DataSet): Fox[Array[Byte]] = {
+        val width = Math.clamp(w.getOrElse(DefaultThumbnailWidth), 1, MaxThumbnailWidth)
+        val height = Math.clamp(h.getOrElse(DefaultThumbnailHeight), 1, MaxThumbnailHeight)
+        dataSetService.thumbnailCache.find(
+          thumbnailCacheKey(organizationName, dataSetName, dataLayerName, width, height)) match {
+          case Some(a) =>
+            Fox.successful(a)
+          case _ =>
+            val defaultCenterOpt = dataSet.adminViewConfiguration.flatMap(c =>
+              c.get("position").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Vec3Int])))
+            val defaultZoomOpt = dataSet.adminViewConfiguration.flatMap(c =>
+              c.get("zoom").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Double])))
+            dataSetService
+              .clientFor(dataSet)(GlobalAccessContext)
+              .flatMap(
+                _.requestDataLayerThumbnail(organizationName,
+                                            dataLayerName,
+                                            width,
+                                            height,
+                                            defaultZoomOpt,
+                                            defaultCenterOpt))
+              .map { result =>
+                // We don't want all images to expire at the same time. Therefore, we add some random variation
+                dataSetService.thumbnailCache.insert(
+                  thumbnailCacheKey(organizationName, dataSetName, dataLayerName, width, height),
+                  result,
+                  Some((ThumbnailCacheDuration.toSeconds + math.random * 2.hours.toSeconds) seconds)
+                )
+                result
+              }
         }
+      }
 
-        for {
-          dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName) ?~> notFoundMessage(
-            dataSetName) ~> NOT_FOUND
-          _ <- dataSetDataLayerDAO.findOneByNameForDataSet(dataLayerName, dataSet._id) ?~> Messages(
-            "dataLayer.notFound",
-            dataLayerName) ~> NOT_FOUND
-          image <- imageFromCacheIfPossible(dataSet)
-        } yield {
-          Ok(image).as("image/jpeg").withHeaders(CACHE_CONTROL -> "public, max-age=86400")
-        }
+      for {
+        dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName) ?~> notFoundMessage(
+          dataSetName) ~> NOT_FOUND
+        _ <- dataSetDataLayerDAO.findOneByNameForDataSet(dataLayerName, dataSet._id) ?~> Messages(
+          "dataLayer.notFound",
+          dataLayerName) ~> NOT_FOUND
+        image <- imageFromCacheIfPossible(dataSet)
+      } yield {
+        addRemoteOriginHeaders(Ok(image)).as("image/jpeg").withHeaders(CACHE_CONTROL -> "public, max-age=86400")
+      }
     }
 
   @ApiOperation(hidden = true, value = "")
@@ -141,26 +141,25 @@ class DataSetController @Inject()(userService: UserService,
 
   @ApiOperation(hidden = true, value = "")
   def list: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
-      UsingFilters(
-        Filter("isActive", (value: Boolean, el: DataSet) => Fox.successful(el.isUsable == value)),
-        Filter("isUnreported",
-               (value: Boolean, el: DataSet) => Fox.successful(dataSetService.isUnreported(el) == value)),
-        Filter(
-          "isEditable",
-          (value: Boolean, el: DataSet) =>
-            for { isEditable <- dataSetService.isEditableBy(el, request.identity) } yield {
-              isEditable && value || !isEditable && !value
-          }
-        )
-      ) { filter =>
-        for {
-          dataSets <- dataSetDAO.findAll ?~> "dataSet.list.failed"
-          filtered <- filter.applyOn(dataSets)
-          js <- listGrouped(filtered, request.identity) ?~> "dataSet.list.failed"
-        } yield {
-          addRemoteOriginHeaders(Ok(Json.toJson(js)))
+    UsingFilters(
+      Filter("isActive", (value: Boolean, el: DataSet) => Fox.successful(el.isUsable == value)),
+      Filter("isUnreported", (value: Boolean, el: DataSet) => Fox.successful(dataSetService.isUnreported(el) == value)),
+      Filter(
+        "isEditable",
+        (value: Boolean, el: DataSet) =>
+          for { isEditable <- dataSetService.isEditableBy(el, request.identity) } yield {
+            isEditable && value || !isEditable && !value
         }
+      )
+    ) { filter =>
+      for {
+        dataSets <- dataSetDAO.findAll ?~> "dataSet.list.failed"
+        filtered <- filter.applyOn(dataSets)
+        js <- listGrouped(filtered, request.identity) ?~> "dataSet.list.failed"
+      } yield {
+        addRemoteOriginHeaders(Ok(Json.toJson(js)))
       }
+    }
   }
 
   private def listGrouped(datasets: List[DataSet], requestingUser: Option[User])(

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -4,7 +4,6 @@ import java.io.File
 
 import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.accesscontext.GlobalAccessContext
-import com.scalableminds.util.mvc.ResultBox
 import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
 import com.scalableminds.webknossos.datastore.SkeletonTracing.SkeletonTracing
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
@@ -44,7 +43,6 @@ class TaskController @Inject()(taskCreationService: TaskCreationService,
                                nmlService: AnnotationUploadService,
                                sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller
-    with ResultBox
     with ProtoGeometryImplicits
     with FoxImplicits {
 

--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -214,4 +214,3 @@ trait ExtendedController
     with InjectedController
     with ValidationHelpers
     with LazyLogging
-

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
@@ -9,16 +9,16 @@ import scala.concurrent.ExecutionContext
 
 class Application @Inject()(redisClient: DataStoreRedisStore)(implicit ec: ExecutionContext) extends Controller {
 
+  override def allowRemoteOrigin: Boolean = true
+
   def health: Action[AnyContent] = Action.async { implicit request =>
     log() {
-      AllowRemoteOrigin {
-        for {
-          before <- Fox.successful(System.currentTimeMillis())
-          _ <- redisClient.checkHealth
-          afterRedis = System.currentTimeMillis()
-          _ = logger.info(s"Answering ok for Datastore health check, took ${afterRedis - before} ms")
-        } yield Ok("Ok")
-      }
+      for {
+        before <- Fox.successful(System.currentTimeMillis())
+        _ <- redisClient.checkHealth
+        afterRedis = System.currentTimeMillis()
+        _ = logger.info(s"Answering ok for Datastore health check, took ${afterRedis - before} ms")
+      } yield Ok("Ok")
     }
   }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -49,6 +49,8 @@ class BinaryDataController @Inject()(
 )(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller {
 
+  override def allowRemoteOrigin: Boolean = true
+
   val binaryDataService: BinaryDataService = binaryDataServiceHolder.binaryDataService
   isosurfaceServiceHolder.dataStoreIsosurfaceConfig =
     (binaryDataService, mappingService, config.Datastore.Isosurface.timeout, config.Datastore.Isosurface.actorPoolSize)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
@@ -3,6 +3,4 @@ package com.scalableminds.webknossos.datastore.controllers
 import com.scalableminds.util.mvc.ExtendedController
 import com.scalableminds.util.requestlogging.RequestLogging
 
-trait Controller
-    extends ExtendedController
-      with RequestLogging
+trait Controller extends ExtendedController with RequestLogging

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Controller.scala
@@ -1,60 +1,8 @@
 package com.scalableminds.webknossos.datastore.controllers
 
-import java.io.FileInputStream
-
-import com.google.protobuf.CodedInputStream
 import com.scalableminds.util.mvc.ExtendedController
 import com.scalableminds.util.requestlogging.RequestLogging
-import com.typesafe.scalalogging.LazyLogging
-import net.liftweb.common.Box
-import net.liftweb.util.Helpers.tryo
-import play.api.libs.json.{JsError, Reads}
-import play.api.mvc.Results._
-import play.api.mvc._
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
-
-import scala.concurrent.{ExecutionContext, Future}
 
 trait Controller
-    extends InjectedController
-    with ExtendedController
-    with RemoteOriginHelpers
-    with ValidationHelpers
-    with LazyLogging
-    with RequestLogging
-
-trait RemoteOriginHelpers {
-
-  def AllowRemoteOrigin(f: => Future[Result])(implicit ec: ExecutionContext): Future[Result] =
-    f.map(addHeadersToResult)
-
-  def AllowRemoteOrigin(f: => Result): Result =
-    addHeadersToResult(f)
-
-  def addHeadersToResult(result: Result): Result =
-    result.withHeaders("Access-Control-Allow-Origin" -> "*", "Access-Control-Max-Age" -> "600")
-
-}
-
-trait ValidationHelpers {
-
-  def validateJson[A: Reads](implicit bodyParsers: PlayBodyParsers, ec: ExecutionContext): BodyParser[A] =
-    bodyParsers.json.validate(
-      _.validate[A].asEither.left.map(e => BadRequest(JsError.toJson(e)))
-    )
-
-  def validateProto[A <: GeneratedMessage](implicit bodyParsers: PlayBodyParsers,
-                                           companion: GeneratedMessageCompanion[A],
-                                           ec: ExecutionContext): BodyParser[A] =
-    bodyParsers.raw.validate { raw =>
-      if (raw.size < raw.memoryThreshold) {
-        Box(raw.asBytes())
-          .flatMap(x => tryo(companion.parseFrom(x.toArray)))
-          .toRight[Result](BadRequest("invalid request body"))
-      } else {
-        tryo(companion.parseFrom(CodedInputStream.newInstance(new FileInputStream(raw.asFile))))
-          .toRight[Result](BadRequest("invalid request body"))
-      }
-    }
-
-}
+    extends ExtendedController
+      with RequestLogging

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ExportsController.scala
@@ -33,15 +33,15 @@ class ExportsController @Inject()(webKnossosClient: DSRemoteWebKnossosClient,
 
   private val dataBaseDir: Path = Paths.get(config.Datastore.baseFolder)
 
+  override def allowRemoteOrigin: Boolean = true
+
   def download(token: Option[String], jobId: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.downloadJobExport(jobId), token) {
-      AllowRemoteOrigin {
-        for {
-          exportProperties <- webKnossosClient.getJobExportProperties(jobId)
-          fullPath = exportProperties.fullPathIn(dataBaseDir)
-          _ <- bool2Fox(Files.exists(fullPath)) ?~> "job.export.fileNotFound"
-        } yield Ok.sendPath(fullPath, inline = false)
-      }
+      for {
+        exportProperties <- webKnossosClient.getJobExportProperties(jobId)
+        fullPath = exportProperties.fullPathIn(dataBaseDir)
+        _ <- bool2Fox(Files.exists(fullPath)) ?~> "job.export.fileNotFound"
+      } yield Ok.sendPath(fullPath, inline = false)
     }
 
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
@@ -2,17 +2,17 @@ package com.scalableminds.webknossos.datastore.controllers
 
 import javax.inject.Inject
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, InjectedController}
+import play.api.mvc.{Action, AnyContent}
 
-class StandaloneDatastore @Inject()() extends InjectedController with RemoteOriginHelpers {
+class StandaloneDatastore @Inject()() extends Controller {
+
+  override def allowRemoteOrigin: Boolean = true
 
   def buildInfo: Action[AnyContent] = Action {
-    AllowRemoteOrigin {
-      Ok(
+    Ok(
         Json.obj(
           "webknossosDatastore" -> webknossosDatastore.BuildInfo.toMap.mapValues(_.toString),
           "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString)
         ))
-    }
   }
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
@@ -10,9 +10,9 @@ class StandaloneDatastore @Inject()() extends Controller {
 
   def buildInfo: Action[AnyContent] = Action {
     Ok(
-        Json.obj(
-          "webknossosDatastore" -> webknossosDatastore.BuildInfo.toMap.mapValues(_.toString),
-          "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString)
-        ))
+      Json.obj(
+        "webknossosDatastore" -> webknossosDatastore.BuildInfo.toMap.mapValues(_.toString),
+        "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString)
+      ))
   }
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
@@ -208,6 +208,7 @@ class FindDataService @Inject()(dataServicesHolder: BinaryDataServiceHolder)(imp
       for {
         dataConcatenated <- getConcatenatedDataFor(dataSource, dataLayer, positions, resolution) ?~> "dataSet.noData"
         isUint24 = dataLayer.elementClass == ElementClass.uint24
+        _ <- Fox.failure("Nope!")
         convertedData = convertData(dataConcatenated, dataLayer.elementClass, filterZeroes = !isUint24)
       } yield calculateHistogramValues(convertedData, dataLayer.bytesPerElement, isUint24)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/FindDataService.scala
@@ -208,7 +208,6 @@ class FindDataService @Inject()(dataServicesHolder: BinaryDataServiceHolder)(imp
       for {
         dataConcatenated <- getConcatenatedDataFor(dataSource, dataLayer, positions, resolution) ?~> "dataSet.noData"
         isUint24 = dataLayer.elementClass == ElementClass.uint24
-        _ <- Fox.failure("Nope!")
         convertedData = convertData(dataConcatenated, dataLayer.elementClass, filterZeroes = !isUint24)
       } yield calculateHistogramValues(convertedData, dataLayer.bytesPerElement, isUint24)
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
@@ -18,15 +18,15 @@ class Application @Inject()(tracingDataStore: TracingDataStore, redisClient: Tra
 
   def health: Action[AnyContent] = Action.async { implicit request =>
     log() {
-        for {
-          before <- Fox.successful(System.currentTimeMillis())
-          _ <- tracingDataStore.healthClient.checkHealth
-          afterFossil = System.currentTimeMillis()
-          _ <- redisClient.checkHealth
-          afterRedis = System.currentTimeMillis()
-          _ = logger.info(
-            s"Answering ok for Tracingstore health check, took ${afterRedis - before} ms (FossilDB ${afterFossil - before} ms, Redis ${afterRedis - afterFossil} ms).")
-        } yield Ok("Ok")
+      for {
+        before <- Fox.successful(System.currentTimeMillis())
+        _ <- tracingDataStore.healthClient.checkHealth
+        afterFossil = System.currentTimeMillis()
+        _ <- redisClient.checkHealth
+        afterRedis = System.currentTimeMillis()
+        _ = logger.info(
+          s"Answering ok for Tracingstore health check, took ${afterRedis - before} ms (FossilDB ${afterFossil - before} ms, Redis ${afterRedis - afterFossil} ms).")
+      } yield Ok("Ok")
     }
   }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
@@ -14,9 +14,10 @@ class Application @Inject()(tracingDataStore: TracingDataStore, redisClient: Tra
     implicit ec: ExecutionContext)
     extends Controller {
 
+  override def allowRemoteOrigin: Boolean = true
+
   def health: Action[AnyContent] = Action.async { implicit request =>
     log() {
-      AllowRemoteOrigin {
         for {
           before <- Fox.successful(System.currentTimeMillis())
           _ <- tracingDataStore.healthClient.checkHealth
@@ -26,7 +27,6 @@ class Application @Inject()(tracingDataStore: TracingDataStore, redisClient: Tra
           _ = logger.info(
             s"Answering ok for Tracingstore health check, took ${afterRedis - before} ms (FossilDB ${afterFossil - before} ms, Redis ${afterRedis - afterFossil} ms).")
         } yield Ok("Ok")
-      }
     }
   }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -35,14 +35,12 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
     Action.async(validateProto[SkeletonTracings]) { implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos, token) {
-          AllowRemoteOrigin {
-            val tracings: List[Option[SkeletonTracing]] = request.body
-            val mergedTracing = tracingService.merge(tracings.flatten)
-            val processedTracing = tracingService.remapTooLargeTreeIds(mergedTracing)
-            for {
-              newId <- tracingService.save(processedTracing, None, processedTracing.version, toCache = !persist)
-            } yield Ok(Json.toJson(newId))
-          }
+          val tracings: List[Option[SkeletonTracing]] = request.body
+          val mergedTracing = tracingService.merge(tracings.flatten)
+          val processedTracing = tracingService.remapTooLargeTreeIds(mergedTracing)
+          for {
+            newId <- tracingService.save(processedTracing, None, processedTracing.version, toCache = !persist)
+          } yield Ok(Json.toJson(newId))
         }
       }
     }
@@ -54,13 +52,11 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
     Action.async { implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos, token) {
-          AllowRemoteOrigin {
-            for {
-              tracing <- tracingService.find(tracingId, version, applyUpdates = true) ?~> Messages("tracing.notFound")
-              newId <- tracingService.duplicate(tracing, fromTask.getOrElse(false))
-            } yield {
-              Ok(Json.toJson(newId))
-            }
+          for {
+            tracing <- tracingService.find(tracingId, version, applyUpdates = true) ?~> Messages("tracing.notFound")
+            newId <- tracingService.duplicate(tracing, fromTask.getOrElse(false))
+          } yield {
+            Ok(Json.toJson(newId))
           }
         }
       }
@@ -69,12 +65,10 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
   def updateActionLog(token: Option[String], tracingId: String): Action[AnyContent] = Action.async { implicit request =>
     log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-        AllowRemoteOrigin {
-          for {
-            updateLog <- tracingService.updateActionLog(tracingId)
-          } yield {
-            Ok(updateLog)
-          }
+        for {
+          updateLog <- tracingService.updateActionLog(tracingId)
+        } yield {
+          Ok(updateLog)
         }
       }
     }
@@ -84,12 +78,10 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
     implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-          AllowRemoteOrigin {
-            for {
-              statistics <- tracingService.updateActionStatistics(tracingId)
-            } yield {
-              Ok(statistics)
-            }
+          for {
+            statistics <- tracingService.updateActionStatistics(tracingId)
+          } yield {
+            Ok(statistics)
           }
         }
       }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -51,17 +51,15 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
       log() {
         logTime(slackNotificationService.noticeSlowRequest) {
           accessTokenService.validateAccess(UserAccessRequest.webknossos, token) {
-            AllowRemoteOrigin {
-              for {
-                initialData <- request.body.asRaw.map(_.asFile) ?~> Messages("zipFile.notFound")
-                tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
-                resolutionRestrictions = ResolutionRestrictions(minResolution, maxResolution)
-                resolutions <- tracingService
-                  .initializeWithData(tracingId, tracing, initialData, resolutionRestrictions)
-                  .toFox
-                _ <- tracingService.updateResolutionList(tracingId, tracing, resolutions)
-              } yield Ok(Json.toJson(tracingId))
-            }
+            for {
+              initialData <- request.body.asRaw.map(_.asFile) ?~> Messages("zipFile.notFound")
+              tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
+              resolutionRestrictions = ResolutionRestrictions(minResolution, maxResolution)
+              resolutions <- tracingService
+                .initializeWithData(tracingId, tracing, initialData, resolutionRestrictions)
+                .toFox
+              _ <- tracingService.updateResolutionList(tracingId, tracing, resolutions)
+            } yield Ok(Json.toJson(tracingId))
           }
         }
       }
@@ -71,12 +69,10 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
     Action.async(validateProto[VolumeTracings]) { implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos, token) {
-          AllowRemoteOrigin {
-            val tracings: List[Option[VolumeTracing]] = request.body
-            val mergedTracing = tracingService.merge(tracings.flatten)
-            tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist).map { newId =>
-              Ok(Json.toJson(newId))
-            }
+          val tracings: List[Option[VolumeTracing]] = request.body
+          val mergedTracing = tracingService.merge(tracings.flatten)
+          tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist).map { newId =>
+            Ok(Json.toJson(newId))
           }
         }
       }
@@ -87,14 +83,12 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
       log() {
         logTime(slackNotificationService.noticeSlowRequest) {
           accessTokenService.validateAccess(UserAccessRequest.webknossos, token) {
-            AllowRemoteOrigin {
-              for {
-                initialData <- request.body.asRaw.map(_.asFile) ?~> Messages("zipFile.notFound")
-                tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
-                resolutions <- tracingService.initializeWithDataMultiple(tracingId, tracing, initialData).toFox
-                _ <- tracingService.updateResolutionList(tracingId, tracing, resolutions)
-              } yield Ok(Json.toJson(tracingId))
-            }
+            for {
+              initialData <- request.body.asRaw.map(_.asFile) ?~> Messages("zipFile.notFound")
+              tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
+              resolutions <- tracingService.initializeWithDataMultiple(tracingId, tracing, initialData).toFox
+              _ <- tracingService.updateResolutionList(tracingId, tracing, resolutions)
+            } yield Ok(Json.toJson(tracingId))
           }
         }
       }
@@ -104,13 +98,11 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
     implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-          AllowRemoteOrigin {
-            for {
-              tracing <- tracingService.find(tracingId, version) ?~> Messages("tracing.notFound")
-            } yield {
-              val enumerator: Enumerator[Array[Byte]] = tracingService.allDataEnumerator(tracingId, tracing)
-              Ok.chunked(Source.fromPublisher(IterateeStreams.enumeratorToPublisher(enumerator)))
-            }
+          for {
+            tracing <- tracingService.find(tracingId, version) ?~> Messages("tracing.notFound")
+          } yield {
+            val enumerator: Enumerator[Array[Byte]] = tracingService.allDataEnumerator(tracingId, tracing)
+            Ok.chunked(Source.fromPublisher(IterateeStreams.enumeratorToPublisher(enumerator)))
           }
         }
       }
@@ -120,12 +112,10 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
     Action.async { implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-          AllowRemoteOrigin {
-            for {
-              tracing <- tracingService.find(tracingId, version) ?~> Messages("tracing.notFound")
-              data <- tracingService.allDataFile(tracingId, tracing)
-            } yield Ok.sendFile(data)
-          }
+          for {
+            tracing <- tracingService.find(tracingId, version) ?~> Messages("tracing.notFound")
+            data <- tracingService.allDataFile(tracingId, tracing)
+          } yield Ok.sendFile(data)
         }
       }
     }
@@ -134,12 +124,10 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
     Action.async(validateJson[List[WebKnossosDataRequest]]) { implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-          AllowRemoteOrigin {
-            for {
-              tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
-              (data, indices) <- tracingService.data(tracingId, tracing, request.body)
-            } yield Ok(data).withHeaders(getMissingBucketsHeaders(indices): _*)
-          }
+          for {
+            tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
+            (data, indices) <- tracingService.data(tracingId, tracing, request.body)
+          } yield Ok(data).withHeaders(getMissingBucketsHeaders(indices): _*)
         }
       }
     }
@@ -159,19 +147,17 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
     log() {
       logTime(slackNotificationService.noticeSlowRequest) {
         accessTokenService.validateAccess(UserAccessRequest.webknossos, token) {
-          AllowRemoteOrigin {
-            for {
-              tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
-              dataSetBoundingBox = request.body.asJson.flatMap(_.validateOpt[BoundingBox].asOpt.flatten)
-              resolutionRestrictions = ResolutionRestrictions(minResolution, maxResolution)
-              (newId, newTracing) <- tracingService.duplicate(tracingId,
-                                                              tracing,
-                                                              fromTask.getOrElse(false),
-                                                              dataSetBoundingBox,
-                                                              resolutionRestrictions)
-              _ <- Fox.runIfOptionTrue(downsample)(tracingService.downsample(newId, newTracing))
-            } yield Ok(Json.toJson(newId))
-          }
+          for {
+            tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
+            dataSetBoundingBox = request.body.asJson.flatMap(_.validateOpt[BoundingBox].asOpt.flatten)
+            resolutionRestrictions = ResolutionRestrictions(minResolution, maxResolution)
+            (newId, newTracing) <- tracingService.duplicate(tracingId,
+                                                            tracing,
+                                                            fromTask.getOrElse(false),
+                                                            dataSetBoundingBox,
+                                                            resolutionRestrictions)
+            _ <- Fox.runIfOptionTrue(downsample)(tracingService.downsample(newId, newTracing))
+          } yield Ok(Json.toJson(newId))
         }
       }
     }
@@ -182,13 +168,11 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
       log() {
         logTime(slackNotificationService.noticeSlowRequest) {
           accessTokenService.validateAccess(UserAccessRequest.webknossos, token) {
-            AllowRemoteOrigin {
-              for {
-                tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
-                updatedTracing = tracingService.unlinkFallback(tracing, request.body)
-                newId <- tracingService.save(updatedTracing, None, 0L)
-              } yield Ok(Json.toJson(newId))
-            }
+            for {
+              tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
+              updatedTracing = tracingService.unlinkFallback(tracing, request.body)
+              newId <- tracingService.save(updatedTracing, None, 0L)
+            } yield Ok(Json.toJson(newId))
           }
         }
       }
@@ -198,14 +182,12 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
     Action.async(parse.multipartFormData) { implicit request =>
       log() {
         accessTokenService.validateAccess(UserAccessRequest.writeTracing(tracingId), token) {
-          AllowRemoteOrigin {
-            for {
-              tracing <- tracingService.find(tracingId)
-              currentVersion <- request.body.dataParts("currentVersion").headOption.flatMap(_.toIntOpt).toFox
-              zipFile <- request.body.files.headOption.map(f => new File(f.ref.path.toString)).toFox
-              largestSegmentId <- tracingService.importVolumeData(tracingId, tracing, zipFile, currentVersion)
-            } yield Ok(Json.toJson(largestSegmentId))
-          }
+          for {
+            tracing <- tracingService.find(tracingId)
+            currentVersion <- request.body.dataParts("currentVersion").headOption.flatMap(_.toIntOpt).toFox
+            zipFile <- request.body.files.headOption.map(f => new File(f.ref.path.toString)).toFox
+            largestSegmentId <- tracingService.importVolumeData(tracingId, tracing, zipFile, currentVersion)
+          } yield Ok(Json.toJson(largestSegmentId))
         }
       }
     }
@@ -213,11 +195,9 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
   def updateActionLog(token: Option[String], tracingId: String): Action[AnyContent] = Action.async { implicit request =>
     log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-        AllowRemoteOrigin {
-          for {
-            updateLog <- tracingService.updateActionLog(tracingId)
-          } yield Ok(updateLog)
-        }
+        for {
+          updateLog <- tracingService.updateActionLog(tracingId)
+        } yield Ok(updateLog)
       }
     }
   }
@@ -225,18 +205,16 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
   def requestIsosurface(token: Option[String], tracingId: String): Action[WebKnossosIsosurfaceRequest] =
     Action.async(validateJson[WebKnossosIsosurfaceRequest]) { implicit request =>
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-        AllowRemoteOrigin {
-          for {
-            // The client expects the isosurface as a flat float-array. Three consecutive floats form a 3D point, three
-            // consecutive 3D points (i.e., nine floats) form a triangle.
-            // There are no shared vertices between triangles.
-            (vertices, neighbors) <- tracingService.createIsosurface(tracingId, request.body)
-          } yield {
-            // We need four bytes for each float
-            val responseBuffer = ByteBuffer.allocate(vertices.length * 4).order(ByteOrder.LITTLE_ENDIAN)
-            responseBuffer.asFloatBuffer().put(vertices)
-            Ok(responseBuffer.array()).withHeaders(getNeighborIndices(neighbors): _*)
-          }
+        for {
+          // The client expects the isosurface as a flat float-array. Three consecutive floats form a 3D point, three
+          // consecutive 3D points (i.e., nine floats) form a triangle.
+          // There are no shared vertices between triangles.
+          (vertices, neighbors) <- tracingService.createIsosurface(tracingId, request.body)
+        } yield {
+          // We need four bytes for each float
+          val responseBuffer = ByteBuffer.allocate(vertices.length * 4).order(ByteOrder.LITTLE_ENDIAN)
+          responseBuffer.asFloatBuffer().put(vertices)
+          Ok(responseBuffer.array()).withHeaders(getNeighborIndices(neighbors): _*)
         }
       }
     }
@@ -249,12 +227,10 @@ class VolumeTracingController @Inject()(val tracingService: VolumeTracingService
 
   def findData(token: Option[String], tracingId: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
-      AllowRemoteOrigin {
-        for {
-          positionOpt <- tracingService.findData(tracingId)
-        } yield {
-          Ok(Json.obj("position" -> positionOpt, "resolution" -> positionOpt.map(_ => Vec3Int(1, 1, 1))))
-        }
+      for {
+        positionOpt <- tracingService.findData(tracingId)
+      } yield {
+        Ok(Json.obj("position" -> positionOpt, "resolution" -> positionOpt.map(_ => Vec3Int(1, 1, 1))))
       }
     }
   }


### PR DESCRIPTION
This allows the CORS headers to be set also in error case by moving the adding of the header directly to the function that creates Result objects from Success or Failures etc (BoxToResultHelpers).
 - Moves the mechanism from the individual routes up to the whole Controller (override allowRemoteOrigin = true)
 - Only controller that still uses the old mechanism (no longer implemented as block wrapper, though) is DataSetController because it has some routes where CORS should be set and some where not. Note that for those two routes the error case will still be missing the headers (would have to extract them to separate controllers to reuse the mechanism. let’s do that only if the need arises).
 - Moves some code from the datastore-specific Controller to the generic ExtendedController trait to reduce import redundancy
 - When reviewing, hide whitespace in github diff. Note that some line breaks may be changed by the formatter.

### Steps to test:
- observe result headers in network tab of /api/datasets (should have cors headers) and /api/teams (should not)
- break a datastore route (e.g. insert line `_ <- Fox.failure("Nope")` after line 454 of the BinaryDataController) – subsequent histogram requests should fail, but still have the header.

### Issues:
- fixes #6078 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
