### PR TITLE
[Blocked] adapt to hi-dpi screen

### DIFF
--- a/frontend/javascripts/oxalis/controller/renderer.ts
+++ b/frontend/javascripts/oxalis/controller/renderer.ts
@@ -22,6 +22,7 @@ function getRenderer() {
         })
       : {};
 
+  renderer.setPixelRatio(window.devicePixelRatio);
   return renderer;
 }
 

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/data_rendering_logic.tsx
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/data_rendering_logic.tsx
@@ -327,6 +327,7 @@ export function computeDataTexturesSetup<
 }
 export function getGpuFactorsWithLabels() {
   return [
+    ["15", "Ultra"],
     ["12", "Very High"],
     ["6", "High"],
     ["3", "Medium"],

--- a/frontend/javascripts/oxalis/view/rendering_utils.ts
+++ b/frontend/javascripts/oxalis/view/rendering_utils.ts
@@ -26,7 +26,7 @@ export const setupRenderArea = (
 ) => {
   // In WebGLRenderer.setViewport() and WebGLRenderer.setScissor()
   // (x, y) is the coordinate of the lower left corner of the rectangular region.
-  const overallHeight = renderer.domElement.height;
+  const overallHeight = renderer.domElement.height / 2;
   renderer.setViewport(x, overallHeight - y - viewportHeight, viewportWidth, viewportHeight);
   renderer.setScissor(x, overallHeight - y - viewportHeight, viewportWidth, viewportHeight);
   renderer.setScissorTest(true);


### PR DESCRIPTION
Blocked by too-thin lines, compare #4791

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### TODO
 - [ ] Make this opt-in (e.g. make the “Ultra“ settings in GPU Utilization menu “Ultra (hidpi)” (if available) and only use devicePixelRatio then)
 - [ ] CI – Cannot read properties of undefined (reading \'devicePixelRatio\')

### Steps to test:
- abc

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [ ] Ready for review
