### PR TITLE
Link to dataset view mode from settings page

### DIFF
--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -17,7 +17,7 @@ import _ from "lodash";
 import moment from "moment";
 import { connect } from "react-redux";
 import type { RouteComponentProps } from "react-router-dom";
-import { withRouter } from "react-router-dom";
+import { withRouter, Link } from "react-router-dom";
 import { UnregisterCallback, Location as HistoryLocation, Action as HistoryAction } from "history";
 import type {
   APIDataSource,
@@ -785,7 +785,16 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
     const form = this.formRef.current;
 
     const { isUserAdmin } = this.props;
-    const titleString = this.props.isEditingMode ? "Update" : "Import";
+    const titleString = this.props.isEditingMode ? "Settings for" : "Import";
+    const datasetLinkOrName = this.props.isEditingMode ? (
+      <Link
+        to={`/datasets/${this.props.datasetId.owningOrganization}/${this.props.datasetId.name}`}
+      >
+        {this.props.datasetId.name}
+      </Link>
+    ) : (
+      this.props.datasetId.name
+    );
     const confirmString =
       this.props.isEditingMode ||
       (this.state.dataset != null && this.state.dataset.dataSource.status == null)
@@ -826,7 +835,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
           bordered={false}
           title={
             <h3>
-              {titleString} Dataset: {this.props.datasetId.name}
+              {titleString} Dataset {datasetLinkOrName}
             </h3>
           }
         >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1390035/189179562-34d2caee-35d3-4b82-b82d-4363ddaf9056.png)

### URL of deployed dev instance (used for testing):
- https://settingspageviewlink.webknossos.xyz

### Steps to test:
- Open settings page of imported dataset, should show link in title (like in screenshot)
- Open import page of not-yet imported dataset, should not show link

### Issues:
- fixes #5117 

------
- [x] Ready for review
