### PR TITLE
Improve Proofreading: Add clear button for auxiliary skeletons/meshes & provide merge/split via context menu on voxel

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added a context menu option to extract the shortest path between two nodes as a new tree. Select the source node and open the context menu by right-clicking on another node in the same tree. [#6423](https://github.com/scalableminds/webknossos/pull/6423)
 - Added a context menu option to separate an agglomerate skeleton using Min-Cut. Activate the Proofreading tool, select the source node and open the context menu by right-clicking on the target node which you would like to separate through Min-Cut. [#6361](https://github.com/scalableminds/webknossos/pull/6361)
 - Added a "clear" button to reset skeletons/meshes after successful mergers/split. [#6459](https://github.com/scalableminds/webknossos/pull/6459)
+- The proofreading tool now supports merging and splitting (via min-cut) agglomerates by rightclicking a segment (and not a node). Note that there still has to be an active node so that both partners of the operation are defined. [#6464](https://github.com/scalableminds/webknossos/pull/6464)
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Zarr-based remote dataset import now also works for public AWS S3 endpoints with no credentials. [#6421](https://github.com/scalableminds/webknossos/pull/6421)
 - Added a context menu option to extract the shortest path between two nodes as a new tree. Select the source node and open the context menu by right-clicking on another node in the same tree. [#6423](https://github.com/scalableminds/webknossos/pull/6423)
 - Added a context menu option to separate an agglomerate skeleton using Min-Cut. Activate the Proofreading tool, select the source node and open the context menu by right-clicking on the target node which you would like to separate through Min-Cut. [#6361](https://github.com/scalableminds/webknossos/pull/6361)
+- Added a "clear" button to reset skeletons/meshes after successful mergers/split. [#6459](https://github.com/scalableminds/webknossos/pull/6459)
 
 ### Changed
 

--- a/frontend/javascripts/libs/toast.tsx
+++ b/frontend/javascripts/libs/toast.tsx
@@ -45,7 +45,8 @@ const Toast = {
     details: string | React.ReactNode | null,
   ) {
     if (!details) {
-      return title;
+      // This also handles empty title strings
+      return title || "Unknown Error";
     }
 
     return (

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -1546,12 +1546,12 @@ class DataApi {
     return (
       `${dataset.dataStore.url}/data/datasets/${dataset.owningOrganization}/${dataset.name}/layers/${layerName}/data?mag=${magString}&` +
       `token=${token}&` +
-      `x=${topLeft[0]}&` +
-      `y=${topLeft[1]}&` +
-      `z=${topLeft[2]}&` +
-      `width=${bottomRight[0] - topLeft[0]}&` +
-      `height=${bottomRight[1] - topLeft[1]}&` +
-      `depth=${bottomRight[2] - topLeft[2]}`
+      `x=${Math.floor(topLeft[0])}&` +
+      `y=${Math.floor(topLeft[1])}&` +
+      `z=${Math.floor(topLeft[2])}&` +
+      `width=${Math.floor(bottomRight[0] - topLeft[0])}&` +
+      `height=${Math.floor(bottomRight[1] - topLeft[1])}&` +
+      `depth=${Math.floor(bottomRight[2] - topLeft[2])}`
     );
   }
 

--- a/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
@@ -1,9 +1,9 @@
 import { Vector3 } from "oxalis/constants";
 
 export type ProofreadAtPositionAction = ReturnType<typeof proofreadAtPosition>;
-export type ClearProofReadingByProductsAction = ReturnType<typeof clearProofReadingByProducts>;
+export type ClearProofreadingByProductsAction = ReturnType<typeof clearProofreadingByProducts>;
 
-export type ProofreadAction = ProofreadAtPositionAction | ClearProofReadingByProductsAction;
+export type ProofreadAction = ProofreadAtPositionAction | ClearProofreadingByProductsAction;
 
 export const proofreadAtPosition = (position: Vector3) =>
   ({
@@ -11,7 +11,7 @@ export const proofreadAtPosition = (position: Vector3) =>
     position,
   } as const);
 
-export const clearProofReadingByProducts = () =>
+export const clearProofreadingByProducts = () =>
   ({
-    type: "CLEAR_PROOF_READING_BY_PRODUCTS",
+    type: "CLEAR_PROOFREADING_BY_PRODUCTS",
   } as const);

--- a/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
@@ -1,11 +1,17 @@
 import { Vector3 } from "oxalis/constants";
 
 export type ProofreadAtPositionAction = ReturnType<typeof proofreadAtPosition>;
+export type ClearProofReadingByProductsAction = ReturnType<typeof clearProofReadingByProducts>;
 
-export type ProofreadAction = ProofreadAtPositionAction;
+export type ProofreadAction = ProofreadAtPositionAction | ClearProofReadingByProductsAction;
 
 export const proofreadAtPosition = (position: Vector3) =>
   ({
     type: "PROOFREAD_AT_POSITION",
     position,
+  } as const);
+
+export const clearProofReadingByProducts = () =>
+  ({
+    type: "CLEAR_PROOF_READING_BY_PRODUCTS",
   } as const);

--- a/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
@@ -2,6 +2,11 @@ import { Vector3 } from "oxalis/constants";
 
 export type ProofreadAtPositionAction = ReturnType<typeof proofreadAtPosition>;
 export type ClearProofreadingByProductsAction = ReturnType<typeof clearProofreadingByProducts>;
+export type ProofreadMergeAction = ReturnType<typeof proofreadMerge>;
+export type MinCutAgglomerateAction = ReturnType<typeof minCutAgglomerateAction>;
+export type MinCutAgglomerateWithPositionAction = ReturnType<
+  typeof minCutAgglomerateWithPositionAction
+>;
 
 export type ProofreadAction = ProofreadAtPositionAction | ClearProofreadingByProductsAction;
 
@@ -14,4 +19,24 @@ export const proofreadAtPosition = (position: Vector3) =>
 export const clearProofreadingByProducts = () =>
   ({
     type: "CLEAR_PROOFREADING_BY_PRODUCTS",
+  } as const);
+
+export const proofreadMerge = (position: Vector3) =>
+  ({
+    type: "PROOFREAD_MERGE",
+    position,
+  } as const);
+
+export const minCutAgglomerateAction = (sourceNodeId: number, targetNodeId: number) =>
+  ({
+    type: "MIN_CUT_AGGLOMERATE",
+    sourceNodeId,
+    targetNodeId,
+  } as const);
+
+export const minCutAgglomerateWithPositionAction = (sourceNodeId: number, position: Vector3) =>
+  ({
+    type: "MIN_CUT_AGGLOMERATE_WITH_POSITION",
+    sourceNodeId,
+    position,
   } as const);

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
@@ -41,7 +41,6 @@ type DeselectActiveTreeAction = ReturnType<typeof deselectActiveTreeAction>;
 type SetActiveGroupAction = ReturnType<typeof setActiveGroupAction>;
 type DeselectActiveGroupAction = ReturnType<typeof deselectActiveGroupAction>;
 export type MergeTreesAction = ReturnType<typeof mergeTreesAction>;
-export type MinCutAgglomerateAction = ReturnType<typeof minCutAgglomerateAction>;
 type SetTreeNameAction = ReturnType<typeof setTreeNameAction>;
 type SelectNextTreeAction = ReturnType<typeof selectNextTreeAction>;
 type SetTreeColorIndexAction = ReturnType<typeof setTreeColorIndexAction>;
@@ -83,7 +82,6 @@ export type SkeletonTracingAction =
   | SetActiveTreeByNameAction
   | DeselectActiveTreeAction
   | MergeTreesAction
-  | MinCutAgglomerateAction
   | SetTreeNameAction
   | SelectNextTreeAction
   | SetTreeColorAction
@@ -197,11 +195,16 @@ export const deleteEdgeAction = (
     timestamp,
   } as const);
 
-export const setActiveNodeAction = (nodeId: number, suppressAnimation: boolean = false) =>
+export const setActiveNodeAction = (
+  nodeId: number,
+  suppressAnimation: boolean = false,
+  suppressCentering: boolean = false,
+) =>
   ({
     type: "SET_ACTIVE_NODE",
     nodeId,
     suppressAnimation,
+    suppressCentering,
   } as const);
 
 export const centerActiveNodeAction = (suppressAnimation: boolean = false) =>
@@ -264,17 +267,26 @@ export const createTreeAction = (timestamp: number = Date.now()) =>
 export const addTreesAndGroupsAction = (
   trees: MutableTreeMap,
   treeGroups: Array<TreeGroup> | null | undefined,
+  treeIdsCallback: ((ids: number[]) => void) | undefined = undefined,
 ) =>
   ({
     type: "ADD_TREES_AND_GROUPS",
     trees,
     treeGroups: treeGroups || [],
+    treeIdsCallback,
   } as const);
 
-export const deleteTreeAction = (treeId?: number) =>
+export const deleteTreeAction = (treeId?: number, suppressActivatingNextNode: boolean = false) =>
+  // If suppressActivatingNextNode is true, the tree will be deleted without activating
+  // another node (nor tree). Use this in cases where you want to avoid changing
+  // the active position (due to the auto-centering). One could also suppress the auto-centering
+  // behavior, but the semantics of changing the active node might also be confusing to the user
+  // (e.g., when proofreading). So, it might be clearer to not have an active node in the first
+  // place.
   ({
     type: "DELETE_TREE",
     treeId,
+    suppressActivatingNextNode,
   } as const);
 
 export const resetSkeletonTracingAction = () =>
@@ -348,13 +360,6 @@ export const deselectActiveGroupAction = () =>
 export const mergeTreesAction = (sourceNodeId: number, targetNodeId: number) =>
   ({
     type: "MERGE_TREES",
-    sourceNodeId,
-    targetNodeId,
-  } as const);
-
-export const minCutAgglomerateAction = (sourceNodeId: number, targetNodeId: number) =>
-  ({
-    type: "MIN_CUT_AGGLOMERATE",
     sourceNodeId,
     targetNodeId,
   } as const);

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.ts
@@ -81,18 +81,16 @@ export class NullBucket {
     return Promise.resolve();
   }
 }
+
+export type TypedArrayConstructor =
+  | Uint8ArrayConstructor
+  | Uint16ArrayConstructor
+  | Uint32ArrayConstructor
+  | Float32ArrayConstructor
+  | BigUint64ArrayConstructor;
 export const getConstructorForElementClass = (
   type: ElementClass,
-): [
-  (
-    | Uint8ArrayConstructor
-    | Uint16ArrayConstructor
-    | Uint32ArrayConstructor
-    | Float32ArrayConstructor
-    | BigUint64ArrayConstructor
-  ),
-  number,
-] => {
+): [TypedArrayConstructor, number] => {
   switch (type) {
     case "int8":
     case "uint8":

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
@@ -803,8 +803,11 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
           const { trees, treeGroups } = action;
           const treesWithNames = ensureTreeNames(state, trees);
           return addTreesAndGroups(skeletonTracing, treesWithNames, treeGroups)
-            .map(([updatedTrees, updatedTreeGroups, newMaxNodeId]) =>
-              update(state, {
+            .map(([updatedTrees, updatedTreeGroups, newMaxNodeId]) => {
+              if (action.treeIdsCallback) {
+                action.treeIdsCallback(Utils.values(updatedTrees).map((tree) => tree.treeId));
+              }
+              return update(state, {
                 tracing: {
                   skeleton: {
                     treeGroups: {
@@ -818,15 +821,15 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
                     },
                   },
                 },
-              }),
-            )
+              });
+            })
             .getOrElse(state);
         }
 
         case "DELETE_TREE": {
-          const { treeId } = action;
+          const { treeId, suppressActivatingNextNode } = action;
           return getTree(skeletonTracing, treeId)
-            .chain((tree) => deleteTree(skeletonTracing, tree))
+            .chain((tree) => deleteTree(skeletonTracing, tree, suppressActivatingNextNode))
             .map(([trees, newActiveTreeId, newActiveNodeId, newMaxNodeId]) =>
               update(state, {
                 tracing: {

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.ts
@@ -621,6 +621,7 @@ export function addTreesAndGroups(
 export function deleteTree(
   skeletonTracing: SkeletonTracing,
   tree: Tree,
+  suppressActivatingNextNode: boolean = false,
 ): Maybe<[TreeMap, number | null | undefined, number | null | undefined, number]> {
   // Delete tree
   const newTrees = _.omit(skeletonTracing.trees, tree.treeId);
@@ -628,7 +629,7 @@ export function deleteTree(
   let newActiveTreeId = null;
   let newActiveNodeId = null;
 
-  if (_.size(newTrees) > 0) {
+  if (_.size(newTrees) > 0 && !suppressActivatingNextNode) {
     // Setting the tree active whose id is the next highest compared to the id of the deleted tree.
     newActiveTreeId = getNearestTreeId(tree.treeId, newTrees);
     // @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -60,7 +60,7 @@ export default function* proofreadMapping(): Saga<any> {
     splitOrMergeOrMinCutAgglomerate,
   );
   yield* takeEvery(["PROOFREAD_AT_POSITION"], proofreadAtPosition);
-  yield* takeEvery(["CLEAR_PROOF_READING_BY_PRODUCTS"], clearProofReadingByProducts);
+  yield* takeEvery(["CLEAR_PROOFREADING_BY_PRODUCTS"], clearProofreadingByProducts);
 }
 
 function proofreadCoarseResolutionIndex(): number {
@@ -539,7 +539,7 @@ function* splitOrMergeOrMinCutAgglomerate(
   }
 }
 
-function* clearProofReadingByProducts() {
+function* clearProofreadingByProducts() {
   for (const treeId of loadedAgglomerateSkeletonIds) {
     yield* put(deleteTreeAction(treeId));
   }

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -9,25 +9,37 @@ import {
   deleteTreeAction,
   loadAgglomerateSkeletonAction,
   MergeTreesAction,
-  MinCutAgglomerateAction,
+  setActiveNodeAction,
   setTreeNameAction,
 } from "oxalis/model/actions/skeletontracing_actions";
 import {
   initializeEditableMappingAction,
   setMappingIsEditableAction,
 } from "oxalis/model/actions/volumetracing_actions";
-import type { ProofreadAtPositionAction } from "oxalis/model/actions/proofread_actions";
+import type {
+  MinCutAgglomerateAction,
+  MinCutAgglomerateWithPositionAction,
+  ProofreadAtPositionAction,
+  ProofreadMergeAction,
+} from "oxalis/model/actions/proofread_actions";
 import {
   enforceSkeletonTracing,
   findTreeByName,
   findTreeByNodeId,
+  getActiveNode,
+  getActiveTree,
+  getTree,
   getTreeNameForAgglomerateSkeleton,
 } from "oxalis/model/accessors/skeletontracing_accessor";
 import {
   pushSaveQueueTransaction,
   setVersionNumberAction,
 } from "oxalis/model/actions/save_actions";
-import { splitAgglomerate, mergeAgglomerate } from "oxalis/model/sagas/update_actions";
+import {
+  splitAgglomerate,
+  mergeAgglomerate,
+  UpdateAction,
+} from "oxalis/model/sagas/update_actions";
 import Model from "oxalis/model";
 import api from "oxalis/api/internal_api";
 import {
@@ -47,12 +59,12 @@ import { V3 } from "libs/mjs";
 import { removeIsosurfaceAction } from "oxalis/model/actions/annotation_actions";
 import { loadAgglomerateSkeletonWithId } from "oxalis/model/sagas/skeletontracing_saga";
 import { getConstructorForElementClass } from "oxalis/model/bucket_data_handling/bucket";
-import { Tree } from "oxalis/store";
+import { Tree, VolumeTracing } from "oxalis/store";
 import { APISegmentationLayer } from "types/api_flow_types";
 import { setBusyBlockingInfoAction } from "oxalis/model/actions/ui_actions";
 import _ from "lodash";
 
-export default function* proofreadMapping(): Saga<any> {
+export default function* proofreadRootSaga(): Saga<void> {
   yield* take("INITIALIZE_SKELETONTRACING");
   yield* take("WK_READY");
   yield* takeEvery(
@@ -60,7 +72,11 @@ export default function* proofreadMapping(): Saga<any> {
     splitOrMergeOrMinCutAgglomerate,
   );
   yield* takeEvery(["PROOFREAD_AT_POSITION"], proofreadAtPosition);
-  yield* takeEvery(["CLEAR_PROOFREADING_BY_PRODUCTS"], clearProofreadingByProducts);
+  yield* takeEvery(["CLEAR_PROOFREADING_BY_PRODUCTS"], clearProofreadingByproducts);
+  yield* takeEvery(
+    ["PROOFREAD_MERGE", "MIN_CUT_AGGLOMERATE_WITH_POSITION"],
+    handleProofreadMergeOrMinCut,
+  );
 }
 
 function proofreadCoarseResolutionIndex(): number {
@@ -127,7 +143,7 @@ function* proofreadAtPosition(action: ProofreadAtPositionAction): Saga<void> {
 
   /* Load agglomerate skeleton of the agglomerate at the click position */
 
-  const treeName = yield* call(
+  const treeNameAndId = yield* call(
     loadAgglomerateSkeletonWithId,
     loadAgglomerateSkeletonAction(layerName, volumeTracing.mappingName, segmentId),
   );
@@ -138,7 +154,8 @@ function* proofreadAtPosition(action: ProofreadAtPositionAction): Saga<void> {
 
   yield* call(loadCoarseAdHocMesh, layerName, segmentId, position);
 
-  if (treeName == null) return;
+  if (treeNameAndId == null) return;
+  const [treeName] = treeNameAndId;
 
   const skeletonTracing = yield* select((state) => enforceSkeletonTracing(state.tracing));
   const { trees } = skeletonTracing;
@@ -169,28 +186,15 @@ function* loadFineAdHocMeshesInProximity(
     (nodePosition) =>
       V3.scaledSquaredDist(nodePosition, position, scale) <= proximityDistanceSquared,
   );
-  const resolutionInfo = getResolutionInfo(volumeTracingLayer.resolutions);
-  const mag = resolutionInfo.getLowestResolution();
 
-  const fallbackLayerName = volumeTracingLayer.fallbackLayer;
-  if (fallbackLayerName == null) return;
+  const getUnmappedDataValue = yield* call(createGetUnmappedDataValueFn, volumeTracingLayer);
+  if (!getUnmappedDataValue) {
+    return;
+  }
 
   // Request unmapped segmentation ids
-  const segmentIdsArrayBuffers: ArrayBuffer[] = yield* all(
-    nodePositionsInProximity.map((nodePosition) =>
-      call(
-        [api.data, api.data.getRawDataCuboid],
-        fallbackLayerName,
-        nodePosition,
-        V3.add(nodePosition, mag),
-      ),
-    ),
-  );
-
-  const { elementClass } = yield* select((state) => getLayerByName(state.dataset, layerName));
-  const [TypedArrayClass] = getConstructorForElementClass(elementClass);
-  const segmentIdsInProximity = segmentIdsArrayBuffers.map((buffer) =>
-    Number(new TypedArrayClass(buffer)[0]),
+  const segmentIdsInProximity = yield* all(
+    nodePositionsInProximity.map((nodePosition) => call(getUnmappedDataValue, nodePosition)),
   );
 
   if (oldSegmentIdsInProximity != null) {
@@ -297,34 +301,16 @@ function* splitOrMergeOrMinCutAgglomerate(
     return;
   }
 
-  const layerName = volumeTracingId;
-  const isHdf5MappingEnabled = yield* call(ensureHdf5MappingIsEnabled, layerName);
-  if (!isHdf5MappingEnabled) return;
-
-  const busyBlockingInfo = yield* select((state) => state.uiInformation.busyBlockingInfo);
-  if (busyBlockingInfo.isBusy) {
-    console.warn(`Ignoring proofreading action (reason: ${busyBlockingInfo.reason || "null"})`);
+  const preparation = yield* call(
+    prepareSplitOrMerge,
+    volumeTracingId,
+    volumeTracing,
+    volumeTracingLayer,
+  );
+  if (!preparation) {
     return;
   }
-
-  yield* put(setBusyBlockingInfoAction(true, "Proofreading action"));
-
-  if (!volumeTracing.mappingIsEditable) {
-    try {
-      yield* call(createEditableMapping);
-    } catch (e) {
-      console.error(e);
-      yield* put(setBusyBlockingInfoAction(false));
-      return;
-    }
-  }
-
-  /* Find out the agglomerate IDs at the two node positions */
-
-  const resolutionInfo = getResolutionInfo(volumeTracingLayer.resolutions);
-  // The mag the agglomerate skeleton corresponds to should be the finest available mag of the volume tracing layer
-  const agglomerateFileMag = resolutionInfo.getLowestResolution();
-  const agglomerateFileZoomstep = resolutionInfo.getLowestResolutionIndex();
+  const { layerName, agglomerateFileMag, getDataValue } = preparation;
   const { sourceNodeId, targetNodeId } = action;
 
   const skeletonTracing = yield* select((state) => enforceSkeletonTracing(state.tracing));
@@ -340,35 +326,26 @@ function* splitOrMergeOrMinCutAgglomerate(
 
   const sourceNodePosition = sourceTree.nodes.get(sourceNodeId).position;
   const targetNodePosition = targetTree.nodes.get(targetNodeId).position;
-  const sourceNodeAgglomerateId = yield* call(
-    [api.data, api.data.getDataValue],
-    layerName,
-    sourceNodePosition,
-    agglomerateFileZoomstep,
-  );
-  const targetNodeAgglomerateId = yield* call(
-    [api.data, api.data.getDataValue],
-    layerName,
-    targetNodePosition,
-    agglomerateFileZoomstep,
-  );
 
-  const volumeTracingWithEditableMapping = yield* select((state) =>
-    getActiveSegmentationTracing(state),
+  const partnerInfos = yield* call(
+    getPartnerAgglomerateIds,
+    volumeTracingLayer,
+    getDataValue,
+    sourceNodePosition,
+    targetNodePosition,
   );
-  if (
-    volumeTracingWithEditableMapping == null ||
-    volumeTracingWithEditableMapping.mappingName == null
-  ) {
-    yield* put(setBusyBlockingInfoAction(false));
+  if (!partnerInfos) {
     return;
   }
+  const { sourceNodeAgglomerateId, targetNodeAgglomerateId, volumeTracingWithEditableMapping } =
+    partnerInfos;
+
   const editableMappingId = volumeTracingWithEditableMapping.mappingName;
 
   /* Send the respective split/merge update action to the backend (by pushing to the save queue
      and saving immediately) */
 
-  const items = [];
+  const items: UpdateAction[] = [];
   if (action.type === "MERGE_TREES") {
     if (sourceNodeAgglomerateId === targetNodeAgglomerateId) {
       Toast.error("Segments that should be merged need to be in different agglomerates.");
@@ -399,66 +376,21 @@ function* splitOrMergeOrMinCutAgglomerate(
       ),
     );
   } else if (action.type === "MIN_CUT_AGGLOMERATE") {
-    if (sourceNodeAgglomerateId !== targetNodeAgglomerateId) {
-      Toast.error("Segments need to be in the same agglomerate to perform a min-cut.");
-      yield* put(setBusyBlockingInfoAction(false));
+    const shouldReturn = yield* call(
+      performMinCut,
+      sourceNodeAgglomerateId,
+      targetNodeAgglomerateId,
+      sourceNodePosition,
+      targetNodePosition,
+      agglomerateFileMag,
+      editableMappingId,
+      volumeTracingId,
+      sourceTree,
+      items,
+    );
+    if (shouldReturn) {
       return;
     }
-
-    currentlyPerformingMinCut = true;
-
-    const tracingStoreUrl = yield* select((state) => state.tracing.tracingStore.url);
-    const segmentsInfo = {
-      segmentPosition1: sourceNodePosition,
-      segmentPosition2: targetNodePosition,
-      mag: agglomerateFileMag,
-      agglomerateId: sourceNodeAgglomerateId,
-      editableMappingId,
-    };
-
-    const edgesToRemove = yield* call(
-      getEdgesForAgglomerateMinCut,
-      tracingStoreUrl,
-      volumeTracingId,
-      segmentsInfo,
-    );
-
-    for (const edge of edgesToRemove) {
-      let firstNodeId;
-      let secondNodeId;
-      for (const node of sourceTree.nodes.values()) {
-        if (_.isEqual(node.position, edge.position1)) {
-          firstNodeId = node.id;
-        } else if (_.isEqual(node.position, edge.position2)) {
-          secondNodeId = node.id;
-        }
-        if (firstNodeId && secondNodeId) {
-          break;
-        }
-      }
-
-      if (!firstNodeId || !secondNodeId) {
-        Toast.warning(
-          `Unable to find all nodes for positions ${!firstNodeId ? edge.position1 : null}${
-            !secondNodeId ? [", ", edge.position2] : null
-          } in ${sourceTree.name}.`,
-        );
-        yield* put(setBusyBlockingInfoAction(false));
-        currentlyPerformingMinCut = false;
-        return;
-      }
-
-      yield* put(deleteEdgeAction(firstNodeId, secondNodeId));
-      items.push(
-        splitAgglomerate(
-          sourceNodeAgglomerateId,
-          edge.position1,
-          edge.position2,
-          agglomerateFileMag,
-        ),
-      );
-    }
-    currentlyPerformingMinCut = false;
   }
 
   if (items.length === 0) {
@@ -473,19 +405,10 @@ function* splitOrMergeOrMinCutAgglomerate(
 
   yield* call([api.data, api.data.reloadBuckets], layerName);
 
-  const newSourceNodeAgglomerateId = yield* call(
-    [api.data, api.data.getDataValue],
-    layerName,
-    sourceNodePosition,
-    agglomerateFileZoomstep,
-  );
-
-  const newTargetNodeAgglomerateId = yield* call(
-    [api.data, api.data.getDataValue],
-    layerName,
-    targetNodePosition,
-    agglomerateFileZoomstep,
-  );
+  const [newSourceNodeAgglomerateId, newTargetNodeAgglomerateId] = yield* all([
+    call(getDataValue, sourceNodePosition),
+    call(getDataValue, targetNodePosition),
+  ]);
 
   /* Rename agglomerate skeleton(s) according to their new id and mapping name */
 
@@ -512,8 +435,349 @@ function* splitOrMergeOrMinCutAgglomerate(
 
   yield* put(setBusyBlockingInfoAction(false));
 
-  /* Remove old meshes and load updated meshes */
+  yield* removeOldMeshesAndLoadUpdatedMeshes(
+    layerName,
+    sourceNodeAgglomerateId,
+    targetNodeAgglomerateId,
+    newSourceNodeAgglomerateId,
+    sourceNodePosition,
+    newTargetNodeAgglomerateId,
+    targetNodePosition,
+  );
+}
 
+function* performMinCut(
+  sourceNodeAgglomerateId: number,
+  targetNodeAgglomerateId: number,
+  sourceNodePosition: Vector3,
+  targetNodePosition: Vector3,
+  agglomerateFileMag: Vector3,
+  editableMappingId: string,
+  volumeTracingId: string,
+  sourceTree: Tree | null,
+  items: UpdateAction[],
+): Saga<boolean> {
+  if (sourceNodeAgglomerateId !== targetNodeAgglomerateId) {
+    Toast.error(
+      "Segments need to be in the same agglomerate to perform a min-cut splitting operation.",
+    );
+    yield* put(setBusyBlockingInfoAction(false));
+    return true;
+  }
+
+  currentlyPerformingMinCut = true;
+  const tracingStoreUrl = yield* select((state) => state.tracing.tracingStore.url);
+  const segmentsInfo = {
+    segmentPosition1: sourceNodePosition,
+    segmentPosition2: targetNodePosition,
+    mag: agglomerateFileMag,
+    agglomerateId: sourceNodeAgglomerateId,
+    editableMappingId,
+  };
+
+  const edgesToRemove = yield* call(
+    getEdgesForAgglomerateMinCut,
+    tracingStoreUrl,
+    volumeTracingId,
+    segmentsInfo,
+  );
+
+  for (const edge of edgesToRemove) {
+    if (sourceTree) {
+      let firstNodeId;
+      let secondNodeId;
+      for (const node of sourceTree.nodes.values()) {
+        if (_.isEqual(node.position, edge.position1)) {
+          firstNodeId = node.id;
+        } else if (_.isEqual(node.position, edge.position2)) {
+          secondNodeId = node.id;
+        }
+        if (firstNodeId && secondNodeId) {
+          break;
+        }
+      }
+
+      if (!firstNodeId || !secondNodeId) {
+        Toast.warning(
+          `Unable to find all nodes for positions ${!firstNodeId ? edge.position1 : null}${
+            !secondNodeId ? [", ", edge.position2] : null
+          } in ${sourceTree.name}.`,
+        );
+        yield* put(setBusyBlockingInfoAction(false));
+        currentlyPerformingMinCut = false;
+        return true;
+      }
+      yield* put(deleteEdgeAction(firstNodeId, secondNodeId));
+    }
+
+    items.push(
+      splitAgglomerate(sourceNodeAgglomerateId, edge.position1, edge.position2, agglomerateFileMag),
+    );
+  }
+  currentlyPerformingMinCut = false;
+
+  return false;
+}
+
+function* clearProofreadingByproducts() {
+  for (const treeId of loadedAgglomerateSkeletonIds) {
+    yield* put(deleteTreeAction(treeId, true));
+  }
+
+  loadedAgglomerateSkeletonIds = [];
+
+  const volumeTracingLayer = yield* select((state) => getActiveSegmentationTracingLayer(state));
+  if (volumeTracingLayer == null || volumeTracingLayer.tracingId == null) return;
+  const layerName = volumeTracingLayer.tracingId;
+
+  for (const segmentId of coarselyLoadedSegmentIds) {
+    yield* put(removeIsosurfaceAction(layerName, segmentId));
+  }
+  coarselyLoadedSegmentIds = [];
+}
+
+function* handleProofreadMergeOrMinCut(
+  action: ProofreadMergeAction | MinCutAgglomerateWithPositionAction,
+) {
+  const allowUpdate = yield* select((state) => state.tracing.restrictions.allowUpdate);
+  if (!allowUpdate) return;
+
+  const volumeTracingLayer = yield* select((state) => getActiveSegmentationTracingLayer(state));
+  if (volumeTracingLayer == null) return;
+  const volumeTracing = yield* select((state) => getActiveSegmentationTracing(state));
+  if (volumeTracing == null) return;
+  const { tracingId: volumeTracingId } = volumeTracing;
+
+  const preparation = yield* call(
+    prepareSplitOrMerge,
+    volumeTracingId,
+    volumeTracing,
+    volumeTracingLayer,
+  );
+  if (!preparation) {
+    return;
+  }
+  const { layerName, agglomerateFileMag, getDataValue } = preparation;
+
+  const skeletonTracing = yield* select((state) => enforceSkeletonTracing(state.tracing));
+
+  const sourceTree = getActiveTree(skeletonTracing).getOrElse(null);
+  const sourceNodeId = skeletonTracing.activeNodeId;
+
+  if (sourceTree == null || sourceNodeId == null) {
+    yield* put(setBusyBlockingInfoAction(false));
+    return;
+  }
+
+  const sourceNodePosition = sourceTree.nodes.get(sourceNodeId).position;
+  const targetNodePosition = V3.floor(action.position);
+
+  const partnerInfos = yield* call(
+    getPartnerAgglomerateIds,
+    volumeTracingLayer,
+    getDataValue,
+    sourceNodePosition,
+    targetNodePosition,
+  );
+  if (!partnerInfos) {
+    return;
+  }
+  const { sourceNodeAgglomerateId, targetNodeAgglomerateId, volumeTracingWithEditableMapping } =
+    partnerInfos;
+  const editableMappingId = volumeTracingWithEditableMapping.mappingName;
+
+  /* Send the respective split/merge update action to the backend (by pushing to the save queue
+     and saving immediately) */
+
+  const items: UpdateAction[] = [];
+
+  if (action.type === "PROOFREAD_MERGE") {
+    if (sourceNodeAgglomerateId === targetNodeAgglomerateId) {
+      Toast.error("Segments that should be merged need to be in different agglomerates.");
+      yield* put(setBusyBlockingInfoAction(false));
+      return;
+    }
+    items.push(
+      mergeAgglomerate(
+        sourceNodeAgglomerateId,
+        targetNodeAgglomerateId,
+        sourceNodePosition,
+        targetNodePosition,
+        agglomerateFileMag,
+      ),
+    );
+  } else if (action.type === "MIN_CUT_AGGLOMERATE_WITH_POSITION") {
+    if (partnerInfos.unmappedSourceId === partnerInfos.unmappedTargetId) {
+      Toast.error(
+        "The selected positions are both part of the same base segment and cannot be split. Please select another position or use the nodes of the agglomerate skeleton to perform the split.",
+      );
+      yield* put(setBusyBlockingInfoAction(false));
+      return;
+    }
+    const shouldReturn = yield* call(
+      performMinCut,
+      sourceNodeAgglomerateId,
+      targetNodeAgglomerateId,
+      sourceNodePosition,
+      targetNodePosition,
+      agglomerateFileMag,
+      editableMappingId,
+      volumeTracingId,
+      null,
+      items,
+    );
+    if (shouldReturn) {
+      return;
+    }
+  }
+
+  if (items.length === 0) {
+    yield* put(setBusyBlockingInfoAction(false));
+    return;
+  }
+
+  yield* put(pushSaveQueueTransaction(items, "mapping", volumeTracingId));
+  yield* call([Model, Model.ensureSavedState]);
+
+  /* Reload the segmentation */
+
+  yield* call([api.data, api.data.reloadBuckets], layerName);
+
+  const [newSourceNodeAgglomerateId, newTargetNodeAgglomerateId] = yield* all([
+    call(getDataValue, sourceNodePosition),
+    call(getDataValue, targetNodePosition),
+  ]);
+
+  /* Reload agglomerate skeleton */
+  if (volumeTracing.mappingName == null) return;
+
+  const currentlyActiveNode = (yield* call(getActiveNode, skeletonTracing)).getOrElse(null);
+  const activeNodePosition = currentlyActiveNode?.position;
+
+  yield* put(deleteTreeAction(sourceTree.treeId, true));
+  const treeNameAndId = yield* call(
+    loadAgglomerateSkeletonWithId,
+    loadAgglomerateSkeletonAction(layerName, volumeTracing.mappingName, newSourceNodeAgglomerateId),
+  );
+  if (treeNameAndId) {
+    loadedAgglomerateSkeletonIds.push(treeNameAndId[1]);
+  }
+
+  // Make the "same" node active as before. Since we deleted
+  // and reloaded the skeleton, it's not the same node identity,
+  // which is why we use the old's node position to select the new node.
+  yield* selectNodeByPosition(activeNodePosition, treeNameAndId);
+
+  yield* put(setBusyBlockingInfoAction(false));
+
+  yield* removeOldMeshesAndLoadUpdatedMeshes(
+    layerName,
+    sourceNodeAgglomerateId,
+    targetNodeAgglomerateId,
+    newSourceNodeAgglomerateId,
+    sourceNodePosition,
+    newTargetNodeAgglomerateId,
+    targetNodePosition,
+  );
+}
+
+// Helper functions
+
+function* prepareSplitOrMerge(
+  volumeTracingId: string,
+  volumeTracing: VolumeTracing,
+  volumeTracingLayer: APISegmentationLayer,
+): Saga<{
+  layerName: string;
+  agglomerateFileMag: Vector3;
+  getDataValue: (position: Vector3) => Promise<number>;
+} | null> {
+  const layerName = volumeTracingId;
+  const isHdf5MappingEnabled = yield* call(ensureHdf5MappingIsEnabled, layerName);
+  if (!isHdf5MappingEnabled) {
+    return null;
+  }
+
+  const busyBlockingInfo = yield* select((state) => state.uiInformation.busyBlockingInfo);
+  if (busyBlockingInfo.isBusy) {
+    console.warn(`Ignoring proofreading action (reason: ${busyBlockingInfo.reason || "null"})`);
+    return null;
+  }
+
+  yield* put(setBusyBlockingInfoAction(true, "Proofreading action"));
+
+  if (!volumeTracing.mappingIsEditable) {
+    try {
+      yield* call(createEditableMapping);
+    } catch (e) {
+      console.error(e);
+      yield* put(setBusyBlockingInfoAction(false));
+      return null;
+    }
+  }
+
+  /* Find out the agglomerate IDs at the two node positions */
+  const resolutionInfo = getResolutionInfo(volumeTracingLayer.resolutions);
+  // The mag the agglomerate skeleton corresponds to should be the finest available mag of the volume tracing layer
+  const agglomerateFileMag = resolutionInfo.getLowestResolution();
+  const agglomerateFileZoomstep = resolutionInfo.getLowestResolutionIndex();
+
+  const getDataValue = (nodePosition: Vector3) =>
+    api.data.getDataValue(layerName, nodePosition, agglomerateFileZoomstep);
+
+  return { layerName, agglomerateFileMag, getDataValue };
+}
+
+function* getPartnerAgglomerateIds(
+  volumeTracingLayer: APISegmentationLayer,
+  getDataValue: (position: Vector3) => Promise<number>,
+  sourceNodePosition: Vector3,
+  targetNodePosition: Vector3,
+): Saga<{
+  volumeTracingWithEditableMapping: VolumeTracing & { mappingName: string };
+  sourceNodeAgglomerateId: number;
+  targetNodeAgglomerateId: number;
+  unmappedSourceId: number;
+  unmappedTargetId: number;
+} | null> {
+  const getUnmappedDataValue = yield* call(createGetUnmappedDataValueFn, volumeTracingLayer);
+  if (!getUnmappedDataValue) {
+    return null;
+  }
+  const [sourceNodeAgglomerateId, targetNodeAgglomerateId, unmappedSourceId, unmappedTargetId] =
+    yield* all([
+      call(getDataValue, sourceNodePosition),
+      call(getDataValue, targetNodePosition),
+      call(getUnmappedDataValue, sourceNodePosition),
+      call(getUnmappedDataValue, targetNodePosition),
+    ]);
+
+  const volumeTracingWithEditableMapping = yield* select((state) =>
+    getActiveSegmentationTracing(state),
+  );
+  const mappingName = volumeTracingWithEditableMapping?.mappingName;
+  if (volumeTracingWithEditableMapping == null || mappingName == null) {
+    yield* put(setBusyBlockingInfoAction(false));
+    return null;
+  }
+  return {
+    volumeTracingWithEditableMapping: { ...volumeTracingWithEditableMapping, mappingName },
+    sourceNodeAgglomerateId,
+    targetNodeAgglomerateId,
+    unmappedSourceId,
+    unmappedTargetId,
+  };
+}
+
+function* removeOldMeshesAndLoadUpdatedMeshes(
+  layerName: string,
+  sourceNodeAgglomerateId: number,
+  targetNodeAgglomerateId: number,
+  newSourceNodeAgglomerateId: number,
+  sourceNodePosition: Vector3,
+  newTargetNodeAgglomerateId: number,
+  targetNodePosition: Vector3,
+) {
   if (proofreadUsingMeshes()) {
     // Remove old over segmentation meshes
     if (oldSegmentIdsInProximity != null) {
@@ -539,19 +803,58 @@ function* splitOrMergeOrMinCutAgglomerate(
   }
 }
 
-function* clearProofreadingByProducts() {
-  for (const treeId of loadedAgglomerateSkeletonIds) {
-    yield* put(deleteTreeAction(treeId));
-  }
-
-  loadedAgglomerateSkeletonIds = [];
-
-  const volumeTracingLayer = yield* select((state) => getActiveSegmentationTracingLayer(state));
-  if (volumeTracingLayer == null || volumeTracingLayer.tracingId == null) return;
+function* createGetUnmappedDataValueFn(
+  volumeTracingLayer: APISegmentationLayer,
+): Saga<((nodePosition: Vector3) => Promise<number>) | null> {
+  if (volumeTracingLayer.tracingId == null) return null;
   const layerName = volumeTracingLayer.tracingId;
 
-  for (const segmentId of coarselyLoadedSegmentIds) {
-    yield* put(removeIsosurfaceAction(layerName, segmentId));
+  const resolutionInfo = getResolutionInfo(volumeTracingLayer.resolutions);
+  const mag = resolutionInfo.getLowestResolution();
+
+  const fallbackLayerName = volumeTracingLayer.fallbackLayer;
+  if (fallbackLayerName == null) return null;
+  const TypedArrayClass = yield* select((state) => {
+    const { elementClass } = getLayerByName(state.dataset, layerName);
+    return getConstructorForElementClass(elementClass)[0];
+  });
+
+  return async (nodePosition: Vector3) => {
+    const buffer = await api.data.getRawDataCuboid(
+      fallbackLayerName,
+      nodePosition,
+      V3.add(nodePosition, mag),
+    );
+
+    return Number(new TypedArrayClass(buffer)[0]);
+  };
+}
+
+function* selectNodeByPosition(
+  activeNodePosition: Vector3 | undefined,
+  treeNameAndId: [string, number] | null,
+) {
+  if (!activeNodePosition || !treeNameAndId) {
+    return;
   }
-  coarselyLoadedSegmentIds = [];
+
+  const newTree = yield* select((state) => {
+    if (!state.tracing.skeleton) {
+      return null;
+    }
+    return getTree(state.tracing.skeleton, treeNameAndId[1]).getOrElse(null);
+  });
+  if (!newTree) {
+    return;
+  }
+  let nodeToActivate = null;
+  for (const node of newTree.nodes.values()) {
+    if (_.isEqual(node.position, activeNodePosition)) {
+      nodeToActivate = node.id;
+      break;
+    }
+  }
+  if (nodeToActivate) {
+    yield* put(setActiveNodeAction(nodeToActivate, false, true));
+  }
 }

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -1,5 +1,5 @@
 import { Radio, Tooltip, Badge, Space, Popover, RadioChangeEvent, Dropdown, Menu } from "antd";
-import { DownOutlined, ExportOutlined } from "@ant-design/icons";
+import { ClearOutlined, DownOutlined, ExportOutlined } from "@ant-design/icons";
 import { useSelector, useDispatch } from "react-redux";
 import React, { useEffect, useState } from "react";
 
@@ -53,6 +53,7 @@ import Store, { OxalisState, VolumeTracing } from "oxalis/store";
 import features from "features";
 import { getInterpolationInfo } from "oxalis/model/sagas/volume/volume_interpolation_saga";
 import { getVisibleSegmentationLayer } from "oxalis/model/accessors/dataset_accessor";
+import { clearProofReadingByProducts } from "oxalis/model/actions/proofread_actions";
 
 const narrowButtonStyle = {
   paddingLeft: 10,
@@ -856,6 +857,9 @@ function ToolSpecificSettings({
     showCreateCellButton &&
     (adaptedActiveTool === AnnotationToolEnum.BRUSH ||
       adaptedActiveTool === AnnotationToolEnum.ERASE_BRUSH);
+  const dispatch = useDispatch();
+  const handleClearProofReading = () => dispatch(clearProofReadingByProducts());
+
   return (
     <>
       {showCreateTreeButton ? (
@@ -907,6 +911,17 @@ function ToolSpecificSettings({
       ) : null}
 
       {adaptedActiveTool === AnnotationToolEnum.FILL_CELL ? <FillModeSwitch /> : null}
+
+      {adaptedActiveTool === AnnotationToolEnum.PROOFREAD ? (
+        <ButtonComponent
+          title="Clear auxiliary skeletons and meshes which were loaded while proofreading segments. Use this if you are done with correcting mergers or splits in a segment pair."
+          onClick={handleClearProofReading}
+          className="narrow"
+          style={{ marginLeft: 12 }}
+        >
+          <ClearOutlined />
+        </ButtonComponent>
+      ) : null}
     </>
   );
 }

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -914,7 +914,7 @@ function ToolSpecificSettings({
 
       {adaptedActiveTool === AnnotationToolEnum.PROOFREAD ? (
         <ButtonComponent
-          title="Clear auxiliary skeletons and meshes which were loaded while proofreading segments. Use this if you are done with correcting mergers or splits in a segment pair."
+          title="Clear auxiliary skeletons and meshes that were loaded while proofreading segments. Use this if you are done with correcting mergers or splits in a segment pair."
           onClick={handleClearProofreading}
           className="narrow"
           style={{ marginLeft: 12 }}

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -53,7 +53,7 @@ import Store, { OxalisState, VolumeTracing } from "oxalis/store";
 import features from "features";
 import { getInterpolationInfo } from "oxalis/model/sagas/volume/volume_interpolation_saga";
 import { getVisibleSegmentationLayer } from "oxalis/model/accessors/dataset_accessor";
-import { clearProofReadingByProducts } from "oxalis/model/actions/proofread_actions";
+import { clearProofreadingByProducts } from "oxalis/model/actions/proofread_actions";
 
 const narrowButtonStyle = {
   paddingLeft: 10,
@@ -858,7 +858,7 @@ function ToolSpecificSettings({
     (adaptedActiveTool === AnnotationToolEnum.BRUSH ||
       adaptedActiveTool === AnnotationToolEnum.ERASE_BRUSH);
   const dispatch = useDispatch();
-  const handleClearProofReading = () => dispatch(clearProofReadingByProducts());
+  const handleClearProofreading = () => dispatch(clearProofreadingByProducts());
 
   return (
     <>
@@ -915,7 +915,7 @@ function ToolSpecificSettings({
       {adaptedActiveTool === AnnotationToolEnum.PROOFREAD ? (
         <ButtonComponent
           title="Clear auxiliary skeletons and meshes which were loaded while proofreading segments. Use this if you are done with correcting mergers or splits in a segment pair."
-          onClick={handleClearProofReading}
+          onClick={handleClearProofreading}
           className="narrow"
           style={{ marginLeft: 12 }}
         >

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -52,8 +52,8 @@ import Store, { OxalisState, VolumeTracing } from "oxalis/store";
 
 import features from "features";
 import { getInterpolationInfo } from "oxalis/model/sagas/volume/volume_interpolation_saga";
-import { getVisibleSegmentationLayer } from "oxalis/model/accessors/dataset_accessor";
 import { clearProofreadingByProducts } from "oxalis/model/actions/proofread_actions";
+import { hasAgglomerateMapping } from "oxalis/controller/combinations/segmentation_handlers";
 
 const narrowButtonStyle = {
   paddingLeft: 10,
@@ -550,10 +550,8 @@ function ChangeBrushSizeButton() {
 export default function ToolbarView() {
   const hasVolume = useSelector((state: OxalisState) => state.tracing.volumes.length > 0);
   const hasSkeleton = useSelector((state: OxalisState) => state.tracing.skeleton != null);
-  const hasAgglomerateMappings = useSelector((state: OxalisState) => {
-    const visibleSegmentationLayer = getVisibleSegmentationLayer(state);
-    return (visibleSegmentationLayer?.agglomerates?.length ?? 0) > 0;
-  });
+  const isAgglomerateMappingEnabled = useSelector(hasAgglomerateMapping);
+
   const [lastForcefulDisabledTool, setLastForcefulDisabledTool] = useState<AnnotationTool | null>(
     null,
   );
@@ -808,7 +806,7 @@ export default function ToolbarView() {
           />
         </RadioButtonWithTooltip>
 
-        {hasSkeleton && hasVolume && hasAgglomerateMappings ? (
+        {hasSkeleton && hasVolume && isAgglomerateMappingEnabled.value ? (
           <RadioButtonWithTooltip
             title="Proofreading Tool - Modify an agglomerated segmentation. Other segmentation modifications, like brushing, are not allowed if this tool is used."
             disabledTitle={disabledInfosForTools[AnnotationToolEnum.PROOFREAD].explanation}

--- a/frontend/javascripts/oxalis/view/right-border-tabs/connectome_tab/connectome_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/connectome_tab/connectome_view.tsx
@@ -190,7 +190,7 @@ function ensureTypeToString(synapseTypesAndNames: {
   const { synapseTypes, typeToString } = synapseTypesAndNames;
 
   if (typeToString.length === 0) {
-    Toast.error(`Couldn't read synapseTypes mapping. Please add a json file containing the synapseTypes next to the connectome file.
+    Toast.error(`Couldn't read synapseTypes mapping. Please add a json file (name should be equal to connectome file name) containing the synapseTypes next to the connectome file.
 The format should be: \`{
   "synapse_type_names": [ "type1", "type2", ... ]
 }\``);
@@ -796,7 +796,7 @@ class ConnectomeView extends React.Component<Props, State> {
           image={Empty.PRESENTED_IMAGE_SIMPLE}
           description={
             <span>
-              No connectome file available for this dataset.{" "}
+              No connectome file available for this segmentation layer.{" "}
               <a href="https://docs.webknossos.org/webknossos/connectome_viewer.html">
                 Read more about this feature in the documentation.
               </a>


### PR DESCRIPTION
Also see https://github.com/scalableminds/webknossos/pull/6464 which is also contained in this PR.

![image](https://user-images.githubusercontent.com/2486553/189684812-89d35282-f2b2-44d8-a3ad-f95c28fc7dcb.png)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open dataset with agglomerate mapping and activate that
- use proof reading tool to load some skeletons and meshes
- use clear button to remove the loaded skeletons and meshes

### Issues:
- fixes #6427

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
