### PR TITLE
Added total runtime information to VX reports

### DIFF
--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -20,6 +20,7 @@ import {
   CheckCircleOutlined,
   ExclamationCircleOutlined,
   LeftOutlined,
+  FieldTimeOutlined,
 } from "@ant-design/icons";
 import MiniSearch from "minisearch";
 import ColorHash from "color-hash";
@@ -36,7 +37,7 @@ import {
   VoxelyticsWorkflowReport,
 } from "types/api_flow_types";
 import { getVoxelyticsLogs } from "admin/admin_rest_api";
-import { formatDateMedium, formatDistance, formatDistanceStrict } from "libs/format_utils";
+import { formatDateMedium, formatDistance, formatDistanceStrict, formatDurationStrict } from "libs/format_utils";
 import DAGView from "./dag_view";
 import TaskView from "./task_view";
 import { formatLog } from "./log_tab";
@@ -452,6 +453,12 @@ export default function TaskListView({
     );
   };
 
+  const totalRuntime = report.run.tasks
+    .filter((t) => "endTime" in t && "beginTime" in t)
+    .reduce((sum, t) => {
+      return sum.add(moment.duration(moment(t.endTime).diff(moment(t.beginTime))));
+    }, moment.duration(0));
+
   const {
     workflow: { name: readableWorkflowName },
     run: { beginTime: runBeginTimeString },
@@ -465,13 +472,14 @@ export default function TaskListView({
       }}
     >
       <Col xs={10} style={{ display: "flex", flexDirection: "column" }}>
-        <h3>
-          {readableWorkflowName}{" "}
-          <span style={{ color: "#51686e" }}>
-            {" "}
-            {formatDateMedium(new Date(runBeginTimeString))}
-          </span>
-        </h3>
+        <h3 style={{ marginBottom: 0 }}>{readableWorkflowName} </h3>
+        <h4 style={{ color: "#51686e" }}>
+            {formatDateMedium(new Date(runBeginTimeString))}{" "}
+          <Tooltip title={formatDurationStrict(totalRuntime)}>
+            <FieldTimeOutlined style={{ marginLeft: 20 }} />
+            {totalRuntime.humanize()}
+          </Tooltip>
+        </h4>
         <div style={{ flex: 1, position: "relative" }}>
           <DAGView
             key={filteredTasks.map((t) => t.taskName).join("_")}

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -459,9 +459,16 @@ export default function TaskListView({
   };
 
   const totalRuntime = report.run.tasks
-    .filter((t) => "endTime" in t && "beginTime" in t)
     .reduce(
-      (sum, t) => sum.add(moment.duration(moment(t.endTime).diff(moment(t.beginTime)))),
+      (sum, t) => {
+        if (t.state === VoxelyticsRunState.RUNNING) {
+          return sum.add(moment.duration(moment().diff(moment(t.beginTime))));
+        } else if (t.beginTime != null && t.endTime != null) {
+          return sum.add(moment.duration(moment(t.endTime).diff(moment(t.beginTime))));
+        } else {
+          return sum;
+        }
+      },
       moment.duration(0),
     );
 

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -458,19 +458,15 @@ export default function TaskListView({
     );
   };
 
-  const totalRuntime = report.run.tasks
-    .reduce(
-      (sum, t) => {
-        if (t.state === VoxelyticsRunState.RUNNING) {
-          return sum.add(moment.duration(moment().diff(moment(t.beginTime))));
-        } else if (t.beginTime != null && t.endTime != null) {
-          return sum.add(moment.duration(moment(t.endTime).diff(moment(t.beginTime))));
-        } else {
-          return sum;
-        }
-      },
-      moment.duration(0),
-    );
+  const totalRuntime = report.run.tasks.reduce((sum, t) => {
+    if (t.state === VoxelyticsRunState.RUNNING) {
+      return sum.add(moment.duration(moment().diff(moment(t.beginTime))));
+    } else if (t.beginTime != null && t.endTime != null) {
+      return sum.add(moment.duration(moment(t.endTime).diff(moment(t.beginTime))));
+    } else {
+      return sum;
+    }
+  }, moment.duration(0));
 
   const {
     workflow: { name: readableWorkflowName },

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -37,7 +37,12 @@ import {
   VoxelyticsWorkflowReport,
 } from "types/api_flow_types";
 import { getVoxelyticsLogs } from "admin/admin_rest_api";
-import { formatDateMedium, formatDistance, formatDistanceStrict, formatDurationStrict } from "libs/format_utils";
+import {
+  formatDateMedium,
+  formatDistance,
+  formatDistanceStrict,
+  formatDurationStrict,
+} from "libs/format_utils";
 import DAGView from "./dag_view";
 import TaskView from "./task_view";
 import { formatLog } from "./log_tab";
@@ -455,9 +460,10 @@ export default function TaskListView({
 
   const totalRuntime = report.run.tasks
     .filter((t) => "endTime" in t && "beginTime" in t)
-    .reduce((sum, t) => {
-      return sum.add(moment.duration(moment(t.endTime).diff(moment(t.beginTime))));
-    }, moment.duration(0));
+    .reduce(
+      (sum, t) => sum.add(moment.duration(moment(t.endTime).diff(moment(t.beginTime)))),
+      moment.duration(0),
+    );
 
   const {
     workflow: { name: readableWorkflowName },
@@ -474,7 +480,7 @@ export default function TaskListView({
       <Col xs={10} style={{ display: "flex", flexDirection: "column" }}>
         <h3 style={{ marginBottom: 0 }}>{readableWorkflowName} </h3>
         <h4 style={{ color: "#51686e" }}>
-            {formatDateMedium(new Date(runBeginTimeString))}{" "}
+          {formatDateMedium(new Date(runBeginTimeString))}{" "}
           <Tooltip title={formatDurationStrict(totalRuntime)}>
             <FieldTimeOutlined style={{ marginLeft: 20 }} />
             {totalRuntime.humanize()}

--- a/frontend/javascripts/libs/format_utils.ts
+++ b/frontend/javascripts/libs/format_utils.ts
@@ -187,7 +187,7 @@ export function formatDistanceStrict(start: Date | number, end: Date | number): 
 export function formatDurationStrict(duration: Duration): string {
   const parts: Array<string> = [];
   if (Math.floor(duration.asDays()) > 0) {
-    parts.push(`${Math.floor(duration.asDays())} days`);
+    parts.push(`${Math.floor(duration.asDays())}d`);
   }
   if (duration.hours() > 0) {
     parts.push(`${duration.hours()}h`);

--- a/frontend/javascripts/libs/format_utils.ts
+++ b/frontend/javascripts/libs/format_utils.ts
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment, { Duration } from "moment";
 import { presetPalettes } from "@ant-design/colors";
 import type { Vector3, Vector6 } from "oxalis/constants";
 import { Unicode } from "oxalis/constants";
@@ -182,7 +182,9 @@ export function formatDistance(start: Date | number, end: Date | number): string
 }
 export function formatDistanceStrict(start: Date | number, end: Date | number): string {
   const duration = moment.duration(moment(start).diff(moment(end)));
-
+  return formatDurationStrict(duration);
+}
+export function formatDurationStrict(duration: Duration): string {
   const parts: Array<string> = [];
   if (Math.floor(duration.asDays()) > 0) {
     parts.push(`${Math.floor(duration.asDays())} days`);

--- a/frontend/javascripts/libs/format_utils.ts
+++ b/frontend/javascripts/libs/format_utils.ts
@@ -190,13 +190,13 @@ export function formatDurationStrict(duration: Duration): string {
     parts.push(`${Math.floor(duration.asDays())} days`);
   }
   if (duration.hours() > 0) {
-    parts.push(`${duration.hours()} hours`);
+    parts.push(`${duration.hours()}h`);
   }
   if (duration.minutes() > 0) {
-    parts.push(`${duration.minutes()} minutes`);
+    parts.push(`${duration.minutes()}m`);
   }
   if (duration.seconds() > 0) {
-    parts.push(`${duration.seconds()} seconds`);
+    parts.push(`${duration.seconds()}s`);
   }
   return parts.join(" ");
 }


### PR DESCRIPTION
Add an indicator for the total runtime of all tasks of a workflow to the VX reports. I also shorted the string formatting for time durations to make them more compact/fit the UI better.

Runtime:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/1105056/194546222-c308661b-144a-450d-ab0b-c818466c9b3f.png">

Runtime Tooltip with detailed information:
<img width="202" alt="image" src="https://user-images.githubusercontent.com/1105056/194546499-8efc557f-33c9-482d-8426-29d434242273.png">

Shortened time duration strings:
<img width="849" alt="image" src="https://user-images.githubusercontent.com/1105056/194546523-41701659-08e7-4d09-9f7d-5bb8868fad01.png">


### Steps to test:
- Open any VX report with one or more tasks that are completed / have some CPU time.

### Issues:
- fixes None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
