### PR TITLE
allow all resolutions if there is no volume annotation in the nml

### DIFF
--- a/.circleci/slack-notification.sh
+++ b/.circleci/slack-notification.sh
@@ -17,6 +17,7 @@ if [ "${CIRCLE_BRANCH}" == "master" ] ; then
     author=${author/valentin-pinkau/<@valentin>}
     author=${author/youri-k/<@youri>}
     author=${author/Dagobert42/<@Arthur Hilbert>}
+    author=${author/leowe/<@leowe>}
     channel="webknossos-bots"
     commitmsg="$(git log --format=%s -n 1)"
     pullregex="(.*)#([0-9]+)(.*)"

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fix occasionally "disappearing" data. [#6055](https://github.com/scalableminds/webknossos/pull/6055)
 - Fixed a bug where remote-origin headers were omitted in error case. [#6098](https://github.com/scalableminds/webknossos/pull/6098)
 - Increased the timeouts for some internal operations like downsampling volume annotations. [#6103](https://github.com/scalableminds/webknossos/pull/6103)
+- Fixed a bug that led to an error when drag-'n-dropping an empty volume annotation in the dataset view. [#6116](https://github.com/scalableminds/webknossos/pull/6116)
 
 ### Removed
 - The previously disabled Import Skeleton Button has been removed. The functionality is available via the context menu for datasets with active ID mappings. [#6073](https://github.com/scalableminds/webknossos/pull/6073)

--- a/frontend/javascripts/messages.js
+++ b/frontend/javascripts/messages.js
@@ -289,7 +289,7 @@ instead. Only enable this option if you understand its effect. All layers will n
   "annotation.finish": "Are you sure you want to permanently finish this annotation?",
   "annotation.was_finished": "Annotation was archived",
   "annotation.no_fallback_data_included":
-    "This download does only include the volume data annotated in this annotation. The fallback volume data is excluded.",
+    "This download only includes the volume data annotated in this annotation. The fallback volume data is excluded.",
   "annotation.was_re_opened": "Annotation was reopened",
   "annotation.delete": "Do you really want to reset and cancel this annotation?",
   "annotation.was_edited": "Successfully updated annotation",

--- a/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
@@ -60,16 +60,16 @@ trait PathUtils extends LazyLogging {
     } catch {
       case _: AccessDeniedException =>
         val errorMsg = s"Error access denied. Directory: ${directory.toAbsolutePath}"
-        logger.error(errorMsg)
+        logger.warn(errorMsg)
         Failure(errorMsg)
       case _: NoSuchFileException =>
         val errorMsg = s"No such directory. Directory: ${directory.toAbsolutePath}"
-        logger.error(errorMsg)
+        logger.warn(errorMsg)
         Failure(errorMsg)
       case ex: Exception =>
         val errorMsg =
           s"Error: ${ex.getClass.getCanonicalName} - ${ex.getMessage}. Directory: ${directory.toAbsolutePath}"
-        logger.error(ex.getClass.getCanonicalName)
+        logger.warn(ex.getClass.getCanonicalName)
         Failure(errorMsg)
     }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -202,7 +202,7 @@ class VolumeTracingService @Inject()(
         saveBucket(dataLayer, bucketPosition, bytes, tracing.version)
       }
     }
-    // if none of the tracings contained any volume data. do not save buckets, use full resolution list
+    // if none of the tracings contained any volume data, use the dataset’s full resolution list
     if (savedResolutions.isEmpty) return getRequiredMags(tracing).map(_.toSet)
 
     unzipResult.map(_ => savedResolutions.toSet)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -186,10 +186,14 @@ class VolumeTracingService @Inject()(
   def initializeWithData(tracingId: String,
                          tracing: VolumeTracing,
                          initialData: File,
-                         resolutionRestrictions: ResolutionRestrictions): Box[Set[Vec3Int]] = {
+                         resolutionRestrictions: ResolutionRestrictions): Fox[Set[Vec3Int]] = {
     if (tracing.version != 0L) {
       return Failure("Tracing has already been edited.")
     }
+
+    val resolutionSet = resolutionSetFromZipfile(initialData)
+    // if none of the tracings contained any volume data. do not save buckets, use full resolution list
+    if (resolutionSet.isEmpty) return getRequiredMags(tracing).map(_.toSet)
 
     val dataLayer = volumeTracingLayer(tracingId, tracing)
     val savedResolutions = new mutable.HashSet[Vec3Int]()

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -191,10 +191,6 @@ class VolumeTracingService @Inject()(
       return Failure("Tracing has already been edited.")
     }
 
-    val resolutionSet = resolutionSetFromZipfile(initialData)
-    // if none of the tracings contained any volume data. do not save buckets, use full resolution list
-    if (resolutionSet.isEmpty) return getRequiredMags(tracing).map(_.toSet)
-
     val dataLayer = volumeTracingLayer(tracingId, tracing)
     val savedResolutions = new mutable.HashSet[Vec3Int]()
 
@@ -206,6 +202,9 @@ class VolumeTracingService @Inject()(
         saveBucket(dataLayer, bucketPosition, bytes, tracing.version)
       }
     }
+    // if none of the tracings contained any volume data. do not save buckets, use full resolution list
+    if (savedResolutions.isEmpty) return getRequiredMags(tracing).map(_.toSet)
+
     unzipResult.map(_ => savedResolutions.toSet)
   }
 


### PR DESCRIPTION
- When uploading a NML check whether there are any volume annotations, if there are none, allow all resolutions
- add `leowe` to slack notifications
- fix small language mistake
- change `logger.error` to `logger.warn` for filesystem checking for the data set indexing

### URL of deployed dev instance (used for testing):
- https://emptytracing.webknossos.xyz/

### Steps to test:
- Open any dataset (e.g. `l4_sample`)
- Create a empty annotation, download it, and then drag and drop it in the view (or use [this](https://github.com/scalableminds/webknossos/files/8262647/l4_sample__explorational__suser__bb74f7.zip) empty annotation)
- A new annotation should open without an error message

### Issues:
- fixes #6063 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
