### PR TITLE
fix alignment of annotation name and description button

### DIFF
--- a/frontend/javascripts/components/text_with_description.js
+++ b/frontend/javascripts/components/text_with_description.js
@@ -28,29 +28,35 @@ class TextWithDescription extends React.PureComponent<Props> {
 
     return (
       <React.Fragment>
-        {isEditable ? (
-          // $FlowIssue[incompatible-type]
-          <EditableTextLabel {...editableProps} />
-        ) : (
-          <span style={{ margin: "0 10px", display: "inline-block" }}>
-            {this.props.markdown ? (
-              <Markdown
-                source={this.props.value}
-                options={{ html: false, breaks: true, linkify: true }}
-                container="span"
-              />
+        <span className={hasDescription ? "flex-container" : null} style={{ alignItems: "center" }}>
+          <span className={hasDescription ? "flex-item" : null} style={{ flexGrow: 0 }}>
+            {hasDescription ? (
+              <Tooltip title="Show description" placement="bottom">
+                <Popover title="Description" trigger="click" content={markdownDescription}>
+                  <i className="fas fa-align-justify" style={{ cursor: "pointer" }} />
+                </Popover>
+              </Tooltip>
+            ) : null}
+          </span>
+          <span className={hasDescription ? "flex-item" : null}>
+            {isEditable ? (
+              // $FlowIssue[incompatible-type]
+              <EditableTextLabel {...editableProps} />
             ) : (
-              this.props.value
+              <span style={{ margin: "0 10px", display: "inline-block" }}>
+                {this.props.markdown ? (
+                  <Markdown
+                    source={this.props.value}
+                    options={{ html: false, breaks: true, linkify: true }}
+                    container="span"
+                  />
+                ) : (
+                  this.props.value
+                )}
+              </span>
             )}
           </span>
-        )}
-        {hasDescription ? (
-          <Tooltip title="Show description" placement="bottom">
-            <Popover title="Description" trigger="click" content={markdownDescription}>
-              <i className="fas fa-align-justify" style={{ cursor: "pointer" }} />
-            </Popover>
-          </Tooltip>
-        ) : null}
+        </span>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- check annotation names in dashboard

### Issues:
- fixes #6092 

------
- [x] Ready for review

Looks like this now:
![Screenshot 2022-03-16 at 15 42 23](https://user-images.githubusercontent.com/46814136/158617570-3f599edc-8f90-45fc-9050-c8a9c5ee1b4e.png)