### PR TITLE
Fix benign error toast for public annotations and other improvements

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,9 +17,9 @@ Added a warning for when the resolution in the XY viewport on z=1-downsampled da
 - For the api routes that return annotation info objects, the user field was renamed to owner. User still exists as an alias, but will be removed in a future release. [#6250](https://github.com/scalableminds/webknossos/pull/6250)
 - When creating a task from a base annotation, the starting position/rotation and bounding box as specified during task creation are now used and overwrite the ones from the original base annotation. [#6249](https://github.com/scalableminds/webknossos/pull/6249)
 
-
 ### Fixed
 - Fixed that the context menu broke webKnossos when opening it in dataset-view-mode while no segmentation layer was visible. [#6259](https://github.com/scalableminds/webknossos/pull/6259)
+- Fixed benign error toast when viewing a public annotation without being logged in. [#6271](https://github.com/scalableminds/webknossos/pull/6271)
 
 ### Removed
 

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -339,13 +339,17 @@ export function updateTaskType(taskTypeId: string, taskType: APITaskType): Promi
 
 // ### Teams
 export async function getTeams(): Promise<Array<APITeam>> {
-  const teams = await Request.receiveJSON("/api/teams");
+  const teams = await Request.receiveJSON("/api/teams", {
+    doNotInvestigate: true,
+  });
   assertResponseLimit(teams);
   return teams;
 }
 
 export async function getEditableTeams(): Promise<Array<APITeam>> {
-  const teams = await Request.receiveJSON("/api/teams?isEditable=true");
+  const teams = await Request.receiveJSON("/api/teams?isEditable=true", {
+    doNotInvestigate: true,
+  });
   assertResponseLimit(teams);
   return teams;
 }

--- a/frontend/javascripts/admin/datastore_health_check.ts
+++ b/frontend/javascripts/admin/datastore_health_check.ts
@@ -49,7 +49,6 @@ const pingDataStoreIfAppropriate = memoizedThrottle(async (requestedUrl: string)
       const healthEndpoint = `${url}/${path}/health`;
       Request.triggerRequest(healthEndpoint, {
         doNotInvestigate: true,
-        // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{ doNotInvestigate: true; mode: ... Remove this comment to see the full error message
         mode: "cors",
         timeout: 5000,
       }).then(

--- a/frontend/javascripts/dashboard/dataset/team_selection_component.tsx
+++ b/frontend/javascripts/dashboard/dataset/team_selection_component.tsx
@@ -41,16 +41,20 @@ class TeamSelectionComponent extends React.PureComponent<Props, State> {
     this.setState({
       isFetchingData: true,
     });
-    const possibleTeams = this.props.allowNonEditableTeams
-      ? await getTeams()
-      : await getEditableTeams();
-    this.setState({
-      possibleTeams,
-      isFetchingData: false,
-    });
+    try {
+      const possibleTeams = this.props.allowNonEditableTeams
+        ? await getTeams()
+        : await getEditableTeams();
+      this.setState({
+        possibleTeams,
+        isFetchingData: false,
+      });
 
-    if (this.props.afterFetchedTeams != null) {
-      this.props.afterFetchedTeams(possibleTeams);
+      if (this.props.afterFetchedTeams != null) {
+        this.props.afterFetchedTeams(possibleTeams);
+      }
+    } catch (exception) {
+      console.error("Could not load teams.");
     }
   }
 

--- a/frontend/javascripts/libs/react_helpers.tsx
+++ b/frontend/javascripts/libs/react_helpers.tsx
@@ -68,9 +68,9 @@ export function usePolledState(callback: (arg0: OxalisState) => void, interval: 
   }, interval);
 }
 
-export function makeModalLazy<T extends { isVisible: boolean }>(
-  ComponentFn: (arg: T) => JSX.Element,
-): (arg: T) => JSX.Element | null {
+export function makeComponentLazy<T extends { isVisible: boolean }>(
+  ComponentFn: React.ComponentType<T>,
+): React.ComponentType<T> {
   return function LazyModalWrapper(props: T) {
     const [hasBeenInitialized, setHasBeenInitialized] = useState(false);
     const isVisible = props.isVisible;

--- a/frontend/javascripts/libs/react_helpers.tsx
+++ b/frontend/javascripts/libs/react_helpers.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useStore } from "react-redux";
 import type { OxalisState } from "oxalis/store";
 // From https://overreacted.io/making-setinterval-declarative-with-react-hooks/
@@ -67,4 +67,22 @@ export function usePolledState(callback: (arg0: OxalisState) => void, interval: 
     callback(state);
   }, interval);
 }
+
+export function makeModalLazy<T extends { isVisible: boolean }>(
+  ComponentFn: (arg: T) => JSX.Element,
+): (arg: T) => JSX.Element | null {
+  return function LazyModalWrapper(props: T) {
+    const [hasBeenInitialized, setHasBeenInitialized] = useState(false);
+    const isVisible = props.isVisible;
+    useEffect(() => {
+      setHasBeenInitialized(hasBeenInitialized || isVisible);
+    }, [isVisible]);
+
+    if (isVisible || hasBeenInitialized) {
+      return <ComponentFn {...props} />;
+    }
+    return null;
+  };
+}
+
 export default {};

--- a/frontend/javascripts/libs/request.ts
+++ b/frontend/javascripts/libs/request.ts
@@ -21,6 +21,7 @@ export type RequestOptionsBase<T> = {
   headers?: T;
   host?: string;
   method?: method;
+  mode?: RequestMode;
   params?: string | Record<string, any>;
   showErrorToast?: boolean;
   timeout?: number;

--- a/frontend/javascripts/messages.ts
+++ b/frontend/javascripts/messages.ts
@@ -301,6 +301,7 @@ instead. Only enable this option if you understand its effect. All layers will n
     "This webKnossos instance is not configured to run TIFF export jobs on a dedicated background worker. To learn more about this feature please contact us at ",
   "annotation.python_do_not_share":
     "These snippets are pre-configured and contain your personal access token and annotation meta data. Do not share this information with anyone you do not trust!",
+  "annotation.register_for_token": "Please log in to get an access token for the script below.",
   "project.delete": "Do you really want to delete this project?",
   "project.increase_instances":
     "Do you really want to add one additional instance to all tasks of this project?",

--- a/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.tsx
@@ -29,10 +29,7 @@ const warningColors = {
   color: "rgb(255, 155, 85)",
   borderColor: "rgb(241, 122, 39)",
 };
-const copyPositionDefaultStyle = {
-  padding: "0 10px",
-};
-const copyPositionErrorStyle = { ...copyPositionDefaultStyle, ...warningColors };
+const iconErrorStyle = { ...warningColors };
 const positionInputDefaultStyle = {
   textAlign: "center",
 };
@@ -94,8 +91,7 @@ class DatasetPositionView extends PureComponent<Props> {
   render() {
     const position = V3.floor(getPosition(this.props.flycam));
     const { isOutOfDatasetBounds, isOutOfTaskBounds } = this.isPositionOutOfBounds(position);
-    const copyPositionStyle =
-      isOutOfDatasetBounds || isOutOfTaskBounds ? copyPositionErrorStyle : copyPositionDefaultStyle;
+    const iconColoringStyle = isOutOfDatasetBounds || isOutOfTaskBounds ? iconErrorStyle : {};
     const positionInputStyle =
       isOutOfDatasetBounds || isOutOfTaskBounds
         ? positionInputErrorStyle
@@ -125,7 +121,7 @@ class DatasetPositionView extends PureComponent<Props> {
           <Tooltip title={message["tracing.copy_position"]} placement="bottomLeft">
             <ButtonComponent
               onClick={this.copyPositionToClipboard}
-              style={copyPositionStyle}
+              style={{ padding: "0 10px", ...iconColoringStyle }}
               className="hide-on-small-screen"
             >
               <PushpinOutlined style={positionIconStyle} />
@@ -140,7 +136,7 @@ class DatasetPositionView extends PureComponent<Props> {
             style={positionInputStyle}
             allowDecimals
           />
-          <ShareButton dataset={this.props.dataset} style={copyPositionStyle} />
+          <ShareButton dataset={this.props.dataset} style={iconColoringStyle} />
         </Input.Group>
         {isArbitraryMode ? (
           <Input.Group

--- a/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
@@ -1,7 +1,7 @@
 import { Divider, Modal, Checkbox, Row, Col, Tabs, Typography, Button } from "antd";
 import { CopyOutlined } from "@ant-design/icons";
 import React, { useState } from "react";
-import { makeModalLazy, useFetch } from "libs/react_helpers";
+import { makeComponentLazy, useFetch } from "libs/react_helpers";
 import type { APIAnnotationType } from "types/api_flow_types";
 import Toast from "libs/toast";
 import messages from "messages";
@@ -507,5 +507,5 @@ with wk.webknossos_context(
   );
 }
 
-const DownloadModalView = makeModalLazy(_DownloadModalView);
+const DownloadModalView = makeComponentLazy(_DownloadModalView);
 export default DownloadModalView;

--- a/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.tsx
@@ -17,6 +17,7 @@ import Toast from "libs/toast";
 import * as Utils from "libs/utils";
 import api from "oxalis/api/internal_api";
 import messages from "messages";
+import { makeComponentLazy } from "libs/react_helpers";
 type ProjectInfo = {
   id: string;
   label: string;
@@ -83,7 +84,7 @@ class ButtonWithCheckbox extends PureComponent<ButtonWithCheckboxProps, ButtonWi
   }
 }
 
-class MergeModalView extends PureComponent<Props, MergeModalViewState> {
+class _MergeModalView extends PureComponent<Props, MergeModalViewState> {
   state: MergeModalViewState = {
     projects: [],
     selectedProject: null,
@@ -306,6 +307,8 @@ class MergeModalView extends PureComponent<Props, MergeModalViewState> {
     );
   }
 }
+
+const MergeModalView = makeComponentLazy(_MergeModalView);
 
 function mapStateToProps(state: OxalisState): StateProps {
   return {

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -26,6 +26,7 @@ import UrlManager from "oxalis/controller/url_manager";
 import { setAnnotationVisibilityAction } from "oxalis/model/actions/annotation_actions";
 import { setShareModalVisibilityAction } from "oxalis/model/actions/ui_actions";
 import { ControlModeEnum } from "oxalis/constants";
+import { makeModalLazy } from "libs/react_helpers";
 const RadioGroup = Radio.Group;
 const sharingActiveNode = true;
 type Props = {
@@ -123,7 +124,7 @@ export function ShareButton(props: { dataset: APIDataset; style?: Record<string,
     />
   );
 }
-export default function ShareModalView(props: Props) {
+function _ShareModalView(props: Props) {
   const { isVisible, onOk, annotationType, annotationId } = props;
   const dataset = useSelector((state: OxalisState) => state.dataset);
   const annotationVisibility = useSelector((state: OxalisState) => state.tracing.visibility);
@@ -348,3 +349,6 @@ export default function ShareModalView(props: Props) {
     </Modal>
   );
 }
+
+const ShareModalView = makeModalLazy(_ShareModalView);
+export default ShareModalView;

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -45,13 +45,12 @@ function Hint({ children, style }: { children: React.ReactNode; style: React.CSS
 }
 
 export function useDatasetSharingToken(dataset: APIDataset) {
+  const activeUser = useSelector((state: OxalisState) => state.activeUser);
   const [datasetToken, setDatasetToken] = useState("");
 
   const fetchAndSetToken = async () => {
     try {
-      const sharingToken = await getDatasetSharingToken(dataset, {
-        showErrorToast: false,
-      });
+      const sharingToken = await getDatasetSharingToken(dataset);
       setDatasetToken(sharingToken);
     } catch (error) {
       console.error(error);
@@ -59,8 +58,11 @@ export function useDatasetSharingToken(dataset: APIDataset) {
   };
 
   useEffect(() => {
+    if (!activeUser) {
+      return;
+    }
     fetchAndSetToken();
-  }, [dataset]);
+  }, [dataset, activeUser]);
   return datasetToken;
 }
 export function getUrl(sharingToken: string, includeToken: boolean) {
@@ -133,19 +135,21 @@ function _ShareModalView(props: Props) {
   const [visibility, setVisibility] = useState(annotationVisibility);
   const [sharedTeams, setSharedTeams] = useState<APITeam[]>([]);
   const sharingToken = useDatasetSharingToken(dataset);
+  const activeUser = useSelector((state: OxalisState) => state.activeUser);
   const hasUpdatePermissions = restrictions.allowUpdate && restrictions.allowSave;
   useEffect(() => setVisibility(annotationVisibility), [annotationVisibility]);
 
   const fetchAndSetSharedTeams = async () => {
-    const fetchedSharedTeams = await getTeamsForSharedAnnotation(annotationType, annotationId, {
-      showErrorToast: false,
-    });
+    if (!activeUser) {
+      return;
+    }
+    const fetchedSharedTeams = await getTeamsForSharedAnnotation(annotationType, annotationId);
     setSharedTeams(fetchedSharedTeams);
   };
 
   useEffect(() => {
     fetchAndSetSharedTeams();
-  }, [annotationType, annotationId]);
+  }, [annotationType, annotationId, activeUser]);
 
   const handleCheckboxChange = (event: RadioChangeEvent) => {
     setVisibility(event.target.value as any as APIAnnotationVisibility);

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -26,7 +26,7 @@ import UrlManager from "oxalis/controller/url_manager";
 import { setAnnotationVisibilityAction } from "oxalis/model/actions/annotation_actions";
 import { setShareModalVisibilityAction } from "oxalis/model/actions/ui_actions";
 import { ControlModeEnum } from "oxalis/constants";
-import { makeModalLazy } from "libs/react_helpers";
+import { makeComponentLazy } from "libs/react_helpers";
 const RadioGroup = Radio.Group;
 const sharingActiveNode = true;
 type Props = {
@@ -124,6 +124,7 @@ export function ShareButton(props: { dataset: APIDataset; style?: Record<string,
     />
   );
 }
+
 function _ShareModalView(props: Props) {
   const { isVisible, onOk, annotationType, annotationId } = props;
   const dataset = useSelector((state: OxalisState) => state.dataset);
@@ -350,5 +351,5 @@ function _ShareModalView(props: Props) {
   );
 }
 
-const ShareModalView = makeModalLazy(_ShareModalView);
+const ShareModalView = makeComponentLazy(_ShareModalView);
 export default ShareModalView;

--- a/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.tsx
@@ -7,7 +7,10 @@ import { fetchGistContent } from "libs/gist";
 import { handleGenericError } from "libs/error_handling";
 import Request from "libs/request";
 import messages from "messages";
+import { makeComponentLazy } from "libs/react_helpers";
+
 const { TextArea } = Input;
+
 type UserScriptsModalViewProps = {
   onOK: (...args: Array<any>) => any;
   isVisible: boolean;
@@ -20,7 +23,7 @@ type State = {
   isLoading: boolean;
 };
 
-class UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps, State> {
+class _UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps, State> {
   state: State = {
     code: "",
     isCodeChanged: false,
@@ -146,5 +149,7 @@ class UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps
     );
   }
 }
+
+const UserScriptsModalView = makeComponentLazy(_UserScriptsModalView);
 
 export default UserScriptsModalView;


### PR DESCRIPTION
- Don't show error toast when fetching token or teams failed
- Fix padding of share button
- Make some modals lazy

### URL of deployed dev instance (used for testing):
- https://fixtoast.webknossos.xyz

### Steps to test:
- create a public sharing link for an annotation and open that in incognito tab --> no error toast should be visible
- the share button shouldn't look off, anymore

### Issues:
- fixes https://github.com/scalableminds/webknossos/issues/6262

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
