### PR TITLE
Fix cors headers for datastore+tracingstore buildinfo

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
@@ -1,18 +1,22 @@
 package com.scalableminds.webknossos.datastore.controllers
 
+import com.scalableminds.util.tools.Fox
+
 import javax.inject.Inject
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 
-class StandaloneDatastore @Inject()() extends Controller {
+import scala.concurrent.ExecutionContext
+
+class StandaloneDatastore @Inject()(implicit ec: ExecutionContext) extends Controller {
 
   override def allowRemoteOrigin: Boolean = true
 
-  def buildInfo: Action[AnyContent] = Action {
-    Ok(
-      Json.obj(
+  def buildInfo: Action[AnyContent] = Action.async { implicit request =>
+    Fox.successful(
+      Ok(Json.obj(
         "webknossosDatastore" -> webknossosDatastore.BuildInfo.toMap.mapValues(_.toString),
         "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString)
-      ))
+      )))
   }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/StandaloneTracingstore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/StandaloneTracingstore.scala
@@ -1,14 +1,24 @@
 package com.scalableminds.webknossos.tracingstore.controllers
 
+import com.scalableminds.util.tools.Fox
+import com.scalableminds.webknossos.datastore.controllers.Controller
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, InjectedController}
+import play.api.mvc.{Action, AnyContent}
 
-class StandaloneTracingstore extends InjectedController {
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
 
-  def buildInfo: Action[AnyContent] = Action {
-    Ok(
-      Json.obj(
-        "webknossosTracingstore" -> webknossosTracingstore.BuildInfo.toMap.mapValues(_.toString)
-      ))
+class StandaloneTracingstore @Inject()(implicit ec: ExecutionContext) extends Controller {
+
+  override def allowRemoteOrigin: Boolean = true
+
+  def buildInfo: Action[AnyContent] = Action.async { implicit request =>
+    Fox.successful(
+      Ok(
+        Json.obj(
+          "webknossosTracingstore" -> webknossosTracingstore.BuildInfo.toMap.mapValues(_.toString)
+        )
+      )
+    )
   }
 }


### PR DESCRIPTION
The allowRemoteOrigin = true in controllers unfortunately does not have an effect for actions that do not use the implicit conversion from Box[Result] to Result. We have only very few of them, but the standalone datastore buildinfo request was one of them. I changed that in this PR, and also added the same to the standalone tracingstore buildinfo.

I don’t currently have a good idea for how to make this less implicit, but this should at least lead to fewer errors

### Steps to test:
- Start a standalone datastore with `sbt "webknossosDatastore/run 9090 -Dconfig.file=webknossos-datastore/conf/standalone-datastore.conf"`
- Go to localhost:9090/api/buildinfo and monitor in network tab that response headers include `Access-Control-Allow-Origin: *`

---
- [x] Needs datastore update after deployment
- [x] Ready for review
