### PR TITLE
Fix MeshChunk byteOffset (Long, not Int)

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/MeshFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/MeshFileService.scala
@@ -132,7 +132,7 @@ object NeuroglancerSegmentInfo {
   }
 }
 
-case class MeshChunk(position: Vec3Float, byteOffset: Int, byteSize: Int)
+case class MeshChunk(position: Vec3Float, byteOffset: Long, byteSize: Int)
 
 object MeshChunk {
   implicit val jsonFormat: OFormat[MeshChunk] = Json.format[MeshChunk]
@@ -279,7 +279,7 @@ class MeshFileService @Inject()(config: DataStoreConfig)(implicit ec: ExecutionC
 
       MeshChunk(
         position = globalPosition, // This position is in Voxel Space
-        byteOffset = meshByteStartOffset.toInt + chunkByteOffsets(lod)(currentChunk),
+        byteOffset = meshByteStartOffset + chunkByteOffsets(lod)(currentChunk),
         byteSize = segmentInfo.chunkByteOffsets(lod)(currentChunk),
       )
     }


### PR DESCRIPTION
ByteOffset can be larger than Int range, should be treated as Long all the way through.

- [x] Needs datastore update after deployment
- [x] Ready for review
