### PR TITLE
fix closing of annotation share modal

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -165,7 +165,6 @@ function _ShareModalView(props: Props) {
       return;
     }
     const fetchedSharedTeams = await getTeamsForSharedAnnotation(annotationType, annotationId);
-    console.log("fetchedSharedTeams", fetchedSharedTeams);
     setSharedTeams(fetchedSharedTeams);
   };
 
@@ -310,6 +309,7 @@ function _ShareModalView(props: Props) {
       visible={isVisible}
       width={800}
       onOk={onOk}
+      onCancel={onOk}
       cancelButtonProps={{ style: { display: "none" } }}
     >
       <Row>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://sharemodalclose.webknossos.xyz

### Steps to test:
- close annotation share modal with X or ESC

### Issues:
- fixes #6365 

---
- [x] Ready for review
