### PR TITLE
Fix isosurface loading for volume annotations with mappings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed sharing button for users who are currently visiting a dataset or annotation which was shared with them. [#6438](https://github.com/scalableminds/webknossos/pull/6438)
 - Fixed the duplicate function for annotations with an editable mapping (a.k.a. supervoxel proofreading) layer. [#6446](https://github.com/scalableminds/webknossos/pull/6446)
+- Fixed isosurface loading for volume annotations with mappings. [#6458](https://github.com/scalableminds/webknossos/pull/6458)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
@@ -1,16 +1,13 @@
 package com.scalableminds.webknossos.datastore.controllers
 
-import com.scalableminds.util.tools.Fox
-
-import javax.inject.Inject
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 
-import scala.concurrent.ExecutionContext
+import javax.inject.Inject
 
-class StandaloneDatastore @Inject()(implicit ec: ExecutionContext) extends Controller {
+class StandaloneDatastore @Inject()() extends Controller {
 
-  def buildInfo: Action[AnyContent] = Action { implicit request =>
+  def buildInfo: Action[AnyContent] = Action {
     addRemoteOriginHeaders(
       Ok(
         Json.obj(

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -14,7 +14,7 @@ import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class BinaryDataService(val dataBaseDir: Path, maxCacheSize: Int, val agglomerateService: AgglomerateService)
+class BinaryDataService(val dataBaseDir: Path, maxCacheSize: Int, val agglomerateServiceOpt: Option[AgglomerateService])
     extends FoxImplicits
     with DataSetDeleter
     with LazyLogging {
@@ -53,11 +53,13 @@ class BinaryDataService(val dataBaseDir: Path, maxCacheSize: Int, val agglomerat
       case (request, index) =>
         for {
           data <- handleDataRequest(request)
-          mappedData = convertIfNecessary(
-            request.settings.appliedAgglomerate.isDefined && request.dataLayer.category == Category.segmentation && request.cuboid.mag.maxDim <= MaxMagForAgglomerateMapping,
-            data,
-            agglomerateService.applyAgglomerate(request)
-          )
+          mappedData = agglomerateServiceOpt.map { agglomerateService =>
+            convertIfNecessary(
+              request.settings.appliedAgglomerate.isDefined && request.dataLayer.category == Category.segmentation && request.cuboid.mag.maxDim <= MaxMagForAgglomerateMapping,
+              data,
+              agglomerateService.applyAgglomerate(request)
+            )
+          }.getOrElse(data)
           resultData = convertIfNecessary(request.settings.halfByte, mappedData, convertToHalfByte)
         } yield (resultData, index)
     }
@@ -177,7 +179,8 @@ class BinaryDataService(val dataBaseDir: Path, maxCacheSize: Int, val agglomerat
       agglomerateKey.dataSetName == dataSetName && agglomerateKey.organizationName == organizationName && layerName
         .forall(_ == agglomerateKey.layerName)
 
-    val closedAgglomerateFileHandleCount = agglomerateService.agglomerateFileCache.clear(agglomerateFileMatchPredicate)
+    val closedAgglomerateFileHandleCount =
+      agglomerateServiceOpt.map(_.agglomerateFileCache.clear(agglomerateFileMatchPredicate)).getOrElse(0)
     val closedDataCubeHandleCount = cache.clear(dataCubeMatchPredicate)
     (closedAgglomerateFileHandleCount, closedDataCubeHandleCount)
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
@@ -16,6 +16,6 @@ class BinaryDataServiceHolder @Inject()(config: DataStoreConfig, agglomerateServ
 
   val binaryDataService = new BinaryDataService(Paths.get(config.Datastore.baseFolder),
                                                 config.Datastore.Cache.DataCube.maxEntries,
-                                                agglomerateService)
+                                                Some(agglomerateService))
 
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/StandaloneTracingstore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/StandaloneTracingstore.scala
@@ -5,11 +5,10 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
 
-class StandaloneTracingstore @Inject()(implicit ec: ExecutionContext) extends Controller {
+class StandaloneTracingstore @Inject()() extends Controller {
 
-  def buildInfo: Action[AnyContent] = Action { implicit request =>
+  def buildInfo: Action[AnyContent] = Action {
     addRemoteOriginHeaders(
       Ok(
         Json.obj(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
@@ -3,7 +3,6 @@ package com.scalableminds.webknossos.tracingstore.tracings.editablemapping
 import java.nio.file.Paths
 import java.util
 import java.util.UUID
-
 import com.google.inject.Inject
 import com.scalableminds.util.cache.AlfuFoxCache
 import com.scalableminds.util.geometry.Vec3Int
@@ -29,8 +28,8 @@ import com.scalableminds.webknossos.tracingstore.tracings.{
   VersionedKeyValuePair
 }
 import com.typesafe.scalalogging.LazyLogging
-import net.liftweb.common.Box.tryo
 import net.liftweb.common.{Box, Empty, Full}
+import net.liftweb.util.Helpers.tryo
 import org.jgrapht.alg.flow.PushRelabelMFImpl
 import org.jgrapht.graph.{DefaultWeightedEdge, SimpleWeightedGraph}
 import play.api.libs.json.{JsObject, JsValue, Json, OFormat}
@@ -103,7 +102,7 @@ class EditableMappingService @Inject()(
 
   private def generateId: String = UUID.randomUUID.toString
 
-  val binaryDataService = new BinaryDataService(Paths.get(""), 100, null)
+  val binaryDataService = new BinaryDataService(Paths.get(""), 100, None)
   isosurfaceServiceHolder.tracingStoreIsosurfaceConfig = (binaryDataService, 30 seconds, 1)
   val isosurfaceService: IsosurfaceService = isosurfaceServiceHolder.tracingStoreIsosurfaceService
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -74,7 +74,7 @@ class VolumeTracingService @Inject()(
 
   /* We want to reuse the bucket loading methods from binaryDataService for the volume tracings, however, it does not
      actually load anything from disk, unlike its “normal” instance in the datastore (only from the volume tracing store) */
-  val binaryDataService = new BinaryDataService(Paths.get(""), 100, null)
+  val binaryDataService = new BinaryDataService(Paths.get(""), 100, None)
 
   isosurfaceServiceHolder.tracingStoreIsosurfaceConfig = (binaryDataService, 30 seconds, 1)
   val isosurfaceService: IsosurfaceService = isosurfaceServiceHolder.tracingStoreIsosurfaceService
@@ -391,8 +391,8 @@ class VolumeTracingService @Inject()(
         request.segmentId,
         request.subsamplingStrides,
         request.scale,
-        request.mapping,
-        request.mappingType
+        None,
+        None
       )
       result <- isosurfaceService.requestIsosurfaceViaActor(isosurfaceRequest)
     } yield result


### PR DESCRIPTION
- Set mapping parameters to None in volume tracing service before passing request to Isosurface Service. This is the bugfix
- Refactoring: use `None` instead of `null` for mappingService
- remove some unused imports 

### Steps to test:
- Create volume annotation based on segmentation layer, activate a mapping. Request isosurface (e.g. through proofreading tool before first split/merge action). Should work and look right

---

- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
- [x] Ready for review
