### PR TITLE
Fix NGFF import for datasets with no channel axis

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed importing a dataset from disk. [#6615](https://github.com/scalableminds/webknossos/pull/6615)
 - Fixed a bug in the dataset import view, where the layer name text field would lose focus after each key press. [#6615](https://github.com/scalableminds/webknossos/pull/6615)
 - Fixed importing NGFF Zarr datasets with non-scale transforms. [#6621](https://github.com/scalableminds/webknossos/pull/6621)
+- Fixed a regression in NGFF Zarr import for datasets with no channel axis. [#6636](https://github.com/scalableminds/webknossos/pull/6636)
 
 ### Removed
 

--- a/app/models/binary/explore/NgffExplorer.scala
+++ b/app/models/binary/explore/NgffExplorer.scala
@@ -42,8 +42,11 @@ class NgffExplorer extends RemoteLayerExplorer {
       zarrayPath = magPath.resolve(ZarrHeader.FILENAME_DOT_ZARRAY)
       zarrHeader <- parseJsonFromPath[ZarrHeader](zarrayPath) ?~> s"failed to read zarr header at $zarrayPath"
       axisOrder <- extractAxisOrder(multiscale.axes) ?~> "Could not extract XYZ axis order mapping. Does the data have x, y and z axes, stated in multiscales metadata?"
-      channelAxisIndex <- axisOrder.c.toFox
-    } yield zarrHeader.shape(channelAxisIndex)
+      channelCount = axisOrder.c match {
+        case Some(channeAxislIndex) => zarrHeader.shape(channeAxislIndex)
+        case _                      => 1
+      }
+    } yield channelCount
 
   private def layersFromNgffMultiscale(multiscale: NgffMultiscalesItem,
                                        remotePath: Path,


### PR DESCRIPTION
follow-up for #6609 – axisOrder.c being None wasn’t handled.

### Steps to test (I tested this locally):
- import ngff dataset with no channel dimension (e.g. https://s3.embl.de/i2k-2020/platy-raw.ome.zarr), should run through + load data
- import ngff dataset with channel dimension (e.g. https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr), should also still run through + load data

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
