### PR TITLE
Avoid int overflows for agglomerate tree id

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed isosurface loading for volume annotations with mappings. [#6458](https://github.com/scalableminds/webknossos/pull/6458)
 - Fixed importing of remote datastore (e.g., zarr) when datastore is set up separately. [#6462](https://github.com/scalableminds/webknossos/pull/6462)
 - Fixed a crash which could happen when using the "Automatically clip histogram" feature in certain scenarios. [#6433](https://github.com/scalableminds/webknossos/pull/6433)
+- Fixed loading agglomeate skeletons for agglomerate ids larger than 2^31. [#6472](https://github.com/scalableminds/webknossos/pull/6472)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
@@ -180,7 +180,7 @@ class AgglomerateService @Inject()(config: DataStoreConfig) extends DataConverte
 
       val trees = Seq(
         Tree(
-          treeId = agglomerateId.toInt,
+          treeId = 1,
           createdTimestamp = System.currentTimeMillis(),
           nodes = nodes,
           edges = skeletonEdges,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
@@ -180,7 +180,7 @@ class AgglomerateService @Inject()(config: DataStoreConfig) extends DataConverte
 
       val trees = Seq(
         Tree(
-          treeId = 1,
+          treeId = math.abs(agglomerateId.toInt), // used only to deterministically select tree color
           createdTimestamp = System.currentTimeMillis(),
           nodes = nodes,
           edges = skeletonEdges,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
@@ -506,7 +506,7 @@ class EditableMappingService @Inject()(
 
       trees = Seq(
         Tree(
-          treeId = 1,
+          treeId = math.abs(agglomerateId.toInt), // used only to deterministically select tree color
           createdTimestamp = System.currentTimeMillis(),
           nodes = nodes,
           edges = skeletonEdges,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
@@ -506,7 +506,7 @@ class EditableMappingService @Inject()(
 
       trees = Seq(
         Tree(
-          treeId = agglomerateId.toInt,
+          treeId = 1,
           createdTimestamp = System.currentTimeMillis(),
           nodes = nodes,
           edges = skeletonEdges,


### PR DESCRIPTION
Protobuf skeletons only support int tree ids, not long. We math.abs the id now as a hash function so that a unique deterministic tree color can be selected but no overflows occur, as the frontend won’t handle negative tree ids.

### Steps to test:
- load agglomerate skeletons for agglomerates with very large ids
- they should show

### Issues:
- fixes #6467 

------
- [x] added changelog entry
- [x] Needs datastore update after deployment
- [x] Ready for review
