### PR TITLE
Moved dataset import errors into a modal

### DIFF
--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -6,6 +6,7 @@ import {
   PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
+  WarningOutlined,
 } from "@ant-design/icons";
 import { Link, LinkProps, RouteComponentProps, withRouter } from "react-router-dom";
 import * as React from "react";
@@ -18,6 +19,7 @@ import {
 import Toast from "libs/toast";
 import messages from "messages";
 import CreateExplorativeModal from "dashboard/advanced_dataset/create_explorative_modal";
+import { Modal } from "antd";
 const disabledStyle: React.CSSProperties = {
   pointerEvents: "none",
   color: "var(--ant-disabled)",
@@ -178,7 +180,17 @@ class DatasetActionView extends React.PureComponent<Props, State> {
           Import
         </Link>
         {reloadLink}
-        <div className="text-danger">{dataset.dataSource.status}</div>
+        <a
+          onClick={() =>
+            Modal.error({
+              title: "Cannot load this dataset",
+              content: dataset.dataSource.status,
+            })
+          }
+        >
+          <WarningOutlined />
+          View Error
+        </a>
       </div>
     );
     return (


### PR DESCRIPTION
When wK runs into an issues while importing a dataset, e.g. an invalid `datasource-properties.json`, it produces a lengthy error message to understand the underlying issue. Rendering these long error message in the "Actions" column of the dataset list breaks the UI / creates unnaturally long list entries.

This PR moves the error message into a separate error modal instead fixing the layouting issue while keeping the information accessible. 

<img width="339" alt="image" src="https://user-images.githubusercontent.com/1105056/197745487-01ea38a8-d14c-49ea-a1f8-b887179b5dd5.png">

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Corrupt a dataset on disc by messing up the  `datasource-properties.json`, e.g. make it invalid JSON
- Press "Reload" on your dataset dashboard
- See the "View Error" action
- Check out the modal
- Approve PR

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [X] Ready for review
