### PR TITLE
Fix swagger list-of-string type annotation

### DIFF
--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -6,28 +6,20 @@ import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.util.mvc.Filter
 import com.scalableminds.util.tools.DefaultConverters._
 import com.scalableminds.util.tools.{Fox, JsonHelper, Math}
-import io.swagger.annotations.{
-  Api,
-  ApiImplicitParam,
-  ApiImplicitParams,
-  ApiOperation,
-  ApiParam,
-  ApiResponse,
-  ApiResponses
-}
+import io.swagger.annotations._
+import javax.inject.Inject
+import models.analytics.{AnalyticsService, ChangeDatasetSettingsEvent, OpenDatasetEvent}
 import models.binary._
+import models.organization.OrganizationDAO
 import models.team.TeamDAO
 import models.user.{User, UserDAO, UserService}
+import oxalis.mail.{MailchimpClient, MailchimpTag}
 import oxalis.security.{URLSharing, WkEnv}
 import play.api.i18n.{Messages, MessagesProvider}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import utils.ObjectId
-import javax.inject.Inject
-import models.analytics.{AnalyticsService, ChangeDatasetSettingsEvent, OpenDatasetEvent}
-import models.organization.OrganizationDAO
-import oxalis.mail.{MailchimpClient, MailchimpTag}
 import play.api.mvc.{Action, AnyContent}
+import utils.ObjectId
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -330,7 +322,7 @@ Expects:
     Array(
       new ApiImplicitParam(name = "datasetUpdateTeamsInformation",
                            required = true,
-                           dataType = "List[String]",
+                           dataType = "com.scalableminds.util.swaggerhelpers.ListOfString",
                            paramType = "body")))
   def updateTeams(@ApiParam(value = "The url-safe name of the organization owning the dataset",
                             example = "sample_organization") organizationName: String,

--- a/app/models/annotation/AnnotationUploadService.scala
+++ b/app/models/annotation/AnnotationUploadService.scala
@@ -15,15 +15,12 @@ import net.liftweb.util.Helpers.tryo
 import oxalis.files.TempFileService
 import play.api.i18n.MessagesProvider
 
-import scala.concurrent.ExecutionContext
-
 case class UploadedVolumeLayer(tracing: VolumeTracing, dataZipLocation: String, name: Option[String]) {
   def getDataZipFrom(otherFiles: Map[String, File]): Option[File] =
     otherFiles.get(dataZipLocation)
 }
 
-class AnnotationUploadService @Inject()(tempFileService: TempFileService)(implicit ec: ExecutionContext)
-    extends LazyLogging {
+class AnnotationUploadService @Inject()(tempFileService: TempFileService) extends LazyLogging {
 
   private def extractFromNml(file: File, name: String, overwritingDataSetName: Option[String], isTaskUpload: Boolean)(
       implicit m: MessagesProvider): NmlParseResult =

--- a/app/models/annotation/WKRemoteTracingStoreClient.scala
+++ b/app/models/annotation/WKRemoteTracingStoreClient.scala
@@ -9,7 +9,6 @@ import com.scalableminds.util.tools.Fox.bool2Fox
 import com.scalableminds.util.tools.JsonHelper.{boxFormat, optionFormat}
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, SkeletonTracings}
 import com.scalableminds.webknossos.datastore.VolumeTracing.{VolumeTracing, VolumeTracings}
-import com.scalableminds.webknossos.datastore.models.datasource.DataSourceLike
 import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.scalableminds.webknossos.tracingstore.tracings.TracingSelector
 import com.scalableminds.webknossos.tracingstore.tracings.volume.ResolutionRestrictions

--- a/util/src/main/scala/com/scalableminds/util/swaggerhelpers/ListOfString.scala
+++ b/util/src/main/scala/com/scalableminds/util/swaggerhelpers/ListOfString.scala
@@ -1,0 +1,4 @@
+package com.scalableminds.util.swaggerhelpers
+
+// Use in swagger annotations for List[String] body type
+abstract class ListOfString extends java.util.List[String]


### PR DESCRIPTION
Using the workaround suggested in https://github.com/swagger-api/swagger-play/issues/104#issuecomment-295737502

### URL of deployed dev instance (used for testing):
- https://swaggerlistofstring.webknossos.xyz

### Steps to test:
- Compile, and launch should not log swagger exception
- swagger.json should contain valid definition for update teams route:
```
{
  "in" : "body",
  "name" : "datasetUpdateTeamsInformation",
  "required" : true,
  "schema" : {
    "type" : "array",
    "items" : {
      "type" : "string"
    }
  }
}
```

I also removed an unused import and an unused injection that the compiler warned about.

- [x] Ready for review
