### PR TITLE
Fix zooming out for datasets with very large scale

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed that bounding boxes were deletable in read-only tracings although the delete button was disabled. [#6273](https://github.com/scalableminds/webknossos/pull/6273)
 - Fixed that (old) sharing links with tokens did not work, because the token was removed during a redirection. [#6281](https://github.com/scalableminds/webknossos/pull/6281)
+- Fixed that zooming out for datasets with very large scale was not possible until the coarsest level. [#6304](https://github.com/scalableminds/webknossos/pull/6304)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
@@ -143,12 +143,14 @@ export function _getMaximumZoomForAllResolutions(
   // From that, we calculate the theoretical maximum zoom value. The dataset scale is taken into account,
   // because the entire scene is scaled with that.
   const maxSupportedZoomValue = 2 ** MAX_SUPPORTED_MAGNIFICATION_COUNT * Math.max(...datasetScale);
-  const maximumIterationCount = Math.log(maxSupportedZoomValue) / Math.log(ZOOM_STEP_INTERVAL);
-
   // Since the viewports can be quite large, it can happen that even a zoom value of 1 is not feasible.
   // That's why we start the search with a smaller value than 1. We use the ZOOM_STEP_INTERVAL factor
   // to ensure that the calculated thresholds correspond to the normal zoom behavior.
-  let currentMaxZoomValue = 1 / ZOOM_STEP_INTERVAL ** 20;
+  const ZOOM_IN_START_EXPONENT = 20;
+  let currentMaxZoomValue = 1 / ZOOM_STEP_INTERVAL ** ZOOM_IN_START_EXPONENT;
+  const maximumIterationCount =
+    Math.log(maxSupportedZoomValue) / Math.log(ZOOM_STEP_INTERVAL) + ZOOM_IN_START_EXPONENT;
+
   let currentIterationCount = 0;
   let currentResolutionIndex = 0;
   const maxZoomValueThresholds = [];

--- a/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
@@ -128,19 +128,28 @@ export function _getMaximumZoomForAllResolutions(
   maximumCapacity: number,
   initializedGpuFactor: number,
 ): Array<number> {
-  // maximumIterationCount is used as an upper limit to avoid an endless loop, in case
-  // the following while loop causes havoc for some reason (e.g., because
-  // the calculated bucket size isn't strictly increasing anymore). It means,
-  // that even with the best GPU specs and biggest dataset (i.e., many magnifications),
-  // wk will at most zoom out until a zoom value of ZOOM_STEP_INTERVAL**maximumIterationCount.
-  // With the current values, this would indicate a maximum zoom value of ~ 35 000, meaning
-  // that ~ 15 different magnifications (~ log2 of 35000) are supported properly.
-  const maximumIterationCount = 120;
-  let currentIterationCount = 0;
+  // This function determines which zoom value ranges are valid for the given magnifications.
+  // The calculation iterates through several zoom values and checks the required bucket capacity
+  // against the capacity supported by the GPU.
+  // In each iteration, the last zoom value is incremented as if the user performed a zoom-out action.
+  //
+  // In theory, we could simply abort the loop once a maximum zoom value was found for all magnifications.
+  // However, to avoid an infinite loop in case of violated assumptions (e.g., because the calculated
+  // bucket size isn't strictly increasing anymore), we calculate an iteration limit.
+
+  // For that limit, we specify how many magnifications we want to support at least.
+  // 15 magnifications means that the highest mag would be something like [32768, 32768, 1024].
+  const MAX_SUPPORTED_MAGNIFICATION_COUNT = 15;
+  // From that, we calculate the theoretical maximum zoom value. The dataset scale is taken into account,
+  // because the entire scene is scaled with that.
+  const maxSupportedZoomValue = 2 ** MAX_SUPPORTED_MAGNIFICATION_COUNT * Math.max(...datasetScale);
+  const maximumIterationCount = Math.log(maxSupportedZoomValue) / Math.log(ZOOM_STEP_INTERVAL);
+
   // Since the viewports can be quite large, it can happen that even a zoom value of 1 is not feasible.
   // That's why we start the search with a smaller value than 1. We use the ZOOM_STEP_INTERVAL factor
   // to ensure that the calculated thresholds correspond to the normal zoom behavior.
-  let maxZoomValue = 1 / ZOOM_STEP_INTERVAL ** 20;
+  let currentMaxZoomValue = 1 / ZOOM_STEP_INTERVAL ** 20;
+  let currentIterationCount = 0;
   let currentResolutionIndex = 0;
   const maxZoomValueThresholds = [];
 
@@ -148,7 +157,7 @@ export function _getMaximumZoomForAllResolutions(
     currentIterationCount < maximumIterationCount &&
     currentResolutionIndex < resolutions.length
   ) {
-    const nextZoomValue = maxZoomValue * ZOOM_STEP_INTERVAL;
+    const nextZoomValue = currentMaxZoomValue * ZOOM_STEP_INTERVAL;
     const nextCapacity = calculateTotalBucketCountForZoomLevel(
       viewMode,
       loadingStrategy,
@@ -164,11 +173,11 @@ export function _getMaximumZoomForAllResolutions(
     );
 
     if (nextCapacity > maximumCapacity) {
-      maxZoomValueThresholds.push(maxZoomValue);
+      maxZoomValueThresholds.push(currentMaxZoomValue);
       currentResolutionIndex++;
     }
 
-    maxZoomValue = nextZoomValue;
+    currentMaxZoomValue = nextZoomValue;
     currentIterationCount++;
   }
 


### PR DESCRIPTION
Respect the dataset scale when calculating the maximum iteration limit for the max zoom value determination.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- find a dataset which goes until mag 1024
- set a dataset scale to 600, 600, 1
- open the dataset and maximize the XY viewport
- zoom out (without this PR, zooming out was not possible until mag 1024)

### Issues:
- fixes #6061

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
