### PR TITLE
Omit wk token in buildinfo

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -34,14 +34,12 @@ class Application @Inject()(multiUserDAO: MultiUserDAO,
   def buildInfo: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     for {
       schemaVersion <- releaseInformationDAO.getSchemaVersion.futureBox
-      token <- webKnossosToken(request.identity)
     } yield {
       addRemoteOriginHeaders(
         Ok(Json.obj(
           "webknossos" -> webknossos.BuildInfo.toMap.mapValues(_.toString),
           "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString),
           "schemaVersion" -> schemaVersion.toOption,
-          "token" -> token,
           "localDataStoreEnabled" -> storeModules.localDataStoreEnabled,
           "localTracingStoreEnabled" -> storeModules.localTracingStoreEnabled
         )))


### PR DESCRIPTION
We never manually used this token in the last years, as datastore and tracingstore routes now also take the user auth token for most routes.
I’d argue the risk of accidentally leaking it here is no longer justified (despite its expiry).

### URL of deployed dev instance (used for testing):
- https://buildinfoskiptoken.webknossos.xyz

### Steps to test:
- api/buildinfo should no longer contain the wk token, even if the requesting user is superUser.

------
- [x] Ready for review
