### PR TITLE
Fix rendering of uint8 and uint16 segmentations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,6 +39,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where uploads of wkw datasets with numerical-only layer names would fail. [#6382](https://github.com/scalableminds/webknossos/pull/6382)
 - Public datasets of other organizations are no longer listed during task creation. [#6377](https://github.com/scalableminds/webknossos/pull/6377)
 - Tightened organization isolation security for dataset uploads. [#6378](https://github.com/scalableminds/webknossos/pull/6378)
+- Fixed a regression which caused that uint16 and uint8 segmentations could not be rendered. [#6406](https://github.com/scalableminds/webknossos/pull/6406)
 
 ### Removed
 - Annotation Type was removed from the info tab. [#6330](https://github.com/scalableminds/webknossos/pull/6330)

--- a/frontend/javascripts/oxalis/shaders/segmentation.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/segmentation.glsl.ts
@@ -203,9 +203,9 @@ export const getSegmentationId: ShaderModule = {
       // a cell id with the hovered cell passed via uniforms, for example).
 
       <% if (packingDegreeLookup[segmentationName] === 4) { %>
-        volume_color[1] = vec4(volume_color.r, 0.0, 0.0, 0.0);
+        volume_color[1] = vec4(volume_color[1].r, 0.0, 0.0, 0.0);
       <% } else if (packingDegreeLookup[segmentationName] === 2) { %>
-        volume_color[1] = vec4(volume_color.r, volume_color.g, 0.0, 0.0);
+        volume_color[1] = vec4(volume_color[1].r, volume_color[1].g, 0.0, 0.0);
       <% } %>
 
       <% if (isMappingSupported) { %>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixuintandsegmentation.webknossos.xyz/

### Steps to test:
- open the dsA_2 dataset and check that is rendered
- you can compare https://fixuintandsegmentation.webknossos.xyz/datasets/sample_organization/dsA_2/view#1023,1024,64,0,1 with https://master.webknossos.xyz/datasets/sample_organization/dsA_2/view#1023,1024,64,0,1

### Issues:
- follow-up for https://github.com/scalableminds/webknossos/pull/6317

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
