### PR TITLE
adds redirect to workflow frontend

### DIFF
--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -1,5 +1,5 @@
 // @ts-expect-error ts-migrate(2305) FIXME: Module '"react-router-dom"' has no exported member... Remove this comment to see the full error message
-import { ContextRouter } from "react-router-dom";
+import type { ContextRouter } from "react-router-dom";
 import { Redirect, Route, Router, Switch, useLocation } from "react-router-dom";
 import { Layout, Alert } from "antd";
 import { connect } from "react-redux";

--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -1,9 +1,9 @@
 // @ts-expect-error ts-migrate(2305) FIXME: Module '"react-router-dom"' has no exported member... Remove this comment to see the full error message
-import type { ContextRouter } from "react-router-dom";
-import { Redirect, Route, Router, Switch } from "react-router-dom";
+import { ContextRouter } from "react-router-dom";
+import { Redirect, Route, Router, Switch, useLocation } from "react-router-dom";
 import { Layout, Alert } from "antd";
 import { connect } from "react-redux";
-import React from "react";
+import React, { useEffect } from "react";
 import { createBrowserHistory } from "history";
 import _ from "lodash";
 import AcceptInviteView from "admin/auth/accept_invite_view";
@@ -52,7 +52,7 @@ import TracingLayoutView from "oxalis/view/layouting/tracing_layout_view";
 import UserListView from "admin/user/user_list_view";
 import * as Utils from "libs/utils";
 import features from "features";
-import window from "libs/window";
+import window, { location as windowLocation } from "libs/window";
 import { trackAction } from "oxalis/model/helpers/analytics";
 import { coalesce } from "libs/utils";
 const { Content } = Layout;
@@ -98,6 +98,16 @@ function PageNotFoundView() {
       />
     </div>
   );
+}
+
+function RedirectToWorkflowViewer() {
+  const location = useLocation();
+
+  useEffect(() => {
+    windowLocation.assign(`https://workflows.voxelytics.com${location.pathname}${location.search}`);
+  }, []);
+
+  return null;
 }
 
 class ReactRouter extends React.Component<Props> {
@@ -594,6 +604,7 @@ class ReactRouter extends React.Component<Props> {
               />
               <Route path="/imprint" component={Imprint} />
               <Route path="/privacy" component={Privacy} />
+              <Route path="/workflows" component={RedirectToWorkflowViewer} />
               {!features().isDemoInstance && <Route path="/onboarding" component={Onboarding} />}
               <Route component={PageNotFoundView} />
             </Switch>


### PR DESCRIPTION
Adds a redirect from `/workflows` to `https://workflows.voxelytics.com/workflows` (with sub paths). With this we can already use webKnossos-hosted URLs to point to workflow reports, before it is integrated into webKnossos itself.

------
- [x] Ready for review
