### PR TITLE
Allow assigning task to a user directly

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/22.10.0...HEAD)
 
 ### Added
+- Tasks can now be assigned to individual users directly. [#6528](https://github.com/scalableminds/webknossos/pull/6528)
 
 ### Changed
 - Creating tasks in bulk now also supports referencing task types by their summary instead of id. [#6486](https://github.com/scalableminds/webknossos/pull/6486)

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -196,13 +196,37 @@ Expects:
       for {
         teams <- taskService.getAllowedTeamsForNextTask(user)
         isTeamManagerOrAdmin <- userService.isTeamManagerOrAdminOfOrg(user, user._organization)
-        (task, initializingAnnotationId) <- taskDAO
+        (taskId, initializingAnnotationId) <- taskDAO
           .assignNext(user._id, teams, isTeamManagerOrAdmin) ?~> "task.unavailable"
-        insertedAnnotationBox <- annotationService.createAnnotationFor(user, task, initializingAnnotationId).futureBox
+        insertedAnnotationBox <- annotationService.createAnnotationFor(user, taskId, initializingAnnotationId).futureBox
         _ <- annotationService.abortInitializedAnnotationOnFailure(initializingAnnotationId, insertedAnnotationBox)
         annotation <- insertedAnnotationBox.toFox
         annotationJSON <- annotationService.publicWrites(annotation, Some(user))
       } yield JsonOk(annotationJSON, Messages("task.assigned"))
+    }
+  }
+  @ApiOperation(hidden = true, value = "")
+  def assignOne(id: String, userId: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
+    log() {
+      for {
+        taskIdValidated <- ObjectId.fromString(id)
+        userIdValidated <- ObjectId.fromString(userId)
+        assignee <- userService.findOneById(userIdValidated, useCache = true)
+        teams <- userService.teamIdsFor(userIdValidated)
+        task <- taskDAO.findOne(taskIdValidated)
+        project <- projectDAO.findOne(task._project)
+        _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(request.identity, project._team)) ?~> Messages(
+          "notAllowed")
+        _ <- Fox.assertTrue(userService.isTeamManagerOrAdminOf(request.identity, assignee)) ?~> Messages("notAllowed")
+        (_, initializingAnnotationId) <- taskDAO
+          .assignOneTo(taskIdValidated, userIdValidated, teams) ?~> "task.unavailable"
+        insertedAnnotationBox <- annotationService
+          .createAnnotationFor(assignee, taskIdValidated, initializingAnnotationId)
+          .futureBox
+        _ <- annotationService.abortInitializedAnnotationOnFailure(initializingAnnotationId, insertedAnnotationBox)
+        _ <- insertedAnnotationBox.toFox
+        taskJson <- taskService.publicWrites(task)(GlobalAccessContext)
+      } yield Ok(taskJson)
     }
   }
 

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -433,14 +433,14 @@ class AnnotationService @Inject()(
         tracingStoreClient.duplicateVolumeTracing(volumeId))
     } yield (newSkeletonId, newVolumeId)
 
-  def createAnnotationFor(user: User, task: Task, initializingAnnotationId: ObjectId)(
+  def createAnnotationFor(user: User, taskId: ObjectId, initializingAnnotationId: ObjectId)(
       implicit m: MessagesProvider,
       ctx: DBAccessContext): Fox[Annotation] = {
     def useAsTemplateAndInsert(annotation: Annotation) =
       for {
         dataSetName <- dataSetDAO.getNameById(annotation._dataSet)(GlobalAccessContext) ?~> "dataSet.notFoundForAnnotation"
         dataSet <- dataSetDAO.findOne(annotation._dataSet) ?~> Messages("dataSet.noAccess", dataSetName)
-        (newSkeletonId, newVolumeId) <- tracingsFromBase(annotation, dataSet) ?~> s"Failed to use annotation base as template for task ${task._id} with annotation base ${annotation._id}"
+        (newSkeletonId, newVolumeId) <- tracingsFromBase(annotation, dataSet) ?~> s"Failed to use annotation base as template for task $taskId with annotation base ${annotation._id}"
         annotationLayers <- AnnotationLayer.layersFromIds(newSkeletonId, newVolumeId)
         newAnnotation = annotation.copy(
           _id = initializingAnnotationId,
@@ -455,7 +455,7 @@ class AnnotationService @Inject()(
       } yield newAnnotation
 
     for {
-      annotationBase <- baseForTask(task._id) ?~> "Failed to retrieve annotation base."
+      annotationBase <- baseForTask(taskId) ?~> "Failed to retrieve annotation base."
       result <- useAsTemplateAndInsert(annotationBase).toFox
     } yield result
   }

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -167,6 +167,7 @@ GET           /tasks/experienceDomains                                          
 GET           /tasks/:id                                                                controllers.TaskController.read(id: String)
 DELETE        /tasks/:id                                                                controllers.TaskController.delete(id: String)
 PUT           /tasks/:id                                                                controllers.TaskController.update(id: String)
+POST          /tasks/:id/assign                                                         controllers.TaskController.assignOne(id: String, userId: String)
 GET           /tasks/:id/annotations                                                    controllers.AnnotationController.annotationsForTask(id: String)
 
 # TaskTypes


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Backend: `http --verbose POST http://localhost:9000/api/tasks/633c43cef401002f027ed020/assign?userId=63355628f90100f9011bd738 X-Auth-Token:secretSampleUserToken`
- returns a task json (as I assume it will be called from the admin interface. The returned task stats should have one less open instance)
- the user should then find the task in their dashboard

### Issues:
- fixes #5810

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Ready for review
