### PR TITLE
refactor backend: unify dataclass constructor naming

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -402,7 +402,7 @@ class AnnotationController @Inject()(
   def annotationsForTask(@ApiParam(value = "The id of the task") taskId: String): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {
-        taskIdValidated <- ObjectId.parse(taskId)
+        taskIdValidated <- ObjectId.fromString(taskId)
         task <- taskDAO.findOne(taskIdValidated) ?~> "task.notFound" ~> NOT_FOUND
         project <- projectDAO.findOne(task._project)
         _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(request.identity, project._team))
@@ -446,7 +446,7 @@ class AnnotationController @Inject()(
       restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
       _ <- restrictions.allowFinish(request.identity) ?~> "notAllowed" ~> FORBIDDEN
       newUserId <- (request.body \ "userId").asOpt[String].toFox ?~> "user.id.notFound" ~> NOT_FOUND
-      newUserIdValidated <- ObjectId.parse(newUserId)
+      newUserIdValidated <- ObjectId.fromString(newUserId)
       updated <- annotationService.transferAnnotationToUser(typ, id, newUserIdValidated, request.identity)
       json <- annotationService.publicWrites(updated, Some(request.identity), Some(restrictions))
     } yield JsonOk(json)
@@ -515,7 +515,7 @@ class AnnotationController @Inject()(
           annotation <- provider.provideAnnotation(typ, id, request.identity)
           _ <- bool2Fox(
             annotation._user == request.identity._id && annotation.visibility != AnnotationVisibility.Private) ?~> "notAllowed" ~> FORBIDDEN
-          teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.parse)
+          teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.fromString)
           _ <- Fox.serialCombined(teamIdsValidated)(teamDAO.findOne(_)) ?~> "updateSharedTeams.failed.accessingTeam"
           _ <- annotationService.updateTeamsForSharedAnnotation(annotation._id, teamIdsValidated)
         } yield Ok(Json.toJson(teamIdsValidated))

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -453,7 +453,7 @@ Expects:
       m: MessagesProvider) =
     for {
       user <- userOpt.toFox ?~> Messages("notAllowed") ~> FORBIDDEN
-      projectIdValidated <- ObjectId.parse(projectId)
+      projectIdValidated <- ObjectId.fromString(projectId)
       project <- projectDAO.findOne(projectIdValidated) ?~> Messages("project.notFound", projectId) ~> NOT_FOUND
       _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(user, project._team)) ?~> "notAllowed" ~> FORBIDDEN
       annotations <- annotationDAO.findAllFinishedForProject(projectIdValidated)
@@ -500,7 +500,7 @@ Expects:
 
     for {
       user <- userOpt.toFox ?~> Messages("notAllowed") ~> FORBIDDEN
-      taskTypeIdValidated <- ObjectId.parse(taskTypeId) ?~> "taskType.id.invalid"
+      taskTypeIdValidated <- ObjectId.fromString(taskTypeId) ?~> "taskType.id.invalid"
       taskType <- taskTypeDAO.findOne(taskTypeIdValidated) ?~> "taskType.notFound" ~> NOT_FOUND
       _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(user, taskType._team)) ?~> "notAllowed" ~> FORBIDDEN
       zip <- createTaskTypeZip(taskType)

--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -224,7 +224,7 @@ class AuthenticationController @Inject()(
         } yield organization
       case (None, None, Some(annotationId)) =>
         for {
-          annotationObjectId <- ObjectId.parse(annotationId)
+          annotationObjectId <- ObjectId.fromString(annotationId)
           annotation <- annotationDAO.findOne(annotationObjectId) // Note: this does not work for compound annotations.
           user <- userDAO.findOne(annotation._user)
           organization <- organizationDAO.findOne(user._organization)
@@ -268,7 +268,7 @@ class AuthenticationController @Inject()(
 
   private def canAccessAnnotation(user: User, ctx: DBAccessContext, annotationId: String): Fox[Boolean] = {
     val foundFox = for {
-      annotationIdParsed <- ObjectId.parse(annotationId)
+      annotationIdParsed <- ObjectId.fromString(annotationId)
       annotation <- annotationDAO.findOne(annotationIdParsed)(GlobalAccessContext)
       _ <- bool2Fox(annotation.state != Cancelled)
       restrictions <- annotationProvider.restrictionsFor(AnnotationIdentifier(annotation.typ, annotationIdParsed))(ctx)

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -338,7 +338,7 @@ Expects:
           dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, request.identity._organization) ?~> notFoundMessage(
             dataSetName) ~> NOT_FOUND
           _ <- Fox.assertTrue(dataSetService.isEditableBy(dataSet, Some(request.identity))) ?~> "notAllowed" ~> FORBIDDEN
-          teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.parse(_))
+          teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.fromString(_))
           includeMemberOnlyTeams = request.identity.isDatasetManager
           userTeams <- if (includeMemberOnlyTeams) teamDAO.findAll else teamDAO.findAllEditable
           oldAllowedTeams <- dataSetService.allowedTeamIdsFor(dataSet._id)

--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -68,7 +68,7 @@ class JobsController @Inject()(jobDAO: JobDAO,
   def cancel(id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       _ <- bool2Fox(wkconf.Features.jobsEnabled) ?~> "job.disabled"
-      jobIdValidated <- ObjectId.parse(id)
+      jobIdValidated <- ObjectId.fromString(id)
       job <- jobDAO.findOne(jobIdValidated)
       _ <- jobDAO.updateManualState(jobIdValidated, JobState.CANCELLED)
       js <- jobService.publicWrites(job)

--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -233,13 +233,13 @@ class LegacyApiController @Inject()(annotationController: AnnotationController,
   def taskListTasks: Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     for {
       _ <- Fox.successful(logVersioned(request))
-      userIdOpt <- Fox.runOptional((request.body \ "user").asOpt[String])(ObjectId.parse)
+      userIdOpt <- Fox.runOptional((request.body \ "user").asOpt[String])(ObjectId.fromString)
       projectNameOpt = (request.body \ "project").asOpt[String]
       projectOpt <- Fox.runOptional(projectNameOpt)(projectName =>
         projectDAO.findOneByNameAndOrganization(projectName, request.identity._organization))
       taskIdsOpt <- Fox.runOptional((request.body \ "ids").asOpt[List[String]])(ids =>
-        Fox.serialCombined(ids)(ObjectId.parse))
-      taskTypeIdOpt <- Fox.runOptional((request.body \ "taskType").asOpt[String])(ObjectId.parse)
+        Fox.serialCombined(ids)(ObjectId.fromString))
+      taskTypeIdOpt <- Fox.runOptional((request.body \ "taskType").asOpt[String])(ObjectId.fromString)
       randomizeOpt = (request.body \ "random").asOpt[Boolean]
       tasks <- taskDAO.findAllByProjectAndTaskTypeAndIdsAndUser(projectOpt.map(_._id),
                                                                 taskTypeIdOpt,

--- a/app/controllers/MeshController.scala
+++ b/app/controllers/MeshController.scala
@@ -20,7 +20,7 @@ class MeshController @Inject()(meshDAO: MeshDAO,
 
   def get(id: String): Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     for {
-      idValidated <- ObjectId.parse(id)
+      idValidated <- ObjectId.fromString(id)
       meshInfo <- meshDAO.findOne(idValidated) ?~> "mesh.notFound" ~> NOT_FOUND
       _ <- annotationDAO.findOne(meshInfo._annotation) ?~> "annotation.notFound" ~> NOT_FOUND
       meshInfoJs <- meshService.publicWrites(meshInfo) ?~> "mesh.write.failed"
@@ -44,7 +44,7 @@ class MeshController @Inject()(meshDAO: MeshDAO,
     implicit request =>
       val params = request.body
       for {
-        idValidated <- ObjectId.parse(id)
+        idValidated <- ObjectId.fromString(id)
         meshInfo <- meshDAO.findOne(idValidated) ?~> "mesh.notFound" ~> NOT_FOUND
         _ <- annotationDAO.assertUpdateAccess(meshInfo._annotation) ?~> "notAllowed" ~> FORBIDDEN
         _ <- annotationDAO.assertUpdateAccess(params.annotationId) ?~> "notAllowed" ~> FORBIDDEN
@@ -57,7 +57,7 @@ class MeshController @Inject()(meshDAO: MeshDAO,
 
   def getData(id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      idValidated <- ObjectId.parse(id)
+      idValidated <- ObjectId.fromString(id)
       meshInfo <- meshDAO.findOne(idValidated) ?~> "mesh.notFound" ~> NOT_FOUND
       _ <- annotationDAO.findOne(meshInfo._annotation) ?~> "annotation.notFound" ~> NOT_FOUND
       data <- meshDAO.getData(idValidated) ?~> "mesh.data.get.failed"
@@ -66,7 +66,7 @@ class MeshController @Inject()(meshDAO: MeshDAO,
 
   def updateData(id: String): Action[RawBuffer] = sil.SecuredAction.async(parse.raw) { implicit request =>
     for {
-      idValidated <- ObjectId.parse(id)
+      idValidated <- ObjectId.fromString(id)
       meshInfo <- meshDAO.findOne(idValidated) ?~> "mesh.notFound" ~> NOT_FOUND
       _ <- annotationDAO.assertUpdateAccess(meshInfo._annotation) ?~> "notAllowed" ~> FORBIDDEN
       byteString <- request.body.asBytes(maxLength = 1024 * 1024 * 1024) ?~> "mesh.data.read.failed"
@@ -76,7 +76,7 @@ class MeshController @Inject()(meshDAO: MeshDAO,
 
   def delete(id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      idValidated <- ObjectId.parse(id)
+      idValidated <- ObjectId.fromString(id)
       meshInfo <- meshDAO.findOne(idValidated) ?~> "mesh.notFound" ~> NOT_FOUND
       _ <- annotationDAO.assertUpdateAccess(meshInfo._annotation) ?~> "notAllowed" ~> FORBIDDEN
       _ <- meshDAO.deleteOne(idValidated) ?~> "mesh.delete.failed"

--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -132,7 +132,7 @@ class ReportController @Inject()(reportDAO: ReportDAO,
 
   def projectProgressOverview(teamId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      teamIdValidated <- ObjectId.parse(teamId)
+      teamIdValidated <- ObjectId.fromString(teamId)
       _ <- teamDAO.findOne(teamIdValidated) ?~> "team.notFound" ~> NOT_FOUND
       entries <- reportDAO.projectProgress(teamIdValidated)
     } yield Ok(Json.toJson(entries))
@@ -140,7 +140,7 @@ class ReportController @Inject()(reportDAO: ReportDAO,
 
   def openTasksOverview(teamId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      teamIdValidated <- ObjectId.parse(teamId)
+      teamIdValidated <- ObjectId.fromString(teamId)
       team <- teamDAO.findOne(teamIdValidated) ?~> "team.notFound" ~> NOT_FOUND
       users <- userDAO.findAllByTeams(List(team._id))
       nonUnlistedUsers = users.filter(!_.isUnlisted)

--- a/app/controllers/ScriptController.scala
+++ b/app/controllers/ScriptController.scala
@@ -41,7 +41,7 @@ class ScriptController @Inject()(scriptDAO: ScriptDAO,
 
   def get(scriptId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      scriptIdValidated <- ObjectId.parse(scriptId)
+      scriptIdValidated <- ObjectId.fromString(scriptId)
       script <- scriptDAO.findOne(scriptIdValidated) ?~> "script.notFound" ~> NOT_FOUND
       js <- scriptService.publicWrites(script) ?~> "script.write.failed"
     } yield {
@@ -61,7 +61,7 @@ class ScriptController @Inject()(scriptDAO: ScriptDAO,
   def update(scriptId: String): Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     withJsonBodyUsing(scriptPublicReads) { scriptFromForm =>
       for {
-        scriptIdValidated <- ObjectId.parse(scriptId)
+        scriptIdValidated <- ObjectId.fromString(scriptId)
         oldScript <- scriptDAO.findOne(scriptIdValidated) ?~> "script.notFound" ~> NOT_FOUND
         _ <- bool2Fox(oldScript._owner == request.identity._id) ?~> "script.notOwner" ~> FORBIDDEN
         updatedScript = scriptFromForm.copy(_id = oldScript._id)
@@ -75,7 +75,7 @@ class ScriptController @Inject()(scriptDAO: ScriptDAO,
 
   def delete(scriptId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      scriptIdValidated <- ObjectId.parse(scriptId)
+      scriptIdValidated <- ObjectId.fromString(scriptId)
       oldScript <- scriptDAO.findOne(scriptIdValidated) ?~> "script.notFound" ~> NOT_FOUND
       _ <- bool2Fox(oldScript._owner == request.identity._id) ?~> "script.notOwner" ~> FORBIDDEN
       _ <- scriptDAO.deleteOne(scriptIdValidated) ?~> "script.removalFailed"

--- a/app/controllers/TaskTypeController.scala
+++ b/app/controllers/TaskTypeController.scala
@@ -49,7 +49,7 @@ class TaskTypeController @Inject()(taskTypeDAO: TaskTypeDAO,
 
   def get(taskTypeId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      taskTypeIdValidated <- ObjectId.parse(taskTypeId) ?~> "taskType.id.invalid"
+      taskTypeIdValidated <- ObjectId.fromString(taskTypeId) ?~> "taskType.id.invalid"
       taskType <- taskTypeDAO.findOne(taskTypeIdValidated) ?~> "taskType.notFound" ~> NOT_FOUND
       _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(request.identity, taskType._team))
       js <- taskTypeService.publicWrites(taskType)
@@ -66,7 +66,7 @@ class TaskTypeController @Inject()(taskTypeDAO: TaskTypeDAO,
   def update(taskTypeId: String): Action[JsValue] = sil.SecuredAction.async(parse.json) { implicit request =>
     withJsonBodyUsing(taskTypePublicReads) { taskTypeFromForm =>
       for {
-        taskTypeIdValidated <- ObjectId.parse(taskTypeId) ?~> "taskType.id.invalid"
+        taskTypeIdValidated <- ObjectId.fromString(taskTypeId) ?~> "taskType.id.invalid"
         taskType <- taskTypeDAO.findOne(taskTypeIdValidated) ?~> "taskType.notFound" ~> NOT_FOUND
         _ <- bool2Fox(taskTypeFromForm.tracingType == taskType.tracingType) ?~> "taskType.tracingTypeImmutable"
         _ <- bool2Fox(taskTypeFromForm.settings.resolutionRestrictions == taskType.settings.resolutionRestrictions) ?~> "taskType.resolutionRestrictionsImmutable"
@@ -82,7 +82,7 @@ class TaskTypeController @Inject()(taskTypeDAO: TaskTypeDAO,
 
   def delete(taskTypeId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      taskTypeIdValidated <- ObjectId.parse(taskTypeId) ?~> "taskType.id.invalid"
+      taskTypeIdValidated <- ObjectId.fromString(taskTypeId) ?~> "taskType.id.invalid"
       taskType <- taskTypeDAO.findOne(taskTypeIdValidated) ?~> "taskType.notFound" ~> NOT_FOUND
       _ <- Fox
         .assertTrue(userService.isTeamManagerOrAdminOf(request.identity, taskType._team)) ?~> "notAllowed" ~> FORBIDDEN

--- a/app/controllers/TeamController.scala
+++ b/app/controllers/TeamController.scala
@@ -42,7 +42,7 @@ class TeamController @Inject()(teamDAO: TeamDAO,
   @ApiOperation(hidden = true, value = "")
   def delete(id: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      teamIdValidated <- ObjectId.parse(id)
+      teamIdValidated <- ObjectId.fromString(id)
       _ <- bool2Fox(request.identity.isAdmin) ?~> "user.noAdmin" ~> FORBIDDEN
       team <- teamDAO.findOne(teamIdValidated) ?~> "team.notFound" ~> NOT_FOUND
       _ <- bool2Fox(!team.isOrganizationTeam) ?~> "team.delete.organizationTeam" ~> FORBIDDEN

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -53,7 +53,7 @@ class TimeController @Inject()(userService: UserService,
   def getWorkingHoursOfUser(userId: String, startDate: Long, endDate: Long): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {
-        userIdValidated <- ObjectId.parse(userId)
+        userIdValidated <- ObjectId.fromString(userId)
         user <- userService.findOneById(userIdValidated, useCache = false) ?~> "user.notFound" ~> NOT_FOUND
         isTeamManagerOrAdmin <- userService.isTeamManagerOrAdminOf(request.identity, user)
         _ <- bool2Fox(isTeamManagerOrAdmin || user == request.identity) ?~> "user.notAuthorised" ~> FORBIDDEN

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -51,7 +51,7 @@ class UserController @Inject()(userService: UserService,
     implicit request =>
       log() {
         for {
-          userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+          userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
           user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
           _ <- Fox.assertTrue(userService.isEditableBy(user, request.identity)) ?~> "notAllowed" ~> FORBIDDEN
           js <- userService.publicWrites(user, request.identity)
@@ -114,7 +114,7 @@ class UserController @Inject()(userService: UserService,
       "Get the logged time of the passed user. Only available for admins or team managers of the user in question.")
   def userLoggedTime(userId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+      userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
       user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
       _ <- Fox.assertTrue(userService.isEditableBy(user, request.identity)) ?~> "notAllowed" ~> FORBIDDEN
       loggedTimeAsMap <- timeSpanService.loggedTimeOfUser(user, TimeSpan.groupByMonth)
@@ -137,7 +137,7 @@ class UserController @Inject()(userService: UserService,
       Fox
         .combined(request.body.users.map { userId =>
           for {
-            userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+            userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
             user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
             userEmail <- userService.emailFor(user)
             _ <- Fox.assertTrue(userService.isEditableBy(user, request.identity)) ?~> "notAllowed" ~> FORBIDDEN
@@ -175,7 +175,7 @@ class UserController @Inject()(userService: UserService,
                       includeTotalCount: Option[Boolean] = None): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {
-        userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+        userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
         user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
         _ <- Fox.assertTrue(userService.isEditableBy(user, request.identity)) ?~> "notAllowed" ~> FORBIDDEN
         annotations <- annotationDAO.findAllFor(userIdValidated,
@@ -203,7 +203,7 @@ class UserController @Inject()(userService: UserService,
                 includeTotalCount: Option[Boolean] = None): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {
-        userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+        userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
         user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
         _ <- Fox.assertTrue(userService.isEditableBy(user, request.identity)) ?~> "notAllowed" ~> FORBIDDEN
         annotations <- annotationDAO.findAllFor(userIdValidated,
@@ -341,7 +341,7 @@ class UserController @Inject()(userService: UserService,
             experiencesOpt,
             lastTaskTypeIdOpt) =>
         for {
-          userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+          userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
           user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
           oldExperience <- userService.experiencesFor(user._id)
           oldAssignedMemberships <- userService.teamMembershipsFor(user._id)
@@ -393,7 +393,7 @@ class UserController @Inject()(userService: UserService,
     val issuingUser = request.identity
     withJsonBodyUsing((__ \ "lastTaskTypeId").readNullable[String]) { lastTaskTypeId =>
       for {
-        userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+        userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
         user <- userDAO.findOne(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
         isEditable <- userService.isEditableBy(user, request.identity) ?~> "notAllowed" ~> FORBIDDEN
         _ <- bool2Fox(isEditable | user._id == issuingUser._id)
@@ -408,7 +408,7 @@ class UserController @Inject()(userService: UserService,
   def updateNovelUserExperienceInfos(userId: String): Action[JsObject] =
     sil.SecuredAction.async(validateJson[JsObject]) { implicit request =>
       for {
-        userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+        userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
         _ <- bool2Fox(request.identity._id == userIdValidated) ?~> "notAllowed" ~> FORBIDDEN
         _ <- multiUserDAO.updateNovelUserExperienceInfos(request.identity._multiUser, request.body)
         updatedUser <- userDAO.findOne(userIdValidated)
@@ -420,7 +420,7 @@ class UserController @Inject()(userService: UserService,
   def updateSelectedTheme(userId: String): Action[Theme] =
     sil.SecuredAction.async(validateJson[Theme]) { implicit request =>
       for {
-        userIdValidated <- ObjectId.parse(userId) ?~> "user.id.invalid"
+        userIdValidated <- ObjectId.fromString(userId) ?~> "user.id.invalid"
         _ <- bool2Fox(request.identity._id == userIdValidated) ?~> "notAllowed" ~> FORBIDDEN
         _ <- multiUserDAO.updateSelectedTheme(request.identity._multiUser, request.body)
         updatedUser <- userDAO.findOne(userIdValidated)

--- a/app/controllers/UserTokenController.scala
+++ b/app/controllers/UserTokenController.scala
@@ -198,7 +198,7 @@ class UserTokenController @Inject()(dataSetDAO: DataSetDAO,
       Fox.successful(UserAccessAnswer(granted = false, Some(s"Unsupported acces mode for job exports: $mode")))
     else {
       for {
-        jobIdValidated <- ObjectId.parse(jobId)
+        jobIdValidated <- ObjectId.fromString(jobId)
         jobBox <- jobDAO.findOne(jobIdValidated)(DBAccessContext(userBox)).futureBox
         answer = jobBox match {
           case Full(_) => UserAccessAnswer(granted = true)

--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -166,7 +166,7 @@ class WKRemoteDataStoreController @Inject()(
     implicit request =>
       dataStoreService.validateAccess(name, key) { _ =>
         for {
-          jobIdValidated <- ObjectId.parse(jobId)
+          jobIdValidated <- ObjectId.fromString(jobId)
           job <- jobDAO.findOne(jobIdValidated)(GlobalAccessContext)
           jobOwner <- userDAO.findOne(job._owner)(GlobalAccessContext)
           organization <- organizationDAO.findOne(jobOwner._organization)(GlobalAccessContext)

--- a/app/controllers/WKRemoteWorkerController.scala
+++ b/app/controllers/WKRemoteWorkerController.scala
@@ -46,7 +46,7 @@ class WKRemoteWorkerController @Inject()(jobDAO: JobDAO, jobService: JobService,
     implicit request =>
       for {
         _ <- workerDAO.findOneByKey(key) ?~> "jobs.worker.notFound"
-        jobIdParsed <- ObjectId.parse(id)
+        jobIdParsed <- ObjectId.fromString(id)
         jobBeforeChange <- jobDAO.findOne(jobIdParsed)(GlobalAccessContext)
         _ <- jobDAO.updateStatus(jobIdParsed, request.body)
         jobAfterChange <- jobDAO.findOne(jobIdParsed)(GlobalAccessContext)

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -117,7 +117,7 @@ class AnnotationLayerDAO @Inject()(SQLClient: SQLClient)(implicit ec: ExecutionC
     for {
       rList <- run(sql"select _annotation from webknossos.annotation_layers where tracingId = $tracingId".as[String])
       head: String <- rList.headOption.toFox
-      parsed <- ObjectId.parse(head)
+      parsed <- ObjectId.fromString(head)
     } yield parsed
 
   def replaceTracingId(annotationId: ObjectId, oldTracingId: String, newTracingId: String): Fox[Unit] =
@@ -285,7 +285,7 @@ class AnnotationDAO @Inject()(sqlClient: SQLClient, annotationLayerDAO: Annotati
     for {
       r <- run(sql"""select _task from #$existingCollectionName
              where _user = ${userId.id} and typ = '#${AnnotationType.Task.toString}' and #$stateQuery""".as[String])
-      r <- Fox.serialCombined(r.toList)(ObjectId.parse(_))
+      r <- Fox.serialCombined(r.toList)(ObjectId.fromString(_))
     } yield r
 
   }

--- a/app/models/annotation/AnnotationIdentifier.scala
+++ b/app/models/annotation/AnnotationIdentifier.scala
@@ -17,7 +17,7 @@ object AnnotationIdentifier extends FoxImplicits {
 
   def parse(typ: String, id: String)(implicit ec: ExecutionContext): Fox[AnnotationIdentifier] =
     for {
-      identifier <- ObjectId.parse(id)
+      identifier <- ObjectId.fromString(id)
       typ <- AnnotationType.fromString(typ) ?~> ("Invalid AnnotationType: " + typ)
     } yield AnnotationIdentifier(typ, identifier)
 }

--- a/app/models/annotation/AnnotationInformationProvider.scala
+++ b/app/models/annotation/AnnotationInformationProvider.scala
@@ -30,7 +30,7 @@ class AnnotationInformationProvider @Inject()(
   def provideAnnotation(id: String, userOpt: Option[User])(implicit ctx: DBAccessContext): Fox[Annotation] =
     // this function only supports task/explorational look ups, not compound annotations
     for {
-      annotationIdValidated <- ObjectId.parse(id)
+      annotationIdValidated <- ObjectId.fromString(id)
       _annotation <- annotationDAO.findOne(annotationIdValidated) ?~> "annotation.notFound"
       typ = if (_annotation._task.isEmpty) AnnotationType.Explorational else AnnotationType.Task
       annotationIdentifier = AnnotationIdentifier(typ, annotationIdValidated)

--- a/app/models/binary/DataSet.scala
+++ b/app/models/binary/DataSet.scala
@@ -184,7 +184,7 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
         sql"select _organization from #$existingCollectionName where name = $dataSetName and #$accessQuery order by created asc"
           .as[String])
       r <- rList.headOption.toFox
-      parsed <- ObjectId.parse(r)
+      parsed <- ObjectId.fromString(r)
     } yield parsed
 
   def getIdByName(name: String)(implicit ctx: DBAccessContext): Fox[ObjectId] =
@@ -503,7 +503,7 @@ class DataSetAllowedTeamsDAO @Inject()(sqlClient: SQLClient)(implicit ec: Execut
       (_, team) <- DatasetAllowedteams.filter(_._Dataset === dataSetId.id) join Teams on (_._Team === _._Id)
     } yield team._Id
 
-    run(query.result).flatMap(rows => Fox.serialCombined(rows.toList)(ObjectId.parse(_)))
+    run(query.result).flatMap(rows => Fox.serialCombined(rows.toList)(ObjectId.fromString(_)))
   }
 
   def updateAllowedTeamsForDataSet(_id: ObjectId, allowedTeams: List[ObjectId]): Fox[Unit] = {

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -329,7 +329,7 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
       _ <- bool2Fox(previousDatasetTeams.isEmpty) ?~> "dataSet.initialTeams.teamsNotEmpty"
       userTeams <- teamDAO.findAllEditable
       userTeamIds = userTeams.map(_._id)
-      teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.parse(_))
+      teamIdsValidated <- Fox.serialCombined(teams)(ObjectId.fromString(_))
       _ <- bool2Fox(teamIdsValidated.forall(team => userTeamIds.contains(team))) ?~> "dataset.initialTeams.invalidTeams"
       _ <- dataSetDAO.assertUpdateAccess(dataSet._id) ?~> "dataset.initialTeams.forbidden"
       _ <- dataSetAllowedTeamsDAO.updateAllowedTeamsForDataSet(dataSet._id, teamIdsValidated)

--- a/app/models/organization/Organization.scala
+++ b/app/models/organization/Organization.scala
@@ -90,7 +90,7 @@ class OrganizationDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionCont
     for {
       rList <- run(sql"select _id from webknossos.organizationTeams where _organization = ${o.id}".as[String])
       r <- rList.headOption.toFox
-      parsed <- ObjectId.parse(r)
+      parsed <- ObjectId.fromString(r)
     } yield parsed
 
   def findOrganizationNameForAnnotation(annotationId: ObjectId): Fox[String] =

--- a/app/models/task/TaskType.scala
+++ b/app/models/task/TaskType.scala
@@ -59,7 +59,7 @@ class TaskTypeService @Inject()(teamDAO: TeamDAO, taskTypeDAO: TaskTypeDAO)(impl
     Fox
       .serialCombined(taskTypeIds) { taskTypeId =>
         for {
-          taskTypeIdValidated <- ObjectId.parse(taskTypeId) ?~> "taskType.id.invalid"
+          taskTypeIdValidated <- ObjectId.fromString(taskTypeId) ?~> "taskType.id.invalid"
           taskType <- taskTypeDAO.findOne(taskTypeIdValidated) ?~> "taskType.notFound"
         } yield taskType.tracingType == TracingType.volume || taskType.tracingType == TracingType.hybrid
       }

--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -134,7 +134,7 @@ class TeamDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       r <- run(
         sql"select _id from #$existingCollectionName where _organization = ${organizationId.id} and #$accessQuery"
           .as[String])
-      parsed <- Fox.serialCombined(r.toList)(col => ObjectId.parse(col))
+      parsed <- Fox.serialCombined(r.toList)(col => ObjectId.fromString(col))
     } yield parsed
 
   def findAllForDataSet(dataSetId: ObjectId)(implicit ctx: DBAccessContext): Fox[List[Team]] =

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -263,7 +263,7 @@ class UserTeamRolesDAO @Inject()(userDAO: UserDAO, sqlClient: SQLClient)(implici
       rows: Seq[(String, String, Boolean)] <- run(query.result)
       teamMemberships <- Fox.combined(rows.toList.map {
         case (teamId, _, isTeamManager) =>
-          ObjectId.parse(teamId).map(teamIdValidated => TeamMembership(teamIdValidated, isTeamManager))
+          ObjectId.fromString(teamId).map(teamIdValidated => TeamMembership(teamIdValidated, isTeamManager))
       })
     } yield teamMemberships
   }

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -195,7 +195,7 @@ class UserService @Inject()(conf: WkConf,
 
   def changePasswordInfo(loginInfo: LoginInfo, passwordInfo: PasswordInfo): Fox[PasswordInfo] =
     for {
-      userIdValidated <- ObjectId.parse(loginInfo.providerKey)
+      userIdValidated <- ObjectId.fromString(loginInfo.providerKey)
       user <- findOneById(userIdValidated, useCache = true)(GlobalAccessContext)
       _ <- multiUserDAO.updatePasswordInfo(user._multiUser, passwordInfo)(GlobalAccessContext)
     } yield passwordInfo

--- a/app/models/user/time/TimeSpan.scala
+++ b/app/models/user/time/TimeSpan.scala
@@ -43,8 +43,8 @@ object TimeSpan {
         timeSpan.createdAsDateTime.getMonthOfYear,
         timeSpan.createdAsDateTime.getYear)
 
-  def createFrom(start: Long, end: Long, _user: ObjectId, _annotation: Option[ObjectId]): TimeSpan =
-    TimeSpan(ObjectId.generate, _user, _annotation, time = end - start, lastUpdate = end, created = start)
+  def fromTimestamp(timestamp: Long, _user: ObjectId, _annotation: Option[ObjectId]): TimeSpan =
+    TimeSpan(ObjectId.generate, _user, _annotation, time = 0L, lastUpdate = timestamp, created = timestamp)
 
 }
 

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -103,7 +103,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
     var timeSpansToUpdate: List[(TimeSpan, Long)] = List()
 
     def createNewTimeSpan(timestamp: Long, _user: ObjectId, annotation: Option[Annotation]) = {
-      val timeSpan = TimeSpan.fromTimestamp(timestamp, timestamp, _user, annotation.map(_._id))
+      val timeSpan = TimeSpan.fromTimestamp(timestamp, _user, annotation.map(_._id))
       timeSpansToInsert = timeSpan :: timeSpansToInsert
       timeSpan
     }

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -103,7 +103,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
     var timeSpansToUpdate: List[(TimeSpan, Long)] = List()
 
     def createNewTimeSpan(timestamp: Long, _user: ObjectId, annotation: Option[Annotation]) = {
-      val timeSpan = TimeSpan.createFrom(timestamp, timestamp, _user, annotation.map(_._id))
+      val timeSpan = TimeSpan.fromTimestamp(timestamp, timestamp, _user, annotation.map(_._id))
       timeSpansToInsert = timeSpan :: timeSpansToInsert
       timeSpan
     }

--- a/app/oxalis/security/WebknossosBearerTokenAuthenticatorService.scala
+++ b/app/oxalis/security/WebknossosBearerTokenAuthenticatorService.scala
@@ -71,7 +71,7 @@ class WebknossosBearerTokenAuthenticatorService(settings: BearerTokenAuthenticat
     for {
       tokenAuthenticator <- repository.findOneByValue(tokenValue) ?~> "auth.invalidToken"
       _ <- bool2Fox(tokenAuthenticator.isValid) ?~> "auth.invalidToken"
-      idValidated <- ObjectId.parse(tokenAuthenticator.loginInfo.providerKey) ?~> "auth.invalidToken"
+      idValidated <- ObjectId.fromString(tokenAuthenticator.loginInfo.providerKey) ?~> "auth.invalidToken"
       user <- userService.findOneById(idValidated, useCache = true)
     } yield user
 

--- a/app/utils/SQLHelpers.scala
+++ b/app/utils/SQLHelpers.scala
@@ -32,14 +32,14 @@ case class ObjectId(id: String) {
 object ObjectId extends FoxImplicits {
   implicit val jsonFormat: OFormat[ObjectId] = Json.format[ObjectId]
   def generate: ObjectId = fromBsonId(BSONObjectID.generate)
-  def parse(input: String)(implicit ec: ExecutionContext): Fox[ObjectId] =
-    parseSync(input).toFox ?~> s"The passed resource id ‘$input’ is invalid"
+  def fromString(input: String)(implicit ec: ExecutionContext): Fox[ObjectId] =
+    fromStringSync(input).toFox ?~> s"The passed resource id ‘$input’ is invalid"
   private def fromBsonId(bson: BSONObjectID) = ObjectId(bson.stringify)
-  private def parseSync(input: String) = BSONObjectID.parse(input).map(fromBsonId).toOption
+  private def fromStringSync(input: String) = BSONObjectID.parse(input).map(fromBsonId).toOption
   def dummyId: ObjectId = ObjectId("dummyObjectId")
 
   def stringObjectIdReads(key: String): Reads[String] =
-    Reads.filter[String](JsonValidationError("bsonid.invalid", key))(parseSync(_).isDefined)
+    Reads.filter[String](JsonValidationError("bsonid.invalid", key))(fromStringSync(_).isDefined)
 }
 
 trait SQLTypeImplicits {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/ParsedMappingCache.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/ParsedMappingCache.scala
@@ -18,7 +18,7 @@ case class CachedMapping(
 
 object CachedMapping {
 
-  def from(mappingRequest: DataServiceMappingRequest): CachedMapping =
+  def fromMappingRequest(mappingRequest: DataServiceMappingRequest): CachedMapping =
     storage.CachedMapping(mappingRequest.dataSource.id.team,
                           mappingRequest.dataSource.id.name,
                           mappingRequest.dataLayer.name,
@@ -32,7 +32,7 @@ class ParsedMappingCache(val maxEntries: Int)
   def withCache[T](mappingRequest: DataServiceMappingRequest)(
       loadFn: DataServiceMappingRequest => Fox[AbstractDataLayerMapping])(f: AbstractDataLayerMapping => T): Fox[T] = {
 
-    val cachedMappingInfo = CachedMapping.from(mappingRequest)
+    val cachedMappingInfo = CachedMapping.fromMappingRequest(mappingRequest)
 
     def handleUncachedMapping() = {
       val mappingFox = loadFn(mappingRequest).futureBox.map {


### PR DESCRIPTION
As discussed in  #6241, the naming scheme for dataclass custom constructors should be fromX(). This convention was already largely used since  #6249 and #6195 – this PR replaces the remaining few instances.

### Steps to test:
- CI should be enough, I only used IDE search + replace (except for Timespan, please read that one)

### Issues:
- fixes #6241

------
- [x] Needs datastore update after deployment
- [x] Ready for review
