### PR TITLE
suppress error toasts in isDatasetAccessibleBySwitching API call

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -1889,10 +1889,16 @@ export async function isDatasetAccessibleBySwitching(
   if (commandType.type === ControlModeEnum.TRACE) {
     return Request.receiveJSON(
       `/api/auth/accessibleBySwitching?annotationId=${commandType.annotationId}`,
+      {
+        showErrorToast: false,
+      },
     );
   } else {
     return Request.receiveJSON(
       `/api/auth/accessibleBySwitching?organizationName=${commandType.owningOrganization}&dataSetName=${commandType.name}`,
+      {
+        showErrorToast: false,
+      },
     );
   }
 }


### PR DESCRIPTION
A small PR to hide the error toast for a failing `isDatasetAccessibleBySwitching`API call. 

Before:
https://user-images.githubusercontent.com/1390035/197330382-e48abba3-72e3-45aa-abb3-b0594e0c9d74.png

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Copy the URL of any non-public dataset
- Log out / switch to incognito tab
- Open dataset URL again --> no more crytpic error toast

### Issues:
- fixes #5735

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
