### PR TITLE
improve histogram slider tooltip readability

### DIFF
--- a/frontend/javascripts/oxalis/view/left-border-tabs/histogram_view.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/histogram_view.tsx
@@ -199,7 +199,9 @@ class Histogram extends React.PureComponent<HistogramProps, HistogramState> {
   };
 
   tipFormatter = (value: number) =>
-    value > 10000 ? value.toExponential() : roundTo(value, this.getPrecision()).toString();
+    value >= 100000 || (value < 0.001 && value > -0.001)
+      ? value.toExponential()
+      : roundTo(value, this.getPrecision()).toString();
 
   // eslint-disable-next-line react/sort-comp
   updateMinimumDebounced = _.debounce(

--- a/frontend/javascripts/oxalis/view/left-border-tabs/histogram_view.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/histogram_view.tsx
@@ -199,7 +199,7 @@ class Histogram extends React.PureComponent<HistogramProps, HistogramState> {
   };
 
   tipFormatter = (value: number) =>
-    value >= 100000 || (value < 0.001 && value > -0.001)
+    value >= 100000 || (value < 0.001 && value > -0.001 && value !== 0)
       ? value.toExponential()
       : roundTo(value, this.getPrecision()).toString();
 


### PR DESCRIPTION
Histogrammschiebereglerwerkzeughinweislesbarkeitsverbesserung!

I noticed that uint64 brightness values in the histogram slider tooltip were shown with e notation, which was hard to read. I tweaked the condition for this a bit.

### URL of deployed dev instance (used for testing):
- https://slidertooltipreadable.webknossos.xyz

### Steps to test:
- play with the histogram sliders in the data types dataset, should feel natural

### Issues:
- fixes #6343 

------
- [x] Ready for review
