### PR TITLE
Disable navbar menu overflow due to a bug

### DIFF
--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -682,6 +682,9 @@ function Navbar({ activeUser, isAuthenticated, isInAnnotationView, hasOrganizati
         theme="dark"
         subMenuCloseDelay={subMenuCloseDelay}
         triggerSubMenuAction="click"
+        // There is a bug where the last menu entry disappears behind the overflow indicator
+        // although there is ample space available, see https://github.com/ant-design/ant-design/issues/32277
+        overflowedIndicator={false}
       >
         {[
           <Menu.Item key="0">

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -684,7 +684,7 @@ function Navbar({ activeUser, isAuthenticated, isInAnnotationView, hasOrganizati
         triggerSubMenuAction="click"
         // There is a bug where the last menu entry disappears behind the overflow indicator
         // although there is ample space available, see https://github.com/ant-design/ant-design/issues/32277
-        overflowedIndicator={false}
+        disabledOverflow
       >
         {[
           <Menu.Item key="0">


### PR DESCRIPTION
Disabling the built-in overflow behavior is not ideal, but I'd argue it's the better solution for now, because:
- For the annotation view (where there are lots of elements in the navbar) we have custom-built overflow/collapsing behavior which continues to work
- Having such a narrow browser window that the built-in overflow behavior would be needed should be rather unusual

### URL of deployed dev instance (used for testing):
- https://navbaroverflow.webknossos.xyz

### Steps to test:
- Open the dashboard, the help button shouldn't be behind the overflow indicator

------
(Please delete unneeded items, merge only when none are left open)
- [x] Ready for review
