### PR TITLE
Ome ngff volume annotation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Adding a New Volume Layer via the left border tab now gives the option to restrict resolutions for the new layer. [#6229](https://github.com/scalableminds/webknossos/pull/6229)
 - Added support for segment interpolation with depths > 2. Also, the feature was changed to work on an explicit trigger (either via the button in the toolbar or via the shortcut V). When triggering the interpolation, the current segment id is interpolated between the current slice and the least-recently annotated slice. [#6235](https://github.com/scalableminds/webknossos/pull/6235)
 - Added Route to get OME-NGFF Headers for a data layer (.zattrs file) following the corresponding [spec](https://ngff.openmicroscopy.org/latest/). [#6226](https://github.com/scalableminds/webknossos/pull/6226)
+- Added Route to get OME-NGFF Headers for Volume annotation. [#6242](https://github.com/scalableminds/webknossos/pull/6242)
 
 ### Changed
 - When creating a new annotation with a volume layer (without fallback) for a dataset which has an existing segmentation layer, the original segmentation layer is still listed (and viewable) in the left sidebar. Earlier versions simply hid the original segmentation layer. [#6186](https://github.com/scalableminds/webknossos/pull/6186)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
@@ -174,7 +174,7 @@ class ZarrStreamingController @Inject()(
           "dataSource.notFound") ~> 404
         existingMags = dataLayer.resolutions
 
-        omeNgffHeader = OmeNgffHeader.createFromDataLayerName(dataLayerName,
+        omeNgffHeader = OmeNgffHeader.fromDataLayerName(dataLayerName,
                                                               dataSourceScale = dataSource.scale,
                                                               mags = existingMags)
       } yield Ok(Json.toJson(omeNgffHeader))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
@@ -175,8 +175,8 @@ class ZarrStreamingController @Inject()(
         existingMags = dataLayer.resolutions
 
         omeNgffHeader = OmeNgffHeader.fromDataLayerName(dataLayerName,
-                                                              dataSourceScale = dataSource.scale,
-                                                              mags = existingMags)
+                                                        dataSourceScale = dataSource.scale,
+                                                        mags = existingMags)
       } yield Ok(Json.toJson(omeNgffHeader))
     }
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/OmeNgffHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/OmeNgffHeader.scala
@@ -40,9 +40,9 @@ object OmeNgffOneHeader {
 case class OmeNgffHeader(multiscales: List[OmeNgffOneHeader])
 
 object OmeNgffHeader {
-  def createFromDataLayerName(dataLayerName: String,
-                              dataSourceScale: Vec3Double,
-                              mags: List[Vec3Int]): OmeNgffHeader = {
+  def fromDataLayerName(dataLayerName: String,
+                        dataSourceScale: Vec3Double,
+                        mags: List[Vec3Int]): OmeNgffHeader = {
     val datasets = mags.map(
       mag =>
         OmeNgffDataset(

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/OmeNgffHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/OmeNgffHeader.scala
@@ -40,9 +40,7 @@ object OmeNgffOneHeader {
 case class OmeNgffHeader(multiscales: List[OmeNgffOneHeader])
 
 object OmeNgffHeader {
-  def fromDataLayerName(dataLayerName: String,
-                        dataSourceScale: Vec3Double,
-                        mags: List[Vec3Int]): OmeNgffHeader = {
+  def fromDataLayerName(dataLayerName: String, dataSourceScale: Vec3Double, mags: List[Vec3Int]): OmeNgffHeader = {
     val datasets = mags.map(
       mag =>
         OmeNgffDataset(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -325,10 +325,11 @@ class VolumeTracingController @Inject()(
         tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
 
         existingMags = tracing.resolutions.map(vec3IntFromProto)
+        dataSource <- remoteWebKnossosClient.getDataSource(tracing.organizationName, tracing.dataSetName)
 
-        omeNgffHeader = OmeNgffHeader.fromDataLayerName(tracing.dataSetName,
-                                                              dataSourceScale = Vec3Double(1.0, 1.0, 1.0),
-                                                              mags = existingMags.toList)
+        omeNgffHeader = OmeNgffHeader.fromDataLayerName(tracingId,
+                                                        dataSourceScale = dataSource.scale,
+                                                        mags = existingMags.toList)
       } yield Ok(Json.toJson(omeNgffHeader))
     }
   }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -312,7 +312,7 @@ class VolumeTracingController @Inject()(
   }
 
   /**
-    * Handles a request for .zattrs file for a wkw dataset via a HTTP GET.
+    * Handles a request for .zattrs file for a Volume Tracing via a HTTP GET.
     * Uses the OME-NGFF standard (see https://ngff.openmicroscopy.org/latest/)
     * Used by zarr-streaming.
     */

--- a/webknossos-tracingstore/conf/com.scalableminds.webknossos.tracingstore.routes
+++ b/webknossos-tracingstore/conf/com.scalableminds.webknossos.tracingstore.routes
@@ -27,6 +27,7 @@ POST        /volume/mergedFromContents                          @com.scalablemin
 # Zarr endpoints for volume annotations
 GET         /volume/zarr/:tracingId                             @com.scalableminds.webknossos.tracingstore.controllers.VolumeTracingController.volumeTracingFolderContent(token: Option[String], tracingId: String)
 GET         /volume/zarr/:tracingId/.zgroup                     @com.scalableminds.webknossos.tracingstore.controllers.VolumeTracingController.zGroup(token: Option[String], tracingId: String)
+GET         /volume/zarr/:tracingId/.zattrs                     @com.scalableminds.webknossos.tracingstore.controllers.VolumeTracingController.zAttrs(token: Option[String], tracingId: String)
 GET         /volume/zarr/:tracingId/:mag                        @com.scalableminds.webknossos.tracingstore.controllers.VolumeTracingController.volumeTracingMagFolderContent(token: Option[String], tracingId: String, mag: String)
 GET         /volume/zarr/:tracingId/:mag/.zarray                @com.scalableminds.webknossos.tracingstore.controllers.VolumeTracingController.zArray(token: Option[String], tracingId: String, mag: String)
 GET         /volume/zarr/:tracingId/:mag/:cxyz                  @com.scalableminds.webknossos.tracingstore.controllers.VolumeTracingController.rawZarrCube(token: Option[String], tracingId: String, mag: String, cxyz: String)


### PR DESCRIPTION
### Steps to test:
- send a `GET` request to a route similar to `GET http://localhost:9000/tracings/volume/zarr/18a17837-62e3-43b4-bcaf-da0baaec1b3d/.zattrs?token=secretSampleUserToken`
- Get something back like
```
{
    "multiscales": [
        {
            "version": "0.4",
            "name": "18a17837-62e3-43b4-bcaf-da0baaec1b3d",
            "axes": [
                {
                    "name": "c",
                    "type": "channel"
                },
                {
                    "name": "x",
                    "type": "space",
                    "unit": "nanometer"
                },
                {
                    "name": "y",
                    "type": "space",
                    "unit": "nanometer"
                },
                {
                    "name": "z",
                    "type": "space",
                    "unit": "nanometer"
                }
            ],
            "datasets": [
                {
                    "path": "1",
                    "coordinateTranformations": [
                        {
                            "type": "scale",
                            "scale": [
                                1,
                                11.239999771118164,
                                11.239999771118164,
                                28
                            ]
                        }
                    ]
                },
                {
                    "path": "2-2-1",
                    "coordinateTranformations": [
                        {
                            "type": "scale",
                            "scale": [
                                1,
                                22.479999542236328,
                                22.479999542236328,
                                28
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}
```

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
