### PR TITLE
Fix dataset access by sharing token

### DIFF
--- a/app/models/binary/DataSet.scala
+++ b/app/models/binary/DataSet.scala
@@ -112,14 +112,12 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
     }
 
   override def anonymousReadAccessQ(token: Option[String]): String =
-    "isPublic" + token
-      .map(
-        t =>
-          " or sharingToken = '$t' or _id in (select ans._dataset " +
-            "from webknossos.annotation_privateLinks_ apl " +
-            "join webknossos.annotations_ ans ON apl._annotation = ans._id " +
-            s"where apl.accessToken = '$t')")
-      .getOrElse("")
+    "isPublic" + token.map(t => s""" or sharingToken = '$t'
+               or _id in
+                 (select ans._dataset
+                 from webknossos.annotation_privateLinks_ apl
+                 join webknossos.annotations_ ans ON apl._annotation = ans._id
+                 where apl.accessToken = '$t')""").getOrElse("")
 
   override def readAccessQ(requestingUserId: ObjectId) =
     s"""isPublic


### PR DESCRIPTION
The first line of the access query was no longer an s-string, so the `'$t'` was no longer interpolated but instead included literally.

### Issues:
- fixes dataset access by sharing token

- [x] Ready for review
