### PR TITLE
Better error message when creating team with already-taken name

### DIFF
--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -93,6 +93,14 @@ class TeamDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       parsed <- parseFirst(r, id)
     } yield parsed
 
+  def countByNameAndOrganization(teamName: String, organizationId: ObjectId): Fox[Int] =
+    for {
+      countList <- run(
+        sql"select count(_id) from #$existingCollectionName where name = $teamName and _organization = $organizationId"
+          .as[Int])
+      count <- countList.headOption
+    } yield count
+
   override def findAll(implicit ctx: DBAccessContext): Fox[List[Team]] =
     for {
       accessQuery <- readAccessQuery


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://teamnameassertfree.webknossos.xyz

### Steps to test:
- Create team on `/teams` page
- Should work if name is new
- Should yield readable error message if name is already taken

### Issues:
- fixes #5706

------
- [x] Ready for review
