### PR TITLE
Keep token during url redirection

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ Added a warning for when the resolution in the XY viewport on z=1-downsampled da
 - Fixed that bounding boxes were deletable in read-only tracings although the delete button was disabled. [#6273](https://github.com/scalableminds/webknossos/pull/6273)
 - Fixed that the context menu broke webKnossos when opening it in dataset-view-mode while no segmentation layer was visible. [#6259](https://github.com/scalableminds/webknossos/pull/6259)
 - Fixed benign error toast when viewing a public annotation without being logged in. [#6271](https://github.com/scalableminds/webknossos/pull/6271)
+- Fixed that (old) sharing links with tokens did not work, because the token was removed during a redirection. [#6281](https://github.com/scalableminds/webknossos/pull/6281)
 
 ### Removed
 

--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -315,14 +315,15 @@ class ReactRouter extends React.Component<Props> {
               <SecuredRoute
                 isAuthenticated={isAuthenticated}
                 path="/annotations/:type/:id"
-                render={({ match }: ContextRouter) => {
+                render={({ location, match }: ContextRouter) => {
                   const initialMaybeCompoundType =
                     match.params.type != null
                       ? coalesce(APICompoundTypeEnum, match.params.type)
                       : null;
 
                   if (initialMaybeCompoundType == null) {
-                    return <Redirect to={`/annotations/${match.params.id}`} />;
+                    const { hash, search } = location;
+                    return <Redirect to={`/annotations/${match.params.id}${search}${hash}`} />;
                   }
 
                   return this.tracingView({ match });
@@ -571,7 +572,7 @@ class ReactRouter extends React.Component<Props> {
                         resolutionRestrictions,
                       );
                       trackAction(`Create ${type} tracing`);
-                      return `/annotations/${annotation.typ}/${annotation.id}`;
+                      return `/annotations/${annotation.id}`;
                     }}
                   />
                 )}


### PR DESCRIPTION
Fixes that links with sharing tokens did not work, anymore, since redirecting to the explorational-less route did lose these tokens.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I opened a link like this locally: http://localhost:9000/annotations/Explorational/62aa1cd21a0200d818ab0ac2?token=zSysRSA6cPrv1205dBnoZA#2584,3584,1024,0,1.3
- and ensured that it redirected to http://localhost:9000/annotations/62aa1cd21a0200d818ab0ac2?token=zSysRSA6cPrv1205dBnoZA#2584,3584,1024,0,1.3

### Issues:
- fixes a regression from #6208

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
