### PR TITLE
Unify long-running RPC timeouts

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where deactivated users would still be listed as allowed to access the datasets of their team. [#6070](https://github.com/scalableminds/webknossos/pull/6070)
 - Fix occasionally "disappearing" data. [#6055](https://github.com/scalableminds/webknossos/pull/6055)
 - Fixed a bug where remote-origin headers were omitted in error case. [#6098](https://github.com/scalableminds/webknossos/pull/6098)
+- Increased the timeouts for some internal operations like downsampling volume annotations. [#6103](https://github.com/scalableminds/webknossos/pull/6103)
 
 ### Removed
 - The previously disabled Import Skeleton Button has been removed. The functionality is available via the context menu for datasets with active ID mappings. [#6073](https://github.com/scalableminds/webknossos/pull/6073)

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -3,7 +3,6 @@ package controllers
 import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.accesscontext.DBAccessContext
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
-import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.config.ConfigRenderOptions
 import io.swagger.annotations.{Api, ApiOperation, ApiResponse, ApiResponses}
 import javax.inject.Inject
@@ -23,8 +22,7 @@ class Application @Inject()(multiUserDAO: MultiUserDAO,
                             releaseInformationDAO: ReleaseInformationDAO,
                             conf: WkConf,
                             storeModules: StoreModules,
-                            sil: Silhouette[WkEnv],
-                            rpc: RPC)(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
+                            sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller {
 
   @ApiOperation(value = "Information about the version of webKnossos")

--- a/app/models/annotation/WKRemoteTracingStoreClient.scala
+++ b/app/models/annotation/WKRemoteTracingStoreClient.scala
@@ -179,6 +179,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
         rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataBlocking")
           .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
           .addQueryStringOptional("version", version.map(_.toString))
+          .withLongTimeout
           .getWithBytesResponse
       }
       fetchedAnnotationLayer <- FetchedAnnotationLayer.fromAnnotationLayer(annotationLayer, Right(tracing), data)
@@ -191,6 +192,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
       data <- rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataBlocking")
         .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
         .addQueryStringOptional("version", version.map(_.toString))
+        .withLongTimeout
         .getWithBytesResponse
     } yield data
   }

--- a/app/models/annotation/WKRemoteTracingStoreClient.scala
+++ b/app/models/annotation/WKRemoteTracingStoreClient.scala
@@ -32,6 +32,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
       skeletonTracing <- rpc(s"${tracingStore.url}/tracings/skeleton/${annotationLayer.tracingId}")
         .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
         .addQueryStringOptional("version", version.map(_.toString))
+        .withLongTimeout
         .getWithProtoResponse[SkeletonTracing](SkeletonTracing)
       fetchedAnnotationLayer <- FetchedAnnotationLayer.fromAnnotationLayer(annotationLayer, Left(skeletonTracing))
     } yield fetchedAnnotationLayer
@@ -41,6 +42,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
     logger.debug("Called to get multiple SkeletonTracings." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/skeleton/getMultiple")
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
+      .withLongTimeout
       .postJsonWithProtoResponse[List[Option[TracingSelector]], SkeletonTracings](tracingIds.map(id =>
         id.map(TracingSelector(_))))(SkeletonTracings)
   }
@@ -49,27 +51,28 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
     logger.debug("Called to get multiple VolumeTracings." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/volume/getMultiple")
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
+      .withLongTimeout
       .postJsonWithProtoResponse[List[Option[TracingSelector]], VolumeTracings](tracingIds.map(id =>
         id.map(TracingSelector(_))))(VolumeTracings)
   }
 
   def saveSkeletonTracing(tracing: SkeletonTracing): Fox[String] = {
     logger.debug("Called to save SkeletonTracing." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/skeleton/save")
+    rpc(s"${tracingStore.url}/tracings/skeleton/save").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .postProtoWithJsonResponse[SkeletonTracing, String](tracing)
   }
 
   def saveSkeletonTracings(tracings: SkeletonTracings): Fox[List[Box[Option[String]]]] = {
     logger.debug("Called to save SkeletonTracings." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/skeleton/saveMultiple")
+    rpc(s"${tracingStore.url}/tracings/skeleton/saveMultiple").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .postProtoWithJsonResponse[SkeletonTracings, List[Box[Option[String]]]](tracings)
   }
 
   def saveVolumeTracings(tracings: VolumeTracings): Fox[List[Box[Option[String]]]] = {
     logger.debug("Called to save VolumeTracings." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/volume/saveMultiple")
+    rpc(s"${tracingStore.url}/tracings/volume/saveMultiple").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .postProtoWithJsonResponse[VolumeTracings, List[Box[Option[String]]]](tracings)
   }
@@ -78,7 +81,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
                                versionString: Option[String] = None,
                                isFromTask: Boolean = false): Fox[String] = {
     logger.debug("Called to duplicate SkeletonTracing." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/skeleton/$skeletonTracingId/duplicate")
+    rpc(s"${tracingStore.url}/tracings/skeleton/$skeletonTracingId/duplicate").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .addQueryStringOptional("version", versionString)
       .addQueryString("fromTask" -> isFromTask.toString)
@@ -91,7 +94,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
                              resolutionRestrictions: ResolutionRestrictions = ResolutionRestrictions.empty,
                              downsample: Boolean = false): Fox[String] = {
     logger.debug("Called to duplicate VolumeTracing." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/volume/$volumeTracingId/duplicate")
+    rpc(s"${tracingStore.url}/tracings/volume/$volumeTracingId/duplicate").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .addQueryString("fromTask" -> fromTask.toString)
       .addQueryStringOptional("minResolution", resolutionRestrictions.minStr)
@@ -102,7 +105,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
 
   def mergeSkeletonTracingsByIds(tracingIds: List[String], persistTracing: Boolean): Fox[String] = {
     logger.debug("Called to merge SkeletonTracings by ids." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/skeleton/mergedFromIds")
+    rpc(s"${tracingStore.url}/tracings/skeleton/mergedFromIds").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .addQueryString("persist" -> persistTracing.toString)
       .postJsonWithJsonResponse[List[TracingSelector], String](tracingIds.map(TracingSelector(_)))
@@ -110,7 +113,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
 
   def mergeVolumeTracingsByIds(tracingIds: List[String], persistTracing: Boolean): Fox[String] = {
     logger.debug("Called to merge VolumeTracings by ids." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/volume/mergedFromIds")
+    rpc(s"${tracingStore.url}/tracings/volume/mergedFromIds").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .addQueryString("persist" -> persistTracing.toString)
       .postJsonWithJsonResponse[List[TracingSelector], String](tracingIds.map(TracingSelector(_)))
@@ -118,7 +121,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
 
   def mergeSkeletonTracingsByContents(tracings: SkeletonTracings, persistTracing: Boolean): Fox[String] = {
     logger.debug("Called to merge SkeletonTracings by contents." + baseInfo)
-    rpc(s"${tracingStore.url}/tracings/skeleton/mergedFromContents")
+    rpc(s"${tracingStore.url}/tracings/skeleton/mergedFromContents").withLongTimeout
       .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
       .addQueryString("persist" -> persistTracing.toString)
       .postProtoWithJsonResponse[SkeletonTracings, String](tracings)
@@ -134,7 +137,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
         .addQueryString("persist" -> persistTracing.toString)
         .postProtoWithJsonResponse[VolumeTracings, String](tracings)
       packedVolumeDataZips = packVolumeDataZips(initialData.flatten)
-      _ <- rpc(s"${tracingStore.url}/tracings/volume/$tracingId/initialDataMultiple")
+      _ <- rpc(s"${tracingStore.url}/tracings/volume/$tracingId/initialDataMultiple").withLongTimeout
         .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
         .post(packedVolumeDataZips)
     } yield tracingId
@@ -153,7 +156,7 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
         .postProtoWithJsonResponse[VolumeTracing, String](tracing)
       _ <- initialData match {
         case Some(file) =>
-          rpc(s"${tracingStore.url}/tracings/volume/$tracingId/initialData")
+          rpc(s"${tracingStore.url}/tracings/volume/$tracingId/initialData").withLongTimeout
             .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
             .addQueryStringOptional("minResolution", resolutionRestrictions.minStr)
             .addQueryStringOptional("maxResolution", resolutionRestrictions.maxStr)
@@ -176,10 +179,9 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
         .addQueryStringOptional("version", version.map(_.toString))
         .getWithProtoResponse[VolumeTracing](VolumeTracing)
       data <- Fox.runIf(!skipVolumeData) {
-        rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataBlocking")
+        rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataBlocking").withLongTimeout
           .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
           .addQueryStringOptional("version", version.map(_.toString))
-          .withLongTimeout
           .getWithBytesResponse
       }
       fetchedAnnotationLayer <- FetchedAnnotationLayer.fromAnnotationLayer(annotationLayer, Right(tracing), data)
@@ -189,10 +191,9 @@ class WKRemoteTracingStoreClient(tracingStore: TracingStore, dataSet: DataSet, r
   def getVolumeData(tracingId: String, version: Option[Long] = None): Fox[Array[Byte]] = {
     logger.debug("Called to get volume data." + baseInfo)
     for {
-      data <- rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataBlocking")
+      data <- rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataBlocking").withLongTimeout
         .addQueryString("token" -> RpcTokenHolder.webKnossosToken)
         .addQueryStringOptional("version", version.map(_.toString))
-        .withLongTimeout
         .getWithBytesResponse
     } yield data
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
@@ -156,17 +156,13 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
         s"Sending WS request to $url (ID: $id). " +
           s"RequestBody: '$requestBodyPreview'")
     }
-    request
-      .withMethod("GET")
-      .stream()
-      .map(response => Full(response.bodyAsSource))
-      .recover {
-        case e =>
-          val errorMsg = s"Error sending WS request to $url (ID: $id): " +
-            s"${e.getMessage}\n${e.getStackTrace.mkString("\n    ")}"
-          logger.error(errorMsg)
-          Failure(errorMsg)
-      }
+    request.withMethod("GET").stream().map(response => Full(response.bodyAsSource)).recover {
+      case e =>
+        val errorMsg = s"Error sending WS request to $url (ID: $id): " +
+          s"${e.getMessage}\n${e.getStackTrace.mkString("\n    ")}"
+        logger.error(errorMsg)
+        Failure(errorMsg)
+    }
   }
 
   private def performRequest: Fox[WSResponse] = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
@@ -30,6 +30,11 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
     this
   }
 
+  def withLongTimeout: RPCRequest = {
+    request = request.withRequestTimeout(2 hours)
+    this
+  }
+
   def silent: RPCRequest = {
     verbose = false
     this
@@ -59,7 +64,7 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
   }
 
   def getWithBytesResponse: Fox[Array[Byte]] = {
-    request = request.withMethod("GET").withRequestTimeout(30 minutes)
+    request = request.withMethod("GET")
     extractBytesResponse(performRequest)
   }
 
@@ -153,7 +158,6 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient) extends FoxIm
     }
     request
       .withMethod("GET")
-      .withRequestTimeout(Duration.Inf)
       .stream()
       .map(response => Full(response.bodyAsSource))
       .recover {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SampleDataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SampleDataSourceService.scala
@@ -65,7 +65,7 @@ class SampleDataSourceService @Inject()(rpc: RPC,
 
   def download(id: DataSourceId): Fox[Unit] =
     for {
-      responseBox <- rpc(availableDatasets(id.name).url).get.futureBox
+      responseBox <- rpc(availableDatasets(id.name).url).withLongTimeout.get.futureBox
       _ = responseBox match {
         case Full(response) =>
           val bytes: ByteString = response.bodyAsBytes


### PR DESCRIPTION
Remote calls between wk and datastore/tracingstore had different kind of timeouts (some the default of 2 min, some 30 min, some infinite). This PR introduces the withLongTimeout method for the RPC wrapper, and adds it to the RPCs that are potentially slow (basically everything that handles the content of potentially large skeletons or volume data).

### Steps to test:
- (will be hard to test without very large data)
- downsample a large mag1 volume annotation, should not timeout

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
