### PR TITLE
Add shortlink for successful conversion jobs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Add context-menu option to delete skeleton root group. [#6553](https://github.com/scalableminds/webknossos/pull/6553)
 - Added remaining task time estimation (ETA) for Voxelytics tasks in workflow reporting. [#6564](https://github.com/scalableminds/webknossos/pull/6564)
 - Added a help button to the UI to send questions and feedbacks to the dev team. [#6560](https://github.com/scalableminds/webknossos/pull/6560)
+- Turned successful dataset conversions into a clickable link. [#6583](https://github.com/scalableminds/webknossos/pull/6583)
 
 
 ### Changed

--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -241,8 +241,12 @@ function DatasetView(props: Props) {
           return (
             <Row key={job.id} gutter={16}>
               <Col span={10}>
-                <Tooltip title={tooltip}>{icon}</Tooltip>
-                {` ${job.datasetName || "UNKNOWN"}`}
+                <Tooltip title={tooltip}>{icon}</Tooltip>{" "}
+                {job.state === "SUCCESS" && job.resultLink ? (
+                  <Link to={job.resultLink}>{job.datasetName}</Link>
+                ) : (
+                  job.datasetName || "UNKNOWN"
+                )}
                 {Unicode.NonBreakingSpace}(started at{Unicode.NonBreakingSpace}
                 <FormattedDate timestamp={job.createdAt} />
                 <span>)</span>


### PR DESCRIPTION
PR adds makes the recently converted datasets actionable in the dashboard. Successful dataset conversions can be clicked to open.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Upload a dataset for automatic conversion 
- On success, click link

### Issues:
- fixes #6084

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
