### PR TITLE
Fix precomputed mesh positions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed the positions of precomputed meshes when using a v3 mesh file. [#6588](https://github.com/scalableminds/webknossos/pull/6588)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/controller/scene_controller.ts
+++ b/frontend/javascripts/oxalis/controller/scene_controller.ts
@@ -270,6 +270,7 @@ class SceneController {
     segmentationId: number,
     passive: boolean = false,
     offset: Vector3 | null = null,
+    scale: Vector3 | null = null,
   ): void {
     if (this.isosurfacesGroupsPerSegmentationId[segmentationId] == null) {
       const newGroup = new THREE.Group();
@@ -279,6 +280,9 @@ class SceneController {
       newGroup.cellId = segmentationId;
       // @ts-ignore
       newGroup.passive = passive;
+      if (scale != null) {
+        newGroup.scale.copy(new THREE.Vector3(...scale));
+      }
     }
     const mesh = this.constructIsosurfaceMesh(segmentationId, geometry, passive);
     if (offset) {

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
@@ -680,10 +680,6 @@ function* loadPrecomputedMeshForSegmentId(
           const geometry = yield* call(loader.decodeDracoFileAsync, dracoData);
           // Compute vertex normals to achieve smooth shading
           geometry.computeVertexNormals();
-          // Apply the scale from the segment info, which includes dataset scale and mag
-          if (scale != null) {
-            geometry.scale(...scale);
-          }
 
           yield* call(
             { context: sceneController, fn: sceneController.addIsosurfaceFromGeometry },
@@ -691,6 +687,8 @@ function* loadPrecomputedMeshForSegmentId(
             id,
             false,
             chunk.position,
+            // Apply the scale from the segment info, which includes dataset scale and mag
+            scale,
           );
         } else {
           // V0


### PR DESCRIPTION
by scaling the whole group instead of each chunk on its own. Fixing a regression introduced in https://github.com/scalableminds/webknossos/pull/6552.  See https://scm.slack.com/archives/C5AKLAV0B/p1666683368029709 for context.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Use a v3 meshfile and load a precomputed mesh consisting of multiple chunks. The meshes should appear at the correct position.

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
