### PR TITLE
Hotfix Dataset View Mode

### DIFF
--- a/frontend/javascripts/oxalis/controller/scene_controller.ts
+++ b/frontend/javascripts/oxalis/controller/scene_controller.ts
@@ -392,13 +392,11 @@ class SceneController {
     const taskBoundingBox = getSomeTracing(state.tracing).boundingBox;
     this.buildTaskingBoundingBox(taskBoundingBox);
 
-    if (state.tracing.volumes.length > 0) {
-      this.contour = new ContourGeometry();
-      this.contour.getMeshes().forEach((mesh) => this.annotationToolsGeometryGroup.add(mesh));
+    this.contour = new ContourGeometry();
+    this.contour.getMeshes().forEach((mesh) => this.annotationToolsGeometryGroup.add(mesh));
 
-      this.quickSelectGeometry = new QuickSelectGeometry();
-      this.annotationToolsGeometryGroup.add(this.quickSelectGeometry.getMeshGroup());
-    }
+    this.quickSelectGeometry = new QuickSelectGeometry();
+    this.annotationToolsGeometryGroup.add(this.quickSelectGeometry.getMeshGroup());
 
     if (state.tracing.skeleton != null) {
       this.addSkeleton((_state) => getSkeletonTracing(_state.tracing), true);


### PR DESCRIPTION
always create annotationToolsGeometries to avoid accidental null access; especially, this fixes the broken view-mode

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open DS in view mode

### Issues:
- follow-up to #6542 

------
(Please delete unneeded items, merge only when none are left open)
- [X] Ready for review
