### PR TITLE
Don't show error toast when dataset sharing token could not be acquired

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -50,7 +50,9 @@ export function useDatasetSharingToken(dataset: APIDataset) {
 
   const fetchAndSetToken = async () => {
     try {
-      const sharingToken = await getDatasetSharingToken(dataset);
+      const sharingToken = await getDatasetSharingToken(dataset, {
+        doNotInvestigate: true,
+      });
       setDatasetToken(sharingToken);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I did the following locally:
    - set isDemoInstance = true
    - make one DS public and copy link
    - log out
    - register with new account
    - log in and open DS link
    - without this commit an error toast is shown; with this commit it's fixed

### Issues:
- This fixes a regression caused by https://github.com/scalableminds/webknossos/commit/193f39d875ea047a0d34035f7f4c6a92e58a10f1

------
(Please delete unneeded items, merge only when none are left open)
- [ ] ~Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~ the old changelog entry should describe it sufficiently :sweat_smile: 
- [X] Ready for review
