### PR TITLE
Asynchronous cache for zarr chunk loading

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
   - Add filter functionality to "Access Permissions" column to filter for public datasets.
   - Removed `isActive` and `isPublic` columns to save screen space.
   - Changed data layer entries to display layer names instead of categories, e.g. "color" --> "axons".
+- Sped up initial requests for remote zarr dataset by using asynchronous caching. [#6165](https://github.com/scalableminds/webknossos/pull/6165)
 
 ### Fixed
 - Fixed a bug that led to an error when drag-'n-dropping an empty volume annotation in the dataset view. [#6116](https://github.com/scalableminds/webknossos/pull/6116)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
   private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
   private val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
   private val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
+  private val akkaCaching = "com.typesafe.akka" %% "akka-http-caching" % akkaHttpVersion
   private val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
   private val commonsEmail = "org.apache.commons" % "commons-email" % "1.5"
   private val commonsIo = "commons-io" % "commons-io" % "2.9.0"
@@ -76,6 +77,7 @@ object Dependencies {
     grpcServices,
     scalapbRuntimeGrpc,
     akkaLogging,
+    akkaCaching,
     ehcache,
     gson,
     webknossosWrap,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/DataCubeHandle.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/DataCubeHandle.scala
@@ -1,9 +1,11 @@
 package com.scalableminds.webknossos.datastore.dataformats
 
+import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.models.BucketPosition
-import net.liftweb.common.Box
+
+import scala.concurrent.ExecutionContext
 
 // To be implemented as handle for a cube (e.g. may correspond to one 1GB wkw file)
 trait DataCubeHandle extends SafeCachable {
-  def cutOutBucket(bucket: BucketPosition): Box[Array[Byte]]
+  def cutOutBucket(bucket: BucketPosition)(implicit ec: ExecutionContext): Fox[Array[Byte]]
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
@@ -1,5 +1,6 @@
 package com.scalableminds.webknossos.datastore.dataformats.wkw
 
+import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.dataformats.{BucketProvider, DataCubeHandle}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
@@ -7,14 +8,16 @@ import com.scalableminds.webknossos.wrap.WKWFile
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.{Box, Empty}
 
-class WKWCubeHandle(wkwFile: WKWFile) extends DataCubeHandle {
+import scala.concurrent.{ExecutionContext, Future}
 
-  def cutOutBucket(bucket: BucketPosition): Box[Array[Byte]] = {
+class WKWCubeHandle(wkwFile: WKWFile) extends DataCubeHandle with FoxImplicits {
+
+  def cutOutBucket(bucket: BucketPosition)(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
     val numBlocksPerCubeDimension = wkwFile.header.numBlocksPerCubeDimension
     val blockOffsetX = bucket.x % numBlocksPerCubeDimension
     val blockOffsetY = bucket.y % numBlocksPerCubeDimension
     val blockOffsetZ = bucket.z % numBlocksPerCubeDimension
-    wkwFile.readBlock(blockOffsetX, blockOffsetY, blockOffsetZ)
+    Fox(Future.successful(wkwFile.readBlock(blockOffsetX, blockOffsetY, blockOffsetZ)))
   }
 
   override protected def onFinalize(): Unit =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
@@ -4,6 +4,7 @@ import java.nio.file.{FileSystem, Path}
 
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.util.requestlogging.RateLimitedErrorLogging
+import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.dataformats.{BucketProvider, DataCubeHandle}
 import com.scalableminds.webknossos.datastore.jzarr.ZarrArray
 import com.scalableminds.webknossos.datastore.models.BucketPosition
@@ -13,12 +14,15 @@ import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.Box.tryo
 import net.liftweb.common.{Box, Empty}
 
+import scala.concurrent.ExecutionContext
+
 class ZarrCubeHandle(zarrArray: ZarrArray) extends DataCubeHandle with LazyLogging with RateLimitedErrorLogging {
 
-  def cutOutBucket(bucket: BucketPosition): Box[Array[Byte]] = {
+  def cutOutBucket(bucket: BucketPosition)(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
     val shape = Vec3Int.full(bucket.bucketLength)
     val offset = Vec3Int(bucket.globalXInMag, bucket.globalYInMag, bucket.globalZInMag)
-    tryo(onError = e => logError(e))(zarrArray.readBytesXYZ(shape, offset))
+    zarrArray.readBytesXYZ(shape, offset)
+    // TODO error handling? had to remove the tryo
   }
 
   override protected def onFinalize(): Unit = ()

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ChunkContentsCache.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ChunkContentsCache.scala
@@ -1,8 +1,0 @@
-package com.scalableminds.webknossos.datastore.jzarr
-
-import com.scalableminds.util.cache.LRUConcurrentCache
-import ucar.ma2.{Array => MultiArray}
-
-class ChunkContentsCache(maxSizeBytes: Int, bytesPerEntry: Int) extends LRUConcurrentCache[String, MultiArray] {
-  def maxEntries: Int = maxSizeBytes / bytesPerEntry
-}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ChunkReader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ChunkReader.scala
@@ -72,8 +72,7 @@ class ShortChunkReader(val store: Store, val header: ZarrHeader) extends ChunkRe
 
   val ma2DataType: MADataType = MADataType.SHORT
 
-  override def read(path: String): Future[MultiArray] = {
-    logger.info(f"read chunk $path, this=$this")
+  override def read(path: String): Future[MultiArray] =
     Future.successful(Using.Manager { use =>
       readBytes(path).map { bytes =>
         val typedStorage = new Array[Short](chunkSize)
@@ -84,7 +83,6 @@ class ShortChunkReader(val store: Store, val header: ZarrHeader) extends ChunkRe
         MultiArray.factory(ma2DataType, header.chunkShapeOrdered, typedStorage)
       }.getOrElse(createFilled(ma2DataType))
     }.get)
-  }
 }
 
 class IntChunkReader(val store: Store, val header: ZarrHeader) extends ChunkReader {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrArray.scala
@@ -87,11 +87,10 @@ class ZarrArray(relativePath: ZarrPath, store: Store, header: ZarrHeader) extend
   // @return Byte array in fortran-order with little-endian values
   @throws[IOException]
   @throws[InvalidRangeException]
-  def readBytes(shape: Array[Int], offset: Array[Int])(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
+  def readBytes(shape: Array[Int], offset: Array[Int])(implicit ec: ExecutionContext): Fox[Array[Byte]] =
     for {
       typedData <- readAsFortranOrder(shape, offset)
     } yield BytesConverter.toByteArray(typedData, header.dataType, ByteOrder.LITTLE_ENDIAN)
-  }
 
   @throws[IOException]
   @throws[InvalidRangeException]

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrArray.scala
@@ -5,11 +5,16 @@ import java.nio.ByteOrder
 import java.nio.file.Path
 import java.util
 
+import akka.http.caching.LfuCache
+import akka.http.caching.scaladsl.{Cache, CachingSettings}
 import com.scalableminds.util.geometry.Vec3Int
+import com.scalableminds.util.tools.Fox
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import ucar.ma2.{InvalidRangeException, Array => MultiArray}
 
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 
 object ZarrArray extends LazyLogging {
@@ -49,13 +54,28 @@ class ZarrArray(relativePath: ZarrPath, store: Store, header: ZarrHeader) extend
     ChunkReader.create(store, header)
 
   // cache currently limited to 100 MB per array
-  private lazy val chunkContentsCache: ChunkContentsCache =
-    new ChunkContentsCache(maxSizeBytes = 1000 * 1000 * 100, bytesPerEntry = header.bytesPerChunk)
+  private lazy val chunkContentsCache: Cache[String, MultiArray] = {
+    // new ChunkContentsCache(maxSizeBytes = 1000 * 1000 * 100, bytesPerEntry = header.bytesPerChunk)
+
+    val maxSizeBytes = 1000 * 1000 * 100
+
+    val defaultCachingSettings = CachingSettings("")
+    val lfuCacheSettings =
+      defaultCachingSettings.lfuCacheSettings
+        .withInitialCapacity(maxSizeBytes / header.bytesPerChunk)
+        .withMaxCapacity(maxSizeBytes / header.bytesPerChunk)
+        .withTimeToLive(20.minutes)
+        .withTimeToIdle(10.minutes)
+    val cachingSettings =
+      defaultCachingSettings.withLfuCacheSettings(lfuCacheSettings)
+    val lfuCache: Cache[String, MultiArray] = LfuCache(cachingSettings)
+    lfuCache
+  }
 
   // @return Byte array in fortran-order with little-endian values
   @throws[IOException]
   @throws[InvalidRangeException]
-  def readBytesXYZ(shape: Vec3Int, offset: Vec3Int): Array[Byte] = {
+  def readBytesXYZ(shape: Vec3Int, offset: Vec3Int)(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
     // Assumes that the last three dimensions of the array are x, y, z
     val paddingDimensionsCount = header.shape.length - 3
     val offsetArray = Array.fill(paddingDimensionsCount)(0) :+ offset.x :+ offset.y :+ offset.z
@@ -67,39 +87,45 @@ class ZarrArray(relativePath: ZarrPath, store: Store, header: ZarrHeader) extend
   // @return Byte array in fortran-order with little-endian values
   @throws[IOException]
   @throws[InvalidRangeException]
-  def readBytes(shape: Array[Int], offset: Array[Int]): Array[Byte] = {
-    val typedData = readAsFortranOrder(shape, offset)
-    BytesConverter.toByteArray(typedData, header.dataType, ByteOrder.LITTLE_ENDIAN)
+  def readBytes(shape: Array[Int], offset: Array[Int])(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
+    for {
+      typedData <- readAsFortranOrder(shape, offset)
+    } yield BytesConverter.toByteArray(typedData, header.dataType, ByteOrder.LITTLE_ENDIAN)
   }
 
   @throws[IOException]
   @throws[InvalidRangeException]
-  def readAsFortranOrder(shape: Array[Int], offset: Array[Int]): Object = {
+  def readAsFortranOrder(shape: Array[Int], offset: Array[Int])(implicit ec: ExecutionContext): Fox[Object] = {
     val buffer = MultiArrayUtils.createDataBuffer(header.dataType, shape)
     val chunkIndices = ChunkUtils.computeChunkIndices(header.shape, header.chunks, shape, offset)
-    chunkIndices.foreach { chunkIndex: Array[Int] =>
-      val sourceChunk: MultiArray = getSourceChunkDataWithCache(chunkIndex)
-      val offsetInChunk = computeOffsetInChunk(chunkIndex, offset)
-      if (partialCopyingIsNotNeeded(shape, offsetInChunk)) {
-        return sourceChunk.getStorage
-      } else {
-        val sourceChunkInCOrder: MultiArray =
-          if (header.order == ArrayOrder.C)
-            sourceChunk
-          else MultiArrayUtils.orderFlippedView(sourceChunk)
-        val targetInCOrder: MultiArray =
-          MultiArrayUtils.orderFlippedView(MultiArrayUtils.createArrayWithGivenStorage(buffer, shape.reverse))
-        MultiArrayUtils.copyRange(offsetInChunk, sourceChunkInCOrder, targetInCOrder)
-      }
+    val res = Fox.serialCombined(chunkIndices.toList) { chunkIndex: Array[Int] =>
+      for {
+        sourceChunk: MultiArray <- getSourceChunkDataWithCache(chunkIndex)
+        offsetInChunk = computeOffsetInChunk(chunkIndex, offset)
+        _ = if (partialCopyingIsNotNeeded(shape, offsetInChunk)) {
+          return Future.successful(sourceChunk.getStorage)
+        } else {
+          val sourceChunkInCOrder: MultiArray =
+            if (header.order == ArrayOrder.C)
+              sourceChunk
+            else MultiArrayUtils.orderFlippedView(sourceChunk)
+          val targetInCOrder: MultiArray =
+            MultiArrayUtils.orderFlippedView(MultiArrayUtils.createArrayWithGivenStorage(buffer, shape.reverse))
+          MultiArrayUtils.copyRange(offsetInChunk, sourceChunkInCOrder, targetInCOrder)
+        }
+      } yield ()
     }
-    buffer
+    for {
+      _ <- res
+    } yield buffer
   }
 
-  private def getSourceChunkDataWithCache(chunkIndex: Array[Int]): MultiArray = {
+  private def getSourceChunkDataWithCache(chunkIndex: Array[Int]): Future[MultiArray] = {
     val chunkFilename = getChunkFilename(chunkIndex)
     val chunkFilePath = relativePath.resolve(chunkFilename)
     val storeKey = chunkFilePath.storeKey
-    chunkContentsCache.getOrLoadAndPut(storeKey)(chunkReader.read)
+
+    chunkContentsCache.getOrLoad(storeKey, chunkReader.read)
   }
 
   private def getChunkFilename(chunkIndex: Array[Int]): String =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrArray.scala
@@ -55,17 +55,16 @@ class ZarrArray(relativePath: ZarrPath, store: Store, header: ZarrHeader) extend
 
   // cache currently limited to 100 MB per array
   private lazy val chunkContentsCache: Cache[String, MultiArray] = {
-    // new ChunkContentsCache(maxSizeBytes = 1000 * 1000 * 100, bytesPerEntry = header.bytesPerChunk)
-
     val maxSizeBytes = 1000 * 1000 * 100
 
+    val maxEntries = maxSizeBytes / header.bytesPerChunk
     val defaultCachingSettings = CachingSettings("")
     val lfuCacheSettings =
       defaultCachingSettings.lfuCacheSettings
-        .withInitialCapacity(maxSizeBytes / header.bytesPerChunk)
-        .withMaxCapacity(maxSizeBytes / header.bytesPerChunk)
-        .withTimeToLive(20.minutes)
-        .withTimeToIdle(10.minutes)
+        .withInitialCapacity(maxEntries)
+        .withMaxCapacity(maxEntries)
+        .withTimeToLive(2.hours)
+        .withTimeToIdle(1.hour)
     val cachingSettings =
       defaultCachingSettings.withLfuCacheSettings(lfuCacheSettings)
     val lfuCache: Cache[String, MultiArray] = LfuCache(cachingSettings)


### PR DESCRIPTION
Switches the chunk cache inside zarr array implementation from a synchronous to asynchronous one. This means that concurrent incoming requests that are all cache misses do not each trigger chunk fetching. Only one does and the other requests hook into that.

I use the caching library from akka for this. Side effects include:
 - The new cache is no longer LRU but LFU (frequency based). I do not think this will have much noticeable impact.
 - The new cache has expiry times, which I think is a nice addition made simple by the new akka cache
 - The signatures of many functions had to becomes asynchronous, which makes the code a bit less readable but should be acceptable. It also paves the way for other asynchronous action
 - The exception handling inside ZarrBucketProvider could no longer use the `tryo` shortcut, instead I use `Fox.recover` to achieve the same effect.

### URL of deployed dev instance (used for testing):
- https://zarralru.webknossos.xyz

### Steps to test:
- Load remote zarr dataset, ideally one with very different chunk shape from the requested 32² (talk to me about a datasource-properties.json)
- The first few requests should cause a lot less load, be answered more quickly.
- wkw datasets and local zarr files should still load

### Issues:
- contributes to #6119 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
