### PR TITLE
Add N5 labels to frontend UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ webKnossos is an open-source tool for annotating and exploring large 3D image da
 * Sharing and collaboration features
 * Proof-Reading tools for working with large (over)-segmentations
 * [Standalone datastore component](https://github.com/scalableminds/webknossos/tree/master/webknossos-datastore) for flexible deployments
-* Supported dataset formats: [WKW](https://github.com/scalableminds/webknossos-wrap), [Neuroglancer Precomputed, and BossDB](https://github.com/scalableminds/webknossos-connect), [Zarr](https://zarr.dev)
+* Supported dataset formats: [WKW](https://github.com/scalableminds/webknossos-wrap), [Neuroglancer Precomputed, and BossDB](https://github.com/scalableminds/webknossos-connect), [Zarr](https://zarr.dev), [N5](https://github.com/saalfeldlab/n5)
 * Supported image formats: Grayscale, Segmentation Maps, RGB, Multi-Channel
 * [Support for 3D mesh rendering and on-the-fly isosurface generation](https://docs.webknossos.org/webknossos/mesh_visualization.html)
 * Export and streaming of any dataset and annotation as [Zarr](https://zarr.dev) to third-party tools

--- a/app/models/binary/explore/ExploreRemoteLayerService.scala
+++ b/app/models/binary/explore/ExploreRemoteLayerService.scala
@@ -104,7 +104,7 @@ class ExploreRemoteLayerService @Inject()() extends FoxImplicits with LazyLoggin
     explorers match {
       case Nil => Fox.empty
       case currentExplorer :: remainingExplorers =>
-        reportMutable += s"Trying to explore $remotePath as ${currentExplorer.name}..."
+        reportMutable += s"\nTrying to explore $remotePath as ${currentExplorer.name}..."
         currentExplorer.explore(remotePath, credentials).futureBox.flatMap {
           case Full(layersWithVoxelSizes) =>
             reportMutable += s"Found ${layersWithVoxelSizes.length} ${currentExplorer.name} layers at $remotePath."

--- a/docs/data_formats.md
+++ b/docs/data_formats.md
@@ -9,7 +9,7 @@ Any dataset uploaded to webKnossos.org will automatically be converted to WKW on
 webKnossos natively supports loading and streaming data in the following formats:
 
 - webKnossos-wrap (WKW)
-- Zarr ([OME NGFF v0.4 spec](https://ngff.openmicroscopy.org/latest/))
+- Zarr ([OME NGFF v0.4+ spec](https://ngff.openmicroscopy.org/latest/))
 - Neuroglancer `Pre-Computed` stored on Google Cloud
 - BossDB
 - N5

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -42,8 +42,9 @@ In particular, the following file formats are supported for uploading (and conve
 
 Once the data is uploaded (and potentially converted), you can further configure a dataset's [Settings](#configuring-datasets) and double-check layer properties, finetune access rights & permissions, or set default values for rendering.
 
-### Working with Zarr datasets
-webKnossos supports loading and remotely streaming [Zarr](https://zarr.dev) datasets from a remote HTTP server or the cloud. webKnossos supports loading Zarr v2 datasets according to the [OME NGFF v0.4 spec](https://ngff.openmicroscopy.org/latest/).
+### Working with Zarr and N5 datasets
+webKnossos supports loading and remotely streaming [Zarr](https://zarr.dev) and [N5](https://github.com/saalfeldlab/n5) datasets from a remote source, e.g. Cloud storage (S3) or HTTP server. 
+webKnossos supports loading Zarr datasets according to the [OME NGFF v0.4 spec](https://ngff.openmicroscopy.org/latest/).
 
 webKnossos can load several Zarr sources and assemble them into a webKnossos dataset with several layers, e.g. one Zarr file/source for the `color` layer and one Zarr file/source for a `segmentation` layer.
 
@@ -84,9 +85,6 @@ Rather, any data viewed in webKnossos will be streamed read-only and directly fr
 Any other webKnossos feature, e.g., annotations, and access rights, will be stored in webKnossos and do not affect these services. 
 
 Note that data streaming may count against any usage limits or minutes as defined by these third-party services. Check with the service provider or dataset owner.
-
-### Working with N5 datasets
-We are working on integrating [N5](https://github.com/saalfeldlab/n5) support into webKnossos. If you have datasets in the N5 format and would like to work with us on building, testing, and refining the N5 integration into webKnossos then [please contact us](mailto:hello@webknossos.org).
 
 ### Uploading through the Python API
 For those wishing to automate dataset upload or to do it programmatically, check out the webKnossos [Python library](https://github.com/scalableminds/webknossos-libs). It allows you to create, manage and upload datasets as well. 

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -1448,11 +1448,11 @@ export async function exploreRemoteDataset(
   const { dataSource, report } = await Request.sendJSONReceiveJSON("/api/datasets/exploreRemote", {
     data: credentials
       ? remoteUris.map((uri) => ({
-          remoteUri: uri,
+          remoteUri: uri.trim(),
           user: credentials.username,
           password: credentials.pass,
         }))
-      : remoteUris.map((uri) => ({ remoteUri: uri })),
+      : remoteUris.map((uri) => ({ remoteUri: uri.trim() })),
   });
   if (report.indexOf("403 Forbidden") !== -1 || report.indexOf("401 Unauthorized") !== -1) {
     Toast.error("The data could not be accessed. Please verify the credentials!");

--- a/frontend/javascripts/admin/dataset/dataset_add_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_view.tsx
@@ -132,7 +132,7 @@ function DatasetAddView({ history }: RouteComponentProps) {
               tab={
                 <span>
                   <DatabaseOutlined />
-                  Add Remote Zarr Dataset
+                  Add Remote Zarr / N5 Dataset
                 </span>
               }
               key="2"

--- a/frontend/javascripts/admin/dataset/dataset_add_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_view.tsx
@@ -116,7 +116,7 @@ function DatasetAddView({ history }: RouteComponentProps) {
     <React.Fragment>
       <Layout>
         <Content>
-          <Tabs defaultActiveKey="2" className="container">
+          <Tabs defaultActiveKey="1" className="container">
             <TabPane
               tab={
                 <span>

--- a/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
@@ -242,7 +242,7 @@ function AddZarrLayer({
 }) {
   const isDatasourceConfigStrFalsy = !Form.useWatch("dataSourceJson", form);
   const datasourceUrl: string | null = Form.useWatch("url", form);
-  const [exploreLog, setExploreLog] = useState<string>("");
+  const [exploreLog, setExploreLog] = useState<string | null>(null);
   const [showCredentialsFields, setShowCredentialsFields] = useState<boolean>(false);
   const [usernameOrAccessKey, setUsernameOrAccessKey] = useState<string>("");
   const [passwordOrSecretKey, setPasswordOrSecretKey] = useState<string>("");
@@ -385,7 +385,20 @@ function AddZarrLayer({
           </Col>
         </Row>
       ) : null}
-      <FormItem style={{ marginBottom: 0 }}>
+      {exploreLog ? (
+        <Row gutter={8}>
+          <Col span={24}>
+            <Collapse defaultActiveKey="1">
+              <Panel header="Error Log" key="1">
+                <Hint style={{ width: "90%" }}>
+                  <pre style={{ whiteSpace: "pre-wrap" }}>{exploreLog}</pre>
+                </Hint>
+              </Panel>
+            </Collapse>
+          </Col>
+        </Row>
+      ) : null}
+      <FormItem style={{ marginBottom: 0, marginTop: 20 }}>
         <Row gutter={8}>
           <Col span={18} />
           <Col span={6}>
@@ -400,13 +413,6 @@ function AddZarrLayer({
           </Col>
         </Row>
       </FormItem>
-      <Collapse collapsible={exploreLog ? "header" : "disabled"} style={{ marginTop: 20 }}>
-        <Panel header="Log" key="1">
-          <Hint style={{ width: "90%" }}>
-            <pre style={{ whiteSpace: "pre-wrap" }}>{exploreLog}</pre>
-          </Hint>
-        </Panel>
-      </Collapse>
     </>
   );
 }

--- a/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
@@ -141,7 +141,7 @@ function DatasetAddZarrView(props: Props) {
   return (
     // Using Forms here only to validate fields and for easy layout
     <div style={{ padding: 5 }}>
-      <CardContainer title="Add Remote Zarr Dataset">
+      <CardContainer title="Add Remote Zarr / N5 Dataset">
         <Form form={form} layout="vertical">
           <Modal
             title="Add Layer"
@@ -279,7 +279,9 @@ function AddZarrLayer({
           });
     setExploreLog(report);
     if (!newDataSource) {
-      Toast.error("Exploring this remote dataset did not return a datasource.");
+      Toast.error(
+        "Exploring this remote dataset did not return a datasource. Please check the Log.",
+      );
       return;
     }
     ensureLargestSegmentIdsInPlace(newDataSource);
@@ -292,7 +294,7 @@ function AddZarrLayer({
       existingDatasource = JSON.parse(datasourceConfigStr);
     } catch (e) {
       Toast.error(
-        "The current datasource config contains invalid JSON. Cannot add the new Zarr data.",
+        "The current datasource config contains invalid JSON. Cannot add the new Zarr/N5 data.",
       );
       return;
     }
@@ -312,10 +314,10 @@ function AddZarrLayer({
 
   return (
     <>
-      Please enter a URL that points to the Zarr data you would like to import. If necessary,
-      specify the credentials for the dataset. More layers can be added to the datasource
-      specification below using the Add button. Once you have approved of the resulting datasource
-      you can import it.
+      Please enter a URL that points to the Zarr or N5 data you would like to import. If necessary,
+      specify the credentials for the dataset. For datasets with multiple layers, e.g. raw
+      microscopy and segmentattion data, please add them separately with the ”Add Layer” button
+      below. Once you have approved of the resulting datasource you can import it.
       <FormItem
         style={{ marginTop: 16 }}
         name="url"
@@ -398,7 +400,7 @@ function AddZarrLayer({
           </Col>
         </Row>
       </FormItem>
-      <Collapse bordered={false} collapsible={exploreLog ? "header" : "disabled"}>
+      <Collapse collapsible={exploreLog ? "header" : "disabled"} style={{ marginTop: 20 }}>
         <Panel header="Log" key="1">
           <Hint style={{ width: "90%" }}>
             <pre style={{ whiteSpace: "pre-wrap" }}>{exploreLog}</pre>


### PR DESCRIPTION
This PR adds mentions and label for importing N5 datasets to the frontend UI and in the docs.

Further changes:
- named "explore log" to "error log"
- only show log container when an error occurred
- slight change of wording here and there

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Import a correct N5 dataset --> everything should work as usual
- Import a "wrong" URL  --> check error log

### Issues:
- related to #6480 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
