### PR TITLE
Add backspace keyboard shortcut to delete active node

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Support for a new mesh file format which allows up to billions of meshes. [#6491](https://github.com/scalableminds/webknossos/pull/6491)
 - Remote n5 datasets can now also be explored and added. [#6520](https://github.com/scalableminds/webknossos/pull/6520)
 - Improved performance for applying agglomerate mappings on segmentation data. [#6532](https://github.com/scalableminds/webknossos/pull/6532)
+- Added backspace as an additional keyboard shortcut for deleting the active node. [#6554](https://github.com/scalableminds/webknossos/pull/6554)
 
 ### Changed
 - Creating tasks in bulk now also supports referencing task types by their summary instead of id. [#6486](https://github.com/scalableminds/webknossos/pull/6486)

--- a/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.tsx
+++ b/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.tsx
@@ -106,6 +106,7 @@ class SkeletonKeybindings {
       "2": () => Store.dispatch(toggleInactiveTreesAction()),
       // Delete active node
       delete: () => Store.dispatch(deleteActiveNodeAsUserAction(Store.getState())),
+      backspace: () => Store.dispatch(deleteActiveNodeAsUserAction(Store.getState())),
       c: () => Store.dispatch(createTreeAction()),
       e: () => SkeletonHandlers.moveAlongDirection(),
       r: () => SkeletonHandlers.moveAlongDirection(true),


### PR DESCRIPTION
The default keyboard shortcut to delete a node is `DEL`. This key is not present on the MacOS keyboard. The PR adds backspace as an additional keyboard shortcut to delete the active node.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Select a node
- Press backspace key on Mac keyboard
- Node be gone

### Issues:
- fixes #6511

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
