### PR TITLE
If Layer BoundingBoxes intersect, Use Intersection Center for all Layer Thumbnails

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The default name for volume annotation layers with fallback segmentations is now set to the name of their fallback segmentation layer, no longer “Volume”. [#6373](https://github.com/scalableminds/webknossos/pull/6373)
 - The “reload data” button for dataset and annotation layers is now only shown to users who have administrative permissions for the dataset (because the button clears server caches and file handles). [#6380](https://github.com/scalableminds/webknossos/pull/6380)
 - Requests for missing chunks in zarr datasets now return status code 404 instead of 200 with an empty response. [#6381](https://github.com/scalableminds/webknossos/pull/6381)
+- Dataset layer thumbnails now by default show the center of the intersection of all layer bounding boxes, so all layer thumbnails show the same region. [6411](https://github.com/scalableminds/webknossos/pull/6411)
 
 ### Fixed
 - Fixed a regression where the mapping activation confirmation dialog was never shown. [#6346](https://github.com/scalableminds/webknossos/pull/6346)

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -93,7 +93,12 @@ class DataSetController @Inject()(userService: UserService,
             dataSetService
               .clientFor(dataSet)(GlobalAccessContext)
               .flatMap(
-                _.requestDataLayerThumbnail(organizationName, dataLayerName, width, height, configuredZoomOpt, centerOpt))
+                _.requestDataLayerThumbnail(organizationName,
+                                            dataLayerName,
+                                            width,
+                                            height,
+                                            configuredZoomOpt,
+                                            centerOpt))
               .map { result =>
                 // We don't want all images to expire at the same time. Therefore, we add some random variation
                 dataSetService.thumbnailCache.insert(

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -2,10 +2,12 @@ package controllers
 
 import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
-import com.scalableminds.util.geometry.Vec3Int
+import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.util.mvc.Filter
 import com.scalableminds.util.tools.{Fox, JsonHelper, Math}
+import com.scalableminds.webknossos.datastore.models.datasource.{DataLayerLike, GenericDataSource}
 import io.swagger.annotations._
+
 import javax.inject.Inject
 import models.analytics.{AnalyticsService, ChangeDatasetSettingsEvent, OpenDatasetEvent}
 import models.binary._
@@ -74,7 +76,7 @@ class DataSetController @Inject()(userService: UserService,
                 w: Option[Int],
                 h: Option[Int]): Action[AnyContent] =
     sil.UserAwareAction.async { implicit request =>
-      def imageFromCacheIfPossible(dataSet: DataSet): Fox[Array[Byte]] = {
+      def imageFromCacheIfPossible(dataSet: DataSet, dataSource: GenericDataSource[DataLayerLike]): Fox[Array[Byte]] = {
         val width = Math.clamp(w.getOrElse(DefaultThumbnailWidth), 1, MaxThumbnailWidth)
         val height = Math.clamp(h.getOrElse(DefaultThumbnailHeight), 1, MaxThumbnailHeight)
         dataSetService.thumbnailCache.find(
@@ -82,19 +84,16 @@ class DataSetController @Inject()(userService: UserService,
           case Some(a) =>
             Fox.successful(a)
           case _ =>
-            val defaultCenterOpt = dataSet.adminViewConfiguration.flatMap(c =>
+            val configuredCenterOpt = dataSet.adminViewConfiguration.flatMap(c =>
               c.get("position").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Vec3Int])))
-            val defaultZoomOpt = dataSet.adminViewConfiguration.flatMap(c =>
+            val centerOpt = configuredCenterOpt.orElse(
+              BoundingBox.intersection(dataSource.dataLayers.map(_.boundingBox)).map(_.center))
+            val configuredZoomOpt = dataSet.adminViewConfiguration.flatMap(c =>
               c.get("zoom").flatMap(jsValue => JsonHelper.jsResultToOpt(jsValue.validate[Double])))
             dataSetService
               .clientFor(dataSet)(GlobalAccessContext)
               .flatMap(
-                _.requestDataLayerThumbnail(organizationName,
-                                            dataLayerName,
-                                            width,
-                                            height,
-                                            defaultZoomOpt,
-                                            defaultCenterOpt))
+                _.requestDataLayerThumbnail(organizationName, dataLayerName, width, height, configuredZoomOpt, centerOpt))
               .map { result =>
                 // We don't want all images to expire at the same time. Therefore, we add some random variation
                 dataSetService.thumbnailCache.insert(
@@ -110,10 +109,12 @@ class DataSetController @Inject()(userService: UserService,
       for {
         dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName) ?~> notFoundMessage(
           dataSetName) ~> NOT_FOUND
-        _ <- dataSetDataLayerDAO.findOneByNameForDataSet(dataLayerName, dataSet._id) ?~> Messages(
+        dataSource <- dataSetService.dataSourceFor(dataSet) ?~> "dataSource.notFound" ~> NOT_FOUND
+        usableDataSource <- dataSource.toUsable.toFox ?~> "dataSet.notImported"
+        _ <- bool2Fox(usableDataSource.dataLayers.exists(_.name == dataLayerName)) ?~> Messages(
           "dataLayer.notFound",
           dataLayerName) ~> NOT_FOUND
-        image <- imageFromCacheIfPossible(dataSet)
+        image <- imageFromCacheIfPossible(dataSet, usableDataSource)
       } yield {
         addRemoteOriginHeaders(Ok(image)).as(jpegMimeType).withHeaders(CACHE_CONTROL -> "public, max-age=86400")
       }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
@@ -38,7 +38,7 @@ package object datasource {
     val center: Vec3Int = boundingBox.center
 
     lazy val boundingBox: BoundingBox =
-      BoundingBox.combine(dataLayers.map(_.boundingBox))
+      BoundingBox.union(dataLayers.map(_.boundingBox))
   }
 
   object GenericDataSource {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
@@ -13,7 +13,7 @@ trait BoundingBoxMerger extends ProtoGeometryImplicits {
       boundinBoxB <- boundingBoxBOpt
     } yield {
       com.scalableminds.util.geometry.BoundingBox
-        .combine(List[com.scalableminds.util.geometry.BoundingBox](boundinBoxA, boundinBoxB))
+        .union(List[com.scalableminds.util.geometry.BoundingBox](boundinBoxA, boundinBoxB))
     }
 
   protected def combineUserBoundingBoxes(singleBoundingBoxAOpt: Option[ProtoBoundingBox],


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://thumbnailstablecenter.webknossos.xyz

### Steps to test:
- Set up a dataset with properties so that the layer bounding boxes are not equal
- Request thumbnails for these layers, i.e. `http://localhost:9000/api/datasets/sample_organization/dsA/layers/segmentation/thumbnail`, `http://localhost:9000/api/datasets/sample_organization/dsA/layers/color/thumbnail`
- The thumbnails should show the same region of the dataset

### Issues:
- fixes #6405 

------
- [x] Ready for review
