### PR TITLE
Allow dataset managers to set dataset team permissions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 - Merged the "Shared Annotations" tab into the "Annotations" tab in the user's dashboard. If annotations are shared with you, you can see them in your dashboard. The table can be filtered by owner if you prefer to see only your own annotations. [#6230](https://github.com/scalableminds/webknossos/pull/6230)
 - Changed the name of the volume annotation layer in tasks to be "Volume" instead of "Volume Layer". [#6321](https://github.com/scalableminds/webknossos/pull/6321)
+- Dataset managers are now allowed to change dataset team permissions for all teams they are a member of. [#6336](https://github.com/scalableminds/webknossos/pull/6336)
 
 ### Fixed
 - Fixed that zooming out for datasets with very large scale was not possible until the coarsest level. [#6304](https://github.com/scalableminds/webknossos/pull/6304)

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -339,7 +339,8 @@ Expects:
             dataSetName) ~> NOT_FOUND
           _ <- Fox.assertTrue(dataSetService.isEditableBy(dataSet, Some(request.identity))) ?~> "notAllowed" ~> FORBIDDEN
           teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.parse(_))
-          userTeams <- teamDAO.findAllEditable
+          includeMemberOnlyTeams = request.identity.isDatasetManager
+          userTeams <- if (includeMemberOnlyTeams) teamDAO.findAll else teamDAO.findAllEditable
           oldAllowedTeams <- dataSetService.allowedTeamIdsFor(dataSet._id)
           teamsWithoutUpdate = oldAllowedTeams.filterNot(t => userTeams.exists(_._id == t))
           teamsWithUpdate = teamIdsValidated.filter(t => userTeams.exists(_._id == t))

--- a/docs/users.md
+++ b/docs/users.md
@@ -41,7 +41,7 @@ There are four different roles for webKnossos users divided into global, organiz
 
   - __Admin:__ Manage a whole organization, including full access to all datasets, teams, and projects. Admins can access all administrative settings - similar to `Team Managers` but for all teams - and have full control over all datasets - similar to `Dataset Managers`. They can promote other users to `Admin` or to `Dataset Manager` by using the `Edit Teams and Permissions` modal at the top of the user list. Admins can access ALL annotations, datasets, projects, tasks, etc belonging to their respective organization and can modify any setting of an organization. Admins have the most permissions in your organization, and this role should be assigned with care.
 
-  - __Dataset Manager:__ Manage all datasets of an organization. Dataset Managers have full read/write access to all datasets within their respective organizations regardless of whether a dataset has been made available only to a specific team. Use this role for power users who regularly upload datasets or who need access to all datasets regardless of who created them.
+  - __Dataset Manager:__ Manage all datasets of an organization. Dataset Managers have full read/write access to all datasets within their respective organizations regardless of whether a dataset has been made available only to a specific team. They can also set team permissions for datasets. Use this role for power users who regularly upload datasets or who need access to all datasets regardless of who created them.
   Unlike `Admins`, Dataset Managers do NOT have access to any of the administration interfaces for users, tasks, and projects.
 
 
@@ -69,7 +69,7 @@ For more information regarding (public) dataset sharing and access rights (espec
 | Access time tracking for users of managed teams          	| Yes   	| No              	| Yes          	| No          	|
 | Create scripts (visible to everyone)            	| Yes   	| No              	| Yes          	| No          	|
 | Upload Datasets via UI                           	| Yes   	| Yes             	| Yes          	| No          	|
-| Set team access permissions upon dataset upload    	| Yes   	| Yes              	| Yes          	| No          	|
+| Set team access permissions for datasets    	| Yes   	| Yes              	| Yes          	| No          	|
 | Get tasks again after canceling an instance     	| Yes   	| No              	| Yes          	| No          	|
 | Access to wK Statistics Menu  	| Yes   	| No              	| Yes          	| No          	|
 

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -659,6 +659,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                     <TeamSelectionComponent
                       mode="multiple"
                       value={this.state.selectedTeams}
+                      allowNonEditableTeams
                       onChange={(selectedTeams) => {
                         if (this.formRef.current == null) return;
 

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -202,10 +202,6 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
     }
   }
 
-  isDatasetManagerOrAdmin = () =>
-    this.props.activeUser &&
-    (this.props.activeUser.isAdmin || this.props.activeUser.isDatasetManager);
-
   getDatastoreForUrl(url: string): APIDataStore | null | undefined {
     const uploadableDatastores = this.props.datastores.filter(
       (datastore) => datastore.allowsUpload,
@@ -597,7 +593,8 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
   render() {
     const form = this.formRef.current;
     const { activeUser, withoutCard, datastores } = this.props;
-    const isDatasetManagerOrAdmin = this.isDatasetManagerOrAdmin();
+    const isDatasetManagerOrAdmin = Utils.isUserAdminOrDatasetManager(this.props.activeUser);
+
     const { needsConversion } = this.state;
     const uploadableDatastores = datastores.filter((datastore) => datastore.allowsUpload);
     const hasOnlyOneDatastoreOrNone = uploadableDatastores.length <= 1;
@@ -659,7 +656,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                     <TeamSelectionComponent
                       mode="multiple"
                       value={this.state.selectedTeams}
-                      allowNonEditableTeams
+                      allowNonEditableTeams={isDatasetManagerOrAdmin}
                       onChange={(selectedTeams) => {
                         if (this.formRef.current == null) return;
 

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -44,7 +44,7 @@ function DatasetSettingsSharingTab({
           : null
       }
     >
-      <TeamSelectionComponent mode="multiple" />
+      <TeamSelectionComponent mode="multiple" allowNonEditableTeams />
     </FormItemWithInfo>
   );
 

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -12,7 +12,7 @@ import window from "libs/window";
 import TeamSelectionComponent from "dashboard/dataset/team_selection_component";
 import DatasetAccessListView from "dashboard/advanced_dataset/dataset_access_list_view";
 import { OxalisState } from "oxalis/store";
-import { isUserAdminOrTeamManager } from "libs/utils";
+import { isUserAdminOrDatasetManager, isUserAdminOrTeamManager } from "libs/utils";
 import { FormItemWithInfo } from "./helper_components";
 
 type Props = {
@@ -31,6 +31,7 @@ function DatasetSettingsSharingTab({
   activeUser,
 }: Props) {
   const [sharingToken, setSharingToken] = useState("");
+  const isDatasetManagerOrAdmin = isUserAdminOrDatasetManager(activeUser);
 
   const allowedTeamsComponent = (
     <FormItemWithInfo
@@ -44,7 +45,7 @@ function DatasetSettingsSharingTab({
           : null
       }
     >
-      <TeamSelectionComponent mode="multiple" allowNonEditableTeams />
+      <TeamSelectionComponent mode="multiple" allowNonEditableTeams={isDatasetManagerOrAdmin} />
     </FormItemWithInfo>
   );
 

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -381,8 +381,8 @@ export function isUserAdminOrTeamManager(user: APIUser): boolean {
 export function isUserDatasetManager(user: APIUser): boolean {
   return user.isDatasetManager;
 }
-export function isUserAdminOrDatasetManager(user: APIUser): boolean {
-  return isUserAdmin(user) || isUserDatasetManager(user);
+export function isUserAdminOrDatasetManager(user: APIUser | null | undefined): boolean {
+  return user != null && (isUserAdmin(user) || isUserDatasetManager(user));
 }
 export function getUrlParamsObject(): UrlParams {
   return getUrlParamsObjectFromString(location.search);


### PR DESCRIPTION
Dataset managers are now allowed to change dataset team permissions for all teams they are a member of

### URL of deployed dev instance (used for testing):
- https://datasetmanagersetteams.webknossos.xyz

### Steps to test:
- create additional user
- make them dataset manager
- see that they can set dataset team permissions for teams they are a member of

### Issues:
- fixes https://discuss.webknossos.org/t/problem-about-public-dataset-result-in-webkonossos/1724/5

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [documentation](../blob/master/docs) if applicable
- [x] Ready for review
