### PR TITLE
Initialize volume layer name with fallback segmentation name

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The sharing modal now automatically saves changes of the sharing options. [#6314](https://github.com/scalableminds/webknossos/pull/6314)
 - The Layers tab now displays an Add Skeleton Annotation Layer button with which volume-only annotations can be converted to hybrid annotations. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 - The Zarr directory listings no longer include the current directory “.”. [6359](https://github.com/scalableminds/webknossos/pull/6359)
+- The default name for volume annotation layers with fallback segmentations is now set to the name of their fallback segmentation layer, no longer “Volume”. [#6373](https://github.com/scalableminds/webknossos/pull/6373)
 
 ### Fixed
 - Fixed a regression where the mapping activation confirmation dialog was never shown. [#6346](https://github.com/scalableminds/webknossos/pull/6346)

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -791,7 +791,7 @@ export function createExplorational(
     layers = [
       {
         typ: "Volume",
-        name: "Volume",
+        name: fallbackLayerName || "Volume",
         fallbackLayerName,
         resolutionRestrictions,
       }, // { typ: "Volume", name: "Volume 2" },
@@ -804,7 +804,7 @@ export function createExplorational(
       },
       {
         typ: "Volume",
-        name: "Volume",
+        name: fallbackLayerName || "Volume",
         fallbackLayerName,
         resolutionRestrictions,
       }, // { typ: "Volume", name: "Volume 2" },

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -794,7 +794,7 @@ export function createExplorational(
         name: fallbackLayerName || "Volume",
         fallbackLayerName,
         resolutionRestrictions,
-      }, // { typ: "Volume", name: "Volume 2" },
+      },
     ];
   } else {
     layers = [
@@ -807,7 +807,7 @@ export function createExplorational(
         name: fallbackLayerName || "Volume",
         fallbackLayerName,
         resolutionRestrictions,
-      }, // { typ: "Volume", name: "Volume 2" },
+      },
     ];
   }
 

--- a/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
@@ -102,6 +102,9 @@ export default function AddVolumeLayerModal({
     [dataset, tracing],
   );
   const initialNewLayerName = useMemo(() => {
+    if (preselectedLayerName) {
+      return preselectedLayerName;
+    }
     if (allReadableLayerNames.indexOf("Volume") === -1) {
       return "Volume";
     } else {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://keepsegmentationlayername.webknossos.xyz

### Steps to test:
- Create annotation via dashboard for dataset with segmentation layer, volume layer should have its name
- create skeleton-only annotation, in left sidebar turn segmentation layer into volume annotation, name in modal should be initialized with segmentation layer name 

### Issues:
- fixes #6238 

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
