### PR TITLE
Add layer name to jobs table entry of tiff export job

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -1003,6 +1003,7 @@ export async function getJobs(): Promise<APIJob[]> {
     datasetName: job.commandArgs.dataset_name,
     organizationName: job.commandArgs.organization_name,
     layerName: job.commandArgs.layer_name || job.commandArgs.volume_layer_name,
+    annotationLayerName: job.commandArgs.annotation_layer_name,
     boundingBox: job.commandArgs.bbox,
     exportFileName: job.commandArgs.export_file_name,
     tracingId: job.commandArgs.volume_tracing_id,

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -135,16 +135,18 @@ class JobListView extends React.PureComponent<Props, State> {
     } else if (job.type === "export_tiff" && job.organizationName && job.datasetName) {
       const labelToAnnotationOrDataset =
         job.annotationId != null ? (
-          <Link to={`/annotations/${job.annotationId}`}>annotation of {job.datasetName}</Link>
+          <Link to={`/annotations/${job.annotationId}`}>
+            annotation of dataset {job.datasetName}
+          </Link>
         ) : (
           <Link to={`/datasets/${job.organizationName}/${job.datasetName}/view`}>
-            {job.datasetName}
+            dataset {job.datasetName}
           </Link>
         );
       const layerLabel = job.annotationLayerName || job.layerName;
       return (
         <span>
-          Tiff export from {layerLabel} layer of {labelToAnnotationOrDataset} (Bounding Box{" "}
+          Tiff export of layer {layerLabel} from {labelToAnnotationOrDataset} (Bounding Box{" "}
           {job.boundingBox})
         </span>
       );

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -133,22 +133,19 @@ class JobListView extends React.PureComponent<Props, State> {
     if (job.type === "convert_to_wkw" && job.datasetName) {
       return <span>{`Conversion to WKW of ${job.datasetName}`}</span>;
     } else if (job.type === "export_tiff" && job.organizationName && job.datasetName) {
-      const volumeAnnotationLabel =
+      const labelToAnnotationOrDataset =
         job.annotationId != null ? (
-          <Link to={`/annotations/${job.annotationType || "Explorational"}/${job.annotationId}`}>
-            volume annotation
-          </Link>
+          <Link to={`/annotations/${job.annotationId}`}>annotation of {job.datasetName}</Link>
         ) : (
-          "volume annotation"
-        );
-      const layerLabel = job.tracingId != null ? volumeAnnotationLabel : job.layerName || "a";
-      return (
-        <span>
-          Tiff export from {layerLabel} layer of{" "}
           <Link to={`/datasets/${job.organizationName}/${job.datasetName}/view`}>
             {job.datasetName}
-          </Link>{" "}
-          (Bounding Box {job.boundingBox})
+          </Link>
+        );
+      const layerLabel = job.annotationLayerName || job.layerName;
+      return (
+        <span>
+          Tiff export from {layerLabel} layer of {labelToAnnotationOrDataset} (Bounding Box{" "}
+          {job.boundingBox})
         </span>
       );
     } else if (job.type === "compute_mesh_file" && job.organizationName && job.datasetName) {

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -560,6 +560,7 @@ export type APIJob = {
   readonly datasetName: string | null | undefined;
   readonly exportFileName: string | null | undefined;
   readonly layerName: string | null | undefined;
+  readonly annotationLayerName: string | null | undefined;
   readonly tracingId: string | null | undefined;
   readonly annotationId: string | null | undefined;
   readonly annotationType: string | null | undefined;


### PR DESCRIPTION
This pr adds the layer name to every version of the export tiff job. Previously the names of volume layers were the fallback layers' names if they existed. See
![image](https://user-images.githubusercontent.com/39529669/181265607-91a9d0b2-4459-4843-bb36-f3431e806031.png)

Now the name of the volume layer is used in every case. Even when the volume layer has no fallback.

![image](https://user-images.githubusercontent.com/39529669/181265950-805c66e4-9194-4fe2-a164-cdbbfe124410.png)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I suggest testing locally as a wk-worker is needed for testing.
- You need a running instance of the wk worker that is registered in the database (`yarn enable-jobs`)
- Open an annotation of any dataset with at least one color layer and a segmentation layer.
- create a small bounding box that has only 1 slice in z direction. The smaller the bounding box the faster the jobs are executed.
- Then use the download button in the bounding box tab and start a export job for one color layer and one volume layer without having drawn anything on that volume layer.
- Close the export modal, draw something in the just exported volume layer within the bounds of the bounding box.
- Create a new annotation layer without a fallback layer.
- Also draw something on the new volume layer without fallback within the bounding box. 
- Trigger another export job for volume layer with fallback layer and the volume layer without fallback layer.
- Go to the jobs page. Each export tiff job entry should have the exported's layer's name in it and if it is a volume annotation layer that was exported, there should be a link pointing to the annotation. Else the link should link to the dataset in view mode.

### Issues:
- fixes #[6297](https://github.com/scalableminds/webknossos/issues/6297)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Ready for review
