### PR TITLE
Fixed "clip histogram" button not resetting in some cases

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,6 +41,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Tightened organization isolation security for dataset uploads. [#6378](https://github.com/scalableminds/webknossos/pull/6378)
 - Fixed a bug with undo/redo and volume interpolation/extrusion. [#6403](https://github.com/scalableminds/webknossos/pull/6403)
 - Fixed a regression which caused that uint16 and uint8 segmentations could not be rendered. [#6406](https://github.com/scalableminds/webknossos/pull/6406)
+- Fixed a bug with the clip histogram button to prevent it from showing a loading spinner forever in some cases. [#6407]
 
 ### Removed
 - Annotation Type was removed from the info tab. [#6330](https://github.com/scalableminds/webknossos/pull/6330)

--- a/frontend/javascripts/oxalis/model/sagas/clip_histogram_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/clip_histogram_saga.ts
@@ -98,6 +98,12 @@ async function clipHistogram(action: ClipHistogramAction) {
     Toast.warning(
       "The histogram could not be clipped, because the data did not contain any brightness values greater than 0.",
     );
+
+    // this is required to correctly reset the state of the AsyncButton initiating this action
+    if (action.callback != null) {
+      action.callback();
+    }
+
     return;
   }
 


### PR DESCRIPTION
This PR fix a small issue with an AsyncButton for clipping the histogram not resetting to it's "base"/cklickable state in some case but instead "loading"/"spinning" forever. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Move to an area with no data ("black")
- Click "clip histogram" button
- Oberserve that the button turns into a spinner and returns to its base state ready for clicking again

### Issues:
- fixes #6341

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
