### PR TITLE
Batch nml task upload to avoid uploading too many nmls with one request

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added Volume Interpolation feature. When enabled, it suffices to only label every 2nd slice. The skipped slices will be filled automatically by interpolating between the labeled slices. This feature is disabled by default. Note that the feature is even forbidden for tasks by default, but can be enabled/recommended. [#6162](https://github.com/scalableminds/webknossos/pull/6162)
-- Added a batching mechanism to task creation via nmls to support uploading more that 100 nmls at a time. [#6216](https://github.com/scalableminds/webknossos/pull/6216)
+- Added a batching mechanism to the task creation via NML to support uploading more than 100 NMLs at a time. [#6216](https://github.com/scalableminds/webknossos/pull/6216)
 - Added a long-running job that applies the merging done via a merger mode tracing to a new output dataset. The job is accessible via a button next to the merger mode button once the merger mode is active. [#6086](https://github.com/scalableminds/webknossos/pull/6086)
 - Added support to stream zarr files using the corresponding [zarr spec](https://zarr.readthedocs.io/en/stable/spec/v2.html#storage). [#6144](https://github.com/scalableminds/webknossos/pull/6144)
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added Volume Interpolation feature. When enabled, it suffices to only label every 2nd slice. The skipped slices will be filled automatically by interpolating between the labeled slices. This feature is disabled by default. Note that the feature is even forbidden for tasks by default, but can be enabled/recommended. [#6162](https://github.com/scalableminds/webknossos/pull/6162)
+- Added a batching mechanism to task creation via nmls to support uploading more that 100 nmls at a time. [#6216](https://github.com/scalableminds/webknossos/pull/6216)
 - Added a long-running job that applies the merging done via a merger mode tracing to a new output dataset. The job is accessible via a button next to the merger mode button once the merger mode is active. [#6086](https://github.com/scalableminds/webknossos/pull/6086)
 - Added support to stream zarr files using the corresponding [zarr spec](https://zarr.readthedocs.io/en/stable/spec/v2.html#storage). [#6144](https://github.com/scalableminds/webknossos/pull/6144)
 

--- a/frontend/javascripts/admin/task/task_create_bulk_view.tsx
+++ b/frontend/javascripts/admin/task/task_create_bulk_view.tsx
@@ -11,7 +11,7 @@ import Messages from "messages";
 import Toast from "libs/toast";
 const FormItem = Form.Item;
 const { TextArea } = Input;
-const NUM_TASKS_PER_BATCH = 100;
+export const NUM_TASKS_PER_BATCH = 100;
 export type NewTask = {
   readonly boundingBox: BoundingBoxObject | null | undefined;
   readonly dataSet: string;


### PR DESCRIPTION
This PR batches the task creation via nml to a maximum of 100 per request as this is the limit set by the backend. Previously, trying to upload more than 100 nmls at once resulted in an error. Now the batching prevents this error and triggers one request after another until all nmls are uploaded.

### URL of deployed dev instance (used for testing):
- https://batchnmltaskupload.webknossos.xyz

### Steps to test:
- This test requires a lot of nml files. Therefore you can use the nml file contained in this zip
[tracing.nml.zip](https://github.com/scalableminds/webknossos/files/8709818/tracing.nml.zip). Extract this nml into an empty folder. In that folder create a `.sh` script and past the following code in that file: `for i in {1..150}; do cp tracing.nml "tracing$i.nml"; done`. This code will duplicate the nml file 150 times. Then execute the script.
- Create a new task type for hybrid annotations (with skeleton and volume annotation). If there exists already one, this step can be skipped.
- Open the task admin view, click on Àdd Task` in the top right corner and use the `Create Task` Tab. There fill out the form with the newly created hybrid task type.
- Under `Task Specification` in the form select the `Upload NML File` option.
- Then click on the nml upload zone and select all the nml files created during the first step of this list. You might need to wait a little because of the high count of files.
- Next try to upload all those files as tasks via the `Create Task` button. This should succeed.
- If you try to upload the same amount of tasks on the master, an error should occur, preventing the successful task creation.

### Issues:
- fixes #6194

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
