### PR TITLE
Fix validation of layer selection when trying to start globalization of floodfills

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed loading agglomeate skeletons for agglomerate ids larger than 2^31. [#6472](https://github.com/scalableminds/webknossos/pull/6472)
 - Fixed bug which could lead to conflict-warnings even though there weren't any. [#6477](https://github.com/scalableminds/webknossos/pull/6477)
 - Fixed that one could not change the color of a segment or tree in Firefox. [#6488](https://github.com/scalableminds/webknossos/pull/6488)
+- Fixed validation of layer selection when trying to start globalization of floodfills. [#6497](https://github.com/scalableminds/webknossos/pull/6497)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
@@ -424,7 +424,7 @@ with wk.webknossos_context(
                 <Col span={15}>
                   <LayerSelection
                     layers={layers}
-                    setSelectedLayerName={setSelectedLayerName}
+                    onChange={setSelectedLayerName}
                     tracing={tracing}
                     style={{ width: 330 }}
                   />

--- a/frontend/javascripts/oxalis/view/right-border-tabs/starting_job_modals.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/starting_job_modals.tsx
@@ -81,19 +81,21 @@ export function LayerSelection({
   tracing,
   fixedLayerName,
   layerType,
-  setSelectedLayerName,
+  onChange,
   style,
+  value,
 }: {
   layers: APIDataLayer[];
   tracing: HybridTracing;
   fixedLayerName?: string;
   layerType?: string;
-  setSelectedLayerName?: React.Dispatch<React.SetStateAction<string | null>>;
   style?: React.CSSProperties;
+  // onChange and value should not be renamed, because these are the
+  // default property names for controlled antd FormItems.
+  onChange?: React.Dispatch<React.SetStateAction<string | null>>;
+  value?: string | null;
 }): JSX.Element {
-  const onSelect = setSelectedLayerName
-    ? (layerName: string) => setSelectedLayerName(layerName)
-    : undefined;
+  const onSelect = onChange ? (layerName: string) => onChange(layerName) : undefined;
   const maybeLayerType = layerType || "";
   const maybeSpace = layerType != null ? " " : "";
   return (
@@ -108,6 +110,7 @@ export function LayerSelection({
       disabled={fixedLayerName != null}
       onSelect={onSelect}
       style={style}
+      value={value}
     >
       {layers.map((layer) => {
         const readableName = getReadableNameOfVolumeLayer(layer, tracing) || layer.name;
@@ -135,7 +138,7 @@ function LayerSelectionFormItem({
       rules={[
         {
           required: true,
-          message: `Please select the ${layerType} that should be used for this job.`,
+          message: `Please select the ${layerType} layer that should be used for this job.`,
         },
       ]}
       hidden={layers.length === 1 && fixedLayerName == null}


### PR DESCRIPTION
Additionally, I also changed the globalize button to be always visible, but explain when it's disabled via a tooltip.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- setup worker
- use fill tool for a large cell so that it's only partially computed
- click globalize floodfill button
- select layer
- confirm modal -> shouldn't an invalid form error

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
