### PR TITLE
add swagger annotations for dataset-list and team-list API enpoints

### DIFF
--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -139,7 +139,10 @@ class DataSetController @Inject()(userService: UserService,
     } yield Ok
   }
 
-  @ApiOperation(hidden = true, value = "")
+  @ApiOperation(value = "List all accessible datasets.", nickname = "datasetList")
+  @ApiResponses(
+    Array(new ApiResponse(code = 200, message = "JSON list containing one object per resulting dataset."),
+          new ApiResponse(code = 400, message = badRequestLabel)))
   def list: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     UsingFilters(
       Filter("isActive", (value: Boolean, el: DataSet) => Fox.successful(el.isUsable == value)),

--- a/app/controllers/TeamController.scala
+++ b/app/controllers/TeamController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.tools.Fox
+import io.swagger.annotations._
 import models.team._
 import models.user.UserTeamRolesDAO
 import oxalis.security.WkEnv
@@ -14,6 +15,7 @@ import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.ExecutionContext
 
+@Api
 class TeamController @Inject()(teamDAO: TeamDAO,
                                userTeamRolesDAO: UserTeamRolesDAO,
                                datasetAllowedTeamsDAO: DataSetAllowedTeamsDAO,
@@ -24,7 +26,12 @@ class TeamController @Inject()(teamDAO: TeamDAO,
   private def teamNameReads: Reads[String] =
     (__ \ "name").read[String]
 
-  def list(isEditable: Option[Boolean]): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
+  @ApiOperation(value = "List all accessible teams.", nickname = "teamList")
+  @ApiResponses(
+    Array(new ApiResponse(code = 200, message = "JSON list containing one object per resulting team."),
+          new ApiResponse(code = 400, message = badRequestLabel)))
+  def list(@ApiParam(value = "When true, show only teams the current user can edit.") isEditable: Option[Boolean])
+    : Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     val onlyEditableTeams = isEditable.getOrElse(false)
     for {
       allTeams <- if (onlyEditableTeams) teamDAO.findAllEditable else teamDAO.findAll
@@ -32,6 +39,7 @@ class TeamController @Inject()(teamDAO: TeamDAO,
     } yield Ok(Json.toJson(js))
   }
 
+  @ApiOperation(hidden = true, value = "")
   def delete(id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       teamIdValidated <- ObjectId.parse(id)
@@ -45,6 +53,7 @@ class TeamController @Inject()(teamDAO: TeamDAO,
     } yield JsonOk(Messages("team.deleted"))
   }
 
+  @ApiOperation(hidden = true, value = "")
   def create: Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     withJsonBodyUsing(teamNameReads) { teamName =>
       for {


### PR DESCRIPTION
Adds swagger annotations for GET `api/teams` and GET `api/datasets`.

### Steps to test:
<details>
  <summary>Click for the produced swagger.json</summary>
  
  ```json
{
  "swagger" : "2.0",
  "info" : {
    "version" : "beta",
    "title" : "webknossos",
    "contact" : {
      "name" : ""
    },
    "license" : {
      "name" : "",
      "url" : "http://licenseUrl"
    }
  },
  "host" : "localhost:9000",
  "basePath" : "/",
  "tags" : [ {
    "name" : "datastore"
  }, {
    "name" : "zarr-streaming"
  } ],
  "paths" : {
    "/annotations/{id}/download" : {
      "get" : {
        "summary" : "Download an annotation as NML/ZIP",
        "description" : "",
        "operationId" : "annotationDownload",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "description" : "Id of the stored annotation",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "skeletonVersion",
          "in" : "query",
          "required" : false,
          "type" : "integer",
          "format" : "int64"
        }, {
          "name" : "volumeVersion",
          "in" : "query",
          "required" : false,
          "type" : "integer",
          "format" : "int64"
        }, {
          "name" : "skipVolumeData",
          "in" : "query",
          "required" : false,
          "type" : "boolean"
        } ],
        "responses" : {
          "200" : {
            "description" : "NML or Zip file containing skeleton and/or volume data of this annotation."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/annotations/{typ}/{id}/download" : {
      "get" : {
        "summary" : "Download an annotation as NML/ZIP",
        "description" : "",
        "operationId" : "annotationDownload",
        "parameters" : [ {
          "name" : "typ",
          "in" : "path",
          "description" : "Type of the annotation, one of Task, Explorational, CompoundTask, CompoundProject, CompoundTaskType",
          "required" : true,
          "type" : "string",
          "x-example" : "Explorational"
        }, {
          "name" : "id",
          "in" : "path",
          "description" : "For Task and Explorational annotations, id is an annotation id. For CompoundTask, id is a task id. For CompoundProject, id is a project id. For CompoundTaskType, id is a task type id",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "skeletonVersion",
          "in" : "query",
          "required" : false,
          "type" : "integer",
          "format" : "int64"
        }, {
          "name" : "volumeVersion",
          "in" : "query",
          "required" : false,
          "type" : "integer",
          "format" : "int64"
        }, {
          "name" : "skipVolumeData",
          "in" : "query",
          "required" : false,
          "type" : "boolean"
        } ],
        "responses" : {
          "200" : {
            "description" : "NML or Zip file containing skeleton and/or volume data of this annotation. In case of Compound annotations, multiple such annotations wrapped in another zip"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/annotations/upload" : {
      "post" : {
        "summary" : "Upload NML(s) or ZIP(s) of NML(s) to create a new explorative annotation.\nExpects:\n - As file attachment:\n    - Any number of NML files or ZIP files containing NMLs, optionally with volume data ZIPs referenced from an NML in a ZIP\n    - If multiple annotations are uploaded, they are merged into one.\n       - This is not supported if any of the annotations has multiple volume layers.\n - As form parameter: createGroupForEachFile [String] should be one of \"true\" or \"false\"\n   - If \"true\": in merged annotation, create tree group wrapping the trees of each file\n   - If \"false\": in merged annotation, rename trees with the respective file name as prefix",
        "description" : "",
        "operationId" : "annotationUpload",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing annotation information about the newly created annotation, including the assigned id"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/users/{id}" : {
      "get" : {
        "summary" : "Returns a json with information about the user selected by the passed id",
        "description" : "",
        "operationId" : "userInfoById",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "description" : "Id of the user to query",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/users" : {
      "get" : {
        "summary" : "List all users of whom the requesting user is admin or team-manager.",
        "description" : "",
        "operationId" : "userList",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/user" : {
      "get" : {
        "summary" : "Returns a json with information about the requesting user",
        "description" : "",
        "operationId" : "currentUserInfo",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/users/{id}/loggedTime" : {
      "get" : {
        "summary" : "Get the logged time of the passed user. Only available for admins or team managers of the user in question.",
        "description" : "",
        "operationId" : "userLoggedTime",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/projects/{id}" : {
      "get" : {
        "summary" : "Information about a project selected by id",
        "description" : "",
        "operationId" : "projectInfoById",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "description" : "The id of the project",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing information about this project."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/projects" : {
      "post" : {
        "summary" : "Create a new Project.\nExpects:\n - As JSON object body with keys:\n  - name (string) name of the new project\n  - team (string) id of the team this project is for\n  - priority (int) priority of the project’s tasks\n  - paused (bool, default=False) if the project should be paused at time of creation (its tasks are not distributed)\n  - expectedTime (int, optional) time limit\n  - owner (string) id of a user\n  - isBlacklistedFromReport (boolean) if true, the project is skipped on the progress report tables\n",
        "description" : "",
        "operationId" : "createProject",
        "parameters" : [ {
          "in" : "body",
          "name" : "ProjectParameters",
          "required" : true,
          "schema" : {
            "type" : "string"
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionJsValue"
            }
          }
        }
      }
    },
    "/projects/byName/{name}" : {
      "get" : {
        "summary" : "Information about a project selected by name",
        "description" : "",
        "operationId" : "projectInfoByName",
        "parameters" : [ {
          "name" : "name",
          "in" : "path",
          "description" : "The name of the project",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing information about this project."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/projects/{id}/tasks" : {
      "get" : {
        "summary" : "Information about the tasks of a project selected by project id",
        "description" : "",
        "operationId" : "taskInfosByProjectId",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "description" : "Id of the project",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "limit",
          "in" : "query",
          "description" : "Pagination: limit for the number of tasks to query",
          "required" : false,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "pageNumber",
          "in" : "query",
          "description" : "Pagination: page number, skip the first tasks",
          "required" : false,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "includeTotalCount",
          "in" : "query",
          "description" : "Pagination: if true, include total count in response header as X-Total-Count",
          "required" : false,
          "type" : "boolean"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON list of objects containing information about the tasks of this project project."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/tasks/{id}" : {
      "get" : {
        "summary" : "Information about a task",
        "description" : "",
        "operationId" : "taskInfo",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "description" : "The id of the task",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing information about this task."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/tasks/createFromFiles" : {
      "post" : {
        "summary" : "Create new tasks from existing annotation files\nExpects:\n - As Form data:\n   - taskTypeId (string) id of the task type to be used for the new tasks\n   - neededExperience (Experience) experience domain and level that selects which users can get the new tasks\n   - openInstances (int) if greater than one, multiple instances of the task will be given to users to annotate\n   - projectName (string) name of the project the task should be part of\n   - scriptId (string, optional) id of a user script that should be loaded for the annotators of the new tasks\n   - boundingBox (BoundingBox, optional) limit the bounding box where the annotators should be active\n - As File attachment\n   - A zip file containing base annotations (each either NML or zip with NML + volume) for the new tasks. One task will be created per annotation.\n",
        "description" : "",
        "operationId" : "taskCreateFromFiles",
        "parameters" : [ {
          "in" : "body",
          "name" : "TaskParameters",
          "required" : true,
          "schema" : {
            "type" : "string"
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/teams" : {
      "get" : {
        "summary" : "List all accessible teams.",
        "description" : "",
        "operationId" : "teamList",
        "parameters" : [ {
          "name" : "isEditable",
          "in" : "query",
          "description" : "When true, show only teams the current user can edit.",
          "required" : false,
          "type" : "boolean"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON list containing one object per resulting team."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/datasets/{organizationName}/{dataSetName}" : {
      "get" : {
        "summary" : "Get information about this dataset",
        "description" : "",
        "operationId" : "datasetInfo",
        "parameters" : [ {
          "name" : "organizationName",
          "in" : "path",
          "description" : "The url-safe name of the organization owning the dataset",
          "required" : true,
          "type" : "string",
          "x-example" : "sample_organization"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "description" : "The name of the dataset",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "sharingToken",
          "in" : "query",
          "description" : "Optional sharing token allowing access to datasets your team does not normally have access to.",
          "required" : false,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing dataset information"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      },
      "patch" : {
        "summary" : "Update information for a dataset.\nExpects:\n - As JSON object body with keys:\n  - description (optional string)\n  - displayName (optional string)\n  - sortingKey (optional long)\n  - isPublic (boolean)\n  - tags (list of string)\n - As GET parameters:\n  - organizationName (string): url-safe name of the organization owning the dataset\n  - dataSetName (string): name of the dataset\n",
        "description" : "",
        "operationId" : "datasetUpdate",
        "parameters" : [ {
          "name" : "organizationName",
          "in" : "path",
          "description" : "The url-safe name of the organization owning the dataset",
          "required" : true,
          "type" : "string",
          "x-example" : "sample_organization"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "description" : "The name of the dataset",
          "required" : true,
          "type" : "string"
        }, {
          "in" : "body",
          "name" : "datasetUpdateInformation",
          "required" : true,
          "schema" : {
            "type" : "string"
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionJsValue"
            }
          }
        }
      }
    },
    "/datasets" : {
      "get" : {
        "summary" : "List all accessible datasets.",
        "description" : "",
        "operationId" : "datasetList",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "JSON list containing one object per resulting dataset."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/datasets/{organizationName}/{dataSetName}/sharingToken" : {
      "get" : {
        "summary" : "Sharing token of a dataset",
        "description" : "",
        "operationId" : "datasetSharingToken",
        "parameters" : [ {
          "name" : "organizationName",
          "in" : "path",
          "description" : "The url-safe name of the organization owning the dataset",
          "required" : true,
          "type" : "string",
          "x-example" : "sample_organization"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "description" : "The name of the dataset",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing the key sharingToken with the sharing token string."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/datasets/{organizationName}/{dataSetName}/teams" : {
      "patch" : {
        "summary" : "\"Update teams of a dataset\nExpects:\n - As JSON object body:\n   List of team strings.\n - As GET parameters:\n  - organizationName (string): url-safe name of the organization owning the dataset\n  - dataSetName (string): name of the dataset\n",
        "description" : "",
        "operationId" : "datasetUpdateTeams",
        "parameters" : [ {
          "name" : "organizationName",
          "in" : "path",
          "description" : "The url-safe name of the organization owning the dataset",
          "required" : true,
          "type" : "string",
          "x-example" : "sample_organization"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "description" : "The name of the dataset",
          "required" : true,
          "type" : "string"
        }, {
          "in" : "body",
          "name" : "datasetUpdateTeamsInformation",
          "required" : true,
          "schema" : {
            "type" : "array",
            "items" : {
              "type" : "string"
            }
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionJsValue"
            }
          }
        }
      }
    },
    "/datasets/{organizationName}/{dataSetName}/isValidNewName" : {
      "get" : {
        "summary" : "Check whether a new dataset name is valid",
        "description" : "",
        "operationId" : "newDatasetNameIsValid",
        "parameters" : [ {
          "name" : "organizationName",
          "in" : "path",
          "description" : "The url-safe name of the organization owning the dataset",
          "required" : true,
          "type" : "string",
          "x-example" : "sample_organization"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "description" : "The name of the dataset",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "Name is valid. Empty message."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/userToken/generate" : {
      "post" : {
        "summary" : "Generates a token that can be used for requests to a datastore. The token is valid for 1 day by default.",
        "description" : "",
        "operationId" : "generateTokenForDataStore",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/datastores" : {
      "get" : {
        "summary" : "List all available datastores",
        "description" : "",
        "operationId" : "datastoreList",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "JSON list of objects containing datastore information"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/annotations/{typ}/{id}/info" : {
      "get" : {
        "summary" : "Information about an annotation",
        "description" : "",
        "operationId" : "annotationInfo",
        "parameters" : [ {
          "name" : "typ",
          "in" : "path",
          "description" : "Type of the annotation, one of Task, Explorational, CompoundTask, CompoundProject, CompoundTaskType",
          "required" : true,
          "type" : "string",
          "x-example" : "Explorational"
        }, {
          "name" : "id",
          "in" : "path",
          "description" : "For Task and Explorational annotations, id is an annotation id. For CompoundTask, id is a task id. For CompoundProject, id is a project id. For CompoundTaskType, id is a task type id",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "timestamp",
          "in" : "query",
          "description" : "Timestamp in milliseconds (time at which the request is sent)",
          "required" : true,
          "type" : "integer",
          "format" : "int64"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing information about this annotation."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/annotations/{typ}/{id}/addAnnotationLayer" : {
      "patch" : {
        "operationId" : "addAnnotationLayer",
        "parameters" : [ {
          "name" : "typ",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "id",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnnotationLayerParameters"
            }
          }
        }
      }
    },
    "/annotations/{id}/info" : {
      "get" : {
        "summary" : "Information about an annotation",
        "description" : "",
        "operationId" : "annotationInfo",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "description" : "Id of the stored annotation",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "timestamp",
          "in" : "query",
          "description" : "Timestamp in milliseconds (time at which the request is sent)",
          "required" : true,
          "type" : "integer",
          "format" : "int64"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing information about this annotation."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/tasks/{id}/annotations" : {
      "get" : {
        "summary" : "Information about all annotations for a specific task",
        "description" : "",
        "operationId" : "annotationInfosByTaskId",
        "parameters" : [ {
          "name" : "id",
          "in" : "path",
          "description" : "The id of the task",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "JSON list of objects containing information about the selected annotations."
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/data/datasets/{organizationName}/{dataSetName}/layers/{dataLayerName}/data" : {
      "get" : {
        "tags" : [ "datastore" ],
        "summary" : "Get raw binary data from a bounding box in a dataset layer",
        "description" : "",
        "operationId" : "datasetDownload",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "description" : "Datastore token identifying the requesting user",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "description" : "Name of the dataset’s organization",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "description" : "Dataset name",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataLayerName",
          "in" : "path",
          "description" : "Layer name of the dataset",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "x",
          "in" : "query",
          "description" : "Mag1 x coordinate of the top-left corner of the bounding box",
          "required" : true,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "y",
          "in" : "query",
          "description" : "Mag1 y coordinate of the top-left corner of the bounding box",
          "required" : true,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "z",
          "in" : "query",
          "description" : "Mag1 z coordinate of the top-left corner of the bounding box",
          "required" : true,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "width",
          "in" : "query",
          "description" : "Target-mag width of the bounding box",
          "required" : true,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "height",
          "in" : "query",
          "description" : "Target-mag height of the bounding box",
          "required" : true,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "depth",
          "in" : "query",
          "description" : "Target-mag depth of the bounding box",
          "required" : true,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "mag",
          "in" : "query",
          "description" : "Mag in three-component format (e.g. 1-1-1 or 16-16-8)",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "resolution",
          "in" : "query",
          "required" : false,
          "type" : "integer",
          "format" : "int32"
        }, {
          "name" : "halfByte",
          "in" : "query",
          "description" : "If true, use lossy compression by sending only half-bytes of the data",
          "required" : false,
          "type" : "boolean",
          "default" : false
        }, {
          "name" : "mappingName",
          "in" : "query",
          "description" : "If set, apply set mapping name",
          "required" : false,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "Raw bytes from the dataset"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/data/datasets/finishUpload" : {
      "post" : {
        "tags" : [ "datastore" ],
        "summary" : "Finish dataset upload, call after all chunks have been uploaded via uploadChunk\nExpects:\n - As JSON object body with keys:\n  - uploadId (string): upload id that was also used in chunk upload (this time without file paths)\n  - organization (string): owning organization name\n  - name (string): dataset name\n  - needsConversion (boolean): mark as true for non-wkw datasets. They are stored differently and a conversion job can later be run.\n - As GET parameter:\n  - token (string): datastore token identifying the uploading user\n",
        "description" : "",
        "operationId" : "datasetFinishUpload",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "in" : "body",
          "name" : "uploadInformation",
          "required" : true,
          "schema" : {
            "type" : "string"
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "Empty body, upload was successfully finished"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/data/datasets/reserveUpload" : {
      "post" : {
        "tags" : [ "datastore" ],
        "summary" : "Reserve an upload for a new dataset\nExpects:\n - As JSON object body with keys:\n  - uploadId (string): upload id that was also used in chunk upload (this time without file paths)\n  - organization (string): owning organization name\n  - name (string): dataset name\n  - needsConversion (boolean): mark as true for non-wkw datasets. They are stored differently and a conversion job can later be run.\n  - initialTeams (list of string): names of the webknossos teams dataset should be accessible for\n - As GET parameter:\n  - token (string): datastore token identifying the uploading user\n",
        "description" : "",
        "operationId" : "datasetReserveUpload",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "in" : "body",
          "name" : "reserveUploadInformation",
          "required" : true,
          "schema" : {
            "type" : "string"
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionReserveUploadInformation"
            }
          }
        }
      }
    },
    "/data/datasets/cancelUpload" : {
      "post" : {
        "tags" : [ "datastore" ],
        "summary" : "Cancel a running dataset upload\nExpects:\n - As JSON object body with keys:\n  - uploadId (string): upload id that was also used in chunk upload (this time without file paths)\n - As GET parameter:\n  - token (string): datastore token identifying the uploading user\n",
        "description" : "",
        "operationId" : "datasetCancelUpload",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "in" : "body",
          "name" : "cancelUploadInformation",
          "required" : true,
          "schema" : {
            "type" : "string"
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "Empty body, upload was cancelled"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/data/datasets" : {
      "post" : {
        "tags" : [ "datastore" ],
        "summary" : "Upload a byte chunk for a new dataset\nExpects:\n - As file attachment: A raw byte chunk of the dataset\n - As form parameter:\n  - name (string): dataset name\n  - owningOrganization (string): owning organization name\n  - resumableChunkNumber (int): chunk index\n  - resumableChunkSize (int): chunk size in bytes\n  - resumableTotalChunks (string): total chunk count of the upload\n  - totalFileCount (string): total file count of the upload\n  - resumableIdentifier (string): identifier of the resumable upload and file (\"{uploadId}/{filepath}\")\n - As GET parameter:\n  - token (string): datastore token identifying the uploading user\n",
        "description" : "",
        "operationId" : "datasetUploadChunk",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "Empty body, chunk was saved on the server"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/health" : {
      "get" : {
        "summary" : "Health endpoint",
        "description" : "",
        "operationId" : "health",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/buildinfo" : {
      "get" : {
        "summary" : "Information about the version of webKnossos",
        "description" : "",
        "operationId" : "buildInfo",
        "parameters" : [ ],
        "responses" : {
          "200" : {
            "description" : "JSON object containing information about the version of webKnossos"
          },
          "400" : {
            "description" : "Operation could not be performed. See JSON body for more information."
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}/{dataLayerName}/{mag}/.zarray" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "zArray",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataLayerName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "mag",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}/{dataLayerName}/{mag}/{cxyz}" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "rawZarrCube",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataLayerName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "mag",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "cxyz",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}/.zgroup" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "zGroup",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "dataSourceFolderContents",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}/{dataLayerName}" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "dataLayerFolderContents",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataLayerName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}/{dataLayerName}/.zattrs" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "zAttrs",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataLayerName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}/{dataLayerName}/{mag}" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "dataLayerMagFolderContents",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataLayerName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "mag",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    },
    "/data/zarr/{organizationName}/{dataSetName}/datasource-properties.json" : {
      "get" : {
        "tags" : [ "datastore", "zarr-streaming" ],
        "operationId" : "dataSource",
        "parameters" : [ {
          "name" : "token",
          "in" : "query",
          "required" : false,
          "type" : "string"
        }, {
          "name" : "organizationName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "dataSetName",
          "in" : "path",
          "required" : true,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "headers" : { },
            "schema" : {
              "$ref" : "#/definitions/ActionAnyContent"
            }
          }
        }
      }
    }
  },
  "definitions" : {
    "Action" : {
      "type" : "object"
    },
    "ActionAnyContent" : {
      "type" : "object"
    },
    "ActionMultipartFormDataTemporaryFile" : {
      "type" : "object"
    },
    "ActionJsValue" : {
      "type" : "object"
    },
    "ActionAnnotationLayerParameters" : {
      "type" : "object"
    },
    "ActionUploadInformation" : {
      "type" : "object"
    },
    "ActionReserveUploadInformation" : {
      "type" : "object"
    },
    "ActionCancelUploadInformation" : {
      "type" : "object"
    }
  }
}
```
</details>

### Issues:
- preparation for https://github.com/scalableminds/webknossos-libs/issues/628 and https://github.com/scalableminds/webknossos-libs/issues/725

------
- [x] Ready for review
