### PR TITLE
fix error when loading agglomerate skeleton for single-segment agglomerate

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
@@ -149,9 +149,20 @@ class AgglomerateService @Inject()(config: DataStoreConfig) extends DataConverte
         throw new Exception(s"Agglomerate has too many edges ($edgeCount > $edgeLimit)")
       }
       val positions: Array[Array[Long]] =
-        reader.uint64().readMatrixBlockWithOffset("/agglomerate_to_positions", nodeCount.toInt, 3, positionsRange(0), 0)
-      val edges: Array[Array[Long]] =
-        reader.uint64().readMatrixBlockWithOffset("/agglomerate_to_edges", edgeCount.toInt, 2, edgesRange(0), 0)
+        if (nodeCount == 0L) {
+          Array.empty[Array[Long]]
+        } else {
+          reader
+            .uint64()
+            .readMatrixBlockWithOffset("/agglomerate_to_positions", nodeCount.toInt, 3, positionsRange(0), 0)
+        }
+      val edges: Array[Array[Long]] = {
+        if (edgeCount == 0L) {
+          Array.empty[Array[Long]]
+        } else {
+          reader.uint64().readMatrixBlockWithOffset("/agglomerate_to_edges", edgeCount.toInt, 2, edgesRange(0), 0)
+        }
+      }
 
       val nodeIdStartAtOneOffset = 1
 


### PR DESCRIPTION
In newer hdf handling code we already added zero-length checks, but this old code did not have them. So when loading single-segment agglomerate skeletons, the edges array was empty, which cannot be passed to jhdf5 as is.

- [x] Needs datastore update after deployment
- [x] Ready for review
