### PR TITLE
Use toMagLiteral convenience function for ZarrMag path default

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrDataLayers.scala
@@ -25,8 +25,7 @@ case class ZarrMag(mag: Vec3Int,
                    credentials: Option[FileSystemCredentials],
                    axisOrder: Option[AxisOrder]) {
 
-  lazy val pathWithFallback: String =
-    path.getOrElse(if (mag.isIsotropic) s"${mag.x}" else s"${mag.x}-${mag.y}-${mag.z}")
+  lazy val pathWithFallback: String = path.getOrElse(mag.toMagLiteral(allowScalar = true))
   private lazy val uri: URI = new URI(pathWithFallback)
   private lazy val isRemote: Boolean = FileSystemsHolder.isSupportedRemoteScheme(uri.getScheme)
   lazy val remoteSource: Option[RemoteSourceDescriptor] =


### PR DESCRIPTION
### Steps to test:
- Open a Zarr dataset with no explicit path
- Data should load

### Issues:
- fixes #6443

------
- [x] Needs datastore update after deployment
- [x] Ready for review
