### PR TITLE
zarr html directory listings: minor fix

### DIFF
--- a/webknossos-datastore/app/views/datastoreZarrDatasourceDir.scala.html
+++ b/webknossos-datastore/app/views/datastoreZarrDatasourceDir.scala.html
@@ -39,7 +39,7 @@
     <p>The following are the contents of the folder:</p>
     <ul>
       @folderContents.map { name =>
-        <li><a href="@name/">@name</a></li>
+        <li><a href="@name">@name</a></li>
       }
     </ul>
   </body>


### PR DESCRIPTION
This removes the trailing slash at the link, which invalidates the links to the metadata files. The other links still work fine both for the python client and manuyll.

------
- [x] Ready for review
