### PR TITLE
Fix stack overflow in compactMovedNodesAndEdges

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where some file requests replied with error 400 instead of 404, confusing some zarr clients. [#6515](https://github.com/scalableminds/webknossos/pull/6515)
 - Fixed a bug where the `transform` of a new mesh file wasn't taken into account for the rendering of meshes. [#6552](https://github.com/scalableminds/webknossos/pull/6552) 
+- Fixed a rare crash when splitting/merging a large skeleton. [#6557](https://github.com/scalableminds/webknossos/pull/6557)
 
 ### Removed
 

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -557,6 +557,17 @@ export function diffArrays<T>(
     onlyB,
   };
 }
+export function withoutValues<T>(arr: Array<T>, elements: Array<T>): Array<T> {
+  // This set-based implementation avoids stackoverflow errors from which
+  // _.without(arr, ...elements) suffers.
+  // When measured against a chunk-based _.without approach, this implementation
+  // is 20% faster.
+  // _.pullValues was also tested, but this didn't even terminate in a minute
+  // (whereas the other test sets could be tackled in under one second).
+
+  const auxSet = new Set(elements);
+  return arr.filter((x) => !auxSet.has(x));
+}
 export function zipMaybe<T, U>(maybeA: Maybe<T>, maybeB: Maybe<U>): Maybe<[T, U]> {
   return maybeA.chain((valueA) => maybeB.map((valueB) => [valueA, valueB]));
 }

--- a/frontend/javascripts/oxalis/model/helpers/compaction/compact_update_actions.ts
+++ b/frontend/javascripts/oxalis/model/helpers/compaction/compact_update_actions.ts
@@ -1,12 +1,18 @@
 import _ from "lodash";
 import type { SkeletonTracing, VolumeTracing } from "oxalis/store";
-import type { UpdateAction } from "oxalis/model/sagas/update_actions";
+import type {
+  CreateEdgeUpdateAction,
+  CreateNodeUpdateAction,
+  DeleteEdgeUpdateAction,
+  DeleteNodeUpdateAction,
+  UpdateAction,
+} from "oxalis/model/sagas/update_actions";
 import { moveTreeComponent } from "oxalis/model/sagas/update_actions";
 import compactToggleActions from "oxalis/model/helpers/compaction/compact_toggle_actions";
+import { withoutValues } from "libs/utils";
 
 // The Cantor pairing function assigns one natural number to each pair of natural numbers
-// @ts-expect-error ts-migrate(7006) FIXME: Parameter 'a' implicitly has an 'any' type.
-function cantor(a, b) {
+function cantor(a: number, b: number): number {
   return 0.5 * (a + b) * (a + b + 1) + b;
 }
 
@@ -23,7 +29,10 @@ function compactMovedNodesAndEdges(updateActions: Array<UpdateAction>) {
   // described later.
   let compactedActions = [...updateActions];
   // Detect moved nodes and edges
-  const movedNodesAndEdges = [];
+  const movedNodesAndEdges: Array<
+    | [CreateNodeUpdateAction, DeleteNodeUpdateAction]
+    | [CreateEdgeUpdateAction, DeleteEdgeUpdateAction]
+  > = [];
 
   // Performance improvement: create a map of the deletedNode update actions, key is the nodeId
   const deleteNodeActionsMap = _.keyBy(updateActions, (ua) =>
@@ -52,9 +61,7 @@ function compactMovedNodesAndEdges(updateActions: Array<UpdateAction>) {
 
       if (
         deleteUA != null &&
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'name' does not exist on type 'number | U... Remove this comment to see the full error message
         deleteUA.name === "deleteEdge" &&
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'number | ... Remove this comment to see the full error message
         deleteUA.value.treeId !== createUA.value.treeId
       ) {
         movedNodesAndEdges.push([createUA, deleteUA]);
@@ -65,19 +72,15 @@ function compactMovedNodesAndEdges(updateActions: Array<UpdateAction>) {
   // Group moved nodes and edges by their old and new treeId using the cantor pairing function
   // to create a single unique id
   const groupedMovedNodesAndEdges = _.groupBy(movedNodesAndEdges, ([createUA, deleteUA]) =>
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'number | ... Remove this comment to see the full error message
     cantor(createUA.value.treeId, deleteUA.value.treeId),
   );
 
   // Create a moveTreeComponent update action for each of the groups and insert it at the right spot
   for (const movedPairings of _.values(groupedMovedNodesAndEdges)) {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'number | ... Remove this comment to see the full error message
     const oldTreeId = movedPairings[0][1].value.treeId;
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'number | ... Remove this comment to see the full error message
     const newTreeId = movedPairings[0][0].value.treeId;
     // This could be done with a .filter(...).map(...), but flow cannot comprehend that
-    const nodeIds = movedPairings.reduce((agg, [createUA]) => {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'name' does not exist on type 'number | U... Remove this comment to see the full error message
+    const nodeIds = movedPairings.reduce((agg: number[], [createUA]) => {
       if (createUA.name === "createNode") agg.push(createUA.value.id);
       return agg;
     }, []);
@@ -101,7 +104,6 @@ function compactMovedNodesAndEdges(updateActions: Array<UpdateAction>) {
       compactedActions.splice(
         createTreeUAIndex + 1,
         0,
-        // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(number | UpdateAction | ((...it... Remove this comment to see the full error message
         moveTreeComponent(oldTreeId, newTreeId, nodeIds),
       );
     } else if (deleteTreeUAIndex > -1) {
@@ -109,23 +111,24 @@ function compactMovedNodesAndEdges(updateActions: Array<UpdateAction>) {
       compactedActions.splice(
         deleteTreeUAIndex,
         0,
-        // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(number | UpdateAction | ((...it... Remove this comment to see the full error message
         moveTreeComponent(oldTreeId, newTreeId, nodeIds),
       );
     } else {
       // Insert in front
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(number | UpdateAction | ((...it... Remove this comment to see the full error message
       compactedActions.unshift(moveTreeComponent(oldTreeId, newTreeId, nodeIds));
     }
 
-    // Remove the original create/delete update actions of the moved nodes and edges
-    // Call _.without with chunks to avoid Call Stack Size Exceeded errors due to the arguments spread
-    const movedPairingsChunks = _.chunk(movedPairings, 50000);
-
-    for (const pairingsChunk of movedPairingsChunks) {
-      // @ts-expect-error ts-migrate(2322) FIXME: Type '(number | UpdateAction | ((...items: UpdateA... Remove this comment to see the full error message
-      compactedActions = _.without(compactedActions, ..._.flatten(pairingsChunk));
-    }
+    // Remove the original create/delete update actions of the moved nodes and edges.
+    type CreateOrDeleteNodeOrEdge =
+      | CreateNodeUpdateAction
+      | DeleteNodeUpdateAction
+      | CreateEdgeUpdateAction
+      | DeleteEdgeUpdateAction;
+    compactedActions = withoutValues(
+      compactedActions,
+      // Cast movedPairs type to satisfy _.flatten
+      _.flatten(movedPairings as Array<[CreateOrDeleteNodeOrEdge, CreateOrDeleteNodeOrEdge]>),
+    );
   }
 
   return compactedActions;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixstackoverflow.webknossos.xyz/

### Steps to test:
- I used some sloppy benchmark code like this to validate that no stack overflow is raised anymore (with the spread, the stackoverflow occurs reliably):
```
window.testStackOverflowSet = (amount) => {
  const setup = () => {
    const arr = [];
    for (let i = 0; i < amount; i++) {
      arr.push(moveTreeComponent(0, 1, [1]));
    }
    return arr;
  };

  const arr = setup();
  console.time("without");
  const setWithout = new Set(arr.slice(0, amount - 100));
  const afterArr = arr.filter((x) => !setWithout.has(x));
  console.timeEnd("without");};
```
- in addition to the CI tests, split and merge a tree, save and reload

### Issues:
- fixes rare stackoverflow (see https://scm.airbrake.io/projects/95438/groups/3385305861291043303?filters=%7B%22order%22%3A%22last_notice%22%2C%22resolved%22%3A%22false%22%2C%22search%22%3A%22mh%40brain.mpg.de%22%7D&tab=notice-detail)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
