### PR TITLE
Materialize FileSystemProvider meta file

### DIFF
--- a/webknossos-datastore/conf/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/webknossos-datastore/conf/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -1,1 +1,2 @@
-conf/META-INF/services/java.nio.file.spi.FileSystemProvider
+com.upplication.s3fs.S3FileSystemProvider
+com.scalableminds.webknossos.datastore.storage.httpsfilesystem.HttpsFileSystemProvider


### PR DESCRIPTION
This file in META-INF is needed to register FileSystemsProviders in the JVM.
It was a symlink in the standalone-datastore directory, pointing to the wk one. 
Apparently this gets lost during the build, though, got `provider "https" not found` in docker production deployment