### PR TITLE
Fix duplicate route for Editable Mapping annotations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed the duplicate function for annotations with an editable mapping (a.k.a. supervoxel proofreading) layer. [#6446](https://github.com/scalableminds/webknossos/pull/6446)
 
 ### Removed
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -180,23 +180,28 @@ class VolumeTracingController @Inject()(
                 boundingBox: Option[String]): Action[AnyContent] = Action.async { implicit request =>
     log() {
       logTime(slackNotificationService.noticeSlowRequest) {
-        accessTokenService.validateAccess(UserAccessRequest.webknossos, urlOrHeaderToken(token, request)) {
+        val userToken = urlOrHeaderToken(token, request)
+        accessTokenService.validateAccess(UserAccessRequest.webknossos, userToken) {
           for {
             tracing <- tracingService.find(tracingId) ?~> Messages("tracing.notFound")
-            _ <- bool2Fox(!tracing.getMappingIsEditable) ?~> "Duplicate is not yet implemented for editable mapping annotations"
             dataSetBoundingBox = request.body.asJson.flatMap(_.validateOpt[BoundingBox].asOpt.flatten)
             resolutionRestrictions = ResolutionRestrictions(minResolution, maxResolution)
             editPositionParsed <- Fox.runOptional(editPosition)(Vec3Int.fromUriLiteral)
             editRotationParsed <- Fox.runOptional(editRotation)(Vec3Double.fromUriLiteral)
             boundingBoxParsed <- Fox.runOptional(boundingBox)(BoundingBox.fromLiteral)
-            (newId, newTracing) <- tracingService.duplicate(tracingId,
-                                                            tracing,
-                                                            fromTask.getOrElse(false),
-                                                            dataSetBoundingBox,
-                                                            resolutionRestrictions,
-                                                            editPositionParsed,
-                                                            editRotationParsed,
-                                                            boundingBoxParsed)
+            newEditableMappingId <- Fox.runIf(tracing.mappingIsEditable.contains(true))(
+              editableMappingService.duplicate(tracing.mappingName, tracing, userToken))
+            (newId, newTracing) <- tracingService.duplicate(
+              tracingId,
+              tracing,
+              fromTask.getOrElse(false),
+              dataSetBoundingBox,
+              resolutionRestrictions,
+              editPositionParsed,
+              editRotationParsed,
+              boundingBoxParsed,
+              newEditableMappingId
+            )
             _ <- Fox.runIfOptionTrue(downsample)(tracingService.downsample(newId, newTracing))
           } yield Ok(Json.toJson(newId))
         }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
@@ -97,6 +97,7 @@ class EditableMappingService @Inject()(
         "mappingName" -> editableMappingId,
         "version" -> version,
         "tracingId" -> tracingId,
+        "baseMappingName" -> editableMapping.baseMappingName,
         "createdTimestamp" -> editableMapping.createdTimestamp
       )
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -273,7 +273,8 @@ class VolumeTracingService @Inject()(
                 resolutionRestrictions: ResolutionRestrictions,
                 editPosition: Option[Vec3Int],
                 editRotation: Option[Vec3Double],
-                boundingBox: Option[BoundingBox]): Fox[(String, VolumeTracing)] = {
+                boundingBox: Option[BoundingBox],
+                mappingName: Option[String]): Fox[(String, VolumeTracing)] = {
     val tracingWithBB = addBoundingBoxFromTaskIfRequired(sourceTracing, fromTask, dataSetBoundingBox)
     val tracingWithResolutionRestrictions = restrictMagList(tracingWithBB, resolutionRestrictions)
     val newTracing = tracingWithResolutionRestrictions.copy(
@@ -281,6 +282,7 @@ class VolumeTracingService @Inject()(
       editPosition = editPosition.map(vec3IntToProto).getOrElse(tracingWithResolutionRestrictions.editPosition),
       editRotation = editRotation.map(vec3DoubleToProto).getOrElse(tracingWithResolutionRestrictions.editRotation),
       boundingBox = boundingBoxOptToProto(boundingBox).getOrElse(tracingWithResolutionRestrictions.boundingBox),
+      mappingName = mappingName.orElse(tracingWithResolutionRestrictions.mappingName),
       version = 0
     )
     for {


### PR DESCRIPTION
- Include baseMappingName in the editable mapping info json so that it can be shown by the frontend
- Fix “duplicate”/“copy to my account” for annotations with an editable mapping volume layer

### URL of deployed dev instance (used for testing):
- https://editablemappingimprovements.webknossos.xyz

### Steps to test:
- Edit a mapping, select duplicate from menu
- Duplicated annotation should show the same edited state of the mapping, subsequent edits of the two annotations should not interfere with each other.

### Issues:
- contributes to #6288

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
