### PR TITLE
Fix disappearing "ID mapping" dropdown

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug in the task creation, where creation for some tasks with initial volume data would fail. [#6178](https://github.com/scalableminds/webknossos/pull/6178)
 - Fixed a bug in the task cration, where creation for some tasks with initial volume data would fail. [#6178](https://github.com/scalableminds/webknossos/pull/6178)
 - Fixed a rendering bug which could cause an incorrect magnification to be rendered in rare scenarios. [#6029](https://github.com/scalableminds/webknossos/pull/6029)
+- Fixed a bug which could cause a segmentation layer's "ID mapping" dropdown to disappear. [#6215](https://github.com/scalableminds/webknossos/pull/6215)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
@@ -73,8 +73,6 @@ export const convertCellIdToCSS = (
 ) =>
   id === 0 ? "transparent" : convertHSLAToCSSString(jsConvertCellIdToHSLA(id, customColors, alpha));
 
-const hasSegmentation = () => Model.getVisibleSegmentationLayer() != null;
-
 const needle = "##";
 
 const packMappingNameAndCategory = (mappingName: string, category: MappingType) =>
@@ -170,10 +168,6 @@ class MappingSettingsView extends React.Component<Props, State> {
   };
 
   render() {
-    if (!hasSegmentation()) {
-      return <div className="padded-tab-content">No segmentation available</div>;
-    }
-
     const availableMappings =
       this.props.segmentationLayer != null && this.props.segmentationLayer.mappings != null
         ? this.props.segmentationLayer.mappings

--- a/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
@@ -19,7 +19,6 @@ import {
   setHideUnmappedIdsAction,
   setMappingAction,
 } from "oxalis/model/actions/settings_actions";
-import Model from "oxalis/model";
 import { SwitchSetting } from "oxalis/view/components/setting_input_views";
 import * as Utils from "libs/utils";
 import { jsConvertCellIdToHSLA } from "oxalis/shaders/segmentation.glsl";


### PR DESCRIPTION
PR fixes a bug where the ÌD Mapping` dropdown of a segmentation layer was hidden when the layer opacity is set to 0. 

Possible cause of the bug:
- Previous versions of the wK UI had the "ID Mapping" dropdown/UI separate of the `Segmentation Layer` settings. I.e. the ID mapping dropdown had to "disable"/hide itself, when the `Segmentation` layer was disabled. 
- Since moving the ID mapping setting into the `Segmentation` layer setting, this behavior is no longer required.


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Set `Segmentation` layer opacity to `0`
- Toggle the segmentation layer to refresh React rendering --> ID mapping dropdown should still be visible
- Toggle the ID mapping toggle to refresh React rendering --> ID mapping dropdown should still be visible

### Issues:
- fixes #6210 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
