### PR TITLE
Update immutability-helper package to v3.1.1 with TS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,6 @@ frontend/javascripts/test/snapshots/type-check/*
 **/screenshots/*.new.png
 .nyc_output
 coverage
+coverage-ts
 *.vscode
 .bsp

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "postinstall": "cd tools/proxy && yarn install",
     "typecheck": "yarn tsc",
     "ts": "yarn tsc",
-    "ts-watch": "yarn tsc --watch"
+    "ts-watch": "yarn tsc --watch",
+    "ts-coverage": "typescript-coverage-report"
   },
   "lint-staged": {
     "*.ts": [
@@ -181,7 +182,7 @@
     "flexlayout-react": "^0.5.5",
     "hammerjs": "^2.0.8",
     "history": "^4.7.2",
-    "immutability-helper": "^2.6.6",
+    "immutability-helper": "^3.1.1",
     "javascript-natural-sort": "^0.7.1",
     "js-priority-queue": "^0.1.5",
     "jsonschema": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7645,12 +7645,10 @@ immer@^7.0.8:
   resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.15.tgz#dc3bc6db87401659d2e737c67a21b227c484a4ad"
   integrity sha512-yM7jo9+hvYgvdCQdqvhCNRRio0SCXc8xDPzA25SvKWa7b1WVPjLwQs1VYU5JPXjcJPTqAa5NP5dqpORGYBQ2AA==
 
-immutability-helper@^2.6.6:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.9.1.tgz#71c423ba387e67b6c6ceba0650572f2a2a6727df"
-  integrity sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==
-  dependencies:
-    invariant "^2.2.0"
+immutability-helper@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-3.1.1.tgz#2b86b2286ed3b1241c9e23b7b21e0444f52f77b7"
+  integrity sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==
 
 immutable@^3.7.4:
   version "3.8.2"
@@ -7752,13 +7750,6 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
-
-invariant@^2.2.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 invert-kv@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
As per @philippotto suggestion, I updated the immutability-helper package to v3.1.1. The updated package has been re-written in Typescript and hopefully should provide better type coverage.

@philippotto and I did a quick spot check in some reducers and were pleased that we were given proper type errors :-)

I ran the TS type coverage reporter (`yarn ts-coverage`) but that did not report any differences between `master` and this PR. 🤷 

### Steps to test:
- Introduce some errors in any reducer and be greeted with (helpful?) type errors

### Issues:
- fixes #3055

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
