### PR TITLE
Show reload layer button only to those with permission

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The Layers tab now displays an Add Skeleton Annotation Layer button with which volume-only annotations can be converted to hybrid annotations. [#6330](https://github.com/scalableminds/webknossos/pull/6330)
 - The Zarr directory listings no longer include the current directory “.”. [6359](https://github.com/scalableminds/webknossos/pull/6359)
 - The default name for volume annotation layers with fallback segmentations is now set to the name of their fallback segmentation layer, no longer “Volume”. [#6373](https://github.com/scalableminds/webknossos/pull/6373)
+- The “reload data” button for dataset and annotation layers is now only shown to users who have administrative permissions for the dataset (because the button clears server caches and file handles). [#6380](https://github.com/scalableminds/webknossos/pull/6380)
 
 ### Fixed
 - Fixed a regression where the mapping activation confirmation dialog was never shown. [#6346](https://github.com/scalableminds/webknossos/pull/6346)

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -181,6 +181,9 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
   };
 
   getReloadDataButton = (layerName: string) => {
+    if (!this.props.dataset.isEditable) {
+      return null;
+    }
     const tooltipText =
       "Reload the data from the server. Use this when the data on the server changed.";
     return (


### PR DESCRIPTION
The “reload data” button for dataset and annotation layers is now only shown to users who have administrative permissions for the dataset (because the button clears server caches and file handles).

### URL of deployed dev instance (used for testing):
- https://hidereloadlayerbutton.webknossos.xyz

### Steps to test:
- Register as second user, then as admin activate that user
- share a dataset with their team
- as that user, open the dataset. Layer tab should not feature reload buttons
- as admin/dataset manager/team manager of datast teams, you should still see the reload buttons. 

### Issues:
- fixes #5734

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
