### PR TITLE
Improves mag and voxelSize inferral for remote datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed import of N5 datasets. [#6668](https://github.com/scalableminds/webknossos/pull/6668)
 - Fixed a bug where it was possible to create invalid an state by deleting teams that are referenced elsewhere. [6664](https://github.com/scalableminds/webknossos/pull/6664)
+- Fixed import of remote datasets with multiple layers and differing resolution pyramid. #[6670](https://github.com/scalableminds/webknossos/pull/6670)
 
 ### Removed
 

--- a/app/models/binary/explore/ExploreRemoteLayerService.scala
+++ b/app/models/binary/explore/ExploreRemoteLayerService.scala
@@ -88,7 +88,7 @@ class ExploreRemoteLayerService @Inject()() extends FoxImplicits with LazyLoggin
 
   private def rescaleLayersByCommonVoxelSize(layersWithVoxelSizes: List[(DataLayer, Vec3Double)])(
       implicit ec: ExecutionContext): Fox[(List[DataLayer], Vec3Double)] = {
-    val allVoxelSizes: Set[Vec3Double] = layersWithVoxelSizes
+    val allVoxelSizes = layersWithVoxelSizes
       .flatMap(layerWithVoxelSize => {
         val layer = layerWithVoxelSize._1
         val voxelSize = layerWithVoxelSize._2
@@ -109,11 +109,19 @@ class ExploreRemoteLayerService @Inject()() extends FoxImplicits with LazyLoggin
         val layerVoxelSize = layerWithVoxelSize._2
         val magFactors = (layerVoxelSize / minVoxelSize).toVec3Int
         layer match {
-          case l: ZarrDataLayer         => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
-          case l: ZarrSegmentationLayer => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
-          case l: N5DataLayer           => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
-          case l: N5SegmentationLayer   => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
-          case _                        => throw new Exception("Encountered unsupported layer format during explore remote")
+          case l: ZarrDataLayer =>
+            l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)),
+                   boundingBox = l.boundingBox * magFactors)
+          case l: ZarrSegmentationLayer =>
+            l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)),
+                   boundingBox = l.boundingBox * magFactors)
+          case l: N5DataLayer =>
+            l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)),
+                   boundingBox = l.boundingBox * magFactors)
+          case l: N5SegmentationLayer =>
+            l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)),
+                   boundingBox = l.boundingBox * magFactors)
+          case _ => throw new Exception("Encountered unsupported layer format during explore remote")
         }
       })
     } yield (rescaledLayers, minVoxelSize)
@@ -171,7 +179,6 @@ class ExploreRemoteLayerService @Inject()() extends FoxImplicits with LazyLoggin
         " <~ " + failure.msg + formatChain(failure.chain)
       case _ => ""
     }
-
     failure.msg + formatChain(failure.chain)
   }
 

--- a/app/models/binary/explore/ExploreRemoteLayerService.scala
+++ b/app/models/binary/explore/ExploreRemoteLayerService.scala
@@ -1,6 +1,6 @@
 package models.binary.explore
 
-import com.scalableminds.util.geometry.Vec3Double
+import com.scalableminds.util.geometry.{Vec3Double, Vec3Int}
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.dataformats.n5.{N5DataLayer, N5SegmentationLayer}
 import com.scalableminds.webknossos.datastore.dataformats.zarr._
@@ -18,8 +18,10 @@ import java.nio.file.Path
 import javax.inject.Inject
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 case class ExploreRemoteDatasetParameters(remoteUri: String, user: Option[String], password: Option[String])
+
 object ExploreRemoteDatasetParameters {
   implicit val jsonFormat: OFormat[ExploreRemoteDatasetParameters] = Json.format[ExploreRemoteDatasetParameters]
 }
@@ -34,11 +36,13 @@ class ExploreRemoteLayerService @Inject()() extends FoxImplicits with LazyLoggin
         exploreRemoteLayersForUri(parameters.remoteUri, parameters.user, parameters.password, reportMutable))
       layersWithVoxelSizes = exploredLayersNested.flatten
       _ <- bool2Fox(layersWithVoxelSizes.nonEmpty) ?~> "Detected zero layers"
-      voxelSize <- commonVoxelSize(layersWithVoxelSizes.map(_._2)) ?~> "Could not extract common voxel size from layers"
-      layers = makeLayerNamesUnique(layersWithVoxelSizes.map(_._1))
+      rescaledLayersAndVoxelSize <- rescaleLayersByCommonVoxelSize(layersWithVoxelSizes) ?~> "Could not extract common voxel size from layers"
+      rescaledLayers = rescaledLayersAndVoxelSize._1
+      voxelSize = rescaledLayersAndVoxelSize._2
+      renamedLayers = makeLayerNamesUnique(rescaledLayers)
       dataSource = GenericDataSource[DataLayer](
         DataSourceId("", ""), // Frontend will prompt user for a good name
-        layers,
+        renamedLayers,
         voxelSize
       )
     } yield dataSource
@@ -66,11 +70,54 @@ class ExploreRemoteLayerService @Inject()() extends FoxImplicits with LazyLoggin
     }
   }
 
-  private def commonVoxelSize(voxelSizes: List[Vec3Double])(implicit ec: ExecutionContext): Fox[Vec3Double] =
+  private def magFromVoxelSize(minVoxelSize: Vec3Double, voxelSize: Vec3Double)(
+      implicit ec: ExecutionContext): Fox[Vec3Int] = {
+    def isPowerOfTwo(x: Int): Boolean =
+      x != 0 && (x & (x - 1)) == 0
+
+    val mag = (voxelSize / minVoxelSize).round.toVec3Int
     for {
-      head <- voxelSizes.headOption.toFox
-      _ <- bool2Fox(voxelSizes.forall(_ == head)) ?~> s"voxel sizes for layers are not uniform, got $voxelSizes"
-    } yield head
+      _ <- bool2Fox(isPowerOfTwo(mag.x) && isPowerOfTwo(mag.x) && isPowerOfTwo(mag.x)) ?~> s"invalid mag: $mag. Must all be powers of two"
+    } yield mag
+  }
+
+  private def checkForDuplicateMags(magGroup: List[Vec3Int])(implicit ec: ExecutionContext): Fox[Unit] =
+    for {
+      _ <- bool2Fox(magGroup.length == 1) ?~> s"detected mags are not unique, found $magGroup"
+    } yield ()
+
+  private def rescaleLayersByCommonVoxelSize(layersWithVoxelSizes: List[(DataLayer, Vec3Double)])(
+      implicit ec: ExecutionContext): Fox[(List[DataLayer], Vec3Double)] = {
+    val allVoxelSizes: Set[Vec3Double] = layersWithVoxelSizes
+      .flatMap(layerWithVoxelSize => {
+        val layer = layerWithVoxelSize._1
+        val voxelSize = layerWithVoxelSize._2
+
+        layer.resolutions.map(resolution => voxelSize * resolution.toVec3Double)
+      })
+      .toSet
+    val minVoxelSizeOpt = Try(allVoxelSizes.minBy(_.toTuple)).toOption
+
+    for {
+      minVoxelSize <- option2Fox(minVoxelSizeOpt)
+      allMags <- Fox.combined(allVoxelSizes.map(magFromVoxelSize(minVoxelSize, _)).toList) ?~> s"voxel sizes for layers are not uniform, got ${layersWithVoxelSizes
+        .map(_._2)}"
+      groupedMags = allMags.groupBy(_.maxDim)
+      _ <- Fox.combined(groupedMags.values.map(checkForDuplicateMags).toList)
+      rescaledLayers = layersWithVoxelSizes.map(layerWithVoxelSize => {
+        val layer = layerWithVoxelSize._1
+        val layerVoxelSize = layerWithVoxelSize._2
+        val magFactors = (layerVoxelSize / minVoxelSize).toVec3Int
+        layer match {
+          case l: ZarrDataLayer         => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
+          case l: ZarrSegmentationLayer => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
+          case l: N5DataLayer           => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
+          case l: N5SegmentationLayer   => l.copy(mags = l.mags.map(mag => mag.copy(mag = mag.mag * magFactors)))
+          case _                        => throw new Exception("Encountered unsupported layer format during explore remote")
+        }
+      })
+    } yield (rescaledLayers, minVoxelSize)
+  }
 
   private def exploreRemoteLayersForUri(
       layerUri: String,
@@ -124,6 +171,7 @@ class ExploreRemoteLayerService @Inject()() extends FoxImplicits with LazyLoggin
         " <~ " + failure.msg + formatChain(failure.chain)
       case _ => ""
     }
+
     failure.msg + formatChain(failure.chain)
   }
 

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -52,6 +52,9 @@ case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
   def scale(s: Float): BoundingBox =
     BoundingBox(topLeft.scale(s), (width * s).toInt, (height * s).toInt, (depth * s).toInt)
 
+  def *(that: Vec3Int): BoundingBox =
+    BoundingBox(topLeft * that, width * that.x, height * that.y, depth * that.z)
+
   def toSql: List[Int] =
     List(topLeft.x, topLeft.y, topLeft.z, width, height, depth)
 

--- a/util/src/main/scala/com/scalableminds/util/geometry/Vec3Int.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Vec3Int.scala
@@ -34,6 +34,8 @@ case class Vec3Int(x: Int, y: Int, z: Int) {
 
   def toVec3Float: Vec3Float = Vec3Float(x.toFloat, y.toFloat, z.toFloat)
 
+  def toVec3Double: Vec3Double = Vec3Double(x.toDouble, y.toDouble, z.toDouble)
+
   def move(dx: Int, dy: Int, dz: Int): Vec3Int =
     Vec3Int(x + dx, y + dy, z + dz)
 


### PR DESCRIPTION
### Steps to test:
- Import https://s3.embl.de/i2k-2020/platy-raw.ome.zarr
- You should be able to see both the raw and segmentation data

### Issues:
- fixes #6667 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
