### PR TITLE
Add placeholder text when task search table is empty

### DIFF
--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -193,6 +193,28 @@ class TaskListView extends React.PureComponent<Props, State> {
     );
   }
 
+  renderPlaceholder() {
+    return (
+      <>
+        <p>
+          There are no tasks in the current search. Select search criteria above or create new tasks
+          by clicking on the <strong>Add Task</strong> button.
+        </p>
+        <p>
+          To learn more about the task system in webKnossos,{" "}
+          <a
+            href="https://docs.webknossos.org/webknossos/tasks.html"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            check out the documentation
+          </a>
+          .
+        </p>
+      </>
+    );
+  }
+
   render() {
     const marginRight = {
       marginRight: 20,
@@ -293,6 +315,9 @@ class TaskListView extends React.PureComponent<Props, State> {
               marginBottom: 30,
             }}
             expandedRowRender={(task) => <TaskAnnotationView task={task} />}
+            locale={{
+              emptyText: this.renderPlaceholder(),
+            }}
           >
             <Column
               title="ID"

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -411,7 +411,7 @@ class DashboardTaskListView extends React.PureComponent<PropsWithRouter, State> 
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                checkout the documentation
+                check out the documentation
               </a>
               .
             </p>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://taskadminlistplaceholder.webknossos.xyz

### Steps to test:
- Open `/tasks`, table is empty, but should have explaining placeholder text.

### Issues:
- fixes #6025

------
- [x] Ready for review
