### PR TITLE
In dataset upload, allow un-sorted anisotropic mags in properties.json

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed rare callstack overflow when annotating large areas. [#6076](https://github.com/scalableminds/webknossos/pull/6076)
 - Fixed the "Copy Slice" shortcut (`v` and `shift + v`) in resolutions other than the most detailed one. [#6130](https://github.com/scalableminds/webknossos/pull/6130)
 - Fixed a bug where dataset tags with spaces would be automatically wrapped in quotes. [#6159](https://github.com/scalableminds/webknossos/pull/6159)
+- Fixed a bug where during dataset upload, un-sorted anisotropic mags in the datasource-properties.json could lead to errors. [#6167](https://github.com/scalableminds/webknossos/pull/6167)
 
 ### Removed
 - Removed the functionality to unlink the fallback layer from an existing segmentation layer. Either create an annotation without fallback layer or from within an annotation with a fallback layer, create a new volume layer, instead. [#6146](https://github.com/scalableminds/webknossos/pull/6146)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -120,15 +120,16 @@ class DataSourceService @Inject()(
   private def validateDataSource(dataSource: DataSource): Box[Unit] = {
     def Check(expression: Boolean, msg: String): Option[String] = if (!expression) Some(msg) else None
 
-    // Check, that each dimension increases monotonically between different resolutions.
-    val resolutionsByX = dataSource.dataLayers.map(_.resolutions.sortBy(_.x))
-    val resolutionsByY = dataSource.dataLayers.map(_.resolutions.sortBy(_.y))
-    val resolutionsByZ = dataSource.dataLayers.map(_.resolutions.sortBy(_.z))
+    // Check that when mags are sorted by max dimension, all dimensions are sorted.
+    // This means each dimension increases monotonically.
+    val magsSorted = dataSource.dataLayers.map(_.resolutions.sortBy(_.maxDim))
+    val magsXIsSorted = magsSorted.map(_.map(_.x)) == magsSorted.map(_.map(_.x).sorted)
+    val magsYIsSorted = magsSorted.map(_.map(_.y)) == magsSorted.map(_.map(_.y).sorted)
+    val magsZIsSorted = magsSorted.map(_.map(_.z)) == magsSorted.map(_.map(_.z).sorted)
 
     val errors = List(
       Check(dataSource.scale.isStrictlyPositive, "DataSource scale is invalid"),
-      Check(resolutionsByX == resolutionsByY && resolutionsByX == resolutionsByZ,
-            "Scales do not monotonically increase in all dimensions"),
+      Check(magsXIsSorted && magsYIsSorted && magsZIsSorted, "Mags do not monotonically increase in all dimensions"),
       Check(dataSource.dataLayers.nonEmpty, "DataSource must have at least one dataLayer"),
       Check(dataSource.dataLayers.forall(!_.boundingBox.isEmpty), "DataSource bounding box must not be empty"),
       Check(


### PR DESCRIPTION
In datasource validation there is a check asserting that the mags are consistent (meaning that all dimensions increase monotonically, you cannot have 1-1-2 AND 2-2-1). This check previously relied on the mags also being IN ORDER in the properties.json. This PR removes this latter requirement (I think it was there only accidentally). We double-checked that there are no important code paths that rely on this order.

### Steps to test:
- Edit a datasource-properties.json from the dataset settings page, try saving it (disable frontend validation?)
- inconsistent mags should still be forbidden but any ordering should be fine

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
