### PR TITLE
Fix mapping activation confirmation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The Layers tab now displays an Add Skeleton Annotation Layer button with which volume-only annotations can be converted to hybrid annotations. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 
 ### Fixed
+- Fixed a regression where the mapping activation confirmation dialog was never shown. [#6346](https://github.com/scalableminds/webknossos/pull/6346)
 
 ### Removed
 - Annotation Type was removed from the info tab. [#6330](https://github.com/scalableminds/webknossos/pull/6330)


### PR DESCRIPTION
A breaking change in an antd minor version update led to the Popconfirm no longer appearing before/after the context menu was hidden. I did not succeed trying to stop the propagation of the event that hides the context menu and even if that would've worked, the context menu would've had to be closed manually after the Popconfirm was canceled/confirmed.

Instead, I switched to a `Modal.confirm` which appears even after the context menu is hidden, shows a spinner while the async action in `onConfirm` is performed and arguably looks better :)

### URL of deployed dev instance (used for testing):
- https://fixmappingconfirm.webknossos.xyz

### Steps to test:
- Open a dataset with a meshfile that was computed for a specific agglomerate file (`test-agglomerate-file` dataset)
- Rightclick on a segment - Load Mesh (precomputed)
  - There should be a confirmation modal which activates the respective mapping before loading the mesh iff it is confirmed
  - If the correct mapping is activated already, no confirmation modal should be shown
- Do the same from the segments list

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
