### PR TITLE
Fix task creation with base NML

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed importing a dataset from disk. [#6615](https://github.com/scalableminds/webknossos/pull/6615)
 - Fixed a bug in the dataset import view, where the layer name text field would lose focus after each key press. [#6615](https://github.com/scalableminds/webknossos/pull/6615)
 - Fixed importing NGFF Zarr datasets with non-scale transforms. [#6621](https://github.com/scalableminds/webknossos/pull/6621)
+- Fixed broken creation of tasks using base NMLs. [#6634](https://github.com/scalableminds/webknossos/pull/6634)
 
 ### Removed
 

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -109,8 +109,8 @@ Expects:
       _ <- bool2Fox(inputFiles.nonEmpty) ?~> "nml.file.notFound"
       jsonString <- body.dataParts.get("formJSON").flatMap(_.headOption) ?~> "format.json.missing"
       params <- JsonHelper.parseJsonToFox[NmlTaskParameters](jsonString) ?~> "task.create.failed"
-      _ <- taskCreationService.assertBatchLimit(inputFiles.length, List(params.taskTypeId))
-      taskTypeIdValidated <- ObjectId.fromString(params.taskTypeId) ?~> "taskType.id.invalid"
+      _ <- taskCreationService.assertBatchLimit(inputFiles.length, List(params.taskTypeIdOrSummary))
+      taskTypeIdValidated <- ObjectId.fromString(params.taskTypeIdOrSummary) ?~> "taskType.id.invalid"
       taskType <- taskTypeDAO.findOne(taskTypeIdValidated) ?~> "taskType.notFound" ~> NOT_FOUND
       project <- projectDAO
         .findOneByNameAndOrganization(params.projectName, request.identity._organization) ?~> "project.notFound" ~> NOT_FOUND

--- a/app/models/task/TaskCreationParameters.scala
+++ b/app/models/task/TaskCreationParameters.scala
@@ -25,7 +25,8 @@ object TaskParameters {
   implicit val taskParametersFormat: Format[TaskParameters] = Json.format[TaskParameters]
 }
 
-case class NmlTaskParameters(taskTypeId: String,
+case class NmlTaskParameters(taskTypeIdOrSummary: String,
+                             // taskTypeIdOrSummary named like this for compatibility, note that in NML case only ids are valid.
                              neededExperience: Experience,
                              openInstances: Int,
                              projectName: String,

--- a/app/models/task/TaskCreationService.scala
+++ b/app/models/task/TaskCreationService.scala
@@ -261,7 +261,7 @@ class TaskCreationService @Inject()(taskTypeService: TaskTypeService,
       val parsedNmlTracingBoundingBox = params._1.map(b => BoundingBox(b.topLeft, b.width, b.height, b.depth))
       val bbox = if (nmlFormParams.boundingBox.isDefined) nmlFormParams.boundingBox else parsedNmlTracingBoundingBox
       TaskParameters(
-        nmlFormParams.taskTypeId,
+        nmlFormParams.taskTypeIdOrSummary,
         nmlFormParams.neededExperience,
         nmlFormParams.openInstances,
         nmlFormParams.projectName,


### PR DESCRIPTION
Turns out the frontend now also sends the id with the json key taskTypeIdOrSummary in the createFromFiles case. This PR renames the expected backend parameter to match that.

It does not, however, allow for summaries, this would have made the code quite a bit more complicated.

I’m starting to think that this whole IdOrSummary thing may have been a mistake (as in, the harder-to-maintain code is not justified by the small ux improvement). Let’s discuss that in person next week.

### URL of deployed dev instance (used for testing):
- https://taskcreationnml.webknossos.xyz

### Steps to test:
- test that task creation works with and without passed nml file, and also using the bulk creation tab.

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
