### PR TITLE
Remove most return statements from scala code

### DIFF
--- a/app/controllers/UserTokenController.scala
+++ b/app/controllers/UserTokenController.scala
@@ -181,15 +181,18 @@ class UserTokenController @Inject()(dataSetDAO: DataSetDAO,
         case _                => Fox.successful(false)
       }
 
-    if (tracingId == TracingIds.dummyTracingId) return Fox.successful(UserAccessAnswer(granted = true))
-    for {
-      annotation <- findAnnotationForTracing(tracingId)(GlobalAccessContext) ?~> "annotation.notFound"
-      restrictions <- annotationInformationProvider.restrictionsFor(
-        AnnotationIdentifier(annotation.typ, annotation._id))(GlobalAccessContext) ?~> "restrictions.notFound"
-      allowed <- checkRestrictions(restrictions) ?~> "restrictions.failedToCheck"
-    } yield {
-      if (allowed) UserAccessAnswer(granted = true)
-      else UserAccessAnswer(granted = false, Some(s"No ${mode.toString} access to tracing"))
+    if (tracingId == TracingIds.dummyTracingId)
+      Fox.successful(UserAccessAnswer(granted = true))
+    else {
+      for {
+        annotation <- findAnnotationForTracing(tracingId)(GlobalAccessContext) ?~> "annotation.notFound"
+        restrictions <- annotationInformationProvider.restrictionsFor(
+          AnnotationIdentifier(annotation.typ, annotation._id))(GlobalAccessContext) ?~> "restrictions.notFound"
+        allowed <- checkRestrictions(restrictions) ?~> "restrictions.failedToCheck"
+      } yield {
+        if (allowed) UserAccessAnswer(granted = true)
+        else UserAccessAnswer(granted = false, Some(s"No ${mode.toString} access to tracing"))
+      }
     }
   }
 

--- a/app/models/task/TaskCreationService.scala
+++ b/app/models/task/TaskCreationService.scala
@@ -380,57 +380,56 @@ class TaskCreationService @Inject()(taskTypeService: TaskTypeService,
     val fullTasks = requestedTasks.flatten
     if (fullTasks.isEmpty) {
       // if there is no nonempty task, we directly return all of the errors
-      return Fox.successful(
-        TaskCreationResult.fromBoxResults(requestedTasks.map(_.map(_ => Json.obj())), List.empty[String]))
+      Fox.successful(TaskCreationResult.fromBoxResults(requestedTasks.map(_.map(_ => Json.obj())), List.empty[String]))
+    } else {
+      for {
+        _ <- assertEachHasEitherSkeletonOrVolume(fullTasks) ?~> "task.create.needsEitherSkeletonOrVolume"
+        firstDatasetName <- fullTasks.headOption.map(_._1.dataSet).toFox
+        _ <- assertAllOnSameDataset(fullTasks, firstDatasetName)
+        dataSet <- dataSetDAO.findOneByNameAndOrganization(firstDatasetName, requestingUser._organization) ?~> Messages(
+          "dataSet.notFound",
+          firstDatasetName)
+        _ = if (fullTasks.exists(task => task._1.baseAnnotation.isDefined))
+          slackNotificationService.noticeBaseAnnotationTaskCreation(fullTasks.map(_._1.taskTypeId).distinct,
+                                                                    fullTasks.count(_._1.baseAnnotation.isDefined))
+        tracingStoreClient <- tracingStoreService.clientFor(dataSet)
+        savedSkeletonTracingIds: List[Box[Option[String]]] <- tracingStoreClient.saveSkeletonTracings(
+          SkeletonTracings(requestedTasks.map(taskTuple => SkeletonTracingOpt(taskTuple.map(_._2).openOr(None)))))
+        skeletonTracingIds: List[Box[Option[String]]] = savedSkeletonTracingIds.zip(requestedTasks).map {
+          case (savedId, base) =>
+            base match {
+              case f: Failure => f
+              case _          => savedId
+            }
+        }
+        // Note that volume tracings are saved sequentially to reduce server load
+        volumeTracingIds: List[Box[Option[String]]] <- Fox.serialSequenceBox(requestedTasks) { requestedTask =>
+          saveVolumeTracingIfPresent(requestedTask, tracingStoreClient)
+        }
+        skeletonTracingsIdsMerged = mergeTracingIds((requestedTasks.map(_.map(_._1)), skeletonTracingIds).zipped.toList,
+                                                    isSkeletonId = true)
+        volumeTracingsIdsMerged = mergeTracingIds((requestedTasks.map(_.map(_._1)), volumeTracingIds).zipped.toList,
+                                                  isSkeletonId = false)
+        requestedTasksWithTracingIds = (requestedTasks, skeletonTracingsIdsMerged, volumeTracingsIdsMerged).zipped.toList
+        taskObjects: List[Fox[Task]] = requestedTasksWithTracingIds.map(r =>
+          createTaskWithoutAnnotationBase(r._1.map(_._1), r._2, r._3, requestingUser))
+        zipped = (requestedTasks, skeletonTracingsIdsMerged.zip(volumeTracingsIdsMerged), taskObjects).zipped.toList
+        createAnnotationBaseResults: List[Fox[Unit]] = zipped.map(
+          tuple =>
+            annotationService.createAnnotationBase(
+              taskFox = tuple._3,
+              requestingUser._id,
+              skeletonTracingIdBox = tuple._2._1,
+              volumeTracingIdBox = tuple._2._2,
+              dataSet._id,
+              description = tuple._1.map(_._1.description).openOr(None)
+          ))
+        warnings <- warnIfTeamHasNoAccess(fullTasks.map(_._1), dataSet, requestingUser)
+        zippedTasksAndAnnotations = taskObjects zip createAnnotationBaseResults
+        taskJsons = zippedTasksAndAnnotations.map(tuple => taskToJsonWithOtherFox(tuple._1, tuple._2))
+        result <- TaskCreationResult.fromTaskJsFoxes(taskJsons, warnings)
+      } yield result
     }
-
-    for {
-      _ <- assertEachHasEitherSkeletonOrVolume(fullTasks) ?~> "task.create.needsEitherSkeletonOrVolume"
-      firstDatasetName <- fullTasks.headOption.map(_._1.dataSet).toFox
-      _ <- assertAllOnSameDataset(fullTasks, firstDatasetName)
-      dataSet <- dataSetDAO.findOneByNameAndOrganization(firstDatasetName, requestingUser._organization) ?~> Messages(
-        "dataSet.notFound",
-        firstDatasetName)
-      _ = if (fullTasks.exists(task => task._1.baseAnnotation.isDefined))
-        slackNotificationService.noticeBaseAnnotationTaskCreation(fullTasks.map(_._1.taskTypeId).distinct,
-                                                                  fullTasks.count(_._1.baseAnnotation.isDefined))
-      tracingStoreClient <- tracingStoreService.clientFor(dataSet)
-      savedSkeletonTracingIds: List[Box[Option[String]]] <- tracingStoreClient.saveSkeletonTracings(
-        SkeletonTracings(requestedTasks.map(taskTuple => SkeletonTracingOpt(taskTuple.map(_._2).openOr(None)))))
-      skeletonTracingIds: List[Box[Option[String]]] = savedSkeletonTracingIds.zip(requestedTasks).map {
-        case (savedId, base) =>
-          base match {
-            case f: Failure => f
-            case _          => savedId
-          }
-      }
-      // Note that volume tracings are saved sequentially to reduce server load
-      volumeTracingIds: List[Box[Option[String]]] <- Fox.serialSequenceBox(requestedTasks) { requestedTask =>
-        saveVolumeTracingIfPresent(requestedTask, tracingStoreClient)
-      }
-      skeletonTracingsIdsMerged = mergeTracingIds((requestedTasks.map(_.map(_._1)), skeletonTracingIds).zipped.toList,
-                                                  isSkeletonId = true)
-      volumeTracingsIdsMerged = mergeTracingIds((requestedTasks.map(_.map(_._1)), volumeTracingIds).zipped.toList,
-                                                isSkeletonId = false)
-      requestedTasksWithTracingIds = (requestedTasks, skeletonTracingsIdsMerged, volumeTracingsIdsMerged).zipped.toList
-      taskObjects: List[Fox[Task]] = requestedTasksWithTracingIds.map(r =>
-        createTaskWithoutAnnotationBase(r._1.map(_._1), r._2, r._3, requestingUser))
-      zipped = (requestedTasks, skeletonTracingsIdsMerged.zip(volumeTracingsIdsMerged), taskObjects).zipped.toList
-      createAnnotationBaseResults: List[Fox[Unit]] = zipped.map(
-        tuple =>
-          annotationService.createAnnotationBase(
-            taskFox = tuple._3,
-            requestingUser._id,
-            skeletonTracingIdBox = tuple._2._1,
-            volumeTracingIdBox = tuple._2._2,
-            dataSet._id,
-            description = tuple._1.map(_._1.description).openOr(None)
-        ))
-      warnings <- warnIfTeamHasNoAccess(fullTasks.map(_._1), dataSet, requestingUser)
-      zippedTasksAndAnnotations = taskObjects zip createAnnotationBaseResults
-      taskJsons = zippedTasksAndAnnotations.map(tuple => taskToJsonWithOtherFox(tuple._1, tuple._2))
-      result <- TaskCreationResult.fromTaskJsFoxes(taskJsons, warnings)
-    } yield result
   }
 
   private def assertEachHasEitherSkeletonOrVolume(

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -90,64 +90,64 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
 
   @SuppressWarnings(Array("TraversableHead", "TraversableLast")) // Only functions call this which put at least one timestamp in the seq
   private def trackTime(timestamps: Seq[Long], _user: ObjectId, _annotation: Annotation)(
-      implicit ctx: DBAccessContext): Fox[Unit] = {
+      implicit ctx: DBAccessContext): Fox[Unit] =
     if (timestamps.isEmpty) {
       logger.warn("Timetracking called with empty timestamps list.")
-      return Fox.successful(())
-    }
-    // Only if the annotation belongs to the user, we are going to log the time on the annotation
-    val annotation = if (_annotation._user == _user) Some(_annotation) else None
-    val start = timestamps.head
+      Fox.successful(())
+    } else {
+      // Only if the annotation belongs to the user, we are going to log the time on the annotation
+      val annotation = if (_annotation._user == _user) Some(_annotation) else None
+      val start = timestamps.head
 
-    var timeSpansToInsert: List[TimeSpan] = List()
-    var timeSpansToUpdate: List[(TimeSpan, Long)] = List()
+      var timeSpansToInsert: List[TimeSpan] = List()
+      var timeSpansToUpdate: List[(TimeSpan, Long)] = List()
 
-    def createNewTimeSpan(timestamp: Long, _user: ObjectId, annotation: Option[Annotation]) = {
-      val timeSpan = TimeSpan.createFrom(timestamp, timestamp, _user, annotation.map(_._id))
-      timeSpansToInsert = timeSpan :: timeSpansToInsert
-      timeSpan
-    }
-
-    def updateTimeSpan(timeSpan: TimeSpan, timestamp: Long) = {
-      val duration = timestamp - timeSpan.lastUpdate
-      if (duration >= 0) {
-        timeSpansToUpdate = (timeSpan, timestamp) :: timeSpansToUpdate
-        timeSpan.addTime(duration, timestamp)
-      } else {
-        logger.info(
-          s"Not updating previous timespan due to negative duration $duration ms. (user ${timeSpan._user}, last timespan id ${timeSpan._id}, this=$this)")
+      def createNewTimeSpan(timestamp: Long, _user: ObjectId, annotation: Option[Annotation]) = {
+        val timeSpan = TimeSpan.createFrom(timestamp, timestamp, _user, annotation.map(_._id))
+        timeSpansToInsert = timeSpan :: timeSpansToInsert
         timeSpan
       }
-    }
 
-    var current = lastUserActivities
-      .get(_user)
-      .flatMap(lastActivity => {
-        if (isNotInterrupted(start, lastActivity)) {
-          if (belongsToSameTracing(lastActivity, annotation)) {
-            Some(lastActivity)
-          } else {
-            updateTimeSpan(lastActivity, start)
-            None
-          }
-        } else None
-      })
-      .getOrElse(createNewTimeSpan(start, _user, annotation))
-
-    timestamps.sliding(2).foreach { pair =>
-      val start = pair.head
-      val end = pair.last
-      val duration = end - start
-      if (duration >= MaxTracingPauseMillis) {
-        updateTimeSpan(current, start)
-        current = createNewTimeSpan(end, _user, annotation)
+      def updateTimeSpan(timeSpan: TimeSpan, timestamp: Long) = {
+        val duration = timestamp - timeSpan.lastUpdate
+        if (duration >= 0) {
+          timeSpansToUpdate = (timeSpan, timestamp) :: timeSpansToUpdate
+          timeSpan.addTime(duration, timestamp)
+        } else {
+          // Negative duration. This is expected when updating an annotation with multiple layers.
+          // Each layer reports updates that can overlap time-wise. We do not update the timespan with the negative duration.
+          timeSpan
+        }
       }
-    }
-    current = updateTimeSpan(current, timestamps.last)
-    lastUserActivities.update(_user, current)
 
-    flushToDb(timeSpansToInsert, timeSpansToUpdate)(ctx)
-  }
+      var current = lastUserActivities
+        .get(_user)
+        .flatMap(lastActivity => {
+          if (isNotInterrupted(start, lastActivity)) {
+            if (belongsToSameTracing(lastActivity, annotation)) {
+              Some(lastActivity)
+            } else {
+              updateTimeSpan(lastActivity, start)
+              None
+            }
+          } else None
+        })
+        .getOrElse(createNewTimeSpan(start, _user, annotation))
+
+      timestamps.sliding(2).foreach { pair =>
+        val start = pair.head
+        val end = pair.last
+        val duration = end - start
+        if (duration >= MaxTracingPauseMillis) {
+          updateTimeSpan(current, start)
+          current = createNewTimeSpan(end, _user, annotation)
+        }
+      }
+      current = updateTimeSpan(current, timestamps.last)
+      lastUserActivities.update(_user, current)
+
+      flushToDb(timeSpansToInsert, timeSpansToUpdate)(ctx)
+    }
 
   private def isNotInterrupted(current: Long, last: TimeSpan) = {
     val duration = current - last.lastUpdate

--- a/app/oxalis/mail/MailchimpClient.scala
+++ b/app/oxalis/mail/MailchimpClient.scala
@@ -66,16 +66,18 @@ class MailchimpClient @Inject()(wkConf: WkConf, rpc: RPC, multiUserDAO: MultiUse
     rpc(uri).silent.withBasicAuth(conf.user, conf.password).post(tagBody)
   }
 
-  def tagsForMultiUser(multiUser: MultiUser)(implicit ec: ExecutionContext): Fox[List[MailchimpTag]] = {
-    if (conf.host.isEmpty) return Fox.successful(List.empty)
-    val emailMd5 = SCrypt.md5(multiUser.email)
-    val uri = s"${conf.host}/lists/${conf.listId}/members/$emailMd5/tags"
-    for {
-      response: MailchimpTagsResponse <- rpc(uri).silent
-        .withBasicAuth(conf.user, conf.password)
-        .getWithJsonResponse[MailchimpTagsResponse]
-    } yield response.tags.flatMap(t => MailchimpTag.fromString(t.name))
-  }
+  def tagsForMultiUser(multiUser: MultiUser)(implicit ec: ExecutionContext): Fox[List[MailchimpTag]] =
+    if (conf.host.isEmpty)
+      Fox.successful(List.empty)
+    else {
+      val emailMd5 = SCrypt.md5(multiUser.email)
+      val uri = s"${conf.host}/lists/${conf.listId}/members/$emailMd5/tags"
+      for {
+        response: MailchimpTagsResponse <- rpc(uri).silent
+          .withBasicAuth(conf.user, conf.password)
+          .getWithJsonResponse[MailchimpTagsResponse]
+      } yield response.tags.flatMap(t => MailchimpTag.fromString(t.name))
+    }
 
 }
 

--- a/app/utils/SQLHelpers.scala
+++ b/app/utils/SQLHelpers.scala
@@ -107,13 +107,15 @@ class SimpleSQLDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext
 
   def parseArrayTuple(literal: String): List[String] = {
     val trimmed = literal.drop(1).dropRight(1)
-    if (trimmed.isEmpty) return List()
-
-    val split = trimmed.split(",", -1).toList.map(desanitizeFromArrayTuple)
-    split.map { item =>
-      if (item.startsWith("\"") && item.endsWith("\"")) {
-        item.drop(1).dropRight(1)
-      } else item
+    if (trimmed.isEmpty)
+      List.empty
+    else {
+      val split = trimmed.split(",", -1).toList.map(desanitizeFromArrayTuple)
+      split.map { item =>
+        if (item.startsWith("\"") && item.endsWith("\"")) {
+          item.drop(1).dropRight(1)
+        } else item
+      }
     }
   }
 

--- a/test/backend/SkeletonUpdateActionsUnitTestSuite.scala
+++ b/test/backend/SkeletonUpdateActionsUnitTestSuite.scala
@@ -14,8 +14,9 @@ class SkeletonUpdateActionsUnitTestSuite extends PlaySpec {
   def listConsistsOfLists[T](joinedList: Seq[T], sublist1: Seq[T], sublist2: Seq[T]): Boolean = {
     // assuming sublist1 & sublist2 are different
     if (joinedList.length != sublist1.length + sublist2.length)
-      return false
-    joinedList.forall(el => sublist1.contains(el) || sublist2.contains(el))
+      false
+    else
+      joinedList.forall(el => sublist1.contains(el) || sublist2.contains(el))
   }
 
   "CreateTreeSkeletonAction" should {

--- a/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
@@ -161,8 +161,9 @@ trait PathUtils extends LazyLogging {
 
   def deleteDirectoryRecursively(path: Path): Box[Unit] = {
     val directory = new Directory(new File(path.toString))
-    if (!directory.exists) return Full(())
-    if (directory.deleteRecursively()) {
+    if (!directory.exists)
+      Full(())
+    else if (directory.deleteRecursively()) {
       Full(())
     } else Failure(f"Failed to delete directory $path")
   }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/slacknotification/TSSlackNotificationService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/slacknotification/TSSlackNotificationService.scala
@@ -18,12 +18,12 @@ class TSSlackNotificationService @Inject()(rpc: RPC, config: TracingStoreConfig)
       msg = msg
     )
 
-  def reportFossilWriteError(requestType: String, error: Exception): Unit = {
-    if (error.getMessage.contains("UNAVAILABLE")) return // Filter out expected errors during fossildb restart
-    slackClient.warn(
-      title = s"Error during fossildb write",
-      msg = s"$requestType request to FossilDB failed: ${error.getMessage}"
-    )
-  }
+  def reportFossilWriteError(requestType: String, error: Exception): Unit =
+    if (!error.getMessage.contains("UNAVAILABLE")) { // Filter out expected errors during fossildb restart
+      slackClient.warn(
+        title = s"Error during fossildb write",
+        msg = s"$requestType request to FossilDB failed: ${error.getMessage}"
+      )
+    }
 
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -156,57 +156,63 @@ class VolumeTracingService @Inject()(
     sourceTracing
   }
 
-  def initializeWithDataMultiple(tracingId: String, tracing: VolumeTracing, initialData: File): Fox[Set[Vec3Int]] = {
-    if (tracing.version != 0L) return Failure("Tracing has already been edited.")
-
-    val resolutionSets = new mutable.HashSet[Set[Vec3Int]]()
-    withZipsFromMultiZip(initialData) { (_, dataZip) =>
-      val resolutionSet = resolutionSetFromZipfile(dataZip)
-      if (resolutionSet.nonEmpty) resolutionSets.add(resolutionSet)
-    }
-    // if none of the tracings contained any volume data. do not save buckets, use full resolution list
-    if (resolutionSets.isEmpty) return getRequiredMags(tracing).map(_.toSet)
-
-    val resolutionsDoMatch = resolutionSets.headOption.forall { head =>
-      resolutionSets.forall(_ == head)
-    }
-    if (!resolutionsDoMatch) return Fox.failure("annotation.volume.resolutionsDoNotMatch")
-
-    val mergedVolume = new MergedVolume(tracing.elementClass)
-    for {
-      _ <- withZipsFromMultiZip(initialData)((_, dataZip) => mergedVolume.addLabelSetFromDataZip(dataZip)).toFox
-      _ <- withZipsFromMultiZip(initialData)((index, dataZip) => mergedVolume.addFromDataZip(index, dataZip)).toFox
-      destinationDataLayer = volumeTracingLayer(tracingId, tracing)
-      _ <- mergedVolume.withMergedBuckets { (bucketPosition, bytes) =>
-        saveBucket(destinationDataLayer, bucketPosition, bytes, tracing.version)
+  def initializeWithDataMultiple(tracingId: String, tracing: VolumeTracing, initialData: File): Fox[Set[Vec3Int]] =
+    if (tracing.version != 0L)
+      Failure("Tracing has already been edited.")
+    else {
+      val resolutionSets = new mutable.HashSet[Set[Vec3Int]]()
+      withZipsFromMultiZip(initialData) { (_, dataZip) =>
+        val resolutionSet = resolutionSetFromZipfile(dataZip)
+        if (resolutionSet.nonEmpty) resolutionSets.add(resolutionSet)
       }
-    } yield mergedVolume.presentResolutions
-  }
+      // if none of the tracings contained any volume data. do not save buckets, use full resolution list
+      if (resolutionSets.isEmpty)
+        getRequiredMags(tracing).map(_.toSet)
+      else {
+        val resolutionsDoMatch = resolutionSets.headOption.forall { head =>
+          resolutionSets.forall(_ == head)
+        }
+        if (!resolutionsDoMatch)
+          Fox.failure("annotation.volume.resolutionsDoNotMatch")
+        else {
+          val mergedVolume = new MergedVolume(tracing.elementClass)
+          for {
+            _ <- withZipsFromMultiZip(initialData)((_, dataZip) => mergedVolume.addLabelSetFromDataZip(dataZip)).toFox
+            _ <- withZipsFromMultiZip(initialData)((index, dataZip) => mergedVolume.addFromDataZip(index, dataZip)).toFox
+            destinationDataLayer = volumeTracingLayer(tracingId, tracing)
+            _ <- mergedVolume.withMergedBuckets { (bucketPosition, bytes) =>
+              saveBucket(destinationDataLayer, bucketPosition, bytes, tracing.version)
+            }
+          } yield mergedVolume.presentResolutions
+        }
+      }
+    }
 
   def initializeWithData(tracingId: String,
                          tracing: VolumeTracing,
                          initialData: File,
-                         resolutionRestrictions: ResolutionRestrictions): Fox[Set[Vec3Int]] = {
+                         resolutionRestrictions: ResolutionRestrictions): Fox[Set[Vec3Int]] =
     if (tracing.version != 0L) {
-      return Failure("Tracing has already been edited.")
-    }
+      Failure("Tracing has already been edited.")
+    } else {
 
-    val dataLayer = volumeTracingLayer(tracingId, tracing)
-    val savedResolutions = new mutable.HashSet[Vec3Int]()
+      val dataLayer = volumeTracingLayer(tracingId, tracing)
+      val savedResolutions = new mutable.HashSet[Vec3Int]()
 
-    val unzipResult = withBucketsFromZip(initialData) { (bucketPosition, bytes) =>
-      if (resolutionRestrictions.isForbidden(bucketPosition.mag)) {
-        Fox.successful(())
-      } else {
-        savedResolutions.add(bucketPosition.mag)
-        saveBucket(dataLayer, bucketPosition, bytes, tracing.version)
+      val unzipResult = withBucketsFromZip(initialData) { (bucketPosition, bytes) =>
+        if (resolutionRestrictions.isForbidden(bucketPosition.mag)) {
+          Fox.successful(())
+        } else {
+          savedResolutions.add(bucketPosition.mag)
+          saveBucket(dataLayer, bucketPosition, bytes, tracing.version)
+        }
       }
+      if (savedResolutions.isEmpty) {
+        // if none of the tracings contained any volume data, use the dataset’s full resolution list
+        getRequiredMags(tracing).map(_.toSet)
+      } else
+        unzipResult.map(_ => savedResolutions.toSet)
     }
-    // if none of the tracings contained any volume data, use the dataset’s full resolution list
-    if (savedResolutions.isEmpty) return getRequiredMags(tracing).map(_.toSet)
-
-    unzipResult.map(_ => savedResolutions.toSet)
-  }
 
   def allDataEnumerator(tracingId: String, tracing: VolumeTracing): Enumerator[Array[Byte]] =
     Enumerator.outputStream { os =>
@@ -443,69 +449,75 @@ class VolumeTracingService @Inject()(
     }
 
     // If none of the tracings contained any volume data. Do not save buckets, do not touch resolution list
-    if (resolutionSets.isEmpty) return Fox.successful(())
+    if (resolutionSets.isEmpty)
+      Fox.successful(())
+    else {
+      val resolutionsIntersection: Set[Vec3Int] = resolutionSets.headOption.map { head =>
+        resolutionSets.foldLeft(head) { (acc, element) =>
+          acc.intersect(element)
+        }
+      }.getOrElse(Set.empty)
 
-    val resolutionsIntersection: Set[Vec3Int] = resolutionSets.headOption.map { head =>
-      resolutionSets.foldLeft(head) { (acc, element) =>
-        acc.intersect(element)
+      val mergedVolume = new MergedVolume(elementClass)
+
+      tracingSelectors.zip(tracings).foreach {
+        case (selector, tracing) =>
+          val bucketStream = bucketStreamFromSelector(selector, tracing)
+          mergedVolume.addLabelSetFromBucketStream(bucketStream, resolutionsIntersection)
       }
-    }.getOrElse(Set.empty)
 
-    val mergedVolume = new MergedVolume(elementClass)
-
-    tracingSelectors.zip(tracings).foreach {
-      case (selector, tracing) =>
-        val bucketStream = bucketStreamFromSelector(selector, tracing)
-        mergedVolume.addLabelSetFromBucketStream(bucketStream, resolutionsIntersection)
-    }
-
-    tracingSelectors.zip(tracings).zipWithIndex.foreach {
-      case ((selector, tracing), sourceVolumeIndex) =>
-        val bucketStream = bucketStreamFromSelector(selector, tracing)
-        mergedVolume.addFromBucketStream(sourceVolumeIndex, bucketStream, Some(resolutionsIntersection))
-    }
-    val destinationDataLayer = volumeTracingLayer(newId, newTracing)
-    for {
-      _ <- mergedVolume.withMergedBuckets { (bucketPosition, bucketBytes) =>
-        saveBucket(destinationDataLayer, bucketPosition, bucketBytes, newTracing.version, toCache)
+      tracingSelectors.zip(tracings).zipWithIndex.foreach {
+        case ((selector, tracing), sourceVolumeIndex) =>
+          val bucketStream = bucketStreamFromSelector(selector, tracing)
+          mergedVolume.addFromBucketStream(sourceVolumeIndex, bucketStream, Some(resolutionsIntersection))
       }
-      _ <- updateResolutionList(newId, newTracing, mergedVolume.presentResolutions)
-    } yield ()
+      val destinationDataLayer = volumeTracingLayer(newId, newTracing)
+      for {
+        _ <- mergedVolume.withMergedBuckets { (bucketPosition, bucketBytes) =>
+          saveBucket(destinationDataLayer, bucketPosition, bucketBytes, newTracing.version, toCache)
+        }
+        _ <- updateResolutionList(newId, newTracing, mergedVolume.presentResolutions)
+      } yield ()
+    }
   }
 
-  def importVolumeData(tracingId: String, tracing: VolumeTracing, zipFile: File, currentVersion: Int): Fox[Long] = {
-    if (currentVersion != tracing.version) return Fox.failure("version.mismatch")
+  def importVolumeData(tracingId: String, tracing: VolumeTracing, zipFile: File, currentVersion: Int): Fox[Long] =
+    if (currentVersion != tracing.version)
+      Fox.failure("version.mismatch")
+    else {
 
-    val resolutionSet = resolutionSetFromZipfile(zipFile)
-    val resolutionsDoMatch =
-      resolutionSet.isEmpty || resolutionSet == resolveLegacyResolutionList(tracing.resolutions)
-        .map(vec3IntFromProto)
-        .toSet
+      val resolutionSet = resolutionSetFromZipfile(zipFile)
+      val resolutionsDoMatch =
+        resolutionSet.isEmpty || resolutionSet == resolveLegacyResolutionList(tracing.resolutions)
+          .map(vec3IntFromProto)
+          .toSet
 
-    if (!resolutionsDoMatch) return Fox.failure("annotation.volume.resolutionsDoNotMatch")
-
-    val volumeLayer = volumeTracingLayer(tracingId, tracing)
-    val mergedVolume = new MergedVolume(tracing.elementClass, tracing.largestSegmentId)
-    for {
-      _ <- mergedVolume.addLabelSetFromDataZip(zipFile).toFox
-      _ = mergedVolume.addFromBucketStream(sourceVolumeIndex = 0, volumeLayer.bucketProvider.bucketStream())
-      _ <- mergedVolume.addFromDataZip(sourceVolumeIndex = 1, zipFile).toFox
-      _ <- mergedVolume.withMergedBuckets { (bucketPosition, bucketBytes) =>
-        saveBucket(volumeLayer, bucketPosition, bucketBytes, tracing.version + 1)
+      if (!resolutionsDoMatch)
+        Fox.failure("annotation.volume.resolutionsDoNotMatch")
+      else {
+        val volumeLayer = volumeTracingLayer(tracingId, tracing)
+        val mergedVolume = new MergedVolume(tracing.elementClass, tracing.largestSegmentId)
+        for {
+          _ <- mergedVolume.addLabelSetFromDataZip(zipFile).toFox
+          _ = mergedVolume.addFromBucketStream(sourceVolumeIndex = 0, volumeLayer.bucketProvider.bucketStream())
+          _ <- mergedVolume.addFromDataZip(sourceVolumeIndex = 1, zipFile).toFox
+          _ <- mergedVolume.withMergedBuckets { (bucketPosition, bucketBytes) =>
+            saveBucket(volumeLayer, bucketPosition, bucketBytes, tracing.version + 1)
+          }
+          updateGroup = UpdateActionGroup[VolumeTracing](
+            tracing.version + 1,
+            System.currentTimeMillis(),
+            None,
+            List(ImportVolumeData(mergedVolume.largestSegmentId.toPositiveLong)),
+            None,
+            None,
+            None,
+            None,
+            None)
+          _ <- handleUpdateGroup(tracingId, updateGroup, tracing.version)
+        } yield mergedVolume.largestSegmentId.toPositiveLong
       }
-      updateGroup = UpdateActionGroup[VolumeTracing](
-        tracing.version + 1,
-        System.currentTimeMillis(),
-        None,
-        List(ImportVolumeData(mergedVolume.largestSegmentId.toPositiveLong)),
-        None,
-        None,
-        None,
-        None,
-        None)
-      _ <- handleUpdateGroup(tracingId, updateGroup, tracing.version)
-    } yield mergedVolume.largestSegmentId.toPositiveLong
-  }
+    }
 
   def dummyTracing: VolumeTracing = ???
 


### PR DESCRIPTION
return in scala is generally harmful, compare article at https://tpolecat.github.io/2014/05/09/return.html

This PR removes most return statements from our code
 - except those in the jzarr and datastore.storage packages (because PR #6335  does that
 - except those that I did not know how to convert without rewriting a lot of code (DataFinder, IsosurfaceService, CumsumParser)

It is recommended to hide whitespace in the diff view :)

### URL of deployed dev instance (used for testing):
- https://fewerreturnsinscala.webknossos.xyz

### Steps to test:
- create task, trace some, download + upload volume data, should still work as expected

### Issues:
- contributes to #6356 

------
- [x] Needs datastore update after deployment
- [x] Ready for review
