### PR TITLE
Skip current directory “.” in zarr directory listings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 - The Layers tab now displays an Add Skeleton Annotation Layer button with which volume-only annotations can be converted to hybrid annotations. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
+- The Zarr directory listings no longer include the current directory “.”. [6359](https://github.com/scalableminds/webknossos/pull/6359)
 
 ### Fixed
 - Fixed a regression where the mapping activation confirmation dialog was never shown. [#6346](https://github.com/scalableminds/webknossos/pull/6346)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
@@ -50,7 +50,7 @@ class ZarrStreamingController @Inject()(
             views.html.datastoreZarrDatasourceDir(
               "Datastore",
               s"$organizationName/$dataSetName",
-              Map(s"$dataSetName" -> ".") ++ layerNames.map { x =>
+              layerNames.map { x =>
                 (x, s"$dataSetName/$x")
               }.toMap
             ))
@@ -73,7 +73,7 @@ class ZarrStreamingController @Inject()(
             views.html.datastoreZarrDatasourceDir(
               "Datastore",
               "%s/%s/%s".format(organizationName, dataSetName, dataLayerName),
-              Map(s"$dataLayerName" -> ".") ++ mags.map { mag =>
+              mags.map { mag =>
                 (mag.toMagLiteral(), s"$dataLayerName/${mag.toMagLiteral()}")
               }.toMap
             )).withHeaders()
@@ -97,7 +97,7 @@ class ZarrStreamingController @Inject()(
             views.html.datastoreZarrDatasourceDir(
               "Datastore",
               "%s/%s/%s/%s".format(organizationName, dataSetName, dataLayerName, mag),
-              Map(mag -> ".")
+              Map.empty
             )).withHeaders()
       }
     }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -254,7 +254,7 @@ class VolumeTracingController @Inject()(
             views.html.datastoreZarrDatasourceDir(
               "Tracingstore",
               "%s".format(tracingId),
-              Map(tracingId -> ".") ++ existingMags.map { mag =>
+              existingMags.map { mag =>
                 (mag.toMagLiteral(allowScalar = true), mag.toMagLiteral(allowScalar = true))
               }.toMap
             )).withHeaders()
@@ -275,7 +275,7 @@ class VolumeTracingController @Inject()(
             views.html.datastoreZarrDatasourceDir(
               "Tracingstore",
               "%s".format(tracingId),
-              Map(mag -> ".")
+              Map.empty
             )).withHeaders()
       }
     }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://zarrnodot.webknossos.xyz

### Steps to test:
- Visit zarr streaming directory listing at `/data/zarr/:orga/:dataset`, should not include current directory (“.”)

### Issues:
- fixes #6336 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
