### PR TITLE
Fix assertion that referenced teams cannot be deleted

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Bulk task creation now needs the taskTypeId, the task type summary will no longer be accepted. [#6640](https://github.com/scalableminds/webknossos/pull/6640)
 
 ### Fixed
+- Fixed a bug where it was possible to create invalid an state by deleting teams that are referenced elsewhere. [6664](https://github.com/scalableminds/webknossos/pull/6664)
 
 ### Removed
 

--- a/app/controllers/TeamController.scala
+++ b/app/controllers/TeamController.scala
@@ -46,8 +46,8 @@ class TeamController @Inject()(teamDAO: TeamDAO,
       _ <- bool2Fox(request.identity.isAdmin) ?~> "user.noAdmin" ~> FORBIDDEN
       team <- teamDAO.findOne(teamIdValidated) ?~> "team.notFound" ~> NOT_FOUND
       _ <- bool2Fox(!team.isOrganizationTeam) ?~> "team.delete.organizationTeam" ~> FORBIDDEN
-      _ <- teamDAO.deleteOne(teamIdValidated)
       _ <- teamService.assertNoReferences(teamIdValidated) ?~> "team.delete.inUse" ~> FORBIDDEN
+      _ <- teamDAO.deleteOne(teamIdValidated)
       _ <- userTeamRolesDAO.removeTeamFromAllUsers(teamIdValidated)
       _ <- datasetAllowedTeamsDAO.removeTeamFromAllDatasets(teamIdValidated)
     } yield JsonOk(Messages("team.deleted"))


### PR DESCRIPTION
Order matters :grimacing: 

### URL of deployed dev instance (used for testing):
- https://fixdeleteteamsassertion.webknossos.xyz

### Steps to test:
- Add a team, create a project or task type for this team
- Try to delete the team
- Should be denied
- After page refresh, the team should still be listed

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
