### PR TITLE
Add "shift + w" shortcut to cycle backwards through tools

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added workflow reporting and logging features for Voxelytics into webKnossos. If activated, the workflows can be accessed from the `Administration` > `Voxelytics` menu item. [#6416](https://github.com/scalableminds/webknossos/pull/6416) [#6460](https://github.com/scalableminds/webknossos/pull/6460)
 - The color of a segments can now be changed in the segments tab. Rightclick a segment in the list and select "Change Color" to open a color picker. [#6372](https://github.com/scalableminds/webknossos/pull/6372)
 - Added possibility to read N5 datasets. [#6466](https://github.com/scalableminds/webknossos/pull/6466)
+- Added "shift + w" shortcut to cycle backwards through annotation tools. [#6493](https://github.com/scalableminds/webknossos/pull/6493)
 
 ### Changed
 - Selecting a node with the proofreading tool won't have any side effects anymore. Previous versions could load additional agglomerate skeletons in certain scenarios which could be confusing. [#6477](https://github.com/scalableminds/webknossos/pull/6477)

--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -100,7 +100,8 @@ Note that you can enable *Classic Controls* which will behave slightly different
 | CTRL + SHIFT + Left Mouse Drag    | Remove Voxels From Segment                                     |
 | Alt + Mouse Move                  | Move                                                        |
 | C                                 | Create New Segment                                             |
-| W                                 | Toggle Modes (Move / Skeleton / Trace / Brush / ...)        |
+| W                                 | Cycle Through Tools (Move / Skeleton / Trace / Brush / ...)    |
+| SHIFT + W                         | Cycle Backwards Through Tools (Move / Proofread / Bounding Box / Pick Cell / ...) |
 | SHIFT + Mousewheel or SHIFT + I, O | Change Brush Size (Brush Mode)                             |
 | V                                 | Interpolate current segment between last labeled and current slice |
 

--- a/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.tsx
+++ b/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.tsx
@@ -89,6 +89,10 @@ const cycleTools = () => {
   Store.dispatch(cycleToolAction());
 };
 
+const cycleToolsBackwards = () => {
+  Store.dispatch(cycleToolAction(true));
+};
+
 type StateProps = {
   tracing: Tracing;
   activeTool: AnnotationTool;
@@ -438,6 +442,7 @@ class PlaneController extends React.PureComponent<Props> {
       },
       q: downloadScreenshot,
       w: cycleTools,
+      "shift + w": cycleToolsBackwards,
     };
     // TODO: Find a nicer way to express this, while satisfying flow
     const emptyDefaultHandler = {

--- a/frontend/javascripts/oxalis/model/actions/ui_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/ui_actions.ts
@@ -72,9 +72,10 @@ export const setToolAction = (tool: AnnotationTool) =>
     type: "SET_TOOL",
     tool,
   } as const);
-export const cycleToolAction = () =>
+export const cycleToolAction = (backwards: boolean = false) =>
   ({
     type: "CYCLE_TOOL",
+    backwards,
   } as const);
 export const setThemeAction = (value: Theme) =>
   ({

--- a/frontend/javascripts/oxalis/model/reducers/reducer_helpers.ts
+++ b/frontend/javascripts/oxalis/model/reducers/reducer_helpers.ts
@@ -144,6 +144,26 @@ export function getNextTool(state: OxalisState): AnnotationTool | null {
 
   return null;
 }
+export function getPreviousTool(state: OxalisState): AnnotationTool | null {
+  const disabledToolInfo = getDisabledInfoForTools(state);
+  const tools = Object.keys(AnnotationToolEnum) as AnnotationTool[];
+  const currentToolIndex = tools.indexOf(state.uiInformation.activeTool);
+
+  // Search backwards for the next tool which is not disabled.
+  for (
+    let newToolIndex = currentToolIndex - 1;
+    newToolIndex > currentToolIndex - tools.length;
+    newToolIndex--
+  ) {
+    const newTool = tools[(tools.length + newToolIndex) % tools.length];
+
+    if (!disabledToolInfo[newTool].isDisabled) {
+      return newTool;
+    }
+  }
+
+  return null;
+}
 export function setToolReducer(state: OxalisState, tool: AnnotationTool) {
   if (tool === state.uiInformation.activeTool) {
     return state;

--- a/frontend/javascripts/oxalis/model/reducers/ui_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/ui_reducer.ts
@@ -1,7 +1,11 @@
 import type { Action } from "oxalis/model/actions/actions";
 import type { OxalisState } from "oxalis/store";
 import { updateKey } from "oxalis/model/helpers/deep_update";
-import { setToolReducer, getNextTool } from "oxalis/model/reducers/reducer_helpers";
+import {
+  setToolReducer,
+  getNextTool,
+  getPreviousTool,
+} from "oxalis/model/reducers/reducer_helpers";
 import { hideBrushReducer } from "oxalis/model/reducers/volumetracing_reducer_helpers";
 
 function UiReducer(state: OxalisState, action: Action): OxalisState {
@@ -62,7 +66,7 @@ function UiReducer(state: OxalisState, action: Action): OxalisState {
         return state;
       }
 
-      const nextTool = getNextTool(state);
+      const nextTool = action.backwards ? getPreviousTool(state) : getNextTool(state);
 
       if (nextTool == null) {
         // Don't change the current tool if another tool could not be selected.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open an annotation and use shift + w to cycle through tools backwards

### Issues:
- fixes #6299 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
