### PR TITLE
Allow merge and min-cut when rightclicking on voxel (instead of node)

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added a context menu option to extract the shortest path between two nodes as a new tree. Select the source node and open the context menu by right-clicking on another node in the same tree. [#6423](https://github.com/scalableminds/webknossos/pull/6423)
 - Added a context menu option to separate an agglomerate skeleton using Min-Cut. Activate the Proofreading tool, select the source node and open the context menu by right-clicking on the target node which you would like to separate through Min-Cut. [#6361](https://github.com/scalableminds/webknossos/pull/6361)
 - Added a "clear" button to reset skeletons/meshes after successful mergers/split. [#6459](https://github.com/scalableminds/webknossos/pull/6459)
-- The proofreading tool now supports merging, splitting and min-cutting agglomerates by rightclicking a segment (and not a node). Note that there still has to be an active node so that both partners of the operation are defined. [#6464](https://github.com/scalableminds/webknossos/pull/6464)
+- The proofreading tool now supports merging and splitting (via min-cut) agglomerates by rightclicking a segment (and not a node). Note that there still has to be an active node so that both partners of the operation are defined. [#6464](https://github.com/scalableminds/webknossos/pull/6464)
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added a context menu option to extract the shortest path between two nodes as a new tree. Select the source node and open the context menu by right-clicking on another node in the same tree. [#6423](https://github.com/scalableminds/webknossos/pull/6423)
 - Added a context menu option to separate an agglomerate skeleton using Min-Cut. Activate the Proofreading tool, select the source node and open the context menu by right-clicking on the target node which you would like to separate through Min-Cut. [#6361](https://github.com/scalableminds/webknossos/pull/6361)
 - Added a "clear" button to reset skeletons/meshes after successful mergers/split. [#6459](https://github.com/scalableminds/webknossos/pull/6459)
+- The proofreading tool now supports merging, splitting and min-cutting agglomerates by rightclicking a segment (and not a node). Note that there still has to be an active node so that both partners of the operation are defined. [#6464](https://github.com/scalableminds/webknossos/pull/6464)
 
 ### Changed
 

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -1546,12 +1546,12 @@ class DataApi {
     return (
       `${dataset.dataStore.url}/data/datasets/${dataset.owningOrganization}/${dataset.name}/layers/${layerName}/data?mag=${magString}&` +
       `token=${token}&` +
-      `x=${topLeft[0]}&` +
-      `y=${topLeft[1]}&` +
-      `z=${topLeft[2]}&` +
-      `width=${bottomRight[0] - topLeft[0]}&` +
-      `height=${bottomRight[1] - topLeft[1]}&` +
-      `depth=${bottomRight[2] - topLeft[2]}`
+      `x=${Math.floor(topLeft[0])}&` +
+      `y=${Math.floor(topLeft[1])}&` +
+      `z=${Math.floor(topLeft[2])}&` +
+      `width=${Math.floor(bottomRight[0] - topLeft[0])}&` +
+      `height=${Math.floor(bottomRight[1] - topLeft[1])}&` +
+      `depth=${Math.floor(bottomRight[2] - topLeft[2])}`
     );
   }
 

--- a/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
@@ -3,16 +3,12 @@ import { Vector3 } from "oxalis/constants";
 export type ProofreadAtPositionAction = ReturnType<typeof proofreadAtPosition>;
 export type ClearProofreadingByProductsAction = ReturnType<typeof clearProofreadingByProducts>;
 export type ProofreadMergeAction = ReturnType<typeof proofreadMerge>;
-export type ProofreadSplitAction = ReturnType<typeof proofreadSplit>;
 export type MinCutAgglomerateAction = ReturnType<typeof minCutAgglomerateAction>;
 export type MinCutAgglomerateWithPositionAction = ReturnType<
   typeof minCutAgglomerateWithPositionAction
 >;
 
-export type ProofreadAction =
-  | ProofreadAtPositionAction
-  | ClearProofreadingByProductsAction
-  | ProofreadSplitAction;
+export type ProofreadAction = ProofreadAtPositionAction | ClearProofreadingByProductsAction;
 
 export const proofreadAtPosition = (position: Vector3) =>
   ({
@@ -28,12 +24,6 @@ export const clearProofreadingByProducts = () =>
 export const proofreadMerge = (position: Vector3) =>
   ({
     type: "PROOFREAD_MERGE",
-    position,
-  } as const);
-
-export const proofreadSplit = (position: Vector3) =>
-  ({
-    type: "PROOFREAD_SPLIT",
     position,
   } as const);
 

--- a/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
@@ -2,8 +2,13 @@ import { Vector3 } from "oxalis/constants";
 
 export type ProofreadAtPositionAction = ReturnType<typeof proofreadAtPosition>;
 export type ClearProofreadingByProductsAction = ReturnType<typeof clearProofreadingByProducts>;
+export type ProofreadMergeAction = ReturnType<typeof proofreadMerge>;
+export type ProofreadSplitAction = ReturnType<typeof proofreadSplit>;
 
-export type ProofreadAction = ProofreadAtPositionAction | ClearProofreadingByProductsAction;
+export type ProofreadAction =
+  | ProofreadAtPositionAction
+  | ClearProofreadingByProductsAction
+  | ProofreadSplitAction;
 
 export const proofreadAtPosition = (position: Vector3) =>
   ({
@@ -14,4 +19,16 @@ export const proofreadAtPosition = (position: Vector3) =>
 export const clearProofreadingByProducts = () =>
   ({
     type: "CLEAR_PROOFREADING_BY_PRODUCTS",
+  } as const);
+
+export const proofreadMerge = (position: Vector3) =>
+  ({
+    type: "PROOFREAD_MERGE",
+    position,
+  } as const);
+
+export const proofreadSplit = (position: Vector3) =>
+  ({
+    type: "PROOFREAD_SPLIT",
+    position,
   } as const);

--- a/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/proofread_actions.ts
@@ -4,6 +4,10 @@ export type ProofreadAtPositionAction = ReturnType<typeof proofreadAtPosition>;
 export type ClearProofreadingByProductsAction = ReturnType<typeof clearProofreadingByProducts>;
 export type ProofreadMergeAction = ReturnType<typeof proofreadMerge>;
 export type ProofreadSplitAction = ReturnType<typeof proofreadSplit>;
+export type MinCutAgglomerateAction = ReturnType<typeof minCutAgglomerateAction>;
+export type MinCutAgglomerateWithPositionAction = ReturnType<
+  typeof minCutAgglomerateWithPositionAction
+>;
 
 export type ProofreadAction =
   | ProofreadAtPositionAction
@@ -30,5 +34,19 @@ export const proofreadMerge = (position: Vector3) =>
 export const proofreadSplit = (position: Vector3) =>
   ({
     type: "PROOFREAD_SPLIT",
+    position,
+  } as const);
+
+export const minCutAgglomerateAction = (sourceNodeId: number, targetNodeId: number) =>
+  ({
+    type: "MIN_CUT_AGGLOMERATE",
+    sourceNodeId,
+    targetNodeId,
+  } as const);
+
+export const minCutAgglomerateWithPositionAction = (sourceNodeId: number, position: Vector3) =>
+  ({
+    type: "MIN_CUT_AGGLOMERATE_WITH_POSITION",
+    sourceNodeId,
     position,
   } as const);

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
@@ -195,11 +195,16 @@ export const deleteEdgeAction = (
     timestamp,
   } as const);
 
-export const setActiveNodeAction = (nodeId: number, suppressAnimation: boolean = false) =>
+export const setActiveNodeAction = (
+  nodeId: number,
+  suppressAnimation: boolean = false,
+  suppressCentering: boolean = false,
+) =>
   ({
     type: "SET_ACTIVE_NODE",
     nodeId,
     suppressAnimation,
+    suppressCentering,
   } as const);
 
 export const centerActiveNodeAction = (suppressAnimation: boolean = false) =>

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
@@ -59,7 +59,7 @@ export type LoadAgglomerateSkeletonAction = ReturnType<typeof loadAgglomerateSke
 export type RemoveAgglomerateSkeletonAction = ReturnType<typeof removeAgglomerateSkeletonAction>;
 type NoAction = ReturnType<typeof noAction>;
 
-export type SkeletonTracingAction = 
+export type SkeletonTracingAction =
   | InitializeSkeletonTracingAction
   | CreateNodeAction
   | DeleteNodeAction
@@ -262,11 +262,13 @@ export const createTreeAction = (timestamp: number = Date.now()) =>
 export const addTreesAndGroupsAction = (
   trees: MutableTreeMap,
   treeGroups: Array<TreeGroup> | null | undefined,
+  treeIdsCallback: ((ids: number[]) => void) | undefined = undefined,
 ) =>
   ({
     type: "ADD_TREES_AND_GROUPS",
     trees,
     treeGroups: treeGroups || [],
+    treeIdsCallback,
   } as const);
 
 export const deleteTreeAction = (treeId?: number, suppressActivatingNextNode: boolean = false) =>

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
@@ -271,10 +271,17 @@ export const addTreesAndGroupsAction = (
     treeGroups: treeGroups || [],
   } as const);
 
-export const deleteTreeAction = (treeId?: number) =>
+export const deleteTreeAction = (treeId?: number, suppressActivatingNextNode: boolean = false) =>
+  // If suppressActivatingNextNode is true, the tree will be deleted without activating
+  // another node (nor tree). Use this in cases where you want to avoid changing
+  // the active position (due to the auto-centering). One could also suppress the auto-centering
+  // behavior, but the semantics of changing the active node might also be confusing to the user
+  // (e.g., when proofreading). So, it might be clearer to not have an active node in the first
+  // place.
   ({
     type: "DELETE_TREE",
     treeId,
+    suppressActivatingNextNode,
   } as const);
 
 export const resetSkeletonTracingAction = () =>

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
@@ -41,7 +41,6 @@ type DeselectActiveTreeAction = ReturnType<typeof deselectActiveTreeAction>;
 type SetActiveGroupAction = ReturnType<typeof setActiveGroupAction>;
 type DeselectActiveGroupAction = ReturnType<typeof deselectActiveGroupAction>;
 export type MergeTreesAction = ReturnType<typeof mergeTreesAction>;
-export type MinCutAgglomerateAction = ReturnType<typeof minCutAgglomerateAction>;
 type SetTreeNameAction = ReturnType<typeof setTreeNameAction>;
 type SelectNextTreeAction = ReturnType<typeof selectNextTreeAction>;
 type SetTreeColorIndexAction = ReturnType<typeof setTreeColorIndexAction>;
@@ -60,7 +59,7 @@ export type LoadAgglomerateSkeletonAction = ReturnType<typeof loadAgglomerateSke
 export type RemoveAgglomerateSkeletonAction = ReturnType<typeof removeAgglomerateSkeletonAction>;
 type NoAction = ReturnType<typeof noAction>;
 
-export type SkeletonTracingAction =
+export type SkeletonTracingAction = 
   | InitializeSkeletonTracingAction
   | CreateNodeAction
   | DeleteNodeAction
@@ -83,7 +82,6 @@ export type SkeletonTracingAction =
   | SetActiveTreeByNameAction
   | DeselectActiveTreeAction
   | MergeTreesAction
-  | MinCutAgglomerateAction
   | SetTreeNameAction
   | SelectNextTreeAction
   | SetTreeColorAction
@@ -355,13 +353,6 @@ export const deselectActiveGroupAction = () =>
 export const mergeTreesAction = (sourceNodeId: number, targetNodeId: number) =>
   ({
     type: "MERGE_TREES",
-    sourceNodeId,
-    targetNodeId,
-  } as const);
-
-export const minCutAgglomerateAction = (sourceNodeId: number, targetNodeId: number) =>
-  ({
-    type: "MIN_CUT_AGGLOMERATE",
     sourceNodeId,
     targetNodeId,
   } as const);

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.ts
@@ -81,18 +81,16 @@ export class NullBucket {
     return Promise.resolve();
   }
 }
+
+export type TypedArrayConstructor =
+  | Uint8ArrayConstructor
+  | Uint16ArrayConstructor
+  | Uint32ArrayConstructor
+  | Float32ArrayConstructor
+  | BigUint64ArrayConstructor;
 export const getConstructorForElementClass = (
   type: ElementClass,
-): [
-  (
-    | Uint8ArrayConstructor
-    | Uint16ArrayConstructor
-    | Uint32ArrayConstructor
-    | Float32ArrayConstructor
-    | BigUint64ArrayConstructor
-  ),
-  number,
-] => {
+): [TypedArrayConstructor, number] => {
   switch (type) {
     case "int8":
     case "uint8":

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
@@ -803,8 +803,11 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
           const { trees, treeGroups } = action;
           const treesWithNames = ensureTreeNames(state, trees);
           return addTreesAndGroups(skeletonTracing, treesWithNames, treeGroups)
-            .map(([updatedTrees, updatedTreeGroups, newMaxNodeId]) =>
-              update(state, {
+            .map(([updatedTrees, updatedTreeGroups, newMaxNodeId]) => {
+              if (action.treeIdsCallback) {
+                action.treeIdsCallback(Utils.values(updatedTrees).map((tree) => tree.treeId));
+              }
+              return update(state, {
                 tracing: {
                   skeleton: {
                     treeGroups: {
@@ -818,8 +821,8 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
                     },
                   },
                 },
-              }),
-            )
+              });
+            })
             .getOrElse(state);
         }
 

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
@@ -824,9 +824,9 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
         }
 
         case "DELETE_TREE": {
-          const { treeId } = action;
+          const { treeId, suppressActivatingNextNode } = action;
           return getTree(skeletonTracing, treeId)
-            .chain((tree) => deleteTree(skeletonTracing, tree))
+            .chain((tree) => deleteTree(skeletonTracing, tree, suppressActivatingNextNode))
             .map(([trees, newActiveTreeId, newActiveNodeId, newMaxNodeId]) =>
               update(state, {
                 tracing: {

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.ts
@@ -621,6 +621,7 @@ export function addTreesAndGroups(
 export function deleteTree(
   skeletonTracing: SkeletonTracing,
   tree: Tree,
+  suppressActivatingNextNode: boolean = false,
 ): Maybe<[TreeMap, number | null | undefined, number | null | undefined, number]> {
   // Delete tree
   const newTrees = _.omit(skeletonTracing.trees, tree.treeId);
@@ -628,7 +629,7 @@ export function deleteTree(
   let newActiveTreeId = null;
   let newActiveNodeId = null;
 
-  if (_.size(newTrees) > 0) {
+  if (_.size(newTrees) > 0 && !suppressActivatingNextNode) {
     // Setting the tree active whose id is the next highest compared to the id of the deleted tree.
     newActiveTreeId = getNearestTreeId(tree.treeId, newTrees);
     // @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -461,8 +461,10 @@ function* splitOrMergeOrMinCutAgglomerate(
 
   yield* call([api.data, api.data.reloadBuckets], layerName);
 
-  const newSourceNodeAgglomerateId = yield* call(getDataValue, sourceNodePosition);
-  const newTargetNodeAgglomerateId = yield* call(getDataValue, targetNodePosition);
+  const [newSourceNodeAgglomerateId, newTargetNodeAgglomerateId] = yield* all([
+    call(getDataValue, sourceNodePosition),
+    call(getDataValue, targetNodePosition),
+  ]);
 
   /* Rename agglomerate skeleton(s) according to their new id and mapping name */
 
@@ -610,8 +612,10 @@ function* handleProofreadMergeAndSplit(action: ProofreadMergeAction) {
 
   yield* call([api.data, api.data.reloadBuckets], layerName);
 
-  const newSourceNodeAgglomerateId = yield* call(getDataValue, sourceNodePosition);
-  const newTargetNodeAgglomerateId = yield* call(getDataValue, targetNodePosition);
+  const [newSourceNodeAgglomerateId, newTargetNodeAgglomerateId] = yield* all([
+    call(getDataValue, sourceNodePosition),
+    call(getDataValue, targetNodePosition),
+  ]);
 
   /* Reload agglomerate skeleton */
   if (volumeTracing.mappingName == null) return;
@@ -690,8 +694,10 @@ function* getPartnerAgglomerateIds(
   sourceNodeAgglomerateId: number;
   targetNodeAgglomerateId: number;
 } | null> {
-  const sourceNodeAgglomerateId = yield* call(getDataValue, sourceNodePosition);
-  const targetNodeAgglomerateId = yield* call(getDataValue, targetNodePosition);
+  const [sourceNodeAgglomerateId, targetNodeAgglomerateId] = yield* all([
+    call(getDataValue, sourceNodePosition),
+    call(getDataValue, targetNodePosition),
+  ]);
 
   const volumeTracingWithEditableMapping = yield* select((state) =>
     getActiveSegmentationTracing(state),

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -141,7 +141,7 @@ function* proofreadAtPosition(action: ProofreadAtPositionAction): Saga<void> {
 
   /* Load agglomerate skeleton of the agglomerate at the click position */
 
-  const treeName = yield* call(
+  const treeNameAndId = yield* call(
     loadAgglomerateSkeletonWithId,
     loadAgglomerateSkeletonAction(layerName, volumeTracing.mappingName, segmentId),
   );
@@ -152,7 +152,8 @@ function* proofreadAtPosition(action: ProofreadAtPositionAction): Saga<void> {
 
   yield* call(loadCoarseAdHocMesh, layerName, segmentId, position);
 
-  if (treeName == null) return;
+  if (treeNameAndId == null) return;
+  const [treeName] = treeNameAndId;
 
   const skeletonTracing = yield* select((state) => enforceSkeletonTracing(state.tracing));
   const { trees } = skeletonTracing;
@@ -667,10 +668,13 @@ function* handleProofreadMergeOrSplitOrMinCut(
   /* Reload agglomerate skeleton */
   if (volumeTracing.mappingName == null) return;
   yield* put(deleteTreeAction(sourceTree.treeId, true));
-  yield* call(
+  const treeNameAndId = yield* call(
     loadAgglomerateSkeletonWithId,
     loadAgglomerateSkeletonAction(layerName, volumeTracing.mappingName, newSourceNodeAgglomerateId),
   );
+  if (treeNameAndId) {
+    loadedAgglomerateSkeletonIds.push(treeNameAndId[1]);
+  }
 
   yield* put(setBusyBlockingInfoAction(false));
 

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -458,7 +458,9 @@ function* performMinCut(
   items: UpdateAction[],
 ): Saga<boolean> {
   if (sourceNodeAgglomerateId !== targetNodeAgglomerateId) {
-    Toast.error("Segments need to be in the same agglomerate to perform a min-cut splitting operation.");
+    Toast.error(
+      "Segments need to be in the same agglomerate to perform a min-cut splitting operation.",
+    );
     yield* put(setBusyBlockingInfoAction(false));
     return true;
   }

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
@@ -80,6 +80,9 @@ import {
 import type { ServerSkeletonTracing } from "types/api_flow_types";
 
 function* centerActiveNode(action: Action): Saga<void> {
+  if ("suppressCentering" in action && action.suppressCentering) {
+    return;
+  }
   if (["DELETE_NODE", "DELETE_BRANCHPOINT"].includes(action.type)) {
     const centerNewNode = yield* select(
       (state: OxalisState) => state.userConfiguration.centerNewNode,

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
@@ -374,11 +374,16 @@ export function* loadAgglomerateSkeletonWithId(
       addTreesAndGroupsAction(
         createMutableTreeMapFromTreeArray(parsedTracing.trees),
         parsedTracing.treeGroups,
-        (newTreeIds) => (usedTreeIds = newTreeIds),
+        (newTreeIds) => {
+          usedTreeIds = newTreeIds;
+        },
       ),
     );
+    // @ts-ignore TS infers usedTreeIds to be never, but it should be number[] if its not null
     if (usedTreeIds == null || usedTreeIds.length !== 1) {
-      throw new Error("Assumption violated while adding agglomerate skeleton");
+      throw new Error(
+        "Assumption violated while adding agglomerate skeleton. Exactly one tree should have been added.",
+      );
     } else {
       console.log(usedTreeIds);
     }

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
@@ -387,8 +387,6 @@ export function* loadAgglomerateSkeletonWithId(
       throw new Error(
         "Assumption violated while adding agglomerate skeleton. Exactly one tree should have been added.",
       );
-    } else {
-      console.log(usedTreeIds);
     }
   } catch (e) {
     // Hide the progress notification and handle the error

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -54,6 +54,7 @@ import features from "features";
 import { getInterpolationInfo } from "oxalis/model/sagas/volume/volume_interpolation_saga";
 import { getVisibleSegmentationLayer } from "oxalis/model/accessors/dataset_accessor";
 import { clearProofreadingByProducts } from "oxalis/model/actions/proofread_actions";
+import { hasAgglomerateMapping } from "oxalis/controller/combinations/segmentation_handlers";
 
 const narrowButtonStyle = {
   paddingLeft: 10,
@@ -550,10 +551,8 @@ function ChangeBrushSizeButton() {
 export default function ToolbarView() {
   const hasVolume = useSelector((state: OxalisState) => state.tracing.volumes.length > 0);
   const hasSkeleton = useSelector((state: OxalisState) => state.tracing.skeleton != null);
-  const hasAgglomerateMappings = useSelector((state: OxalisState) => {
-    const visibleSegmentationLayer = getVisibleSegmentationLayer(state);
-    return (visibleSegmentationLayer?.agglomerates?.length ?? 0) > 0;
-  });
+  const isAgglomerateMappingEnabled = useSelector(hasAgglomerateMapping);
+
   const [lastForcefulDisabledTool, setLastForcefulDisabledTool] = useState<AnnotationTool | null>(
     null,
   );
@@ -808,7 +807,7 @@ export default function ToolbarView() {
           />
         </RadioButtonWithTooltip>
 
-        {hasSkeleton && hasVolume && hasAgglomerateMappings ? (
+        {hasSkeleton && hasVolume && isAgglomerateMappingEnabled.value ? (
           <RadioButtonWithTooltip
             title="Proofreading Tool - Modify an agglomerated segmentation. Other segmentation modifications, like brushing, are not allowed if this tool is used."
             disabledTitle={disabledInfosForTools[AnnotationToolEnum.PROOFREAD].explanation}

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -52,7 +52,6 @@ import Store, { OxalisState, VolumeTracing } from "oxalis/store";
 
 import features from "features";
 import { getInterpolationInfo } from "oxalis/model/sagas/volume/volume_interpolation_saga";
-import { getVisibleSegmentationLayer } from "oxalis/model/accessors/dataset_accessor";
 import { clearProofreadingByProducts } from "oxalis/model/actions/proofread_actions";
 import { hasAgglomerateMapping } from "oxalis/controller/combinations/segmentation_handlers";
 

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -742,7 +742,7 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
               </Tooltip>
             )}
           </Menu.Item>,
-          isAgglomerateMappingEnabled.value && (
+          isAgglomerateMappingEnabled.value ? (
             <Menu.Item
               key="merge-agglomerate-skeleton"
               disabled={activeNodeId == null}
@@ -756,8 +756,8 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
                 </Tooltip>
               )}
             </Menu.Item>
-          ),
-          isAgglomerateMappingEnabled.value && (
+          ) : null,
+          isAgglomerateMappingEnabled.value ? (
             <Menu.Item
               key="min-cut-agglomerate-at-position"
               disabled={activeNodeId == null}
@@ -774,7 +774,7 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
                 </Tooltip>
               )}
             </Menu.Item>
-          ),
+          ) : null,
         ]
       : [];
   const segmentationLayerName =
@@ -867,7 +867,6 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
   let allActions: Array<JSX.Element | null> = [];
 
   if (isSkeletonToolActive) {
-    // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
     allActions = skeletonActions.concat(nonSkeletonActions).concat(boundingBoxActions);
   } else if (isBoundingBoxToolActive) {
     allActions = boundingBoxActions.concat(nonSkeletonActions).concat(skeletonActions);

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -742,35 +742,39 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
               </Tooltip>
             )}
           </Menu.Item>,
-          <Menu.Item
-            key="merge-agglomerate-skeleton"
-            disabled={!isAgglomerateMappingEnabled.value || activeNodeId == null}
-            onClick={() => Store.dispatch(proofreadMerge(globalPosition))}
-          >
-            {isAgglomerateMappingEnabled.value ? (
-              <span>Merge with active segment</span>
-            ) : (
-              <Tooltip title={isAgglomerateMappingEnabled.reason}>
+          isAgglomerateMappingEnabled.value && (
+            <Menu.Item
+              key="merge-agglomerate-skeleton"
+              disabled={activeNodeId == null}
+              onClick={() => Store.dispatch(proofreadMerge(globalPosition))}
+            >
+              {activeNodeId != null ? (
                 <span>Merge with active segment</span>
-              </Tooltip>
-            )}
-          </Menu.Item>,
-          <Menu.Item
-            key="min-cut-agglomerate-at-position"
-            disabled={!isAgglomerateMappingEnabled.value || activeNodeId == null}
-            onClick={() =>
-              activeNodeId &&
-              Store.dispatch(minCutAgglomerateWithPositionAction(activeNodeId, globalPosition))
-            }
-          >
-            {isAgglomerateMappingEnabled.value ? (
-              <span>Split from active segment (Min-Cut)</span>
-            ) : (
-              <Tooltip title={isAgglomerateMappingEnabled.reason}>
+              ) : (
+                <Tooltip title={"Cannot merge because there's no active node id."}>
+                  <span>Merge with active segment</span>
+                </Tooltip>
+              )}
+            </Menu.Item>
+          ),
+          isAgglomerateMappingEnabled.value && (
+            <Menu.Item
+              key="min-cut-agglomerate-at-position"
+              disabled={activeNodeId == null}
+              onClick={() =>
+                activeNodeId &&
+                Store.dispatch(minCutAgglomerateWithPositionAction(activeNodeId, globalPosition))
+              }
+            >
+              {activeNodeId != null ? (
                 <span>Split from active segment (Min-Cut)</span>
-              </Tooltip>
-            )}
-          </Menu.Item>,
+              ) : (
+                <Tooltip title={"Cannot split because there's no active node id."}>
+                  <span>Split from active segment (Min-Cut)</span>
+                </Tooltip>
+              )}
+            </Menu.Item>
+          ),
         ]
       : [];
   const segmentationLayerName =

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -711,7 +711,7 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
     dispatch(loadAdHocMeshAction(segmentId, globalPosition));
   };
 
-  const activeNodeId = skeletonTracing != null ? skeletonTracing.activeNodeId : null;
+  const activeNodeId = skeletonTracing?.activeNodeId;
   const isVolumeBasedToolActive = VolumeTools.includes(activeTool);
   const isBoundingBoxToolActive = activeTool === AnnotationToolEnum.BOUNDING_BOX;
   const skeletonActions =
@@ -986,7 +986,7 @@ function ContextMenuInner(propsWithInputRef: PropsWithRef) {
 
   if (contextMenuPosition != null && maybeViewport != null) {
     const activeTreeId = skeletonTracing != null ? skeletonTracing.activeTreeId : null;
-    const activeNodeId = skeletonTracing != null ? skeletonTracing.activeNodeId : null;
+    const activeNodeId = skeletonTracing?.activeNodeId;
 
     let nodeContextMenuTree: Tree | null = null;
     let nodeContextMenuNode: MutableNode | null = null;

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -84,6 +84,7 @@ import api from "oxalis/api/internal_api";
 import messages from "messages";
 import { extractPathAsNewTree } from "oxalis/model/reducers/skeletontracing_reducer_helpers";
 import Store from "oxalis/store";
+import { proofreadMerge, proofreadSplit } from "oxalis/model/actions/proofread_actions";
 const { SubMenu } = Menu;
 
 /* eslint-disable react/no-unused-prop-types */
@@ -670,6 +671,7 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
   const dispatch = useDispatch();
   const isAgglomerateMappingEnabled = useSelector(hasAgglomerateMapping);
   const isConnectomeMappingEnabled = useSelector(hasConnectomeFile);
+
   useEffect(() => {
     (async () => {
       await maybeFetchMeshFiles(visibleSegmentationLayer, dataset, false);
@@ -705,6 +707,7 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
     dispatch(loadAdHocMeshAction(segmentId, globalPosition));
   };
 
+  const activeNodeId = skeletonTracing != null ? skeletonTracing.activeNodeId : null;
   const isVolumeBasedToolActive = VolumeTools.includes(activeTool);
   const isBoundingBoxToolActive = activeTool === AnnotationToolEnum.BOUNDING_BOX;
   const skeletonActions =
@@ -733,6 +736,32 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
             ) : (
               <Tooltip title={isAgglomerateMappingEnabled.reason}>
                 <span>Import Agglomerate Skeleton {shortcutBuilder(["SHIFT", "middleMouse"])}</span>
+              </Tooltip>
+            )}
+          </Menu.Item>,
+          <Menu.Item
+            key="merge-agglomerate-skeleton"
+            disabled={!isAgglomerateMappingEnabled.value || activeNodeId == null}
+            onClick={() => Store.dispatch(proofreadMerge(globalPosition))}
+          >
+            {isAgglomerateMappingEnabled.value ? (
+              <span>Merge with currently active segment</span>
+            ) : (
+              <Tooltip title={isAgglomerateMappingEnabled.reason}>
+                <span>Merge with currently active segment</span>
+              </Tooltip>
+            )}
+          </Menu.Item>,
+          <Menu.Item
+            key="split-agglomerate-skeleton"
+            disabled={!isAgglomerateMappingEnabled.value || activeNodeId == null}
+            onClick={() => Store.dispatch(proofreadSplit(globalPosition))}
+          >
+            {isAgglomerateMappingEnabled.value ? (
+              <span>Split from currently active segment</span>
+            ) : (
+              <Tooltip title={isAgglomerateMappingEnabled.reason}>
+                <span>Split from currently active segment</span>
               </Tooltip>
             )}
           </Menu.Item>,

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -87,7 +87,6 @@ import {
   minCutAgglomerateAction,
   minCutAgglomerateWithPositionAction,
   proofreadMerge,
-  proofreadSplit,
 } from "oxalis/model/actions/proofread_actions";
 const { SubMenu } = Menu;
 
@@ -757,19 +756,6 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
             )}
           </Menu.Item>,
           <Menu.Item
-            key="split-agglomerate-skeleton"
-            disabled={!isAgglomerateMappingEnabled.value || activeNodeId == null}
-            onClick={() => Store.dispatch(proofreadSplit(globalPosition))}
-          >
-            {isAgglomerateMappingEnabled.value ? (
-              <span>Split from active segment</span>
-            ) : (
-              <Tooltip title={isAgglomerateMappingEnabled.reason}>
-                <span>Split from active segment</span>
-              </Tooltip>
-            )}
-          </Menu.Item>,
-          <Menu.Item
             key="min-cut-agglomerate-at-position"
             disabled={!isAgglomerateMappingEnabled.value || activeNodeId == null}
             onClick={() =>
@@ -778,10 +764,10 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
             }
           >
             {isAgglomerateMappingEnabled.value ? (
-              <span>(Min-)Cut from active segment</span>
+              <span>Split from active segment (Min-Cut)</span>
             ) : (
               <Tooltip title={isAgglomerateMappingEnabled.reason}>
-                <span>(Min-)Cut from active segment</span>
+                <span>Split from active segment (Min-Cut)</span>
               </Tooltip>
             )}
           </Menu.Item>,

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -39,7 +39,6 @@ import {
 import {
   deleteEdgeAction,
   mergeTreesAction,
-  minCutAgglomerateAction,
   deleteNodeAction,
   setActiveNodeAction,
   createTreeAction,
@@ -84,7 +83,12 @@ import api from "oxalis/api/internal_api";
 import messages from "messages";
 import { extractPathAsNewTree } from "oxalis/model/reducers/skeletontracing_reducer_helpers";
 import Store from "oxalis/store";
-import { proofreadMerge, proofreadSplit } from "oxalis/model/actions/proofread_actions";
+import {
+  minCutAgglomerateAction,
+  minCutAgglomerateWithPositionAction,
+  proofreadMerge,
+  proofreadSplit,
+} from "oxalis/model/actions/proofread_actions";
 const { SubMenu } = Menu;
 
 /* eslint-disable react/no-unused-prop-types */
@@ -745,10 +749,10 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
             onClick={() => Store.dispatch(proofreadMerge(globalPosition))}
           >
             {isAgglomerateMappingEnabled.value ? (
-              <span>Merge with currently active segment</span>
+              <span>Merge with active segment</span>
             ) : (
               <Tooltip title={isAgglomerateMappingEnabled.reason}>
-                <span>Merge with currently active segment</span>
+                <span>Merge with active segment</span>
               </Tooltip>
             )}
           </Menu.Item>,
@@ -758,10 +762,26 @@ function NoNodeContextMenuOptions(props: NoNodeContextMenuProps): JSX.Element {
             onClick={() => Store.dispatch(proofreadSplit(globalPosition))}
           >
             {isAgglomerateMappingEnabled.value ? (
-              <span>Split from currently active segment</span>
+              <span>Split from active segment</span>
             ) : (
               <Tooltip title={isAgglomerateMappingEnabled.reason}>
-                <span>Split from currently active segment</span>
+                <span>Split from active segment</span>
+              </Tooltip>
+            )}
+          </Menu.Item>,
+          <Menu.Item
+            key="min-cut-agglomerate-at-position"
+            disabled={!isAgglomerateMappingEnabled.value || activeNodeId == null}
+            onClick={() =>
+              activeNodeId &&
+              Store.dispatch(minCutAgglomerateWithPositionAction(activeNodeId, globalPosition))
+            }
+          >
+            {isAgglomerateMappingEnabled.value ? (
+              <span>(Min-)Cut from active segment</span>
+            ) : (
+              <Tooltip title={isAgglomerateMappingEnabled.reason}>
+                <span>(Min-)Cut from active segment</span>
               </Tooltip>
             )}
           </Menu.Item>,

--- a/frontend/javascripts/oxalis/view/right-border-tabs/connectome_tab/connectome_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/connectome_tab/connectome_view.tsx
@@ -190,7 +190,7 @@ function ensureTypeToString(synapseTypesAndNames: {
   const { synapseTypes, typeToString } = synapseTypesAndNames;
 
   if (typeToString.length === 0) {
-    Toast.error(`Couldn't read synapseTypes mapping. Please add a json file containing the synapseTypes next to the connectome file.
+    Toast.error(`Couldn't read synapseTypes mapping. Please add a json file (name should be equal to connectome file name) containing the synapseTypes next to the connectome file.
 The format should be: \`{
   "synapse_type_names": [ "type1", "type2", ... ]
 }\``);
@@ -796,7 +796,7 @@ class ConnectomeView extends React.Component<Props, State> {
           image={Empty.PRESENTED_IMAGE_SIMPLE}
           description={
             <span>
-              No connectome file available for this dataset.{" "}
+              No connectome file available for this segmentation layer.{" "}
               <a href="https://docs.webknossos.org/webknossos/connectome_viewer.html">
                 Read more about this feature in the documentation.
               </a>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- [https://___.webknossos.xyzhttps://proofreadingqolsplitandmerge.webknossos.xyz/](https://proofreadingqolsplitandmerge.webknossos.xyz/)

### Steps to test:
- create annotation for test-agglomerate-file DS
- select hdf5 mapping
- select proofreading tool
- click on segment to load agglomerate skeleton
- merging
  - select a node
  - rightclick on another segment (not a node) and select "merge with active segment"
    - --> segments should get merged (agglomerate skeleton will be reloaded)

~- splitting~
  ~- select a node~
    ~- rightclick on the same segment somewhere where it makes sense* and select "split from active segment"~
    ~- segments should get split~
- min-cutting
  - select a node
    - rightclick on the same segment somewhere where it makes sense** and select "min-cut from active segment"
    - segments should get split

Footnotes:
~\* for the user it's virtually impossible to know which voxel position would work for splitting, since one cannot see the oversegmentation (a toast will appear which tells you about this, though). if one clicks in the vicinity of another node of the same agglomerate skeleton, the chances are good that the split will succeed. however, it still might be the case that one clicks on the same over-segment. even if the split works, the user might get confused because nothing visibly happens. this is the case, when there are multiple edges which need to be split (however, the user action would only remove one edge).~
** for min-cutting there is the same risk of rightclicking the very same oversegment. however, if the target position refers to another over-segment, the split should succeed regardless of how many (indirect) edges exist, because they will be deleted by the min-cut.

the above problems might be only of theoretical nature. when working with actual segmentations and mergers/splits (and not dummy ones), the problem might be negligible. if these still appear, wk will recommend to use the agglomerate structure to perform the split or min-cut.

### Issues:
- fixes #6426

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
