### PR TITLE
Swagger Annotations: remove None defaults for non-required endpoints

### DIFF
--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -143,30 +143,24 @@ class DataSetController @Inject()(userService: UserService,
     Array(new ApiResponse(code = 200, message = "JSON list containing one object per resulting dataset."),
           new ApiResponse(code = 400, message = badRequestLabel)))
   def list(
-      @ApiParam(value = "Optional filtering: If true, list only active datasets, if false, list only inactive datasets",
-                defaultValue = "None")
+      @ApiParam(value = "Optional filtering: If true, list only active datasets, if false, list only inactive datasets")
       isActive: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only unreported datasets (a.k.a. no longer available on the datastore), if false, list only reported datasets",
-        defaultValue = "None"
+          "Optional filtering: If true, list only unreported datasets (a.k.a. no longer available on the datastore), if false, list only reported datasets"
       )
       isUnreported: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only datasets the requesting user is allowed to edit, if false, list only datasets the requesting user is not allowed to edit",
-        defaultValue = "None"
+          "Optional filtering: If true, list only datasets the requesting user is allowed to edit, if false, list only datasets the requesting user is not allowed to edit"
       )
       isEditable: Option[Boolean],
-      @ApiParam(value = "Optional filtering: List only datasets of the organization specified by its url-safe name",
-                defaultValue = "None",
+      @ApiParam(value = "Optional filtering: List only datasets of the organization specified by its url-safe name"
                 example = "sample_organization")
       organizationName: Option[String],
-      @ApiParam(value = "Optional filtering: List only datasets of the requesting user’s organization",
-                defaultValue = "None")
+      @ApiParam(value = "Optional filtering: List only datasets of the requesting user’s organization")
       onlyMyOrganization: Option[Boolean],
-      @ApiParam(value = "Optional filtering: List only datasets uploaded by the user with this id",
-                defaultValue = "None")
+      @ApiParam(value = "Optional filtering: List only datasets uploaded by the user with this id")
       uploaderId: Option[String]
   ): Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     UsingFilters(

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -147,15 +147,13 @@ class DataSetController @Inject()(userService: UserService,
       isActive: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only unreported datasets (a.k.a. no longer available on the datastore), if false, list only reported datasets"
-      )
+          "Optional filtering: If true, list only unreported datasets (a.k.a. no longer available on the datastore), if false, list only reported datasets")
       isUnreported: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only datasets the requesting user is allowed to edit, if false, list only datasets the requesting user is not allowed to edit"
-      )
+          "Optional filtering: If true, list only datasets the requesting user is allowed to edit, if false, list only datasets the requesting user is not allowed to edit")
       isEditable: Option[Boolean],
-      @ApiParam(value = "Optional filtering: List only datasets of the organization specified by its url-safe name"
+      @ApiParam(value = "Optional filtering: List only datasets of the organization specified by its url-safe name",
                 example = "sample_organization")
       organizationName: Option[String],
       @ApiParam(value = "Optional filtering: List only datasets of the requesting user’s organization")

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -243,18 +243,15 @@ class UserController @Inject()(userService: UserService,
   def list(
       @ApiParam(
         value =
-          "Optional filtering: If true, list only users the requesting user is allowed to administrate, if false, list only datasets the requesting user is not allowed to administrate"
-      )
+          "Optional filtering: If true, list only users the requesting user is allowed to administrate, if false, list only datasets the requesting user is not allowed to administrate")
       isEditable: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only users who are team manager or admin, if false, list only users who are neither team manager nor admin"
-      )
+          "Optional filtering: If true, list only users who are team manager or admin, if false, list only users who are neither team manager nor admin")
       isTeamManagerOrAdmin: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only users who are admin, if false, list only users who are not admin"
-      )
+          "Optional filtering: If true, list only users who are admin, if false, list only users who are not admin")
       isAdmin: Option[Boolean]
   ): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     UsingFilters(

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -243,20 +243,18 @@ class UserController @Inject()(userService: UserService,
   def list(
       @ApiParam(
         value =
-          "Optional filtering: If true, list only users the requesting user is allowed to administrate, if false, list only datasets the requesting user is not allowed to administrate",
-        defaultValue = "None"
+          "Optional filtering: If true, list only users the requesting user is allowed to administrate, if false, list only datasets the requesting user is not allowed to administrate"
       )
       isEditable: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only users who are team manager or admin, if false, list only users who are neither team manager nor admin",
-        defaultValue = "None"
+          "Optional filtering: If true, list only users who are team manager or admin, if false, list only users who are neither team manager nor admin"
       )
       isTeamManagerOrAdmin: Option[Boolean],
       @ApiParam(
         value =
-          "Optional filtering: If true, list only users who are admin, if false, list only users who are not admin",
-        defaultValue = "None")
+          "Optional filtering: If true, list only users who are admin, if false, list only users who are not admin"
+      )
       isAdmin: Option[Boolean]
   ): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     UsingFilters(


### PR DESCRIPTION
This removes the "None" string defaults from where the parameters are not required. This affects the routes "userList" and "datasetList".

This was already the case for most routes (see https://webknossos.org/swagger.json, searching for `"required": false`).

------
- [x] Ready for review
