### PR TITLE
Load 5000 versions instead of 500 for the paginated version restore list

### DIFF
--- a/frontend/javascripts/oxalis/view/version_list.tsx
+++ b/frontend/javascripts/oxalis/view/version_list.tsx
@@ -27,7 +27,7 @@ import api from "oxalis/api/internal_api";
 import Toast from "libs/toast";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 
-const ENTRIES_PER_PAGE = 500;
+const ENTRIES_PER_PAGE = 5000;
 
 type Props = {
   versionedObjectType: SaveQueueType;


### PR DESCRIPTION
Loading 500 versions only takes ~100ms and there are tracings with more than 500k versions. So, the page size should be higher.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- shouldn't be necessary

### Issues:
- follow up for #5421 

