### PR TITLE
Fix broken context menu in dataset-view-mode when no segmentation layer is visible

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ Added a warning for when the resolution in the XY viewport on z=1-downsampled da
 
 
 ### Fixed
+- Fixed that the context menu broke webKnossos when opening it in dataset-view-mode while no segmentation layer was visible. [#6259](https://github.com/scalableminds/webknossos/pull/6259)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -350,11 +350,13 @@ function NodeContextMenuOptions({
   volumeTracing,
   infoRows,
   allowUpdate,
-}: NodeContextMenuOptionsProps) {
+}: NodeContextMenuOptionsProps): JSX.Element {
   const dispatch = useDispatch();
 
   if (skeletonTracing == null) {
-    return null;
+    throw new Error(
+      "NodeContextMenuOptions should not have been called without existing skeleton tracing.",
+    );
   }
 
   const { userBoundingBoxes } = skeletonTracing;
@@ -613,7 +615,7 @@ function getBoundingBoxMenuOptions({
   ];
 }
 
-function NoNodeContextMenuOptions(props: NoNodeContextMenuProps) {
+function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
   const {
     skeletonTracing,
     volumeTracing,
@@ -797,10 +799,6 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps) {
     allActions = boundingBoxActions.concat(nonSkeletonActions).concat(skeletonActions);
   } else {
     allActions = nonSkeletonActions.concat(skeletonActions).concat(boundingBoxActions);
-  }
-
-  if (allActions.length === 0) {
-    return null;
   }
 
   return (
@@ -1000,7 +998,6 @@ function ContextMenuInner(propsWithInputRef: PropsWithRef) {
     // for the following two expressions, since this breaks
     // antd's internal population of the correct class names
     // for the menu.
-    // @ts-expect-error ts-migrate(2322) FIXME: Type 'Element | null' is not assignable to type 'E... Remove this comment to see the full error message
     overlay =
       maybeClickedNodeId != null
         ? NodeContextMenuOptions({
@@ -1010,8 +1007,6 @@ function ContextMenuInner(propsWithInputRef: PropsWithRef) {
             ...props,
           })
         : NoNodeContextMenuOptions({
-            // @ts-expect-error ts-migrate(2783) FIXME: 'activeTool' is specified more than once, so this ... Remove this comment to see the full error message
-            activeTool,
             segmentIdAtPosition,
             infoRows,
             viewport: maybeViewport,

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -886,7 +886,6 @@ function ContextMenuInner(propsWithInputRef: PropsWithRef) {
   const { inputRef, ...props } = propsWithInputRef;
   const {
     skeletonTracing,
-    activeTool,
     maybeClickedNodeId,
     contextMenuPosition,
     hideContextMenu,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I opened l4_sample, hid the segmentation layer and used the context menu. Before the changes, the page crashed. Now, a context menu with one entry (the clicked position) is shown

### Issues:
- fixes #6258

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
