### PR TITLE
Fix markdown issues in docs

### DIFF
--- a/docs/data_formats.md
+++ b/docs/data_formats.md
@@ -7,6 +7,7 @@ The webKnosso-wrap (WKW) container format is used for all internal voxel data re
 Any dataset uploaded to webKnossos.org, will automatically be converted to WKW on upload - given its source file format is supported by webKnossos. Alternatively, you can manually convert your datasets using the [webKnossos Cuber CLI tools](https://docs.webknossos.org/wkcuber/index.html) or use a custom script based on the [webKnossos Python libray](https://docs.webknossos.org/webknossos-py/index.html).
 
 Additionally, webKnossos.org supports connecting and loading data from:
+
 - Neuroglancer Pre-Computed Dataset stored on Google Cloud
 - BossDB
 
@@ -321,6 +322,7 @@ Groups can be freely nested inside each other.
 webKnossos supports [dynamic, on-demand re-mapping of the segmentation IDs](./volume_annotation.md#mappings--on-demand-agglomeration) allowing you to quickly toggle between different agglomeration strategies for a segmentation layer. These "agglomerate" files need to be pre-computed and put into the correct (sub)-directory inside a segmentation layer for webKnossos to identify and read them (self-hosted instance only).
 
 webKnossos supports two formats for these agglomerates:
+
 - JSON -> `mappings` directory
 - HDF5 -> `agglomerates` directory
  (JSON-format) or `agglomerates` directory (HDF5-format) :

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -26,6 +26,7 @@ webKnossos uses the [WKW-format](./data_formats.md#wkw-datasets) internally to d
 If your data is already in WKW you can simply drag your folder (or zip archive of that folder) into the upload view.
 
 If your data is not in WKW, you can either:
+
 - upload the data in a supported file format and webKnossos will automatically convert it to WKW ([webknossos.org](https://webknossos.org) only). Depending on the size of the dataset, the conversion will take some time. You can check the progress at the "Jobs" page or the "My Datasets" page in the dashboard (both will update automatically).
 - [Convert](#converting-datasets) your data manually to WKW.
 
@@ -41,6 +42,7 @@ Once the data is uploaded (and potentially converted), you can further configure
 
 ### Working with Neuroglancer and BossDB dataset
 On webKnossos.org you can work directly with 
+
 - datasets in the Neuroglancer precomputed format stored in the Google Cloud
 - datasets provided by a BossDB server
 
@@ -66,7 +68,9 @@ We are working on integrating full Zarr support into webKnossos. If you have dat
 ### Uploading through the Python API
 For those wishing to automate dataset upload or to do it programmatically, check out the webKnossos [Python library](https://github.com/scalableminds/webknossos-libs). It allows you to create, manage and upload datasets as well. 
 
-### Uploading through the File System (Self-Hosted Instances Only)
+### Uploading through the File System
+-- (Self-Hosted Instances Only)-- 
+
 On self-hosted instances, large datasets can be efficiently imported by placing them directly in the file system:
 
 * Place the dataset at `<webKnossos directory>/binaryData/<Organization name>/<Dataset name>`. For example `/opt/webknossos/binaryData/Springfield_University/great_dataset`.
@@ -81,7 +85,8 @@ Typically webKnossos can infer all the required metadata for a dataset automatic
     If you uploaded the dataset along with a `datasource-properties.json` metadata file, the dataset will be imported automatically without any additional manual steps.
 
 
-#### Using Symbolic Links (Self-Hosted Instances Only)
+#### Using Symbolic Links
+-- Self-Hosted Instances Only --
 
 When you have direct file system access, you can also use symbolic links to import your data into webKnossos. This might be useful when you want to create new datasets based on potentially very large raw microscopy data and symlink it to one or several segmentation layers.
 
@@ -106,6 +111,7 @@ services:
 Any dataset uploaded through the web interface at [webknossos.org](https://webknossos.org) is automatically converted for compatibility.
 
 For manual conversion, we provide the following software tools and libraries:
+
 - The [webKnossos Cuber](https://docs.webknossos.org/wkcuber/index.html) is a CLI tool that can convert many formats to WKW. 
 - For other file formats, the [Python webKnossos libray](https://docs.webknossos.org/webknossos-py/index.html) can be an option for custom scripting.
 
@@ -125,6 +131,7 @@ The *Data* tab contains the settings for correctly reading the dataset as the co
 - `Scale`: The physical size of a voxel in nanometers, e.g., `11, 11, 24`
 
 For each detected layer:
+
 - `Bounding Box`: The position and extents of the dataset layer in voxel coordinates. The format is `x, y, z, x_size,y_size, z_size` or respectively `min_x, min_y, min_z, (max_x - min_x), (max_y - min_y), (max_z - min_z)`.
 - `Largest Segment ID`: The highest ID that is currently used in the respective segmentation layer. This is required for volume annotations where new objects with incrementing IDs are created. Only applies to segmentation layers.
 
@@ -153,6 +160,7 @@ Read more in [the Sharing guide](./sharing.md).
 The *View configuration* tab lets you set defaults for viewing this dataset. Anytime a user opens a dataset or creates a new annotation based on this dataset, these default values will be applied. 
 
 Defaults include:
+
 - `Position`: Default position of the dataset in voxel coordinates. When opening the dataset, users will be located at this position.
 - `Zoom`: Default zoom.
 - `Interpolation`: Whether interpolation should be enabled by default.
@@ -163,6 +171,7 @@ Defaults include:
 Of course, the defaults can all be overwritten and adjusted once a user opens the dataset in the main webKnossos interface and makes changes to any of these settings in his viewports. 
 
 For self-hosted webKnossos instances, there are two ways to set default *View Configuration* settings:
+
 - in the web UI as described above
 - inside the `datasource_properties.json` on disk
 
@@ -197,20 +206,23 @@ scalable minds also offers a dataset alignment tool called *Voxelytics Align*.
 
 For convenience and testing, we provide a list of sample datasets for webKnossos:
 
-- Sample_e2006_wkw: https://static.webknossos.org/data/e2006_wkw.zip
-Raw SBEM data and segmentation (sample cutout, 120MB).
-Connectomic reconstruction of the inner plexiform layer in the mouse retina.
-M Helmstaedter, KL Briggman, S Turaga, V Jain, HS Seung, W Denk.
-Nature. 08 August 2013. https://doi.org/10.1038/nature12346
+- Sample_e2006_wkw: 
+  - [https://static.webknossos.org/data/e2006_wkw.zip](https://static.webknossos.org/data/e2006_wkw.zip)
+  - Raw SBEM data and segmentation (sample cutout, 120MB).
+  Connectomic reconstruction of the inner plexiform layer in the mouse retina.
+  - M Helmstaedter, KL Briggman, S Turaga, V Jain, HS Seung, W Denk.
+  - Nature. 08 August 2013. [https://doi.org/10.1038/nature12346](https://doi.org/10.1038/nature12346)
 
-- Sample_FD0144_wkw: https://static.webknossos.org/data/FD0144_wkw.zip
-Raw SBEM data and segmentation (sample cutout, 316 MB).
-FluoEM, virtual labeling of axons in three-dimensional electron microscopy data for long-range connectomics.
-F Drawitsch, A Karimi, KM Boergens, M Helmstaedter.
-eLife. 14 August 2018. https://doi.org/10.7554/eLife.38976
+- Sample_FD0144_wkw: 
+  - [https://static.webknossos.org/data/FD0144_wkw.zip](https://static.webknossos.org/data/FD0144_wkw.zip)
+  - Raw SBEM data and segmentation (sample cutout, 316 MB).
+  - FluoEM, virtual labeling of axons in three-dimensional electron microscopy data for long-range connectomics.
+  - F Drawitsch, A Karimi, KM Boergens, M Helmstaedter.
+  - eLife. 14 August 2018. [https://doi.org/10.7554/eLife.38976](https://doi.org/10.7554/eLife.38976)
 
-- Sample_MPRAGE_250um: https://static.webknossos.org/data/MPRAGE_250um.zip
-MRI data (250 MB).
-T1-weighted in vivo human whole brain MRI dataset with an ultrahigh isotropic resolution of 250 μm.
-F Lüsebrink, A Sciarra, H Mattern, R Yakupov, O Speck.
-Scientific Data. 14 March 2017. https://doi.org/10.1038/sdata.2017.32
+- Sample_MPRAGE_250um: 
+  - [https://static.webknossos.org/data/MPRAGE_250um.zip](https://static.webknossos.org/data/MPRAGE_250um.zip)
+  - MRI data (250 MB).
+  - T1-weighted in vivo human whole brain MRI dataset with an ultrahigh isotropic resolution of 250 μm.
+  - F Lüsebrink, A Sciarra, H Mattern, R Yakupov, O Speck.
+  - Scientific Data. 14 March 2017. https://doi.org/10.1038/sdata.2017.32

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,8 +10,8 @@ We also provide intro calls to answer your questions or walk you through the pla
 
 ## I have a very large dataset and need help annotating it
 There are two options to help you with data annotation:
-1. Invite collaborators to your webKnossos organization, set up a project to work on, and assign them sub-volumes of your data for annotation. See the [page on tasks and projects for more info](./tasks.md). 
 
+1. Invite collaborators to your webKnossos organization, set up a project to work on, and assign them sub-volumes of your data for annotation. See the [page on tasks and projects for more info](./tasks.md). 
 2. We also offer professional services to help with annotation. We can do both [manual annotations](https://webknossos.org/services/annotations) for your data or apply [automated segmentations](https://webknossos.org/services/automated-segmentation) on large-scale datasets.
 
 ## Where can I ask questions or report issues on webKnossos?
@@ -38,6 +38,7 @@ Smaller datasets (up to multiple GB) can be uploaded directly through the web in
 ## Can I host the webKnossos data in my own compute cluster (on-premise installation)?
 
 webKnossos consists of two components that allow for versatile deployment options:
+
 1. The webKnossos main component handles user and task management.
 2. The datastore component serves data requests and stores skeleton and volume annotations.
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -3,6 +3,7 @@
 webKnossos.org includes several compute-intensive and automated workflows that are processed in the background. Depending on the operation and dataset size, these workflows may take some time (from minutes to hours) to finish. 
 
 Example workflows:
+
 - [converting datasets on upload](./datasets.md#uploading-through-the-web-browser)
 - [automated analysis](./automated_analysis.md), e.g., nuclei inferal 
 - [mesh file (pre)-computation](./mesh_visualization.md)
@@ -15,6 +16,7 @@ These workflows are executed in background worker tasks as so-called *processing
 A list of all past and currently running jobs can be found from the administration menu in the navbar (Admin -> *Processing Jobs*).
 
 Depending on the job workflow you may:
+
 - view the resulting resource, e.g., a new segmentation 
 - download the data, e.g., Tiff export
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -3,10 +3,12 @@ webKnossos is built for working collaboratively and sharing your work with colle
 Anything in webKnossos can be shared: the raw datasets, any skeleton or volume annotations, or complex segmentations.
 
 When speaking about collaboration and sharing, we imagine two scenarios supported by webKnossos:
+
 1. Sharing data with outsiders - anyone who is not a member of your webKnossos organization, e.g., colleagues from other institutes, reviewers, publishers, a paper publication, and the research community as a whole.
 2. Share data within your organization to collaborate with other members/co-workers
 
 Since webKnossos is a web platform, most resources can be shared as a web link/URL. This makes it super easy to integrate webKnossos in your existing communication workflows, e.g.:
+
 - send collaborators an *email* containing a link to specific, interesting data location or annotations
 - include a link in a *publication* so readers can have direct access to the data to see for themselves
 - share a link through *Slack*, *MS Teams*, or any other messenger service
@@ -27,6 +29,7 @@ webKnossos sharing is tightly integrated with user permissions and access rights
  The the sharing link also encodes additional information, such as your current camera position/rotation, zoom level, any layers that are turned on/off, the selected node, etc ([Details below](#sharing_link_format). In other words, a sharing link typically captures your current webKnossos state so that any recipient can take off from the same situation.
 
  Sharing a dataset is useful for multiple scenarios: 
+
  - You recorded a novel microscopy dataset and want to include links to it in your paper or for reviewers. Use wklink.org to shorten these URLs, e.g. https://wklink.org/5386 ([contact us](mailto:hello@webknossos.org)) to create these shortlinks.
  - You created an interesting, highly-accurate segmentation layer for an existing dataset and want to share it for your publication.
  - You have worked and published several datasets over the years and want to have a single gallery for all your public datasets.
@@ -193,6 +196,7 @@ In addition to sharing your annotation via a link, you can also share your annot
 This is the simplest way to share an annotation with a whole team.
 
 To share an annotation with a certain team, follow these steps:
+
 1. Open your annotation
 2. From the [toolbar](./tracing_ui.md#the-toolbar) select `Share` from the overflow menu next to the `Save` button.
 3. Under *Team Sharing*, select the teams from the dropdown menu.

--- a/docs/skeleton_annotation.md
+++ b/docs/skeleton_annotation.md
@@ -57,6 +57,7 @@ The webKnossos toolbar at the top of the screen contains several tools designed 
 - `Skeleton`: Create skeleton annotations and place nodes with a left mouse click. Read more below.
 
 When the `Skeleton` tool is active, the following modifiers become available:
+
 - `Create new Tree`: Creates a new tree. 
 - `Toggle single node tree mode`: Modifies the behavior of the skeleton annotation tool to create a new tree at each click instead of adding nodes to the active tree. Useful for marking single position objects/seeds, e.g., for marking nuclei. Also called "Soma-clicking mode".
 - `Toggle merger mode`: Modifies the behavior of the skeleton annotation tool to launch the `Merger Mode`. In merger mode skeletons, can be used to "collect" and merge volume segments from an over-segmentation. [Read more about `Merger Mode`](./volume_annotation.md#proof_reading_and_merging_segments).
@@ -127,6 +128,7 @@ Renaming of a group can be done by selecting a group and then entering a new nam
 Common tree operations include splitting and merging trees.
 
 - `Tree splitting` can be done in two ways:
+
   1. Delete the node at which to split. This can be done by right-clicking a node and choosing "Delete this Node". If you have enabled *Classic Controls*, you need to select (*SHIFT + Left Click*) the node first and then delete (*DEL*) it.
   2. Delete an edge between two nodes. Select the first node (*Left Click*), then right-click the second node and select *Delete Edge to this Node*. If you have enabled *Classic Controls*, you need to select the first node with *Shift + Left Click* and then click on the second node with *SHIFT + CTRL + Left Click* on the second node of the edge to delete this connection.
 - `Tree merging` works similarly to edge deletion but will create a new edge between two previously unconnected trees. Select the first node and right-click on a second one to choose *Create Edge & Merge with this Tree*. When using *Classic Controls*, the second node needs to be selected with *SHIFT + ALT + Left Click* to create an edge between the two.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,6 +17,7 @@ It is possible to download all annotations that belong to either a *Project* or 
 ## How To Create Tasks
 
 First, a *Task Type* needs to be created:
+
 1. Open the `Task Types` screen of the admin section and click on `Add Task Type`.
 2. Fill out the form to create the Task Type:
     - Note that the `Description` field supports Markdown formatting.
@@ -25,6 +26,7 @@ First, a *Task Type* needs to be created:
 ![Create a Task Type](./images/tasks_tasktype.png)
 
 Next, you need to set up a *Project*:
+
 1. Open the `Projects` screen of the admin section and click on `Add Project`.
 2. Fill out the form to create the *Project*.
     - Note that you can assign a `Priority` to the Project. A higher value means that Tasks from this Project will be more likely to be assigned to users.
@@ -33,6 +35,7 @@ Next, you need to set up a *Project*:
 ![Create a Project](./images/tasks_project.png)
 
 Now, you are ready to create *Tasks*:
+
 1. Open the `Tasks` screen of the admin section and click on `Add Task`.
 2. Fill out the form create the Task.
     - Enter the starting positions in the lower part of the form.
@@ -56,6 +59,7 @@ Once a user is done working on a task, they can mark the task as `Finished`.
 ![Requesting Tasks in the Dashboard](./images/dashboard_tasks.png)
 
 Finally, you can collect and review the completed data of all annotations within a project:
+
 1. Navigate to the `Project` page
 2. Select to *View* or *Download* all the combined annotations.
 

--- a/docs/tracing_ui.md
+++ b/docs/tracing_ui.md
@@ -59,6 +59,7 @@ Each dataset consists of one or more data and annotation layers. A dataset typic
 - `Histogram`: The Histogram displays sampled color values of the dataset on a logarithmic scale. The slider below the Histogram can be used to adjust the dynamic range of the displayed values. In order to increase the contrast of data, reduce the dynamic range. To decrease the contrast, widen the range. In order to increase the brightness, move the range to the left. To decrease the brightness, move the range to the right.
 
     Above the the histogram, there are icon buttons to further adjust the histogram or otherwise interact with the layer:
+    
         - `pencil`: Manipulate the min/max value of the histogram range. Clips values above/below these limits. 
         - `vertical line`: Automatically adjust the histogram for best contrast. Contrast estimation is based on the data currently available in your viewport.
         - `circle arrow`: Reload the data from server. Useful if the raw data has been changed on disk and you want to refresh your current session.

--- a/docs/tracing_ui.md
+++ b/docs/tracing_ui.md
@@ -17,6 +17,7 @@ The main webKnossos user interface for viewing and annotating datasets is divide
 The toolbar contains frequently used commands, such as saving and sharing, your current position within the dataset, and the ability to switch between various modes for viewing. Further, it provides access to all the tools for annotation, navigation, and more.
 
 The most common buttons are:
+
 - `Settings`: Toggles the visibility of the left-hand side panel with all data and segmentation layers and their respective settings.
 - `Undo` / `Redo`: Undoes the last operation or redoes it if no new changes have been made in the meantime. Undo can only revert changes made in this session (since the moment the annotation view was opened). To revert to older versions use the "Restore Older Version" functionality described later in this list.
 - `Save`: Saves your annotation work. webKnossos automatically saves every 30 seconds.
@@ -32,7 +33,7 @@ Clicking on the position or rotation labels copies the values to the clipboard.
 
 ![The webKnossos toolbar contains many useful features for quick access such as Saving und Undo/Redo](images/tracing_ui_toolbar.png)
 
-The toolbar further features aöl available navigation and annotation tools for quick access:
+The toolbar further features all available navigation and annotation tools for quick access:
 
 - `Move`: Navigate around the dataset.
 - `Skeleton`: Create skeleton annotations and place nodes. [Read more about skeleton annotations](./skeleton_annotation.md#tools).

--- a/docs/users.md
+++ b/docs/users.md
@@ -99,6 +99,7 @@ After that time or by default for any other inactive users, the `Users` list onl
 
 
 When activating new users, a popup opens for
+
   - team assignment
   - access role assignment
 


### PR DESCRIPTION
PR fixes some rendering issues with the docs. It seems like the GitBook markdown rendered wants an empty line before enumerations/unordered lists.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- RTM


------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
