### PR TITLE
Remember the forcefully disabled tool and reenable it if possible

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - The owner of an annotation can allow other users, who may see the annotation, to also edit it. Note that parallel writes are not supported and would lead to conflicts. [#6236](https://github.com/scalableminds/webknossos/pull/6236)
+- WebKnossos now remembers the tool that was active in between enabling and disabling the segmentation layer. [#6362](https://github.com/scalableminds/webknossos/pull/6362)
 - Segmentation layers which were not previously editable now show an (un)lock icon button which shortcuts to the Add Volume Layer modal with the layer being preselected. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 - The NML file in volume annotation download now includes segment metadata like names and anchor positions. [#6347](https://github.com/scalableminds/webknossos/pull/6347)
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - The owner of an annotation can allow other users, who may see the annotation, to also edit it. Note that parallel writes are not supported and would lead to conflicts. [#6236](https://github.com/scalableminds/webknossos/pull/6236)
-- WebKnossos now remembers the tool that was active in between enabling and disabling the segmentation layer. [#6362](https://github.com/scalableminds/webknossos/pull/6362)
+- WebKnossos now remembers the tool that was active in between disabling and enabling the segmentation layer. [#6362](https://github.com/scalableminds/webknossos/pull/6362)
 - Segmentation layers which were not previously editable now show an (un)lock icon button which shortcuts to the Add Volume Layer modal with the layer being preselected. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 - The NML file in volume annotation download now includes segment metadata like names and anchor positions. [#6347](https://github.com/scalableminds/webknossos/pull/6347)
 

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -563,7 +563,7 @@ export default function ToolbarView() {
       // Forget the last disabled tool as another tool besides the move tool was selected.
       setLastForcefulDisabledTool(null);
     }
-  }, [activeTool, disabledInfoForCurrentTool]);
+  }, [activeTool, disabledInfoForCurrentTool, lastForcefulDisabledTool]);
   const isShiftPressed = useKeyPress("Shift");
   const isControlPressed = useKeyPress("Control");
   const isAltPressed = useKeyPress("Alt");

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -515,6 +515,9 @@ export default function ToolbarView() {
     const visibleSegmentationLayer = getVisibleSegmentationLayer(state);
     return (visibleSegmentationLayer?.agglomerates?.length ?? 0) > 0;
   });
+  const [lastForcefulDisabledTool, setLastForcefulDisabledTool] = useState<AnnotationTool | null>(
+    null,
+  );
   const isVolumeModificationAllowed = useSelector(
     (state: OxalisState) => !hasEditableMapping(state),
   );
@@ -546,7 +549,19 @@ export default function ToolbarView() {
   const disabledInfoForCurrentTool = disabledInfosForTools[activeTool];
   useEffect(() => {
     if (disabledInfoForCurrentTool.isDisabled) {
+      setLastForcefulDisabledTool(activeTool);
       Store.dispatch(setToolAction(AnnotationToolEnum.MOVE));
+    } else if (
+      lastForcefulDisabledTool != null &&
+      !disabledInfosForTools[lastForcefulDisabledTool].isDisabled &&
+      activeTool === AnnotationToolEnum.MOVE
+    ) {
+      // Reenable the tool that was disabled before.
+      setLastForcefulDisabledTool(null);
+      Store.dispatch(setToolAction(lastForcefulDisabledTool));
+    } else if (activeTool !== AnnotationToolEnum.MOVE) {
+      // Forget the last disabled tool as another tool besides the move tool was selected.
+      setLastForcefulDisabledTool(null);
     }
   }, [activeTool, disabledInfoForCurrentTool]);
   const isShiftPressed = useKeyPress("Shift");


### PR DESCRIPTION
This PR tackles the problem described in #6293. When shortly disabling the segmentation layer via shortcut `3` to only see the color data the volume tool was deselected. The user then had to manually reselect the previous volume tool. To speed up annotating, the forcefully disabled tool is now remembered and reselected again if it is no longer disabled and no other tool has been selected after this tool was disabled.

### URL of deployed dev instance (used for testing):
- https://rememberactivetool.webknossos.xyz

### Steps to test:
- Open an annotation with a segmentation layer.
- Select the brush tool and hit `3` on the keyboard to disable the segmentation layer.
- The move tool should now be selected as the brush is disabled.
- Hit `3` again and the brush tool should now be automatically selected.
- Do the same for the other volume tools. This should also work.
- Now select the brush tool, hit `3`, and then select the skeleton tool. Hitting `3` again should not select the brush tool.
-  At last, select the brush tool, hit `3`, select the skeleton tool, and then select the move tool again. Hitting `3` again should not select the brush tool as the user intentionally changed the tools in between disabling and enabling the segmentation layer.

### Issues:
- fixes #6293

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
