### PR TITLE
Deduplicate bboxes when importing NML

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Re-phrased some backend (error) messages to improve clarity and provide helping hints. [#6616](https://github.com/scalableminds/webknossos/pull/6616)
 - The layer visibility is now encoded in the sharing link. The user opening the link will see the same layers that were visible when copying the link. [#6634](https://github.com/scalableminds/webknossos/pull/6634)
 - Voxelytics workflows can now be viewed by anyone with the link who is in the right organization. [#6622](https://github.com/scalableminds/webknossos/pull/6622)
+- When importing an annotation into an existing annotation, webKnossos ensures that bounding boxes are not duplicated in case they exist in the current *and* imported annotation. [#6648](https://github.com/scalableminds/webknossos/pull/6648)
+
  
 ### Fixed
 - Fixed a bug in the dataset import view, where the layer name text field would lose focus after each key press. [#6615](https://github.com/scalableminds/webknossos/pull/6615)

--- a/frontend/javascripts/oxalis/model/reducers/annotation_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/annotation_reducer.ts
@@ -9,6 +9,7 @@ import { maybeGetSomeTracing } from "oxalis/model/accessors/tracing_accessor";
 import * as Utils from "libs/utils";
 import { getDisplayedDataExtentInPlaneMode } from "oxalis/model/accessors/view_mode_accessor";
 import { convertServerAnnotationToFrontendAnnotation } from "oxalis/model/reducers/reducer_helpers";
+import _ from "lodash";
 
 const updateTracing = (state: OxalisState, shape: StateShape1<"tracing">): OxalisState =>
   updateKey(state, "tracing", shape);
@@ -174,10 +175,14 @@ function AnnotationReducer(state: OxalisState, action: Action): OxalisState {
         ...bb,
         id: highestBoundingBoxId + index + 1,
       }));
-      const mergedUserBoundingBoxes = [
-        ...tracing.userBoundingBoxes,
-        ...additionalUserBoundingBoxes,
-      ];
+      const mergedUserBoundingBoxes = _.uniqWith(
+        [...tracing.userBoundingBoxes, ...additionalUserBoundingBoxes],
+        (bboxWithId1, bboxWithId2) => {
+          const { id: id1, ...bbox1 } = bboxWithId1;
+          const { id: id2, ...bbox2 } = bboxWithId2;
+          return _.isEqual(bbox1, bbox2);
+        },
+      );
       return updateUserBoundingBoxes(state, mergedUserBoundingBoxes);
     }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://deduplicatebboxes.webknossos.xyz

### Steps to test:
- create an annotation
- create a bbox
- download the NML (use the dropdown menu in the toolbar)
- import the NML with DnD
- the bbox should not be duplicated

### Issues:
- fixes #6562 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
