### PR TITLE
[WIP] provide clean annotation uri, no more Explorational vs Task

### DIFF
--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -39,7 +39,7 @@ PUT           /dataSetConfigurations/default/:organizationName/:dataSetName     
 # Users
 POST          /user/tasks/request                                                       controllers.TaskController.request
 GET           /user/tasks/peek                                                          controllers.TaskController.peekNext
-         
+
 GET           /users                                                                    controllers.UserController.list
 GET           /user                                                                     controllers.UserController.current
 GET           /user/tasks                                                               controllers.UserController.tasks(isFinished: Option[Boolean], limit: Option[Int], pageNumber: Option[Int], includeTotalCount: Option[Boolean])
@@ -116,6 +116,7 @@ PATCH         /annotations/:typ/:id/reopen                                      
 PUT           /annotations/:typ/:id/reset                                               controllers.AnnotationController.reset(typ: String, id: String)
 PATCH         /annotations/:typ/:id/transfer                                            controllers.AnnotationController.transfer(typ: String, id: String)
 
+GET           /annotations/:id/info                                                     controllers.AnnotationController.infoWithoutType(id: String, timestamp: Long)
 GET           /annotations/:typ/:id/info                                                controllers.AnnotationController.info(typ: String, id: String, timestamp: Long)
 PATCH         /annotations/:typ/:id/makeHybrid                                          controllers.AnnotationController.makeHybrid(typ: String, id: String, fallbackLayerName: Option[String])
 PATCH         /annotations/:typ/:id/downsample                                          controllers.AnnotationController.downsample(typ: String, id: String, tracingId: String)


### PR DESCRIPTION
Clean up annotation & task URI schema, get rid of term "explorational"


@Dagobert42 So far I added a new route in the backend, `api/annotations/:id/info`, that will reply with the info json for stored  annotations (Task or Explorational). The rest of the routes still expect the type as before. With this new route you should find out if an annotation is a task or not (_task field empty or not) so that you can then also query the other routes from the front-end.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### Issues:
- fixes #6156

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [ ] Ready for review
