### PR TITLE
install blosc in standalone datastore dockerfile

### DIFF
--- a/webknossos-datastore/Dockerfile
+++ b/webknossos-datastore/Dockerfile
@@ -1,4 +1,7 @@
 FROM openjdk:8-jre
+RUN apt-get update \
+  && apt-get -y install libblosc1 \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /webknossos-datastore \
   && groupadd -g 1000 -r webknossos \


### PR DESCRIPTION
standalone datastore also needs to install blosc for zarr. 
kind of a shot in the dark as there were no readable error messages :(
works on internal datastore though, so this is the only difference that I can think of