### PR TITLE
Do not depend on jzarr, use jblosc, ucarCdm directly

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,8 +43,9 @@ object Dependencies {
   private val jgrapht = "org.jgrapht" % "jgrapht-core" % "1.4.0"
   private val swagger = "io.swagger" %% "swagger-play2" % "1.7.1"
   private val jhdf = "cisd" % "jhdf5" % "19.04.0"
-  private val jzarr = "com.bc.zarr" % "jzarr" % "0.3.5"
+  private val ucarCdm = "edu.ucar" % "cdm-core" % "5.3.3"
   private val s3fs = "org.lasersonlab" % "s3fs" % "2.2.3"
+  private val jblosc = "org.lasersonlab" % "jblosc" % "1.0.1"
   private val scalajHttp = "org.scalaj" %% "scalaj-http" % "2.4.2"
 
   private val sql = Seq(
@@ -87,8 +88,9 @@ object Dependencies {
     akkaHttp,
     redis,
     jhdf,
-    jzarr,
+    ucarCdm,
     s3fs,
+    jblosc,
     scalajHttp
   )
 


### PR DESCRIPTION
Since our code duplicates the functionality of jzarr, we do not need it as a dependency. We had kept that because we relied on *its* dependencies. Now we use those directly (only two are left, jblosc and ucar cdm)

I tested that zarr datasets can still be correctly viewed

contributes to https://github.com/scalableminds/webknossos/issues/6119

- [x] Needs datastore update after deployment
- [x] Ready for review
