### PR TITLE
makes workflow_yamlContent optional

### DIFF
--- a/app/models/voxelytics/VoxelyticsDAO.scala
+++ b/app/models/voxelytics/VoxelyticsDAO.scala
@@ -347,7 +347,7 @@ class VoxelyticsDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContex
                 hostname: String,
                 voxelyticsVersion: String,
                 workflow_hash: String,
-                workflow_yamlContent: String,
+                workflow_yamlContent: Option[String],
                 workflow_config: JsValue): Fox[ObjectId] =
     for {
       _ <- run(

--- a/app/models/voxelytics/WorkflowDescription.scala
+++ b/app/models/voxelytics/WorkflowDescription.scala
@@ -31,7 +31,7 @@ case class WorkflowDescriptionArtifact(path: String,
 
 case class WorkflowDescriptionRun(name: String, user: String, hostname: String, voxelyticsVersion: String)
 
-case class WorkflowDescriptionWorkflow(name: String, hash: String, yamlContent: String)
+case class WorkflowDescriptionWorkflow(name: String, hash: String, yamlContent: Option[String])
 
 case class WorkflowDescription(config: WorkflowDescriptionConfig,
                                artifacts: Map[String, Map[String, WorkflowDescriptionArtifact]],


### PR DESCRIPTION
Actually, the field `workflow_yamlContent` is optional. For example, when constructing the workflow in code (like in the tests).

------
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
