### PR TITLE
Fix applying recommended settings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed applying recommended settings when starting a task which provides recommended settings. [#6175](https://github.com/scalableminds/webknossos/pull/6175)
 
 ### Removed
  - Removed the option to download sample-datasets. To explore webKnossos, use the public sample datasets on webknossos.org. [#6151](https://github.com/scalableminds/webknossos/pull/6151)

--- a/frontend/javascripts/oxalis/view/recommended_configuration_modal.tsx
+++ b/frontend/javascripts/oxalis/view/recommended_configuration_modal.tsx
@@ -44,13 +44,12 @@ export default class RecommendedConfigurationModal extends React.Component<Props
   };
 
   render() {
-    const configurationEntries = _.map(this.props.config, (_value: any, key: string) => {
+    const configurationEntries = _.map(this.props.config, (value, key) => {
       // @ts-ignore Typescript doesn't infer that key will be of type keyof RecommendedConfiguration
       const settingsKey: keyof RecommendedConfiguration = key;
       return {
-        name: settings[settingsKey],
-        // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
-        value: settings[settingsKey].toString(),
+        name: key in settings ? settings[settingsKey] : null,
+        value: value?.toString(),
         comment: settingComments[settingsKey] || "",
       };
     });


### PR DESCRIPTION
This was a regression from porting to typescript. Compare with the earlier version which used `value.toString()` for the `value` key:

https://github.com/scalableminds/webknossos/blame/367d218163ccfbe884f609b70e65ea0c854da5d2/frontend/javascripts/oxalis/view/recommended_configuration_modal.js#L69

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I created a task with a task type which had the following recommend configuration:
```
{
  "zoom": 0.58,
  "fourBit": false,
  "brushSize": 8,
  "moveValue": 500,
  "moveValue3d": 600,
  "rotateValue": 0.01,
  "particleSize": 5,
  "centerNewNode": true,
  "interpolation": true,
  "keyboardDelay": 0,
  "newNodeNewTree": false,
  "loadingStrategy": "BEST_QUALITY_FIRST",
  "clippingDistance": 80,
  "displayCrosshair": true,
  "displayScalebars": false,
  "mouseRotateValue": 0.001,
  "useLegacyBindings": false,
  "overrideNodeRadius": true,
  "sphericalCapRadius": 500,
  "segmentationOpacity": 0,
  "tdViewDisplayPlanes": "WIREFRAME",
  "dynamicSpaceDirection": true,
  "renderMissingDataBlack": false,
  "highlightCommentedNodes": false,
  "clippingDistanceArbitrary": 60,
  "segmentationPatternOpacity": 40,
  "tdViewDisplayDatasetBorders": true
}
```
- on master, after requesting the task (and clicking on OK on the intro), wk crashes because it cannot open the recommended modal
- on this branch, it succeeds

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
