### PR TITLE
Fix for VX report status indicator

### DIFF
--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -559,7 +559,11 @@ function aggregateTaskInfos(
       state = VoxelyticsRunState.SKIPPED;
     } else if (taskInfos.every((t) => t.state === VoxelyticsRunState.PENDING)) {
       state = VoxelyticsRunState.PENDING;
-    } else if (taskInfos.every((t) => t.state === VoxelyticsRunState.COMPLETE)) {
+    } else if (
+      taskInfos.every(
+        (t) => t.state === VoxelyticsRunState.COMPLETE || t.state === VoxelyticsRunState.SKIPPED,
+      )
+    ) {
       state = VoxelyticsRunState.COMPLETE;
       [beginTime, endTime] = aggregateTimes(taskInfos);
     } else if (taskInfos.some((t) => t.state === VoxelyticsRunState.RUNNING)) {


### PR DESCRIPTION
Added a small fix for the VX reporting where a combination of `Completed`+ `Skipped` (sub)-task states would be aggregated as `Failed`. It should be `Completed` instead.

### Issues:
<img width="890" alt="image" src="https://user-images.githubusercontent.com/1105056/194500668-8fce723a-5f3a-49fb-af4a-af22fb4bde00.png">


------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
