### PR TITLE
Fix expanding the sidebar preventing hotkeys from working immediately

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,6 +41,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Tightened organization isolation security for dataset uploads. [#6378](https://github.com/scalableminds/webknossos/pull/6378)
 - Fixed a bug with undo/redo and volume interpolation/extrusion. [#6403](https://github.com/scalableminds/webknossos/pull/6403)
 - Fixed a regression which caused that uint16 and uint8 segmentations could not be rendered. [#6406](https://github.com/scalableminds/webknossos/pull/6406)
+- Fix a bug which prevent keyboard shortcuts from taking affect after expanding/collapsing the sidebar panels using the button icons.[#6410](https://github.com/scalableminds/webknossos/pull/6410) 
 
 ### Removed
 - Annotation Type was removed from the info tab. [#6330](https://github.com/scalableminds/webknossos/pull/6330)

--- a/frontend/javascripts/oxalis/view/components/border_toggle_button.tsx
+++ b/frontend/javascripts/oxalis/view/components/border_toggle_button.tsx
@@ -46,7 +46,9 @@ function BorderToggleButton(props: Props) {
         onClick={(event) => {
           if (event != null) {
             // @ts-expect-error ts-migrate(2339) FIXME: Property 'blur' does not exist on type 'EventTarge... Remove this comment to see the full error message
-            event.target.blur();
+            event.target.blur(); // this will only blur the the wrapped icon <div> element
+            // @ts-expect-error ts-migrate(2339) FIXME: Property 'blur' does not exist on type 'EventTarge... Remove this comment to see the full error message
+            event.target.parentElement.blur(); // this will only blur the <button> element
           }
 
           onClick();


### PR DESCRIPTION
This PR fixes a bug whereby expanding/collpasing the sidebar using the little icon buttons would make the main XYZ viewports lose focs/not respond to keyboard inputs anymore. Instead of having to click in the viewport to restore focs and continue using the keyboard hotkeys this now should work without any addtional click/refocusing.

Techical details:
- It seems to me that the first `blur()` call only every blurred the <div> element of the icon itself. For some reasons, the surround button element still retained focus/control. By also calling `blur()`onthe parent button element the issue resolved itself.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Expand/Collapse sidebar via button
- Press any hotkey, e.g. f or SPACE, and observe that the intended behavior, e.g. movement, occurs

### Issues:
- fixes #5827

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
