### PR TITLE
Small Zarr Fixes

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/BytesConverter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/BytesConverter.scala
@@ -38,17 +38,17 @@ object BytesConverter {
       case ZarrDataType.i8 | ZarrDataType.u8 =>
         val arrayTyped = array.asInstanceOf[Array[Long]]
         val byteBuffer = makeByteBuffer(arrayTyped.length * bytesPerElement, byteOrder)
-        byteBuffer.asLongBuffer().put(arrayTyped).array()
+        byteBuffer.asLongBuffer().put(arrayTyped)
         byteBuffer.array()
       case ZarrDataType.f4 =>
         val arrayTyped = array.asInstanceOf[Array[Float]]
         val byteBuffer = makeByteBuffer(arrayTyped.length * bytesPerElement, byteOrder)
-        byteBuffer.asFloatBuffer().put(arrayTyped).array()
+        byteBuffer.asFloatBuffer().put(arrayTyped)
         byteBuffer.array()
       case ZarrDataType.f8 =>
         val arrayTyped = array.asInstanceOf[Array[Double]]
         val byteBuffer = makeByteBuffer(arrayTyped.length * bytesPerElement, byteOrder)
-        byteBuffer.asDoubleBuffer().put(arrayTyped).array()
+        byteBuffer.asDoubleBuffer().put(arrayTyped)
         byteBuffer.array()
     }
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/jzarr/ZarrHeader.scala
@@ -9,6 +9,7 @@ import com.scalableminds.webknossos.datastore.jzarr.DimensionSeparator.Dimension
 import com.scalableminds.webknossos.datastore.jzarr.ZarrDataType.ZarrDataType
 import com.scalableminds.webknossos.datastore.models.datasource.{DataLayer, ElementClass}
 import net.liftweb.common.Box.tryo
+import play.api.libs.json.Json.WithDefaultValues
 import play.api.libs.json._
 
 case class ZarrHeader(
@@ -133,7 +134,7 @@ object ZarrHeader {
 
   implicit object ZarrHeaderFormat extends Format[ZarrHeader] {
     override def reads(json: JsValue): JsResult[ZarrHeader] =
-      Json.reads[ZarrHeader].reads(json)
+      Json.using[WithDefaultValues].reads[ZarrHeader].reads(json)
 
     override def writes(zarrHeader: ZarrHeader): JsValue =
       Json.obj(


### PR DESCRIPTION
While working on S3 without credentials, I noticed two other zarr bugs that this PR addresses
 - the `.array()` call in the bytes converter is superfluous (copy paste relic), and for float datasets throws exceptions.
 - .zarray files with missing values could not be correctly parsed, due to missing `WithDefaultValues`

### Steps to test:
- I tested that I could now loat a float zarr dataset
- I tested that reading remote zarr datasets with missing `dimension_separator` key in .zarray files works again

------
- [x] Needs datastore update after deployment
- [x] Ready for review
