### PR TITLE
Use sharing token from URL for sharing links if it exists

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -120,7 +120,7 @@ function requestUserToken(): Promise<string> {
   return tokenRequestPromise;
 }
 
-export function getSharingToken(): string | null | undefined {
+export function getSharingTokenFromUrlParameters(): string | null | undefined {
   if (location != null) {
     const params = Utils.getUrlParamsObject();
 
@@ -134,7 +134,7 @@ export function getSharingToken(): string | null | undefined {
 
 let tokenPromise: Promise<string>;
 export function doWithToken<T>(fn: (token: string) => Promise<T>, tries: number = 1): Promise<any> {
-  const sharingToken = getSharingToken();
+  const sharingToken = getSharingTokenFromUrlParameters();
 
   if (sharingToken != null) {
     return fn(sharingToken);

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -38,7 +38,7 @@ import {
   getAnnotationInformation,
   getEmptySandboxAnnotationInformation,
   getDataset,
-  getSharingToken,
+  getSharingTokenFromUrlParameters,
   getUserConfiguration,
   getDatasetViewConfiguration,
   getEditableMapping,
@@ -148,7 +148,7 @@ export async function initialize(
     annotation = await getEmptySandboxAnnotationInformation(
       datasetId,
       initialCommandType.tracingType,
-      getSharingToken(),
+      getSharingTokenFromUrlParameters(),
     );
   } else {
     const { name, owningOrganization } = initialCommandType;
@@ -169,7 +169,7 @@ export async function initialize(
   const initialDatasetSettings = await getDatasetViewConfiguration(
     dataset,
     serverVolumeTracingIds,
-    getSharingToken(),
+    getSharingTokenFromUrlParameters(),
   );
   const annotationSpecificDatasetSettings = applyAnnotationSpecificViewConfiguration(
     annotation,
@@ -230,7 +230,7 @@ async function fetchParallel(
   versions?: Versions,
 ): Promise<[APIDataset, UserConfiguration, Array<ServerTracing>]> {
   return Promise.all([
-    getDataset(datasetId, getSharingToken()),
+    getDataset(datasetId, getSharingTokenFromUrlParameters()),
     getUserConfiguration(), // Fetch the actual tracing from the datastore, if there is an skeletonAnnotation
     annotation ? getTracingsForAnnotation(annotation, versions) : [],
   ]);

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -16,6 +16,7 @@ import {
   editAnnotation,
   sendAnalyticsEvent,
   setOthersMayEditForAnnotation,
+  getSharingTokenFromUrlParameters,
 } from "admin/admin_rest_api";
 import TeamSelectionComponent from "dashboard/dataset/team_selection_component";
 import Toast from "libs/toast";
@@ -61,7 +62,17 @@ export function useDatasetSharingToken(dataset: APIDataset) {
   const activeUser = useSelector((state: OxalisState) => state.activeUser);
   const [datasetToken, setDatasetToken] = useState("");
 
-  const fetchAndSetToken = async () => {
+  const getAndSetToken = async () => {
+    // If the current URL contains a token, we can simply use
+    // that as a sharing token. Otherwise, users who are currently
+    // visiting a sharing URL might not be able to use the share button,
+    // because they might not have permissions to GET the dataset's
+    // sharing token.
+    const urlToken = getSharingTokenFromUrlParameters();
+    if (urlToken != null) {
+      setDatasetToken(urlToken);
+      return;
+    }
     try {
       const sharingToken = await getDatasetSharingToken(dataset, {
         doNotInvestigate: true,
@@ -76,7 +87,7 @@ export function useDatasetSharingToken(dataset: APIDataset) {
     if (!activeUser) {
       return;
     }
-    fetchAndSetToken();
+    getAndSetToken();
   }, [dataset, activeUser]);
   return datasetToken;
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a private dataset
- create a sharing link (A)
- open that link in an incognito window
- click the share button -> the copied url should contain the same token as in (A)

### Issues:
- see https://scm.slack.com/archives/C5AKLAV0B/p1660204300742279?thread_ts=1660202133.556449&cid=C5AKLAV0B

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
