### PR TITLE
Include segmentation layers in handling maximum number of renderable layers restricted by hardware

### DIFF
--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -781,14 +781,9 @@ export function getEnabledLayers(
   datasetConfiguration: DatasetConfiguration,
   options: {
     invert?: boolean;
-    onlyColorLayers: boolean;
-  } = {
-    onlyColorLayers: false,
-  },
+  }={},
 ): Array<DataLayerType> {
-  const dataLayers = options.onlyColorLayers
-    ? getColorLayers(dataset)
-    : dataset.dataSource.dataLayers;
+  const dataLayers = dataset.dataSource.dataLayers;
   const layerSettings = datasetConfiguration.layers;
   return dataLayers.filter((layer) => {
     const settings = layerSettings[layer.name];


### PR DESCRIPTION
This PR adds the existing segmentation layers of a dataset to the `getLayersToRender` function. This function handles the case that the number of activated layers exceeds the maximum available textures available to WebGL via driver/hardware/browser combination.
Previous to this pr, this was only done for color layers and one texture was always reserved for a segmentation layer. Now that there can be multiple segmentation layers, this led to rendering errors when the datasets color layer + segmentation layer count exceeds the hardware limit.
This pr changes the `getLayersToRender` so that it takes segmentation layer into account and at most returns a layer count equal to the hardware limit. This ensures that the code does not try to push all segmentation layers to GPU textures and therefore prevents rendering errors.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I suggest testing this locally as it is easier to create datasets with a lot of layers for testing in that environment.
- Create a dataset with (hardware maximum count - 2) color layers (just create copies of existing color layers). Then add a few segmentation layers to make sure you exceed the hardware limit in case all layers are active.
- Check out the current version of the master and try to view the created test dataset. This should result in rendering errors similar to https://forum.image.sc/t/why-are-the-views-mono-color-without-data/64358.
- Now check out this branch and reload the dataset. This version should no longer have rendering errors. The red error toast indicating too many active layers should still be there until you deactivate enough layers.

### Issues:
- fixes #6108

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Ready for review
