### PR TITLE
Upgrade Silhouette to 7.0.7, Expose Cookie Signer Secret in Config

### DIFF
--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -407,11 +407,10 @@ class LegacyApiController @Inject()(annotationController: AnnotationController,
   def annotationEditV1(typ: String, id: String): Action[JsValue] = sil.SecuredAction.async(parse.json) {
     implicit request =>
       logVersioned(request)
-      val oldRequest = request.request
+      val oldRequest = request
       val newRequest =
         if (request.body.as[JsObject].keys.contains("isPublic"))
-          request.copy(
-            request = oldRequest.withBody(Json.toJson(insertVisibilityInJsObject(oldRequest.body.as[JsObject]))))
+          request.withBody(Json.toJson(insertVisibilityInJsObject(oldRequest.body.as[JsObject])))
         else request
 
       for {

--- a/app/oxalis/security/CombinedAuthenticatorService.scala
+++ b/app/oxalis/security/CombinedAuthenticatorService.scala
@@ -4,6 +4,7 @@ import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.crypto.{Base64AuthenticatorEncoder, Signer}
 import com.mohiva.play.silhouette.api.services.{AuthenticatorResult, AuthenticatorService}
 import com.mohiva.play.silhouette.api.util.{Clock, ExtractableRequest, FingerprintGenerator, IDGenerator}
+import com.mohiva.play.silhouette.crypto.{JcaSigner, JcaSignerSettings}
 import com.mohiva.play.silhouette.impl.authenticators._
 import models.user.UserService
 import play.api.mvc._
@@ -42,9 +43,11 @@ case class CombinedAuthenticatorService(cookieSettings: CookieAuthenticatorSetti
     extends AuthenticatorService[CombinedAuthenticator]
     with Logger {
 
+  private val cookieSigner = new JcaSigner(JcaSignerSettings(conf.Silhouette.CookieAuthenticator.signerSecret))
+
   val cookieAuthenticatorService = new CookieAuthenticatorService(cookieSettings,
                                                                   None,
-                                                                  new IdentityCookieSigner,
+                                                                  cookieSigner,
                                                                   cookieHeaderEncoding,
                                                                   new Base64AuthenticatorEncoder,
                                                                   fingerprintGenerator,

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -132,6 +132,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
       val useFingerprinting: Boolean = get[Boolean]("silhouette.cookieAuthenticator.useFingerprinting")
       val authenticatorExpiry: Duration = get[Duration]("silhouette.cookieAuthenticator.authenticatorExpiry")
       val cookieMaxAge: Duration = get[Duration]("silhouette.cookieAuthenticator.cookieMaxAge")
+      val signerSecret: String = get[String]("silhouette.cookieAuthenticator.signerSecret")
     }
 
     val children = List(TokenAuthenticator, CookieAuthenticator)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -200,6 +200,7 @@ silhouette {
     useFingerprinting = true
     authenticatorExpiry = 30 days
     cookieMaxAge = 365 days
+    signerSecret = "`?IVa2TCaZAZ4TY]B0=tCs9mJdyaA0V<mA4k[sq6gV=2C5y?liAhWF?ZMA0h1EIe"
   }
 
   tokenAuthenticator {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,10 +2,11 @@ import play.sbt.PlayImport._
 import sbt._
 
 object Dependencies {
-  private val akkaVersion = "2.6.14"
+  private val akkaVersion = "2.6.19"
   private val akkaHttpVersion = "10.2.6"
   private val log4jVersion = "2.17.0"
   private val webknossosWrapVersion = "1.1.15"
+  private val silhouetteVersion = "7.0.7"
 
   private val akkaLogging = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
   private val akkaTest = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
@@ -24,16 +25,17 @@ object Dependencies {
   private val liftUtil = "net.liftweb" %% "lift-util" % "3.0.2"
   private val log4jApi = "org.apache.logging.log4j" % "log4j-core" % log4jVersion % Provided
   private val log4jCore = "org.apache.logging.log4j" % "log4j-api" % log4jVersion % Provided
-  private val playFramework = "com.typesafe.play" %% "play" % "2.8.8"
-  private val playJson = "com.typesafe.play" %% "play-json" % "2.8.1"
+  private val playFramework = "com.typesafe.play" %% "play" % "2.8.16"
+  private val playJson = "com.typesafe.play" %% "play-json" % "2.8.2"
   private val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
   private val playIterateesStreams = "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1"
   private val reactiveBson = "org.reactivemongo" %% "reactivemongo-bson" % "0.12.7"
   private val scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.7"
   private val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
   private val scalaTestPlusPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test"
-  private val silhouette = "com.mohiva" %% "play-silhouette" % "6.0.0"
-  private val silhouetteTestkit = "com.mohiva" %% "play-silhouette-testkit" % "5.0.7" % "test"
+  private val silhouette = "io.github.honeycomb-cheesecake" %% "play-silhouette" % silhouetteVersion
+  private val silhouetteTestkit = "io.github.honeycomb-cheesecake" %% "play-silhouette-testkit" % silhouetteVersion % "test"
+  private val silhouetteCrypto = "io.github.honeycomb-cheesecake" %% "play-silhouette-crypto-jca" % silhouetteVersion
   private val trireme = "io.apigee.trireme" % "trireme-core" % "0.9.3"
   private val triremeNode = "io.apigee.trireme" % "trireme-node12src" % "0.9.3"
   private val webknossosWrap = "com.scalableminds" %% "webknossos-wrap" % webknossosWrapVersion
@@ -115,6 +117,7 @@ object Dependencies {
     scalaTestPlusPlay,
     silhouette,
     silhouetteTestkit,
+    silhouetteCrypto,
     specs2 % Test,
     trireme,
     triremeNode,


### PR DESCRIPTION
- Upgraded Silhouette to 7.0.7 (note that this supersedes some of the changes of #6534 )
- New config field `silhouette.cookieAuthenticator.signerSecret`

### URL of deployed dev instance (used for testing):
- https://upgradesilhouette.webknossos.xyz

### Steps to test:
- Cookie and token auth should still work as expected
- After changing the secret, existing cookies should be invalidated

------
- [x] Ready for review
