### PR TITLE
Move "User access list" to Settings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
   - Add filter functionality to "Access Permissions" column to filter for public datasets.
   - Removed `isActive` and `isPublic` columns to save screen space.
   - Changed data layer entries to display layer names instead of categories, e.g. "color" --> "axons".
+- Moved the list of "user with access to the selected dataset" from the dashboard to the respective dataset's settings (Sharing Tab). [6166](https://github.com/scalableminds/webknossos/pull/6166)
 
 ### Fixed
 - Fixed a bug that led to an error when drag-'n-dropping an empty volume annotation in the dataset view. [#6116](https://github.com/scalableminds/webknossos/pull/6116)

--- a/frontend/javascripts/admin/onboarding.tsx
+++ b/frontend/javascripts/admin/onboarding.tsx
@@ -21,7 +21,7 @@ import type { OxalisState } from "oxalis/store";
 import Store from "oxalis/store";
 import LinkButton from "components/link_button";
 import { getDatastores, sendInvitesForOrganization } from "admin/admin_rest_api";
-import DatasetImportView from "dashboard/dataset/dataset_import_view";
+import DatasetSettingsView from "dashboard/dataset/dataset_settings_view";
 import DatasetUploadView from "admin/dataset/dataset_upload_view";
 import RegistrationForm from "admin/auth/registration_form";
 import CreditsFooter from "components/credits_footer";
@@ -502,7 +502,7 @@ class OnboardingView extends React.PureComponent<Props, State> {
       )}
       {this.state.datasetNameToImport != null && (
         <Modal visible width="85%" footer={null} maskClosable={false} onCancel={this.advanceStep}>
-          <DatasetImportView
+          <DatasetSettingsView
             isEditingMode={false}
             datasetId={{
               name: this.state.datasetNameToImport || "",

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_access_list_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_access_list_view.tsx
@@ -13,7 +13,6 @@ type State = {
   isLoading: boolean;
 };
 export default class DatasetAccessListView extends React.PureComponent<Props, State> {
-  
   state: State = {
     datasetUsers: [],
     isLoading: false,

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_access_list_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_access_list_view.tsx
@@ -4,6 +4,7 @@ import type { APIDataset, APIUser } from "types/api_flow_types";
 import { getDatasetAccessList } from "admin/admin_rest_api";
 import { handleGenericError } from "libs/error_handling";
 import { stringToColor } from "libs/format_utils";
+
 type Props = {
   dataset: APIDataset;
 };
@@ -12,6 +13,7 @@ type State = {
   isLoading: boolean;
 };
 export default class DatasetAccessListView extends React.PureComponent<Props, State> {
+  
   state: State = {
     datasetUsers: [],
     isLoading: false,
@@ -66,7 +68,6 @@ export default class DatasetAccessListView extends React.PureComponent<Props, St
   renderTable() {
     return (
       <div>
-        <h5>Users with Access Rights</h5>
         <ul>
           {this.state.datasetUsers.map((user: APIUser) => (
             <li key={user.id}>

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -22,12 +22,11 @@ import { getDatasetExtentAsString } from "oxalis/model/accessors/dataset_accesso
 import { stringToColor, formatScale } from "libs/format_utils";
 import { trackAction } from "oxalis/model/helpers/analytics";
 import CategorizationLabel from "oxalis/view/components/categorization_label";
-import DatasetAccessListView from "dashboard/advanced_dataset/dataset_access_list_view";
 import DatasetActionView from "dashboard/advanced_dataset/dataset_action_view";
 import EditableTextIcon from "oxalis/view/components/editable_text_icon";
-import FixedExpandableTable from "components/fixed_expandable_table";
 import FormattedDate from "components/formatted_date";
 import * as Utils from "libs/utils";
+import FixedExpandableTable from "components/fixed_expandable_table";
 
 const { Column } = Table;
 const typeHint: APIMaybeUnimportedDataset[] = [];
@@ -249,11 +248,6 @@ class DatasetTable extends React.PureComponent<Props, State> {
           defaultPageSize: 50,
         }}
         onChange={this.handleChange}
-        expandedRowRender={
-          isUserAdmin || isUserTeamManager
-            ? (dataset) => <DatasetAccessListView dataset={dataset} />
-            : undefined
-        }
         locale={{
           emptyText: this.renderEmptyText(),
         }}

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -37,7 +37,6 @@ type Props = {
   searchQuery: string;
   searchTags: Array<string>;
   isUserAdmin: boolean;
-  isUserTeamManager: boolean;
   isUserDatasetManager: boolean;
   datasetFilteringMode: DatasetFilteringMode;
   reloadDataset: (arg0: APIDatasetId, arg1: Array<APIMaybeUnimportedDataset>) => Promise<void>;
@@ -183,7 +182,6 @@ class DatasetTable extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { isUserAdmin, isUserTeamManager } = this.props;
     const filteredDataSource = this.getFilteredDatasets();
     const { sortedInfo } = this.state;
     const dataSourceSortedByRank = useLruRank

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
@@ -25,7 +25,7 @@ import {
 
 const FormItem = Form.Item;
 
-export default function SimpleAdvancedDataForm({
+export default function DatasetSettingsDataTab({
   isReadOnlyDataset,
   form,
   activeDataSourceEditMode,

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
@@ -8,12 +8,13 @@ import type { RouteComponentProps } from "react-router-dom";
 import { withRouter } from "react-router-dom";
 import { DatasetCacheContext } from "dashboard/dataset/dataset_cache_provider";
 import { confirmAsync } from "./helper_components";
+
 type Props = {
   datasetId: APIDatasetId;
   history: RouteComponentProps["history"];
 };
 
-const ImportDeleteComponent = ({ datasetId, history }: Props) => {
+const DatasetSettingsDeleteTab = ({ datasetId, history }: Props) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [dataset, setDataset] = useState<APIDataset | null | undefined>(null);
   const datasetContext = useContext(DatasetCacheContext);
@@ -66,4 +67,4 @@ const ImportDeleteComponent = ({ datasetId, history }: Props) => {
   );
 };
 
-export default withRouter<RouteComponentProps & Props, any>(ImportDeleteComponent);
+export default withRouter<RouteComponentProps & Props, any>(DatasetSettingsDeleteTab);

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_metadata_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_metadata_tab.tsx
@@ -1,7 +1,8 @@
 import { Input, Col, Row, DatePicker } from "antd";
 import React from "react";
 import { FormItemWithInfo } from "./helper_components";
-export default function ImportGeneralComponent() {
+
+export default function DatasetSettingsMetadataTab() {
   return (
     <div>
       <Row gutter={48}>

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -13,12 +13,15 @@ import window from "libs/window";
 import TeamSelectionComponent from "dashboard/dataset/team_selection_component";
 import { CopyOutlined, RetweetOutlined } from "@ant-design/icons";
 import { FormItemWithInfo } from "./helper_components";
+import DatasetAccessListView from "dashboard/advanced_dataset/dataset_access_list_view";
+
+
 type Props = {
   form: FormInstance | null;
   datasetId: APIDatasetId;
   hasNoAllowedTeams: boolean;
 };
-export default function ImportSharingComponent({ form, datasetId, hasNoAllowedTeams }: Props) {
+export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowedTeams }: Props) {
   const [sharingToken, setSharingToken] = useState("");
   const [dataSet, setDataSet] = useState<APIDataset | null | undefined>(null);
   const allowedTeamsComponent = (

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -18,12 +18,12 @@ import DatasetAccessListView from "dashboard/advanced_dataset/dataset_access_lis
 type Props = {
   form: FormInstance | null;
   datasetId: APIDatasetId;
+  dataset: APIDataset | null | undefined;
   hasNoAllowedTeams: boolean;
 };
 
-export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowedTeams }: Props) {
+export default function DatasetSettingsSharingTab({ form, datasetId, dataset, hasNoAllowedTeams }: Props) {
   const [sharingToken, setSharingToken] = useState("");
-  const [dataset, setDataset] = useState<APIDataset | null | undefined>(null);
 
   const allowedTeamsComponent = (
     <FormItemWithInfo
@@ -43,9 +43,7 @@ export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowe
 
   async function fetch() {
     const newSharingToken = await getDatasetSharingToken(datasetId);
-    const newDataSet = await getDataset(datasetId);
     setSharingToken(newSharingToken);
-    setDataset(newDataSet);
   }
 
   useEffect(() => {

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Checkbox, Tooltip, FormInstance } from "antd";
+import { Button, Input, Checkbox, Tooltip, FormInstance, Collapse, Spin } from "antd";
 import React, { useState, useEffect } from "react";
 import type { APIDataset, APIDatasetId } from "types/api_flow_types";
 import { AsyncButton } from "components/async_clickables";
@@ -11,19 +11,20 @@ import Toast from "libs/toast";
 import features from "features";
 import window from "libs/window";
 import TeamSelectionComponent from "dashboard/dataset/team_selection_component";
-import { CopyOutlined, RetweetOutlined } from "@ant-design/icons";
+import { CopyOutlined, PropertySafetyFilled, RetweetOutlined } from "@ant-design/icons";
 import { FormItemWithInfo } from "./helper_components";
 import DatasetAccessListView from "dashboard/advanced_dataset/dataset_access_list_view";
-
 
 type Props = {
   form: FormInstance | null;
   datasetId: APIDatasetId;
   hasNoAllowedTeams: boolean;
 };
+
 export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowedTeams }: Props) {
   const [sharingToken, setSharingToken] = useState("");
-  const [dataSet, setDataSet] = useState<APIDataset | null | undefined>(null);
+  const [dataset, setDataset] = useState<APIDataset | null | undefined>(null);
+
   const allowedTeamsComponent = (
     <FormItemWithInfo
       name={["dataset", "allowedTeams"]}
@@ -44,7 +45,7 @@ export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowe
     const newSharingToken = await getDatasetSharingToken(datasetId);
     const newDataSet = await getDataset(datasetId);
     setSharingToken(newSharingToken);
-    setDataSet(newDataSet);
+    setDataset(newDataSet);
   }
 
   useEffect(() => {
@@ -80,6 +81,7 @@ export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowe
 
   function getSharingLink() {
     if (!form) return undefined;
+
     const doesNeedToken = !form.getFieldValue("dataset.isPublic");
     const tokenSuffix = `?token=${sharingToken}`;
     return `${window.location.origin}/datasets/${datasetId.owningOrganization}/${
@@ -88,9 +90,9 @@ export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowe
   }
 
   function getAllowUsageCode() {
-    if (dataSet != null) {
-      const dataStoreName = dataSet.dataStore.name;
-      const dataStoreURL = dataSet.dataStore.url;
+    if (dataset != null) {
+      const dataStoreName = dataset.dataStore.name;
+      const dataStoreURL = dataset.dataStore.url;
       return `${dataStoreName}, ${dataStoreURL}, ${datasetId.name}`;
     } else return "";
   }
@@ -182,6 +184,12 @@ export default function DatasetSettingsSharingTab({ form, datasetId, hasNoAllowe
           </Input.Group>
         </FormItemWithInfo>
       )}
+
+      <Collapse collapsible="header" >
+        <Collapse.Panel header="All users with access rights to this dataset" key="1">
+          {dataset ? <DatasetAccessListView dataset={dataset} /> : <Spin tip="Loading..." />}
+        </Collapse.Panel>
+      </Collapse>
     </div>
   ) : null;
 }

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import { Button, Input, Checkbox, Tooltip, FormInstance, Collapse } from "antd";
-import { CopyOutlined, RetweetOutlined } from "@ant-design/icons";
+import { CopyOutlined, InfoCircleOutlined, RetweetOutlined } from "@ant-design/icons";
 import type { APIDataset, APIDatasetId, APIUser } from "types/api_flow_types";
 import { AsyncButton } from "components/async_clickables";
 import { getDatasetSharingToken, revokeDatasetSharingToken } from "admin/admin_rest_api";
@@ -106,9 +106,18 @@ function DatasetSettingsSharingTab({
     if (!activeUser || !dataset) return undefined;
     if (!isUserAdminOrTeamManager(activeUser)) return undefined;
 
+    const header = (
+      <span>
+        All users with access permission to work with this dataset{" "}
+        <Tooltip title="Based on the specified team permissions and individiual user roles. Any changes will only appear after pressing the Save button.">
+          <InfoCircleOutlined style={{ color: "gray" }} />
+        </Tooltip>
+      </span>
+    );
+
     return (
       <Collapse collapsible="header">
-        <Collapse.Panel header="All users with access rights to this dataset" key="1">
+        <Collapse.Panel header={header} key="1">
           <DatasetAccessListView dataset={dataset} />
         </Collapse.Panel>
       </Collapse>

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -51,11 +51,11 @@ import features from "features";
 import { isDatasourceJSONValid } from "types/validation";
 import { enforceValidatedDatasetViewConfiguration } from "types/schemas/dataset_view_configuration_defaults";
 import { Hideable, hasFormError, jsonEditStyle } from "./helper_components";
-import DefaultConfigComponent from "./default_config_component";
-import ImportGeneralComponent from "./import_general_component";
-import ImportSharingComponent from "./import_sharing_component";
-import ImportDeleteComponent from "./import_delete_component";
-import SimpleAdvancedDataForm from "./simple_advanced_data_form";
+import DatasetSettingsViewConfigTab from "./dataset_settings_viewconfig_tab";
+import DatasetSettingsMetadataTab from "./dataset_settings_metadata_tab";
+import DatasetSettingsSharingTab from "./dataset_settings_sharing_tab";
+import DatasetSettingsDeleteTab from "./dataset_settings_delete_tab";
+import DatasetSettingsDataTab from "./dataset_settings_data_tab";
 
 const { TabPane } = Tabs;
 const FormItem = Form.Item;
@@ -153,7 +153,7 @@ function ensureValidScaleOnInferredDataSource(
   return inferredDataSourceClone;
 }
 
-class DatasetImportView extends React.PureComponent<PropsWithFormAndRouter, State> {
+class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, State> {
   formRef = React.createRef<FormInstance>();
   unblock: UnregisterCallback | null | undefined;
   blockTimeoutId: number | null | undefined;
@@ -866,7 +866,7 @@ class DatasetImportView extends React.PureComponent<PropsWithFormAndRouter, Stat
                     // to hidden form elements.
                   }
                   <Hideable hidden={this.state.activeTabKey !== "data"}>
-                    <SimpleAdvancedDataForm
+                    <DatasetSettingsDataTab
                       key="SimpleAdvancedDataForm"
                       isReadOnlyDataset={
                         this.state.dataset != null &&
@@ -903,7 +903,7 @@ class DatasetImportView extends React.PureComponent<PropsWithFormAndRouter, Stat
                   forceRender
                 >
                   <Hideable hidden={this.state.activeTabKey !== "sharing"}>
-                    <ImportSharingComponent
+                    <DatasetSettingsSharingTab
                       form={form}
                       datasetId={this.props.datasetId}
                       hasNoAllowedTeams={hasNoAllowedTeams}
@@ -913,7 +913,7 @@ class DatasetImportView extends React.PureComponent<PropsWithFormAndRouter, Stat
 
                 <TabPane tab={<span>Metadata</span>} key="general" forceRender>
                   <Hideable hidden={this.state.activeTabKey !== "general"}>
-                    <ImportGeneralComponent />
+                    <DatasetSettingsMetadataTab />
                   </Hideable>
                 </TabPane>
 
@@ -923,7 +923,7 @@ class DatasetImportView extends React.PureComponent<PropsWithFormAndRouter, Stat
                   forceRender
                 >
                   <Hideable hidden={this.state.activeTabKey !== "defaultConfig"}>
-                    <DefaultConfigComponent />
+                    <DatasetSettingsViewConfigTab />
                   </Hideable>
                 </TabPane>
 
@@ -931,7 +931,7 @@ class DatasetImportView extends React.PureComponent<PropsWithFormAndRouter, Stat
                   <TabPane tab={<span> Delete Dataset </span>} key="deleteDataset" forceRender>
                     <Hideable hidden={this.state.activeTabKey !== "deleteDataset"}>
                       <DatasetCacheProvider>
-                        <ImportDeleteComponent datasetId={this.props.datasetId} />
+                        <DatasetSettingsDeleteTab datasetId={this.props.datasetId} />
                       </DatasetCacheProvider>
                     </Hideable>
                   </TabPane>
@@ -961,4 +961,4 @@ const mapStateToProps = (state: OxalisState): StateProps => ({
 });
 
 const connector = connect(mapStateToProps);
-export default connector(withRouter<RouteComponentProps & OwnProps, any>(DatasetImportView));
+export default connector(withRouter<RouteComponentProps & OwnProps, any>(DatasetSettingsView));

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -906,6 +906,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
                     <DatasetSettingsSharingTab
                       form={form}
                       datasetId={this.props.datasetId}
+                      dataset={this.state.dataset}
                       hasNoAllowedTeams={hasNoAllowedTeams}
                     />
                   </Hideable>

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_viewconfig_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_viewconfig_tab.tsx
@@ -8,8 +8,10 @@ import { getDefaultLayerViewConfiguration } from "types/schemas/dataset_view_con
 import { layerViewConfigurations } from "messages";
 import type { DatasetLayerConfiguration } from "oxalis/store";
 import { FormItemWithInfo, jsonEditStyle } from "./helper_components";
+
 const FormItem = Form.Item;
-export default function DefaultConfigComponent() {
+
+export default function DatasetSettingsViewConfigTab() {
   const columns = [
     {
       title: "Name",

--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -222,7 +222,6 @@ function DatasetView(props: Props) {
         searchQuery={searchQuery}
         searchTags={searchTags}
         isUserAdmin={Utils.isUserAdmin(user)}
-        isUserTeamManager={Utils.isUserTeamManager(user)}
         isUserDatasetManager={Utils.isUserDatasetManager(user)}
         datasetFilteringMode={datasetFilteringMode}
         updateDataset={context.updateCachedDataset}

--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -23,7 +23,7 @@ import AuthTokenView from "admin/auth/auth_token_view";
 import ChangePasswordView from "admin/auth/change_password_view";
 import DashboardView, { urlTokenToTabKeyMap } from "dashboard/dashboard_view";
 import DatasetAddView from "admin/dataset/dataset_add_view";
-import DatasetImportView from "dashboard/dataset/dataset_import_view";
+import DatasetSettingsView from "dashboard/dataset/dataset_settings_view";
 import DisableGenericDnd from "components/disable_generic_dnd";
 import FinishResetPasswordView from "admin/auth/finish_reset_password_view";
 import JobListView from "admin/job/job_list_view";
@@ -333,7 +333,7 @@ class ReactRouter extends React.Component<Props> {
                 isAuthenticated={isAuthenticated}
                 path="/datasets/:organizationName/:datasetName/import"
                 render={({ match }: ContextRouter) => (
-                  <DatasetImportView
+                  <DatasetSettingsView
                     isEditingMode={false}
                     datasetId={{
                       name: match.params.datasetName || "",
@@ -351,7 +351,7 @@ class ReactRouter extends React.Component<Props> {
                 isAuthenticated={isAuthenticated}
                 path="/datasets/:organizationName/:datasetName/edit"
                 render={({ match }: ContextRouter) => (
-                  <DatasetImportView
+                  <DatasetSettingsView
                     isEditingMode
                     datasetId={{
                       name: match.params.datasetName || "",


### PR DESCRIPTION
PR does two little things:
- move the "Users with Access" list form the main Dashboard->My Datasets (sub)-table to the the settings (under "Sharing Tab") 
- renamed all the react components used in the dataset settings view to reflect that:
  - all components are some tab
  - all components belong to the dataset settings view

### URL of deployed dev instance (used for testing):
- https://useraccesslist.webknossos.xyz/

### Steps to test:
1. Navigate to Dashboard --> My Datasets
    -  Table should no longer be expandable to show "Users with access"
2. Go to Setting for a dataset --> "Sharing Tab"
3. Expand "Users with access" panel. 
4. Tada

### Issues:
- fixes #6068 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
