### PR TITLE
Improve convert to hybrid workflow

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,11 +11,14 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/22.08.0...HEAD)
 
 ### Added
+- Segmentation layers which were not previously editable now show an (un)lock icon button which shortcuts to the Add Volume Layer modal with the layer being preselected. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 
 ### Changed
+- The Layers tab now displays an Add Skeleton Annotation Layer button with which volume-only annotations can be converted to hybrid annotations. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 
 ### Fixed
 
 ### Removed
+- Annotation Type was removed from the info tab. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 
 ### Breaking Changes

--- a/frontend/javascripts/components/hover_icon_button.tsx
+++ b/frontend/javascripts/components/hover_icon_button.tsx
@@ -1,0 +1,32 @@
+import { ButtonProps } from "antd";
+import * as React from "react";
+const { useState } = React;
+
+export type HoverButtonProps = Omit<ButtonProps, "icon"> & {
+  icon: React.ReactElement<any>;
+  hoveredIcon: React.ReactElement<any>;
+};
+
+export function HoverIconButton(props: HoverButtonProps) {
+  const [isMouseOver, setIsMouseOver] = useState<boolean>(false);
+
+  const onMouseEnter = (event: React.MouseEvent) => {
+    setIsMouseOver(true);
+    if (props.onMouseEnter != null) {
+      props.onMouseEnter(event);
+    }
+  };
+  const onMouseLeave = (event: React.MouseEvent) => {
+    setIsMouseOver(false);
+    if (props.onMouseLeave != null) {
+      props.onMouseLeave(event);
+    }
+  };
+
+  return React.cloneElement(isMouseOver ? props.hoveredIcon : props.icon, {
+    ...props,
+    onMouseEnter,
+    onMouseLeave,
+  });
+}
+export default {};

--- a/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
@@ -27,13 +27,13 @@ export function NewVolumeLayerSelection({
   dataset,
   selectedSegmentationLayerIndex,
   setSelectedSegmentationLayerIndex,
-  showLayerSelectionDisabled,
+  disableLayerSelection,
 }: {
   segmentationLayers: Array<APISegmentationLayer>;
   dataset: APIDataset;
   selectedSegmentationLayerIndex: number | null | undefined;
   setSelectedSegmentationLayerIndex: (arg0: number | null | undefined) => void;
-  showLayerSelectionDisabled: boolean | null | undefined;
+  disableLayerSelection: boolean | undefined;
 }) {
   return (
     <div
@@ -54,7 +54,7 @@ export function NewVolumeLayerSelection({
           setSelectedSegmentationLayerIndex(index !== -1 ? index : null);
         }}
         value={selectedSegmentationLayerIndex != null ? selectedSegmentationLayerIndex : -1}
-        disabled={showLayerSelectionDisabled != null ? showLayerSelectionDisabled : false}
+        disabled={disableLayerSelection ?? false}
       >
         <Radio key={-1} value={-1}>
           Create empty layer

--- a/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
@@ -27,11 +27,13 @@ export function NewVolumeLayerSelection({
   dataset,
   selectedSegmentationLayerIndex,
   setSelectedSegmentationLayerIndex,
+  showLayerSelectionDisabled,
 }: {
   segmentationLayers: Array<APISegmentationLayer>;
   dataset: APIDataset;
   selectedSegmentationLayerIndex: number | null | undefined;
   setSelectedSegmentationLayerIndex: (arg0: number | null | undefined) => void;
+  showLayerSelectionDisabled: boolean | null | undefined;
 }) {
   return (
     <div
@@ -52,6 +54,7 @@ export function NewVolumeLayerSelection({
           setSelectedSegmentationLayerIndex(index !== -1 ? index : null);
         }}
         value={selectedSegmentationLayerIndex != null ? selectedSegmentationLayerIndex : -1}
+        disabled={showLayerSelectionDisabled != null ? showLayerSelectionDisabled : false}
       >
         <Radio key={-1} value={-1}>
           Create empty layer

--- a/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
@@ -9,6 +9,7 @@ import {
   getSegmentationLayers,
   getResolutionInfo,
   ResolutionInfo,
+  getSegmentationLayerByName,
 } from "oxalis/model/accessors/dataset_accessor";
 import { getDataset } from "admin/admin_rest_api";
 import { useFetch } from "libs/react_helpers";
@@ -25,16 +26,22 @@ type RestrictResolutionSliderProps = {
 export function NewVolumeLayerSelection({
   segmentationLayers,
   dataset,
-  selectedSegmentationLayerIndex,
-  setSelectedSegmentationLayerIndex,
+  selectedSegmentationLayerName,
+  setSelectedSegmentationLayerName,
   disableLayerSelection,
 }: {
   segmentationLayers: Array<APISegmentationLayer>;
   dataset: APIDataset;
-  selectedSegmentationLayerIndex: number | null | undefined;
-  setSelectedSegmentationLayerIndex: (arg0: number | null | undefined) => void;
+  selectedSegmentationLayerName: string | null | undefined;
+  setSelectedSegmentationLayerName: (arg0: string | null | undefined) => void;
   disableLayerSelection: boolean | undefined;
 }) {
+  const selectedSegmentationLayerIndex =
+    selectedSegmentationLayerName != null
+      ? segmentationLayers.indexOf(
+          getSegmentationLayerByName(dataset, selectedSegmentationLayerName),
+        )
+      : -1;
   return (
     <div
       style={{
@@ -51,9 +58,9 @@ export function NewVolumeLayerSelection({
       <Radio.Group
         onChange={(e) => {
           const index = parseInt(e.target.value);
-          setSelectedSegmentationLayerIndex(index !== -1 ? index : null);
+          setSelectedSegmentationLayerName(index !== -1 ? segmentationLayers[index].name : null);
         }}
-        value={selectedSegmentationLayerIndex != null ? selectedSegmentationLayerIndex : -1}
+        value={selectedSegmentationLayerIndex}
         disabled={disableLayerSelection ?? false}
       >
         <Radio key={-1} value={-1}>
@@ -157,7 +164,7 @@ function CreateExplorativeModal({ datasetId, onClose }: Props) {
   const dataset = useFetch(() => getDataset(datasetId), null, [datasetId]);
   const [annotationType, setAnnotationType] = useState("hybrid");
   const [userDefinedResolutionIndices, setUserDefinedResolutionIndices] = useState([0, 10000]);
-  const [selectedSegmentationLayerIndex, setSelectedSegmentationLayerIndex] = useState(null);
+  const [selectedSegmentationLayerName, setSelectedSegmentationLayerName] = useState(null);
   let modalContent = <Spin />;
 
   if (dataset !== null) {
@@ -165,8 +172,8 @@ function CreateExplorativeModal({ datasetId, onClose }: Props) {
     const selectedSegmentationLayer =
       annotationType !== "skeleton" &&
       segmentationLayers.length > 0 &&
-      selectedSegmentationLayerIndex != null
-        ? segmentationLayers[selectedSegmentationLayerIndex]
+      selectedSegmentationLayerName != null
+        ? getSegmentationLayerByName(dataset, selectedSegmentationLayerName)
         : null;
     const fallbackLayerGetParameter =
       selectedSegmentationLayer != null
@@ -213,9 +220,9 @@ function CreateExplorativeModal({ datasetId, onClose }: Props) {
           <NewVolumeLayerSelection
             segmentationLayers={segmentationLayers}
             dataset={dataset}
-            selectedSegmentationLayerIndex={selectedSegmentationLayerIndex}
+            selectedSegmentationLayerName={selectedSegmentationLayerName}
             // @ts-expect-error ts-migrate(2322) FIXME: Type 'Dispatch<SetStateAction<null>>' is not assig... Remove this comment to see the full error message
-            setSelectedSegmentationLayerIndex={setSelectedSegmentationLayerIndex}
+            setSelectedSegmentationLayerName={setSelectedSegmentationLayerName}
           />
         ) : null}
 

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -320,7 +320,8 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
     const { intensityRange } = layerSettings;
     const layer = getLayerByName(dataset, layerName);
     const isSegmentation = layer.category === "segmentation";
-    const canBeMadeEditable = isSegmentation && layer.tracingId == null;
+    const canBeMadeEditable =
+      isSegmentation && layer.tracingId == null && this.props.controlMode === "TRACE";
     const isVolumeTracing = isSegmentation ? layer.tracingId != null : false;
     const maybeTracingId = isSegmentation ? layer.tracingId : null;
     const maybeVolumeTracing =
@@ -420,7 +421,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
           }}
         >
           <div className="flex-item">
-            {isSegmentation && canBeMadeEditable ? (
+            {canBeMadeEditable ? (
               <Tooltip
                 title="Make this segmentation editable by adding a Volume Annotation Layer."
                 placement="left"

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -419,7 +419,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
         <div
           className="flex-container"
           style={{
-            paddingRight: 5,
+            paddingRight: 1,
           }}
         >
           <div className="flex-item">

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -8,6 +8,8 @@ import {
   WarningOutlined,
   PlusOutlined,
   VerticalAlignMiddleOutlined,
+  LockOutlined,
+  UnlockOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
 import { connect } from "react-redux";
@@ -23,6 +25,7 @@ import {
 } from "types/api_flow_types";
 import { ValueOf } from "types/globals";
 import { AsyncIconButton } from "components/async_clickables";
+import { HoverIconButton } from "components/hover_icon_button";
 import {
   SwitchSetting,
   NumberSliderSetting,
@@ -479,6 +482,8 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
                 placement="left"
               >
                 <ToolOutlined
+                  icon={<LockOutlined />}
+                  hoveredIcon={<UnlockOutlined />}
                   onClick={() => {
                     const segmentationLayers = getSegmentationLayers(dataset);
                     const segmentationLayerIndex = segmentationLayers.indexOf(layer);

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -931,12 +931,11 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
       (el) => !el.isColorLayer,
     ).map((el) => this.getLayerSettings(el.layerName, el.layer, el.isColorLayer));
 
-    const isSkeleton = this.props.tracing.skeleton != null;
-    const isVolume = this.props.tracing.volumes.length > 0;
-    const isHybrid = isSkeleton && isVolume;
-    const isExplorational =
-      this.props.tracing.annotationType === APIAnnotationTypeEnum.Explorational;
-
+    const state = Store.getState();
+    const canBeMadeHybrid =
+      this.props.tracing.skeleton === null &&
+      this.props.tracing.annotationType === APIAnnotationTypeEnum.Explorational &&
+      state.task === null;
     return (
       <div className="tracing-settings-menu">
         {layerSettings}
@@ -960,7 +959,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
           </>
         ) : null}
 
-        {!isHybrid && this.props.tracing.restrictions.allowUpdate && isExplorational ? (
+        {this.props.tracing.restrictions.allowUpdate && canBeMadeHybrid ? (
           <Row justify="center" align="middle">
             <Button
               onClick={this.handleConvertToHybrid}

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -420,24 +420,24 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
           }}
         >
           <div className="flex-item">
-              {(isSegmentation && canBeMadeEditable) ? (
-                <Tooltip
-                  title="Make this segmentation editable by adding a Volume Annotation Layer."
-                  placement="left">
-                  <ToolOutlined
-                    onClick={() => {
-                      const segmentationLayers = getSegmentationLayers(dataset);
-                      const segmentationLayerIndex = segmentationLayers.indexOf(layer);
-                      this.setState({
-                        preselectSegmentationLayerIndex: segmentationLayerIndex,
-                        isAddVolumeLayerModalVisible: true,
-                      });
-                    }}
-                    style={{ marginLeft: 5 }}
-                  />
-                </Tooltip>
-              ) : null
-              }
+            {isSegmentation && canBeMadeEditable ? (
+              <Tooltip
+                title="Make this segmentation editable by adding a Volume Annotation Layer."
+                placement="left"
+              >
+                <ToolOutlined
+                  onClick={() => {
+                    const segmentationLayers = getSegmentationLayers(dataset);
+                    const segmentationLayerIndex = segmentationLayers.indexOf(layer);
+                    this.setState({
+                      preselectSegmentationLayerIndex: segmentationLayerIndex,
+                      isAddVolumeLayerModalVisible: true,
+                    });
+                  }}
+                  style={{ marginLeft: 5 }}
+                />
+              </Tooltip>
+            ) : null}
             <Tooltip
               overlayStyle={{
                 maxWidth: 800,

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -14,7 +14,12 @@ import React from "react";
 import _ from "lodash";
 
 import classnames from "classnames";
-import type { APIDataLayer, APIDataset, EditableLayerProperties } from "types/api_flow_types";
+import {
+  APIAnnotationTypeEnum,
+  APIDataLayer,
+  APIDataset,
+  EditableLayerProperties,
+} from "types/api_flow_types";
 import { ValueOf } from "types/globals";
 import { AsyncIconButton } from "components/async_clickables";
 import {
@@ -929,6 +934,8 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
     const isSkeleton = this.props.tracing.skeleton != null;
     const isVolume = this.props.tracing.volumes.length > 0;
     const isHybrid = isSkeleton && isVolume;
+    const isExplorational =
+      this.props.tracing.annotationType === APIAnnotationTypeEnum.Explorational;
 
     return (
       <div className="tracing-settings-menu">
@@ -953,7 +960,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
           </>
         ) : null}
 
-        {this.props.tracing.restrictions.allowUpdate && !isHybrid ? (
+        {!isHybrid && this.props.tracing.restrictions.allowUpdate && isExplorational ? (
           <Row justify="center" align="middle">
             <Button
               onClick={this.handleConvertToHybrid}

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -51,7 +51,6 @@ import {
   getLayerByName,
   getResolutionInfo,
   getResolutions,
-  getVisibleSegmentationLayer,
   getSegmentationLayers,
 } from "oxalis/model/accessors/dataset_accessor";
 import { getMaxZoomValueForResolution } from "oxalis/model/accessors/flycam_accessor";
@@ -128,8 +127,8 @@ type State = {
   // is shown for that VolumeTracing
   volumeTracingToDownsample: VolumeTracing | null | undefined;
   isAddVolumeLayerModalVisible: boolean;
-  preselectedSegmentationLayerIndex: number | null | undefined;
-  segmentationLayerWasPreselected: boolean | null | undefined;
+  preselectedSegmentationLayerIndex: number | undefined;
+  segmentationLayerWasPreselected: boolean | undefined;
   layerToMergeWithFallback: APIDataLayer | null | undefined;
 };
 
@@ -138,7 +137,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
   state: State = {
     volumeTracingToDownsample: null,
     isAddVolumeLayerModalVisible: false,
-    preselectedSegmentationLayerIndex: null,
+    preselectedSegmentationLayerIndex: undefined,
     segmentationLayerWasPreselected: false,
     layerToMergeWithFallback: null,
   };
@@ -933,16 +932,15 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
     this.setState({
       isAddVolumeLayerModalVisible: false,
       segmentationLayerWasPreselected: false,
-      preselectedSegmentationLayerIndex: null,
+      preselectedSegmentationLayerIndex: undefined,
     });
   };
 
-  handleConvertToHybrid = async () => {
+  addSkeletonAnnotationLayer = async () => {
     await Model.ensureSavedState();
-    const maybeSegmentationLayer = getVisibleSegmentationLayer(Store.getState());
     await convertToHybridTracing(
       this.props.tracing.annotationId,
-      maybeSegmentationLayer != null ? maybeSegmentationLayer.name : null,
+      null,
     );
     location.reload();
   };
@@ -995,7 +993,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
         {this.props.tracing.restrictions.allowUpdate && canBeMadeHybrid ? (
           <Row justify="center" align="middle">
             <Button
-              onClick={this.handleConvertToHybrid}
+              onClick={this.addSkeletonAnnotationLayer}
               style={{
                 width: 235,
                 marginTop: 10,
@@ -1028,7 +1026,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             onCancel={this.hideAddVolumeLayerModal}
             tracing={this.props.tracing}
             preselectedLayerIndex={this.state.preselectedSegmentationLayerIndex}
-            showLayerSelectionDisabled={this.state.segmentationLayerWasPreselected}
+            disableLayerSelection={this.state.segmentationLayerWasPreselected}
           />
         ) : null}
       </div>

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -10,7 +10,6 @@ import {
   VerticalAlignMiddleOutlined,
   LockOutlined,
   UnlockOutlined,
-  ToolOutlined,
 } from "@ant-design/icons";
 import { connect } from "react-redux";
 import React from "react";
@@ -481,7 +480,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
                 title="Make this segmentation editable by adding a Volume Annotation Layer."
                 placement="left"
               >
-                <ToolOutlined
+                <HoverIconButton
                   icon={<LockOutlined />}
                   hoveredIcon={<UnlockOutlined />}
                   onClick={() => {

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -126,7 +126,8 @@ type State = {
   // is shown for that VolumeTracing
   volumeTracingToDownsample: VolumeTracing | null | undefined;
   isAddVolumeLayerModalVisible: boolean;
-  preselectSegmentationLayerIndex: number | null | undefined;
+  preselectedSegmentationLayerIndex: number | null | undefined;
+  segmentationLayerWasPreselected: boolean | null | undefined;
   layerToMergeWithFallback: APIDataLayer | null | undefined;
 };
 
@@ -135,7 +136,8 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
   state: State = {
     volumeTracingToDownsample: null,
     isAddVolumeLayerModalVisible: false,
-    preselectSegmentationLayerIndex: 0,
+    preselectedSegmentationLayerIndex: null,
+    segmentationLayerWasPreselected: false,
     layerToMergeWithFallback: null,
   };
 
@@ -421,24 +423,6 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
           }}
         >
           <div className="flex-item">
-            {canBeMadeEditable ? (
-              <Tooltip
-                title="Make this segmentation editable by adding a Volume Annotation Layer."
-                placement="left"
-              >
-                <ToolOutlined
-                  onClick={() => {
-                    const segmentationLayers = getSegmentationLayers(dataset);
-                    const segmentationLayerIndex = segmentationLayers.indexOf(layer);
-                    this.setState({
-                      preselectSegmentationLayerIndex: segmentationLayerIndex,
-                      isAddVolumeLayerModalVisible: true,
-                    });
-                  }}
-                  style={{ marginLeft: 5 }}
-                />
-              </Tooltip>
-            ) : null}
             <Tooltip
               overlayStyle={{
                 maxWidth: 800,
@@ -489,6 +473,24 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             >
               <InfoCircleOutlined />
             </Tooltip>
+            {canBeMadeEditable ? (
+              <Tooltip
+                title="Make this segmentation editable by adding a Volume Annotation Layer."
+                placement="left"
+              >
+                <ToolOutlined
+                  onClick={() => {
+                    const segmentationLayers = getSegmentationLayers(dataset);
+                    const segmentationLayerIndex = segmentationLayers.indexOf(layer);
+                    this.setState({
+                      isAddVolumeLayerModalVisible: true,
+                      segmentationLayerWasPreselected: true,
+                      preselectedSegmentationLayerIndex: segmentationLayerIndex,
+                    });
+                  }}
+                />
+              </Tooltip>
+            ) : null}
           </div>
           <div className="flex-item">
             {isVolumeTracing ? (
@@ -926,6 +928,8 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
   hideAddVolumeLayerModal = () => {
     this.setState({
       isAddVolumeLayerModalVisible: false,
+      segmentationLayerWasPreselected: false,
+      preselectedSegmentationLayerIndex: null,
     });
   };
 
@@ -1019,7 +1023,8 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             dataset={this.props.dataset}
             onCancel={this.hideAddVolumeLayerModal}
             tracing={this.props.tracing}
-            preselectedLayerIndex={this.state.preselectSegmentationLayerIndex}
+            preselectedLayerIndex={this.state.preselectedSegmentationLayerIndex}
+            showLayerSelectionDisabled={this.state.segmentationLayerWasPreselected}
           />
         ) : null}
       </div>

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -51,7 +51,6 @@ import {
   getLayerByName,
   getResolutionInfo,
   getResolutions,
-  getSegmentationLayers,
 } from "oxalis/model/accessors/dataset_accessor";
 import { getMaxZoomValueForResolution } from "oxalis/model/accessors/flycam_accessor";
 import {
@@ -127,7 +126,7 @@ type State = {
   // is shown for that VolumeTracing
   volumeTracingToDownsample: VolumeTracing | null | undefined;
   isAddVolumeLayerModalVisible: boolean;
-  preselectedSegmentationLayerIndex: number | undefined;
+  preselectedSegmentationLayerName: string | undefined;
   segmentationLayerWasPreselected: boolean | undefined;
   layerToMergeWithFallback: APIDataLayer | null | undefined;
 };
@@ -137,7 +136,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
   state: State = {
     volumeTracingToDownsample: null,
     isAddVolumeLayerModalVisible: false,
-    preselectedSegmentationLayerIndex: undefined,
+    preselectedSegmentationLayerName: undefined,
     segmentationLayerWasPreselected: false,
     layerToMergeWithFallback: null,
   };
@@ -483,12 +482,10 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
                   icon={<LockOutlined />}
                   hoveredIcon={<UnlockOutlined />}
                   onClick={() => {
-                    const segmentationLayers = getSegmentationLayers(dataset);
-                    const segmentationLayerIndex = segmentationLayers.indexOf(layer);
                     this.setState({
                       isAddVolumeLayerModalVisible: true,
                       segmentationLayerWasPreselected: true,
-                      preselectedSegmentationLayerIndex: segmentationLayerIndex,
+                      preselectedSegmentationLayerName: layer.name,
                     });
                   }}
                 />
@@ -932,16 +929,13 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
     this.setState({
       isAddVolumeLayerModalVisible: false,
       segmentationLayerWasPreselected: false,
-      preselectedSegmentationLayerIndex: undefined,
+      preselectedSegmentationLayerName: undefined,
     });
   };
 
   addSkeletonAnnotationLayer = async () => {
     await Model.ensureSavedState();
-    await convertToHybridTracing(
-      this.props.tracing.annotationId,
-      null,
-    );
+    await convertToHybridTracing(this.props.tracing.annotationId, null);
     location.reload();
   };
 
@@ -1025,7 +1019,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             dataset={this.props.dataset}
             onCancel={this.hideAddVolumeLayerModal}
             tracing={this.props.tracing}
-            preselectedLayerIndex={this.state.preselectedSegmentationLayerIndex}
+            preselectedLayerName={this.state.preselectedSegmentationLayerName}
             disableLayerSelection={this.state.segmentationLayerWasPreselected}
           />
         ) : null}

--- a/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
@@ -12,6 +12,7 @@ import type { Tracing } from "oxalis/store";
 import { addAnnotationLayer } from "admin/admin_rest_api";
 import {
   getDatasetResolutionInfo,
+  getLayerByName,
   getSegmentationLayers,
 } from "oxalis/model/accessors/dataset_accessor";
 import {
@@ -84,18 +85,18 @@ export default function AddVolumeLayerModal({
   dataset,
   onCancel,
   tracing,
-  preselectedLayerIndex,
+  preselectedLayerName,
   disableLayerSelection,
 }: {
   dataset: APIDataset;
   onCancel: () => void;
   tracing: Tracing;
-  preselectedLayerIndex: number | undefined;
+  preselectedLayerName: string | undefined;
   disableLayerSelection: boolean | undefined;
 }) {
-  const [selectedSegmentationLayerIndex, setSelectedSegmentationLayerIndex] = useState<
-    number | null | undefined
-  >(preselectedLayerIndex);
+  const [selectedSegmentationLayerName, setSelectedSegmentationLayerName] = useState<
+    string | null | undefined
+  >(preselectedLayerName);
   const allReadableLayerNames = useMemo(
     () => getAllReadableLayerNames(dataset, tracing),
     [dataset, tracing],
@@ -141,7 +142,7 @@ export default function AddVolumeLayerModal({
       ...datasetResolutionInfo.getResolutionByIndexOrThrow(resolutionIndices[1]),
     );
 
-    if (selectedSegmentationLayerIndex == null) {
+    if (selectedSegmentationLayerName == null) {
       await addAnnotationLayer(tracing.annotationId, tracing.annotationType, {
         typ: "Volume",
         name: newLayerName,
@@ -152,7 +153,7 @@ export default function AddVolumeLayerModal({
         },
       });
     } else {
-      selectedSegmentationLayer = availableSegmentationLayers[selectedSegmentationLayerIndex];
+      selectedSegmentationLayer = getLayerByName(dataset, selectedSegmentationLayerName);
       const fallbackLayerName = selectedSegmentationLayer.name;
       await addAnnotationLayer(tracing.annotationId, tracing.annotationType, {
         typ: "Volume",
@@ -192,8 +193,8 @@ export default function AddVolumeLayerModal({
         <NewVolumeLayerSelection
           dataset={dataset}
           segmentationLayers={availableSegmentationLayers}
-          selectedSegmentationLayerIndex={selectedSegmentationLayerIndex}
-          setSelectedSegmentationLayerIndex={setSelectedSegmentationLayerIndex}
+          selectedSegmentationLayerName={selectedSegmentationLayerName}
+          setSelectedSegmentationLayerName={setSelectedSegmentationLayerName}
           disableLayerSelection={disableLayerSelection ?? false}
         />
       ) : null}

--- a/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
@@ -84,14 +84,16 @@ export default function AddVolumeLayerModal({
   dataset,
   onCancel,
   tracing,
+  preselectedLayerIndex,
 }: {
   dataset: APIDataset;
   onCancel: () => void;
   tracing: Tracing;
+  preselectedLayerIndex: number | null | undefined;
 }) {
   const [selectedSegmentationLayerIndex, setSelectedSegmentationLayerIndex] = useState<
     number | null | undefined
-  >(null);
+  >(preselectedLayerIndex);
   const allReadableLayerNames = useMemo(
     () => getAllReadableLayerNames(dataset, tracing),
     [dataset, tracing],

--- a/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
@@ -85,11 +85,13 @@ export default function AddVolumeLayerModal({
   onCancel,
   tracing,
   preselectedLayerIndex,
+  showLayerSelectionDisabled,
 }: {
   dataset: APIDataset;
   onCancel: () => void;
   tracing: Tracing;
   preselectedLayerIndex: number | null | undefined;
+  showLayerSelectionDisabled: boolean | null | undefined;
 }) {
   const [selectedSegmentationLayerIndex, setSelectedSegmentationLayerIndex] = useState<
     number | null | undefined
@@ -192,6 +194,9 @@ export default function AddVolumeLayerModal({
           segmentationLayers={availableSegmentationLayers}
           selectedSegmentationLayerIndex={selectedSegmentationLayerIndex}
           setSelectedSegmentationLayerIndex={setSelectedSegmentationLayerIndex}
+          showLayerSelectionDisabled={
+            showLayerSelectionDisabled != null ? showLayerSelectionDisabled : false
+          }
         />
       ) : null}
       <RestrictResolutionSlider

--- a/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
@@ -85,13 +85,13 @@ export default function AddVolumeLayerModal({
   onCancel,
   tracing,
   preselectedLayerIndex,
-  showLayerSelectionDisabled,
+  disableLayerSelection,
 }: {
   dataset: APIDataset;
   onCancel: () => void;
   tracing: Tracing;
-  preselectedLayerIndex: number | null | undefined;
-  showLayerSelectionDisabled: boolean | null | undefined;
+  preselectedLayerIndex: number | undefined;
+  disableLayerSelection: boolean | undefined;
 }) {
   const [selectedSegmentationLayerIndex, setSelectedSegmentationLayerIndex] = useState<
     number | null | undefined
@@ -194,9 +194,7 @@ export default function AddVolumeLayerModal({
           segmentationLayers={availableSegmentationLayers}
           selectedSegmentationLayerIndex={selectedSegmentationLayerIndex}
           setSelectedSegmentationLayerIndex={setSelectedSegmentationLayerIndex}
-          showLayerSelectionDisabled={
-            showLayerSelectionDisabled != null ? showLayerSelectionDisabled : false
-          }
+          disableLayerSelection={disableLayerSelection ?? false}
         />
       ) : null}
       <RestrictResolutionSlider

--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
@@ -11,10 +11,7 @@ import type { Vector3 } from "oxalis/constants";
 import { ControlModeEnum } from "oxalis/constants";
 import { formatScale } from "libs/format_utils";
 import { getBaseVoxel } from "oxalis/model/scaleinfo";
-import {
-  getDatasetExtentAsString,
-  getResolutions,
-} from "oxalis/model/accessors/dataset_accessor";
+import { getDatasetExtentAsString, getResolutions } from "oxalis/model/accessors/dataset_accessor";
 import { getCurrentResolution } from "oxalis/model/accessors/flycam_accessor";
 import { getStats } from "oxalis/model/accessors/skeletontracing_accessor";
 import {

--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
@@ -1,33 +1,27 @@
 import type { Dispatch } from "redux";
 import { Tooltip, Button, Dropdown, Menu } from "antd";
-import { SettingOutlined, InfoCircleOutlined, StarOutlined } from "@ant-design/icons";
+import { SettingOutlined, StarOutlined } from "@ant-design/icons";
 import { connect } from "react-redux";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import Markdown from "react-remarkable";
 import React from "react";
 import { Link } from "react-router-dom";
 import type { APIDataset, APIUser } from "types/api_flow_types";
-import { APIAnnotationTypeEnum } from "types/api_flow_types";
 import type { Vector3 } from "oxalis/constants";
 import { ControlModeEnum } from "oxalis/constants";
-import { convertToHybridTracing } from "admin/admin_rest_api";
 import { formatScale } from "libs/format_utils";
 import { getBaseVoxel } from "oxalis/model/scaleinfo";
 import {
   getDatasetExtentAsString,
   getResolutions,
-  getVisibleSegmentationLayer,
 } from "oxalis/model/accessors/dataset_accessor";
 import { getCurrentResolution } from "oxalis/model/accessors/flycam_accessor";
 import { getStats } from "oxalis/model/accessors/skeletontracing_accessor";
-import { location } from "libs/window";
 import {
   setAnnotationNameAction,
   setAnnotationDescriptionAction,
 } from "oxalis/model/actions/annotation_actions";
-import ButtonComponent from "oxalis/view/components/button_component";
 import EditableTextLabel from "oxalis/view/components/editable_text_label";
-import Model from "oxalis/model";
 import features from "features";
 import type { OxalisState, Task, Tracing } from "oxalis/store";
 import Store from "oxalis/store";
@@ -476,55 +470,6 @@ class DatasetInfoTabView extends React.PureComponent<Props, State> {
     );
   }
 
-  handleConvertToHybrid = async () => {
-    await Model.ensureSavedState();
-    const maybeSegmentationLayer = getVisibleSegmentationLayer(Store.getState());
-    await convertToHybridTracing(
-      this.props.tracing.annotationId,
-      maybeSegmentationLayer != null ? maybeSegmentationLayer.name : null,
-    );
-    location.reload();
-  };
-
-  getTracingType(isDatasetViewMode: boolean) {
-    if (isDatasetViewMode) return null;
-    const isSkeleton = this.props.tracing.skeleton != null;
-    const isVolume = this.props.tracing.volumes.length > 0;
-    const isHybrid = isSkeleton && isVolume;
-    const { allowUpdate } = this.props.tracing.restrictions;
-    const isExplorational =
-      this.props.tracing.annotationType === APIAnnotationTypeEnum.Explorational;
-
-    if (isHybrid) {
-      return (
-        <p>
-          Annotation Type:{" "}
-          <Tooltip title="Skeleton and Volume">
-            Hybrid <InfoCircleOutlined />
-          </Tooltip>
-        </p>
-      );
-    } else {
-      return (
-        <p>
-          Annotation Type: {isVolume ? "Volume" : "Skeleton"}
-          {allowUpdate && isExplorational ? (
-            <ButtonComponent
-              style={{
-                marginLeft: 10,
-              }}
-              size="small"
-              onClick={this.handleConvertToHybrid}
-              title="Skeleton and Volume"
-            >
-              Convert to Hybrid
-            </ButtonComponent>
-          ) : null}
-        </p>
-      );
-    }
-  }
-
   maybePrintOwner() {
     const { activeUser } = this.props;
     const { owner } = this.props.tracing;
@@ -614,7 +559,6 @@ class DatasetInfoTabView extends React.PureComponent<Props, State> {
       <div className="flex-overflow padded-tab-content">
         <div className="info-tab-block">
           {this.getTracingName(isDatasetViewMode)}
-          {this.getTracingType(isDatasetViewMode)}
           {this.getDatasetName(isDatasetViewMode)}
           {this.maybePrintOwner()}
         </div>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a volume-only annotation
- Annotation Type: X is removed from info tab
- the layers tab now displays an Add Skeleton Annotation Layer button with the old convert to hybrid functionality
- segmentation layers which were not previously editable now show an (un)lock icon button which shortcuts to the "add volume layer" modal with the layer being preselected
- should be disallowed for tasks

### Issues:
- fixes #6209

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
