### PR TITLE
Enable "What's new" in navbar for everybody

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added backspace as an additional keyboard shortcut for deleting the active node. [#6554](https://github.com/scalableminds/webknossos/pull/6554)
 - Tasks can now be assigned to individual users directly. [#6551](https://github.com/scalableminds/webknossos/pull/6551)
 - When reloading a layer, because the underlying data has changed, the histogram will also be reloaded and reflect the changes. [#6537](https://github.com/scalableminds/webknossos/pull/6537)
+- Enable "What's New" update information for all instances. [#6563](https://github.com/scalableminds/webknossos/pull/6563)
 
 ### Changed
 - Creating tasks in bulk now also supports referencing task types by their summary instead of id. [#6486](https://github.com/scalableminds/webknossos/pull/6486)

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -394,10 +394,6 @@ function DashboardSubMenu({ collapse, ...other }: { collapse: boolean } & SubMen
 function NotificationIcon({ activeUser }: { activeUser: APIUser }) {
   const maybeUnreadReleaseCount = useOlvyUnreadReleasesCount(activeUser);
 
-  if (!features().isDemoInstance) {
-    return null;
-  }
-
   const handleShowWhatsNewView = () => {
     const [newUserSync] = updateNovelUserExperienceInfos(activeUser, {
       lastViewedWhatsNewTimestamp: new Date().getTime(),


### PR DESCRIPTION
The "What's new" updates are really cool and super helpful to stay up-to-date with the latest infos on webKnossos. ATM, they are limited to just wk.org. This PR enables them for the open-source version too.

### Steps to test:
- None

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
