### PR TITLE
Remove wrongly-typed field from Mailchimp tag response

### DIFF
--- a/app/oxalis/mail/MailchimpClient.scala
+++ b/app/oxalis/mail/MailchimpClient.scala
@@ -82,7 +82,7 @@ class MailchimpClient @Inject()(wkConf: WkConf, rpc: RPC, multiUserDAO: MultiUse
 }
 
 case class MailchimpTagsResponse(tags: List[MailchimpTagResponse])
-case class MailchimpTagResponse(id: String, name: String, date_added: String)
+case class MailchimpTagResponse(name: String, date_added: String)
 
 object MailchimpTagResponse {
   implicit val jsonFormat: OFormat[MailchimpTagResponse] = Json.format[MailchimpTagResponse]


### PR DESCRIPTION
The id field in mailchimp tag listing responses is not a string, but int. This lead to the response parsing failing :facepalm: We don’t even use the id.

This should fix the tagging for inactive/active users after the third week. (see MailchimpTicker.scala)

### Steps to test:
- I tested that the response can now be parsed and that the contains checks for existing tags works.

- [x] Ready for review
