### PR TITLE
Remove superfluous datastoreName param for convertToWkw job

### DIFF
--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -75,17 +75,17 @@ class JobsController @Inject()(jobDAO: JobDAO,
     } yield Ok(js)
   }
 
-  def runConvertToWkwJob(organizationName: String,
-                         dataSetName: String,
-                         scale: String,
-                         dataStoreName: String): Action[AnyContent] =
+  // Note that the dataset has to be registered by reserveUpload via the datastore first.
+  def runConvertToWkwJob(organizationName: String, dataSetName: String, scale: String): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       log(Some(slackNotificationService.noticeFailedJobRequest)) {
         for {
-          _ <- workerService.assertDataStoreHasWorkers(dataStoreName)
           organization <- organizationDAO.findOneByName(organizationName) ?~> Messages("organization.notFound",
                                                                                        organizationName)
           _ <- bool2Fox(request.identity._organization == organization._id) ~> FORBIDDEN
+          dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, organization._id) ?~> Messages(
+            "dataSet.notFound",
+            dataSetName) ~> NOT_FOUND
           command = "convert_to_wkw"
           commandArgs = Json.obj(
             "organization_name" -> organizationName,
@@ -93,8 +93,7 @@ class JobsController @Inject()(jobDAO: JobDAO,
             "scale" -> scale,
             "webknossos_token" -> RpcTokenHolder.webKnossosToken
           )
-
-          job <- jobService.submitJob(command, commandArgs, request.identity, dataStoreName) ?~> "job.couldNotRunCubing"
+          job <- jobService.submitJob(command, commandArgs, request.identity, dataSet._dataStore) ?~> "job.couldNotRunCubing"
           js <- jobService.publicWrites(job)
         } yield Ok(js)
       }
@@ -114,7 +113,6 @@ class JobsController @Inject()(jobDAO: JobDAO,
         dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, organization._id) ?~> Messages(
           "dataSet.notFound",
           dataSetName) ~> NOT_FOUND
-        _ <- workerService.assertDataStoreHasWorkers(dataSet._dataStore)
         command = "compute_mesh_file"
         commandArgs = Json.obj(
           "organization_name" -> organizationName,
@@ -142,7 +140,6 @@ class JobsController @Inject()(jobDAO: JobDAO,
           dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, organization._id) ?~> Messages(
             "dataSet.notFound",
             dataSetName) ~> NOT_FOUND
-          _ <- workerService.assertDataStoreHasWorkers(dataSet._dataStore)
           command = "infer_nuclei"
           commandArgs = Json.obj(
             "organization_name" -> organizationName,
@@ -171,7 +168,6 @@ class JobsController @Inject()(jobDAO: JobDAO,
           dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, organization._id) ?~> Messages(
             "dataSet.notFound",
             dataSetName) ~> NOT_FOUND
-          _ <- workerService.assertDataStoreHasWorkers(dataSet._dataStore)
           command = "infer_neurons"
           commandArgs = Json.obj(
             "organization_name" -> organizationName,
@@ -208,7 +204,6 @@ class JobsController @Inject()(jobDAO: JobDAO,
           dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, organization._id) ?~> Messages(
             "dataSet.notFound",
             dataSetName) ~> NOT_FOUND
-          _ <- workerService.assertDataStoreHasWorkers(dataSet._dataStore)
           command = "globalize_floodfills"
           commandArgs = Json.obj(
             "organization_name" -> organizationName,
@@ -244,7 +239,6 @@ class JobsController @Inject()(jobDAO: JobDAO,
             "dataSet.notFound",
             dataSetName) ~> NOT_FOUND
           _ <- jobService.assertTiffExportBoundingBoxLimits(bbox)
-          _ <- workerService.assertDataStoreHasWorkers(dataSet._dataStore)
           userAuthToken <- wkSilhouetteEnvironment.combinedAuthenticatorService.findOrCreateToken(
             request.identity.loginInfo)
           command = "export_tiff"
@@ -287,7 +281,6 @@ class JobsController @Inject()(jobDAO: JobDAO,
           dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, organization._id) ?~> Messages(
             "dataSet.notFound",
             dataSetName) ~> NOT_FOUND
-          _ <- workerService.assertDataStoreHasWorkers(dataSet._dataStore)
           userAuthToken <- wkSilhouetteEnvironment.combinedAuthenticatorService.findOrCreateToken(
             request.identity.loginInfo)
           command = "materialize_volume_annotation"

--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -45,7 +45,7 @@ class WKRemoteDataStoreController @Inject()(
   val bearerTokenService: WebknossosBearerTokenAuthenticatorService =
     wkSilhouetteEnvironment.combinedAuthenticatorService.tokenAuthenticatorService
 
-  def validateDataSetUpload(name: String, key: String, token: String): Action[ReserveUploadInformation] =
+  def reserveDataSetUpload(name: String, key: String, token: String): Action[ReserveUploadInformation] =
     Action.async(validateJson[ReserveUploadInformation]) { implicit request =>
       dataStoreService.validateAccess(name, key) { dataStore =>
         val uploadInfo = request.body

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -371,7 +371,7 @@ class JobService @Inject()(wkConf: WkConf,
       _ = analyticsService.track(RunJobEvent(owner, command))
     } yield job
 
-  def assertDataStoreHasWorkers(dataStoreName: String)(implicit ctx: DBAccessContext): Fox[Unit] =
+  private def assertDataStoreHasWorkers(dataStoreName: String)(implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- dataStoreDAO.findOneByName(dataStoreName)
       _ <- workerDAO.findOneByDataStore(dataStoreName)

--- a/app/models/job/Worker.scala
+++ b/app/models/job/Worker.scala
@@ -1,15 +1,13 @@
 package models.job
 
 import akka.actor.ActorSystem
-import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.mvc.Formatter
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.helpers.IntervalScheduler
 import com.scalableminds.webknossos.schema.Tables._
 import com.typesafe.scalalogging.LazyLogging
 import models.binary.DataStoreDAO
-
-import javax.inject.Inject
 import oxalis.telemetry.SlackNotificationService
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.{JsObject, Json}
@@ -17,6 +15,7 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.Rep
 import utils.{ObjectId, SQLClient, SQLDAO, WkConf}
 
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -82,12 +81,6 @@ class WorkerService @Inject()(conf: WkConf, dataStoreDAO: DataStoreDAO, workerDA
       "lastHeartBeat" -> worker.lastHeartBeat,
       "lastHeartBeatIsRecent" -> lastHeartBeatIsRecent(worker)
     )
-
-  def assertDataStoreHasWorkers(dataStoreName: String)(implicit ctx: DBAccessContext): Fox[Unit] =
-    for {
-      _ <- dataStoreDAO.findOneByName(dataStoreName)
-      _ <- workerDAO.findOneByDataStore(dataStoreName) ?~> "jobs.noWorkerForDatastore"
-    } yield ()
 
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -81,7 +81,7 @@ features {
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
   # to enable jobs for local development, use "yarn enable-jobs" to also activate it in the database
-  jobsEnabled = false
+  jobsEnabled = true
   voxelyticsEnabled = false
   # For new users, the dashboard will show a banner which encourages the user to check out the following dataset.
   # If isDemoInstance == true, `/createExplorative/hybrid/true` is appended to the URL so that a new tracing is opened.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -81,7 +81,7 @@ features {
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
   # to enable jobs for local development, use "yarn enable-jobs" to also activate it in the database
-  jobsEnabled = true
+  jobsEnabled = false
   voxelyticsEnabled = false
   # For new users, the dashboard will show a banner which encourages the user to check out the following dataset.
   # If isDemoInstance == true, `/createExplorative/hybrid/true` is appended to the URL so that a new tracing is opened.

--- a/conf/messages
+++ b/conf/messages
@@ -354,7 +354,7 @@ job.couldNotRunNeuronInferral = Failed to start neuron inferral job.
 job.couldNotRunGlobalizeFloodfills = Failed to start job for globalizing floodfills.
 job.couldNotRunApplyMergerMode = Failed to start job to apply merger mode tracing.
 job.disabled = Long-running jobs are not enabled for this webKnossos instance.
-jobs.worker.notFound = Could not find this worker in the database.
+job.worker.notFound = Could not find this worker in the database.
 job.export.fileNotFound = Exported file not found. The link may be expired.
 job.export.tiff.invalidBoundingBox = The selected bounding box could not be parsed, must be x,y,z,width,height,depth
 job.export.tiff.volumeExceeded = The volume of the selected bounding box is too large.
@@ -365,7 +365,7 @@ job.inferNeurons.notAllowed.organization = Currently neuron inferral is only all
 job.meshFile.notAllowed.organization = Calculating mesh files is only allowed for datasets of your own organization.
 job.globalizeFloodfill.notAllowed.organization = Globalizing floodfills is only allowed for datasets of your own organization.
 job.applyMergerMode.notAllowed.organization = Applying merger mode tracings is only allowed for datasets of your own organization.
-jobs.noWorkerFound = Processing jobs are not available for the datastore this dataset belongs to.
+job.noWorkerForDatastore = Processing jobs are not available for the datastore this dataset belongs to.
 
 voxelytics.disabled = Voxelytics workflow reporting and logging are not enabled for this webKnossos instance.
 voxelytics.runNotFound = Workflow runs not found

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -86,7 +86,7 @@ GET           /datastores                                                       
 PUT           /datastores/:name/datasource                                              controllers.WKRemoteDataStoreController.updateOne(name: String, key: String)
 PUT           /datastores/:name/datasources                                             controllers.WKRemoteDataStoreController.updateAll(name: String, key: String)
 PATCH         /datastores/:name/status                                                  controllers.WKRemoteDataStoreController.statusUpdate(name: String, key: String)
-POST          /datastores/:name/verifyUpload                                            controllers.WKRemoteDataStoreController.validateDataSetUpload(name: String, key: String, token: String)
+POST          /datastores/:name/reserveUpload                                           controllers.WKRemoteDataStoreController.reserveDataSetUpload(name: String, key: String, token: String)
 POST          /datastores/:name/reportDatasetUpload                                     controllers.WKRemoteDataStoreController.reportDatasetUpload(name: String, key: String, token: String, dataSetName: String, dataSetSizeBytes: Long)
 POST          /datastores/:name/deleteDataset                                           controllers.WKRemoteDataStoreController.deleteDataset(name: String, key: String)
 GET           /datastores/:name/jobExportProperties                                     controllers.WKRemoteDataStoreController.jobExportProperties(name: String, key: String, jobId: String)
@@ -226,7 +226,7 @@ GET           /time/user/:userId                                                
 GET           /jobs/request                                                             controllers.WKRemoteWorkerController.requestJobs(key: String)
 GET           /jobs                                                                     controllers.JobsController.list
 GET           /jobs/status                                                              controllers.JobsController.status
-POST          /jobs/run/convertToWkw/:organizationName/:dataSetName                     controllers.JobsController.runConvertToWkwJob(organizationName: String, dataSetName: String, scale: String, dataStoreName: String)
+POST          /jobs/run/convertToWkw/:organizationName/:dataSetName                     controllers.JobsController.runConvertToWkwJob(organizationName: String, dataSetName: String, scale: String)
 POST          /jobs/run/computeMeshFile/:organizationName/:dataSetName                  controllers.JobsController.runComputeMeshFileJob(organizationName: String, dataSetName: String, layerName: String, mag: String, agglomerateView: Option[String])
 POST          /jobs/run/exportTiff/:organizationName/:dataSetName                       controllers.JobsController.runExportTiffJob(organizationName: String, dataSetName: String, bbox: String, layerName: Option[String], annotationLayerName: Option[String], annotationId: Option[String], annotationType: Option[String], hideUnmappedIds: Option[Boolean], mappingName: Option[String], mappingType: Option[String])
 POST          /jobs/run/inferNuclei/:organizationName/:dataSetName                      controllers.JobsController.runInferNucleiJob(organizationName: String, dataSetName: String, layerName: String, newDatasetName: String)

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -1072,10 +1072,9 @@ export async function startConvertToWkwJob(
   datasetName: string,
   organizationName: string,
   scale: Vector3,
-  datastoreName: string,
 ): Promise<APIJob> {
   return Request.receiveJSON(
-    `/api/jobs/run/convertToWkw/${organizationName}/${datasetName}?scale=${scale.toString()}&dataStoreName=${datastoreName}`,
+    `/api/jobs/run/convertToWkw/${organizationName}/${datasetName}?scale=${scale.toString()}`,
     {
       method: "POST",
     },

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -310,7 +310,6 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                   formValues.name,
                   activeUser.organization,
                   formValues.scale,
-                  datastore.name,
                 );
               } catch (error) {
                 maybeError = error;

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -97,7 +97,7 @@ Expects:
         for {
           isKnownUpload <- uploadService.isKnownUpload(request.body.uploadId)
           _ <- if (!isKnownUpload) {
-            (remoteWebKnossosClient.validateDataSourceUpload(request.body, urlOrHeaderToken(token, request)) ?~> "dataSet.upload.validation.failed")
+            (remoteWebKnossosClient.reserveDataSourceUpload(request.body, urlOrHeaderToken(token, request)) ?~> "dataSet.upload.validation.failed")
               .flatMap(_ => uploadService.reserveUpload(request.body))
           } else Fox.successful(())
         } yield Ok

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebKnossosClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebKnossosClient.scala
@@ -82,10 +82,10 @@ class DSRemoteWebKnossosClient @Inject()(
       .silent
       .put(dataSources)
 
-  def validateDataSourceUpload(info: ReserveUploadInformation, userTokenOpt: Option[String]): Fox[Unit] =
+  def reserveDataSourceUpload(info: ReserveUploadInformation, userTokenOpt: Option[String]): Fox[Unit] =
     for {
       userToken <- option2Fox(userTokenOpt) ?~> "validateDataSourceUpload.noUserToken"
-      _ <- rpc(s"$webKnossosUri/api/datastores/$dataStoreName/verifyUpload")
+      _ <- rpc(s"$webKnossosUri/api/datastores/$dataStoreName/reserveUpload")
         .addQueryString("key" -> dataStoreKey)
         .addQueryString("token" -> userToken)
         .post(info)


### PR DESCRIPTION
Since dataset uploads are now always reserved first (introduced in #4999), the dataStoreName is no longer required as a parameter for convert_to_wkw. Instead, we can look up the dataset in the db to get the datastore name.

Also in this PR: 
 - renamed the reserve routes and methods to better match their current behavior.
 - moved `assertDataStoreHasWorkers` down into submitJob so that it is only needed once (it was the same for all jobs anyway)

### Steps to test:
- after `yarn enable jobs`, upload a dataset (e.g. tif file) in the dataset upload view. job should be started normally and appear in job list view.

### Issues:
- fixes #6598 

------
- [x] Needs datastore update after deployment
- [x] Ready for review
