### PR TITLE
In e2e tests, disable datastore filesystem watcher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,8 @@ services:
         "testOnly e2e.* --
           -Dtracingstore.fossildb.address=fossildb
           -Dtracingstore.redis.address=redis
-          -Ddatastore.redis.address=redis"
+          -Ddatastore.redis.address=redis
+          -Ddatastore.watchFileSystem.enabled=false"
     volumes:
       - ./binaryData/Connectomics department:/home/${USER_NAME:-sbt-user}/webknossos/binaryData/Organization_X
 


### PR DESCRIPTION
The snapshot tests use a custom mocked db content including datasets. Those were overwritten sometimes by the filesystem watching of the datastore. Additionally there was a race condition, as this watching happens in 1min intervals, asynchronous to the test’s reset-db task.

This PR passes an additional argument to the test runner, disabling this file system watcher entirely for the tests.

### Steps to test:
- I tested locally that even with `datastore.watchFileSystem.interval = 5 seconds` in the application.conf, the logging did not show file system scanning
- CI should pass

### Issues:
- fixes #6419

------
- [x] Ready for review
