### PR TITLE
Add second (non-admin) user to "initial data" trigger

### DIFF
--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -52,6 +52,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
 
       object User {
         val email: String = get[String]("webKnossos.sampleOrganization.user.email")
+        val email2: String = get[String]("webKnossos.sampleOrganization.user.email2")
         val password: String = get[String]("webKnossos.sampleOrganization.user.password")
         val token: String = get[String]("webKnossos.sampleOrganization.user.token")
         val isSuperUser: Boolean = get[Boolean]("webKnossos.sampleOrganization.user.isSuperUser")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -63,6 +63,7 @@ webKnossos {
     enabled = true
     user {
       email = "sample@scm.io"
+      email2 = "sample2@scm.io"
       password = "secret"
       token = "secretSampleUserToken"
       isSuperUser = true


### PR DESCRIPTION
Testing permission-related functionality often requires a user which doesn't have admin rights. Setting that user up is relatively tedious (especially on dev instances) and I don't see a reason why there shouldn't be a second default user by default (of course, only when `sampleOrganization == true`). Since the same password is used for both default users, one only needs to adapt one character in the email to log into the other account.

@fm3 What do you think about this? The config doesn't read as elegant as before, but I think the gains are worth it. Configuring another password for the second user didn't seem worth it to me, on the other hand.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- log in with `sample@scm.io`:`secret`
- log in with `sample2@scm.io`:`secret`

------
- [X] Ready for review
