### PR TITLE
Turn off deleting of bounding boxes in read only annotations

### DIFF
--- a/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
+++ b/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
@@ -487,7 +487,7 @@ export class UserBoundingBoxInput extends React.PureComponent<UserBoundingBoxInp
               }
             >
               <DeleteOutlined
-                onClick={onDelete}
+                onClick={allowUpdate ? onDelete : () => {}}
                 style={allowUpdate ? iconStyle : disabledIconStyle}
                 disabled={!allowUpdate}
               />


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a task.
- Open the created task by yourself and create some bounding boxes via the bounding box tab.
- Finish the task and go to the task list view. Search for your user and the task you just finished. View the task.
- Open the bounding box tab and try to delete one of the bounding boxes. This should no longer work 🎉.

### Issues:
- fixes #6041

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Ready for review
