### PR TITLE
Disallow deactivating users with active tasks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The maximum brush size now depends on the available magnifications. Consequentially, one can use a larger brush size when the magnifications of a volume layer are restricted. [#6066](https://github.com/scalableminds/webknossos/pull/6066)
 - Improved stability and speed of volume annotations when annotating large areas. [#6055](https://github.com/scalableminds/webknossos/pull/6055)
 - In dataset upload, linking layers of existing datasets is no longer restricted to public datasets. [#6097](https://github.com/scalableminds/webknossos/pull/6097)
+- Deactivating users with currently active tasks is no longer allowed. [#6099](https://github.com/scalableminds/webknossos/pull/6099)
 
 ### Fixed
 - Fixed a bug that led to crashing the layer settings once the icon for the downsample modal was clicked. [#6058](https://github.com/scalableminds/webknossos/pull/6058)

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -224,6 +224,17 @@ class AnnotationDAO @Inject()(sqlClient: SQLClient, annotationLayerDAO: Annotati
     } yield parsed
   }
 
+  def findActiveTaskIdsForUser(userId: ObjectId): Fox[List[ObjectId]] = {
+
+    val stateQuery = getStateQuery(isFinished = Some(false))
+    for {
+      r <- run(sql"""select _task from #$existingCollectionName
+             where _user = ${userId.id} and typ = '#${AnnotationType.Task.toString}' and #$stateQuery""".as[String])
+      r <- Fox.serialCombined(r.toList)(ObjectId.parse(_))
+    } yield r
+
+  }
+
   def countAllFor(userId: ObjectId, isFinished: Option[Boolean], annotationType: AnnotationType)(
       implicit ctx: DBAccessContext): Fox[Int] = {
     val stateQuery = getStateQuery(isFinished)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://disallowdeactivatingwithtask.webknossos.xyz

### Steps to test:
- Create second user, give them experience, create task, have them request it
- Deactivating this user should no longer work, give readable error message
- Deactivating users with no active tasks should work still

### Issues:
- fixes #6049 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
