### PR TITLE
Deduplicate merged bounding boxes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Creating tasks in bulk now also supports referencing task types by their summary instead of id. [#6486](https://github.com/scalableminds/webknossos/pull/6486)
 - Navbar changes: Move dropdown menu into separate Menu button. Removed toggle-button (cog icon)for left-hand side bar from navbar. [#6558](https://github.com/scalableminds/webknossos/pull/6558)
 - Upgraded Typescript to v4.8 [#6567](https://github.com/scalableminds/webknossos/pull/6567)
+- When merging annotations, bounding boxes are no longer duplicated. [#6576](https://github.com/scalableminds/webknossos/pull/6576)
 
 ### Fixed
 - Fixed a bug where some file requests replied with error 400 instead of 404, confusing some zarr clients. [#6515](https://github.com/scalableminds/webknossos/pull/6515)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
@@ -24,7 +24,11 @@ trait BoundingBoxMerger extends ProtoGeometryImplicits {
     // note that the singleBoundingBox field is deprecated but still supported here to avoid database evolutions
     val singleBoundingBoxes =
       (singleBoundingBoxAOpt ++ singleBoundingBoxBOpt).map(bb => ProtoNamedBoundingBox(0, boundingBox = bb))
-    (userBoundingBoxesA ++ userBoundingBoxesB ++ singleBoundingBoxes).zipWithIndex.map(uBB => uBB._1.copy(id = uBB._2))
+
+    var boundingBoxMap: Map[Any, ProtoNamedBoundingBox] = Map()
+    (userBoundingBoxesA ++ userBoundingBoxesB ++ singleBoundingBoxes).foreach(uBB =>
+      boundingBoxMap += ((uBB.boundingBox, uBB.name, uBB.color, uBB.isVisible) -> uBB))
+    boundingBoxMap.values.zipWithIndex.map(uBB => uBB._1.copy(id = uBB._2)).toSeq
   }
 
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
@@ -24,11 +24,8 @@ trait BoundingBoxMerger extends ProtoGeometryImplicits {
     // note that the singleBoundingBox field is deprecated but still supported here to avoid database evolutions
     val singleBoundingBoxes =
       (singleBoundingBoxAOpt ++ singleBoundingBoxBOpt).map(bb => ProtoNamedBoundingBox(0, boundingBox = bb))
-
-    var boundingBoxMap: Map[Any, ProtoNamedBoundingBox] = Map()
-    (userBoundingBoxesA ++ userBoundingBoxesB ++ singleBoundingBoxes).foreach(uBB =>
-      boundingBoxMap += ((uBB.boundingBox, uBB.name, uBB.color, uBB.isVisible) -> uBB))
-    boundingBoxMap.values.zipWithIndex.map(uBB => uBB._1.copy(id = uBB._2)).toSeq
+    val allBoundingBoxes = userBoundingBoxesA ++ userBoundingBoxesB ++ singleBoundingBoxes
+    allBoundingBoxes.map(_.copy(id = 0)).distinct.zipWithIndex.map(uBB => uBB._1.copy(id = uBB._2))
   }
 
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://boundingboxmerger.webknossos.xyz/

### Steps to test:
- Create a skeleton annotation (A1) with multiple bounding boxes
- Export the annotation
- Create a new annotation (A2) and import the newly exported annotation
- Optional: Change a name of a bounding box in the annotation A1
- Merge annotation A2 into A1 (possibly into a new annotation)
- Observe the number of bounding boxes. Bounding boxes with no changed properties should be merged.

### Issues:
- contributes to #6562 (only the back-end part)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
