### PR TITLE
Unify timestamp representation with Instant

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -68,7 +68,7 @@ class AnnotationController @Inject()(
     with FoxImplicits {
 
   implicit val timeout: Timeout = Timeout(5 seconds)
-  private val taskReopenAllowed = (conf.Features.taskReopenAllowed + (10 seconds)).toMillis
+  private val taskReopenAllowed = conf.Features.taskReopenAllowed + (10 seconds)
 
   @ApiOperation(value = "Information about an annotation, supplying the type explicitly",
                 nickname = "annotationInfoByType")
@@ -187,7 +187,7 @@ class AnnotationController @Inject()(
         isAdminOrTeamManager <- userService.isTeamManagerOrAdminOf(user, annotation._team)
         _ <- bool2Fox(annotation.state == AnnotationState.Finished) ?~> "annotation.reopen.notFinished"
         _ <- bool2Fox(isAdminOrTeamManager || annotation._user == user._id) ?~> "annotation.reopen.notAllowed"
-        _ <- bool2Fox(isAdminOrTeamManager || System.currentTimeMillis - annotation.modified < taskReopenAllowed) ?~> "annotation.reopen.tooLate"
+        _ <- bool2Fox(isAdminOrTeamManager || (annotation.modified + taskReopenAllowed).isPast) ?~> "annotation.reopen.tooLate"
       } yield ()
 
     for {

--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -4,6 +4,7 @@ import akka.util.Timeout
 import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.geometry.BoundingBox
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.models.annotation.AnnotationLayerType.AnnotationLayerType
 import com.scalableminds.webknossos.datastore.models.annotation.{AnnotationLayer, AnnotationLayerType}
@@ -98,7 +99,8 @@ class AnnotationController @Inject()(
           .publicWrites(annotation, request.identity, Some(restrictions)) ?~> "annotation.write.failed"
         _ <- Fox.runOptional(request.identity) { user =>
           if (typedTyp == AnnotationType.Task || typedTyp == AnnotationType.Explorational) {
-            timeSpanService.logUserInteraction(timestamp, user, annotation) // log time when a user starts working
+            timeSpanService
+              .logUserInteraction(Instant(timestamp), user, annotation) // log time when a user starts working
           } else Fox.successful(())
         }
         _ = Fox.runOptional(request.identity)(user => userDAO.updateLastActivity(user._id))
@@ -345,7 +347,7 @@ class AnnotationController @Inject()(
       } yield result
   }
 
-  private def finishAnnotation(typ: String, id: String, issuingUser: User, timestamp: Long)(
+  private def finishAnnotation(typ: String, id: String, issuingUser: User, timestamp: Instant)(
       implicit ctx: DBAccessContext): Fox[(Annotation, String)] =
     for {
       annotation <- provider.provideAnnotation(typ, id, issuingUser) ~> NOT_FOUND
@@ -360,7 +362,7 @@ class AnnotationController @Inject()(
     implicit request =>
       log() {
         for {
-          (updated, message) <- finishAnnotation(typ, id, request.identity, timestamp) ?~> "annotation.finish.failed"
+          (updated, message) <- finishAnnotation(typ, id, request.identity, Instant(timestamp)) ?~> "annotation.finish.failed"
           restrictions <- provider.restrictionsFor(typ, id)
           json <- annotationService.publicWrites(updated, Some(request.identity), Some(restrictions))
         } yield JsonOk(json, Messages(message))
@@ -373,7 +375,7 @@ class AnnotationController @Inject()(
       log() {
         withJsonAs[JsArray](request.body \ "annotations") { annotationIds =>
           val results = Fox.serialSequence(annotationIds.value.toList) { jsValue =>
-            jsValue.asOpt[String].toFox.flatMap(id => finishAnnotation(typ, id, request.identity, timestamp))
+            jsValue.asOpt[String].toFox.flatMap(id => finishAnnotation(typ, id, request.identity, Instant(timestamp)))
           }
 
           results.map { _ =>

--- a/app/controllers/AnnotationPrivateLinkController.scala
+++ b/app/controllers/AnnotationPrivateLinkController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.FoxImplicits
 import io.swagger.annotations._
@@ -54,7 +55,7 @@ class AnnotationPrivateLinkController @Inject()(
   private def findAnnotationByPrivateLinkIfNotExpired(accessToken: String): Fox[Annotation] =
     for {
       annotationPrivateLink <- annotationPrivateLinkDAO.findOneByAccessToken(accessToken)
-      _ <- bool2Fox(annotationPrivateLink.expirationDateTime.forall(_ > System.currentTimeMillis())) ?~> "Token expired" ~> 404
+      _ <- bool2Fox(annotationPrivateLink.expirationDateTime.forall(_ > Instant.now)) ?~> "Token expired" ~> 404
       annotation <- annotationDAO.findOne(annotationPrivateLink._annotation)(GlobalAccessContext)
     } yield annotation
 
@@ -96,7 +97,7 @@ class AnnotationPrivateLinkController @Inject()(
         idValidated <- ObjectId.fromString(id)
 
         annotationPrivateLink <- annotationPrivateLinkDAO.findOne(idValidated)
-        _ <- bool2Fox(annotationPrivateLink.expirationDateTime.forall(_ > System.currentTimeMillis())) ?~> "Token expired" ~> NOT_FOUND
+        _ <- bool2Fox(annotationPrivateLink.expirationDateTime.forall(_ > Instant.now)) ?~> "Token expired" ~> NOT_FOUND
         _ <- annotationDAO.findOne(annotationPrivateLink._annotation) ?~> "annotation.notFound" ~> NOT_FOUND
 
         annotationPrivateLinkJs <- annotationPrivateLinkService.publicWrites(annotationPrivateLink)

--- a/app/controllers/DataSetController.scala
+++ b/app/controllers/DataSetController.scala
@@ -4,6 +4,7 @@ import com.mohiva.play.silhouette.api.Silhouette
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.util.mvc.Filter
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, JsonHelper, Math}
 import com.scalableminds.webknossos.datastore.models.datasource.{DataLayer, DataLayerLike, GenericDataSource}
 import io.swagger.annotations._
@@ -54,7 +55,7 @@ class DataSetController @Inject()(userService: UserService,
   private val dataSetPublicReads =
     ((__ \ 'description).readNullable[String] and
       (__ \ 'displayName).readNullable[String] and
-      (__ \ 'sortingKey).readNullable[Long] and
+      (__ \ 'sortingKey).readNullable[Instant] and
       (__ \ 'isPublic).read[Boolean] and
       (__ \ 'tags).read[List[String]] and
       (__ \ 'folderId).readNullable[ObjectId]).tupled

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -93,7 +93,7 @@ Samplecountry
     defaultOrganization._id,
     "Sample",
     "User",
-    System.currentTimeMillis(),
+    Instant.now,
     Json.obj(),
     userService.createLoginInfo(userId),
     isAdmin = true,
@@ -114,7 +114,7 @@ Samplecountry
     defaultOrganization._id,
     "Non-Admin",
     "User",
-    System.currentTimeMillis(),
+    Instant.now,
     Json.obj(),
     userService.createLoginInfo(userId2),
     isAdmin = false,
@@ -125,7 +125,7 @@ Samplecountry
   )
   private val defaultPublication = Publication(
     ObjectId("5c766bec6c01006c018c7459"),
-    Some(System.currentTimeMillis()),
+    Some(Instant.now),
     Some("https://static.webknossos.org/images/oxalis.svg"),
     Some("Dummy Title that is usually very long and contains highly scientific terms"),
     Some(

--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -47,7 +47,7 @@ class JobsController @Inject()(jobDAO: JobDAO,
     for {
       _ <- bool2Fox(wkconf.Features.jobsEnabled) ?~> "job.disabled"
       jobs <- jobDAO.findAll
-      jobsJsonList <- Fox.serialCombined(jobs.sortBy(-_.created))(jobService.publicWrites)
+      jobsJsonList <- Fox.serialCombined(jobs.sortBy(_.created).reverse)(jobService.publicWrites)
     } yield Ok(Json.toJson(jobsJsonList))
   }
 

--- a/app/controllers/MaintenanceController.scala
+++ b/app/controllers/MaintenanceController.scala
@@ -42,7 +42,7 @@ class MaintenanceController @Inject()(sil: Silhouette[WkEnv],
     for {
       multiUser <- multiUserDAO.findOne(request.identity._multiUser)
       _ <- bool2Fox(multiUser.isSuperUser)
-      _ <- maintenanceDAO.updateExpirationTime(Instant(0))
+      _ <- maintenanceDAO.updateExpirationTime(Instant.zero)
     } yield Ok("maintenance.close.success")
   }
 

--- a/app/controllers/MaintenanceController.scala
+++ b/app/controllers/MaintenanceController.scala
@@ -1,7 +1,9 @@
 package controllers
 
 import com.mohiva.play.silhouette.api.Silhouette
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
+
 import javax.inject.Inject
 import models.user.MultiUserDAO
 import oxalis.security.WkEnv
@@ -9,6 +11,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import slick.jdbc.PostgresProfile.api._
 import utils.{SQLClient, SimpleSQLDAO}
+import scala.concurrent.duration._
 
 import scala.concurrent.ExecutionContext
 
@@ -18,10 +21,12 @@ class MaintenanceController @Inject()(sil: Silhouette[WkEnv],
     extends Controller
     with FoxImplicits {
 
+  private val maintenanceDuration: FiniteDuration = 10 minutes
+
   def info: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     for {
       expirationTime <- maintenanceDAO.getExpirationTime
-      isMaintenance = expirationTime.getTime >= System.currentTimeMillis
+      isMaintenance = !expirationTime.isPast
     } yield Ok(Json.obj("isMaintenance" -> Json.toJson(isMaintenance)))
   }
 
@@ -29,7 +34,7 @@ class MaintenanceController @Inject()(sil: Silhouette[WkEnv],
     for {
       multiUser <- multiUserDAO.findOne(request.identity._multiUser)
       _ <- bool2Fox(multiUser.isSuperUser)
-      _ <- maintenanceDAO.updateExpirationTime(new java.sql.Timestamp(System.currentTimeMillis + 1000 * 60 * 10))
+      _ <- maintenanceDAO.updateExpirationTime(Instant.in(maintenanceDuration))
     } yield Ok("maintenance.init.success")
   }
 
@@ -37,7 +42,7 @@ class MaintenanceController @Inject()(sil: Silhouette[WkEnv],
     for {
       multiUser <- multiUserDAO.findOne(request.identity._multiUser)
       _ <- bool2Fox(multiUser.isSuperUser)
-      _ <- maintenanceDAO.updateExpirationTime(new java.sql.Timestamp(0))
+      _ <- maintenanceDAO.updateExpirationTime(Instant(0))
     } yield Ok("maintenance.close.success")
   }
 
@@ -45,14 +50,14 @@ class MaintenanceController @Inject()(sil: Silhouette[WkEnv],
 
 class MaintenanceDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext) extends SimpleSQLDAO(sqlClient) {
 
-  def getExpirationTime: Fox[java.sql.Timestamp] =
+  def getExpirationTime: Fox[Instant] =
     for {
-      timeList <- run(sql"select maintenanceExpirationTime from webknossos.maintenance".as[java.sql.Timestamp])
+      timeList <- run(sql"select maintenanceExpirationTime from webknossos.maintenance".as[Instant])
       time <- timeList.headOption.toFox
     } yield time
 
-  def updateExpirationTime(newTimestamp: java.sql.Timestamp): Fox[Unit] =
+  def updateExpirationTime(newExpirationTime: Instant): Fox[Unit] =
     for {
-      _ <- run(sql"update webknossos.maintenance set maintenanceExpirationTime = $newTimestamp".as[java.sql.Timestamp])
+      _ <- run(sqlu"update webknossos.maintenance set maintenanceExpirationTime = $newExpirationTime")
     } yield ()
 }

--- a/app/controllers/OrganizationController.scala
+++ b/app/controllers/OrganizationController.scala
@@ -70,7 +70,7 @@ class OrganizationController @Inject()(organizationDAO: OrganizationDAO,
     implicit val ctx: DBAccessContext = GlobalAccessContext
     for {
       invite <- inviteDAO.findOneByTokenValue(inviteToken)
-      _ <- bool2Fox(invite.expirationDateTime.isAfterNow)
+      _ <- bool2Fox(!invite.expirationDateTime.isPast)
       organization <- organizationDAO.findOne(invite._organization)
       organizationJson <- organizationService.publicWrites(organization)
     } yield Ok(organizationJson)

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -105,8 +105,8 @@ class TimeController @Inject()(userService: UserService,
     for {
       userJs <- userService.compactWrites(user)
       timeJs <- timeSpanDAO.findAllByUserWithTask(user._id,
-                                                  Some(Instant(startDate.getTimeInMillis)),
-                                                  Some(Instant(endDate.getTimeInMillis)))
+                                                  Some(Instant.fromCalendar(startDate)),
+                                                  Some(Instant.fromCalendar(endDate)))
     } yield Json.obj("user" -> userJs, "timelogs" -> timeJs)
 
 }

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -2,9 +2,10 @@ package controllers
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
-
 import com.mohiva.play.silhouette.api.Silhouette
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
+
 import javax.inject.Inject
 import models.user._
 import models.user.time.TimeSpanDAO
@@ -104,8 +105,8 @@ class TimeController @Inject()(userService: UserService,
     for {
       userJs <- userService.compactWrites(user)
       timeJs <- timeSpanDAO.findAllByUserWithTask(user._id,
-                                                  Some(startDate.getTimeInMillis),
-                                                  Some(endDate.getTimeInMillis))
+                                                  Some(Instant(startDate.getTimeInMillis)),
+                                                  Some(Instant(endDate.getTimeInMillis)))
     } yield Json.obj("user" -> userJs, "timelogs" -> timeJs)
 
 }

--- a/app/controllers/WKRemoteTracingStoreController.scala
+++ b/app/controllers/WKRemoteTracingStoreController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.tracingstore.TracingUpdatesReport
@@ -48,7 +49,7 @@ class WKRemoteTracingStoreController @Inject()(
           _ <- Fox.runOptional(report.statistics) { statistics =>
             annotationDAO.updateStatistics(annotation._id, statistics)
           }
-          _ <- annotationDAO.updateModified(annotation._id, System.currentTimeMillis)
+          _ <- annotationDAO.updateModified(annotation._id, Instant.now)
           userBox <- bearerTokenService.userForTokenOpt(report.userToken).futureBox
           _ <- Fox.runOptional(userBox)(user => timeSpanService.logUserInteraction(report.timestamps, user, annotation))
           _ <- Fox.runOptional(userBox)(user =>

--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -1,15 +1,16 @@
 package models.analytics
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.scalalogging.LazyLogging
+
 import javax.inject.Inject
 import models.annotation.Annotation
 import models.binary.{DataSet, DataStore}
 import models.organization.Organization
 import models.user.{MultiUserDAO, User, UserDAO}
-import org.joda.time.DateTime
 import play.api.libs.json._
 import utils.{ObjectId, WkConf}
 
@@ -101,7 +102,6 @@ trait AnalyticsEvent {
         "webknossos_uri" -> analyticsLookUpService.webknossos_uri
       )
     }
-  def timestamp: String = DateTime.now().getMillis.toString
 
   def user: User
 
@@ -113,7 +113,7 @@ trait AnalyticsEvent {
       Json.obj(
         "event_type" -> eventType,
         "user_id" -> userId,
-        "time" -> timestamp,
+        "time" -> Instant.now.epochMillis.toString,
         "user_properties" -> userProperties,
         "event_properties" -> eventProperties,
         "session_id" -> sessionId

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -507,10 +507,10 @@ class AnnotationDAO @Inject()(sqlClient: SQLClient, annotationLayerDAO: Annotati
       _ <- run(sqlu"update webknossos.annotations set tags = '#${writeArrayTuple(tags)}' where _id = $id")
     } yield ()
 
-  def updateModified(id: ObjectId, modified: Long)(implicit ctx: DBAccessContext): Fox[Unit] =
+  def updateModified(id: ObjectId, modified: Instant)(implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- assertUpdateAccess(id)
-      _ <- run(sqlu"update webknossos.annotations set modified = ${new java.sql.Timestamp(modified)} where _id = $id")
+      _ <- run(sqlu"update webknossos.annotations set modified = $modified where _id = $id")
     } yield ()
 
   def updateStatistics(id: ObjectId, statistics: JsObject)(implicit ctx: DBAccessContext): Fox[Unit] =

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -1,6 +1,7 @@
 package models.annotation
 
 import com.scalableminds.util.accesscontext.DBAccessContext
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
 import com.scalableminds.webknossos.datastore.models.annotation.{AnnotationLayer, AnnotationLayerType}
 import com.scalableminds.webknossos.schema.Tables._
@@ -36,8 +37,8 @@ case class Annotation(
     tracingTime: Option[Long] = None,
     typ: AnnotationType.Value = AnnotationType.Explorational,
     othersMayEdit: Boolean = false,
-    created: Long = System.currentTimeMillis,
-    modified: Long = System.currentTimeMillis,
+    created: Instant = Instant.now,
+    modified: Instant = Instant.now,
     isDeleted: Boolean = false
 ) extends FoxImplicits {
 
@@ -172,8 +173,8 @@ class AnnotationDAO @Inject()(sqlClient: SQLClient, annotationLayerDAO: Annotati
         r.tracingtime,
         typ,
         r.othersmayedit,
-        r.created.getTime,
-        r.modified.getTime,
+        Instant.fromSql(r.created),
+        Instant.fromSql(r.modified),
         r.isdeleted
       )
     }
@@ -405,7 +406,7 @@ class AnnotationDAO @Inject()(sqlClient: SQLClient, annotationLayerDAO: Annotati
          '#${a.state}', '#${sanitize(a.statistics.toString)}',
          '#${writeArrayTuple(a.tags.toList)}', ${a.tracingTime}, '#${a.typ}',
          ${a.othersMayEdit},
-         ${new java.sql.Timestamp(a.created)}, ${new java.sql.Timestamp(a.modified)}, ${a.isDeleted})
+         ${a.created}, ${a.modified}, ${a.isDeleted})
          """
     val insertLayerQueries = annotationLayerDAO.insertLayerQueries(a._id, a.annotationLayers)
     for {
@@ -432,8 +433,8 @@ class AnnotationDAO @Inject()(sqlClient: SQLClient, annotationLayerDAO: Annotati
                tracingTime = ${a.tracingTime},
                typ = '#${a.typ}',
                othersMayEdit = ${a.othersMayEdit},
-               created = ${new java.sql.Timestamp(a.created)},
-               modified = ${new java.sql.Timestamp(a.modified)},
+               created = ${a.created},
+               modified = ${a.modified},
                isDeleted = ${a.isDeleted}
              where _id = ${a._id}
           """

--- a/app/models/annotation/AnnotationPrivateLink.scala
+++ b/app/models/annotation/AnnotationPrivateLink.scala
@@ -1,6 +1,7 @@
 package models.annotation
 
 import com.scalableminds.util.accesscontext.DBAccessContext
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables.{AnnotationPrivatelinks, _}
 import oxalis.security.RandomIDGenerator
@@ -16,14 +17,14 @@ import scala.concurrent.ExecutionContext
 case class AnnotationPrivateLink(_id: ObjectId,
                                  _annotation: ObjectId,
                                  accessToken: String,
-                                 expirationDateTime: Option[Long],
+                                 expirationDateTime: Option[Instant],
                                  isDeleted: Boolean = false)
 
 object AnnotationPrivateLink {
   implicit val jsonFormat: OFormat[AnnotationPrivateLink] = Json.format[AnnotationPrivateLink]
 }
 
-case class AnnotationPrivateLinkParams(annotation: String, expirationDateTime: Option[Long])
+case class AnnotationPrivateLinkParams(annotation: String, expirationDateTime: Option[Instant])
 
 object AnnotationPrivateLinkParams {
   implicit val jsonFormat: OFormat[AnnotationPrivateLinkParams] = Json.format[AnnotationPrivateLinkParams]
@@ -56,7 +57,7 @@ class AnnotationPrivateLinkDAO @Inject()(sqlClient: SQLClient)(implicit ec: Exec
         ObjectId(r._Id),
         ObjectId(r._Annotation),
         r.accesstoken,
-        r.expirationdatetime.map(_.getTime),
+        r.expirationdatetime.map(Instant.fromSql),
         r.isdeleted
       )
     )
@@ -64,23 +65,19 @@ class AnnotationPrivateLinkDAO @Inject()(sqlClient: SQLClient)(implicit ec: Exec
   override def readAccessQ(requestingUserId: ObjectId): String =
     s"""(_annotation in (select _id from webknossos.annotations_ where _user = '${requestingUserId.id}'))"""
 
-  def insertOne(aPL: AnnotationPrivateLink): Fox[Unit] = {
-    val time = aPL.expirationDateTime.map(new java.sql.Timestamp(_))
-
+  def insertOne(aPL: AnnotationPrivateLink): Fox[Unit] =
     for {
       _ <- run(
         sqlu"""insert into webknossos.annotation_privateLinks(_id, _annotation, accessToken, expirationDateTime, isDeleted)
-                         values(${aPL._id.id}, ${aPL._annotation.id}, ${aPL.accessToken}, ${time}, ${aPL.isDeleted})""")
+                         values(${aPL._id.id}, ${aPL._annotation.id}, ${aPL.accessToken}, ${aPL.expirationDateTime}, ${aPL.isDeleted})""")
     } yield ()
-  }
 
-  def updateOne(id: ObjectId, annotationId: ObjectId, expirationDateTime: Option[Long])(
+  def updateOne(id: ObjectId, annotationId: ObjectId, expirationDateTime: Option[Instant])(
       implicit ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- assertUpdateAccess(id)
-      time = expirationDateTime.map(new java.sql.Timestamp(_))
-      _ <- run(sqlu"""update webknossos.annotation_privateLinks set _annotation = ${annotationId},
-                            expirationDateTime = $time where _id = $id""")
+      _ <- run(sqlu"""update webknossos.annotation_privateLinks set _annotation = $annotationId,
+                            expirationDateTime = $expirationDateTime where _id = $id""")
     } yield ()
 
   override def findAll(implicit ctx: DBAccessContext): Fox[List[AnnotationPrivateLink]] =
@@ -91,7 +88,7 @@ class AnnotationPrivateLinkDAO @Inject()(sqlClient: SQLClient)(implicit ec: Exec
       parsed <- parseAll(r)
     } yield parsed
 
-  def findAllByAnnotation(annotationId: ObjectId)(implicit ctx: DBAccessContext) =
+  def findAllByAnnotation(annotationId: ObjectId)(implicit ctx: DBAccessContext): Fox[List[AnnotationPrivateLink]] =
     for {
       accessQuery <- readAccessQuery
       r <- run(
@@ -103,7 +100,7 @@ class AnnotationPrivateLinkDAO @Inject()(sqlClient: SQLClient)(implicit ec: Exec
   def findOneByAccessToken(accessToken: String): Fox[AnnotationPrivateLink] =
     for {
       r <- run(
-        sql"select #$columns from #$existingCollectionName where accessToken = ${accessToken}"
+        sql"select #$columns from #$existingCollectionName where accessToken = $accessToken"
           .as[AnnotationPrivatelinksRow])
       parsed <- parseFirst(r, accessToken)
     } yield parsed

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -7,6 +7,7 @@ import com.scalableminds.util.accesscontext.{AuthorizedAccessContext, DBAccessCo
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
 import com.scalableminds.util.io.ZipIO
 import com.scalableminds.util.mvc.Formatter
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{BoxImplicits, Fox, FoxImplicits, TextUtils}
 import com.scalableminds.webknossos.datastore.SkeletonTracing._
 import com.scalableminds.webknossos.datastore.VolumeTracing.{VolumeTracing, VolumeTracingOpt, VolumeTracings}
@@ -458,8 +459,8 @@ class AnnotationService @Inject()(
           annotationLayers = annotationLayers,
           state = Active,
           typ = AnnotationType.Task,
-          created = System.currentTimeMillis,
-          modified = System.currentTimeMillis
+          created = Instant.now,
+          modified = Instant.now
         )
         _ <- annotationDAO.updateInitialized(newAnnotation)
       } yield newAnnotation

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -388,7 +388,7 @@ class AnnotationService @Inject()(
       implicit ctx: DBAccessContext): Fox[String] = {
     def executeFinish: Fox[String] =
       for {
-        _ <- annotationDAO.updateModified(annotation._id, System.currentTimeMillis)
+        _ <- annotationDAO.updateModified(annotation._id, Instant.now)
         _ <- annotationDAO.updateState(annotation._id, AnnotationState.Finished)
       } yield {
         if (annotation._task.isEmpty)

--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -1,6 +1,7 @@
 package models.annotation.nml
 
 import com.scalableminds.util.geometry.Vec3Double
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.util.xml.Xml
 import com.scalableminds.webknossos.datastore.SkeletonTracing._
@@ -11,7 +12,6 @@ import com.sun.xml.txw2.output.IndentingXMLStreamWriter
 import models.annotation.Annotation
 import models.task.Task
 import models.user.User
-import org.joda.time.DateTime
 import play.api.libs.iteratee.Enumerator
 
 import javax.inject.Inject
@@ -329,7 +329,7 @@ class NmlWriter @Inject()(implicit ec: ExecutionContext) extends FoxImplicits {
     }
     Xml.withinElementSync("meta") {
       writer.writeAttribute("name", "timestamp")
-      writer.writeAttribute("content", DateTime.now().getMillis.toString)
+      writer.writeAttribute("content", Instant.now.epochMillis.toString)
     }
     annotationOpt.foreach { annotation =>
       Xml.withinElementSync("meta") {

--- a/app/models/binary/DataSet.scala
+++ b/app/models/binary/DataSet.scala
@@ -2,6 +2,7 @@ package models.binary
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
 import com.scalableminds.webknossos.datastore.models.datasource.DataSetViewConfiguration.DataSetViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
@@ -14,6 +15,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   DataLayerLike => DataLayer
 }
 import com.scalableminds.webknossos.schema.Tables._
+
 import javax.inject.Inject
 import models.organization.OrganizationDAO
 import play.api.libs.json._
@@ -45,10 +47,10 @@ case class DataSet(
     sharingToken: Option[String],
     status: String,
     logoUrl: Option[String],
-    sortingKey: Long = System.currentTimeMillis(),
+    sortingKey: Instant = Instant.now,
     details: Option[JsObject] = None,
     tags: Set[String] = Set.empty,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 ) extends FoxImplicits {
 
@@ -105,10 +107,10 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
         r.sharingtoken,
         r.status,
         r.logourl,
-        r.sortingkey.getTime,
+        Instant.fromSql(r.sortingkey),
         details,
         parseArrayTuple(r.tags).toSet,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       )
     }
@@ -282,14 +284,14 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
   def updateFields(_id: ObjectId,
                    description: Option[String],
                    displayName: Option[String],
-                   sortingKey: Long,
+                   sortingKey: Instant,
                    isPublic: Boolean,
                    folderId: ObjectId)(implicit ctx: DBAccessContext): Fox[Unit] = {
     val q = for { row <- Datasets if notdel(row) && row._Id === _id.id } yield
       (row.description, row.displayname, row.sortingkey, row.ispublic, row._Folder)
     for {
       _ <- assertUpdateAccess(_id)
-      _ <- run(q.update(description, displayName, new java.sql.Timestamp(sortingKey), isPublic, folderId.toString))
+      _ <- run(q.update(description, displayName, sortingKey.toSql, isPublic, folderId.toString))
     } yield ()
   }
 
@@ -322,17 +324,16 @@ class DataSetDAO @Inject()(sqlClient: SQLClient,
     val defaultViewConfiguration: Option[String] = d.defaultViewConfiguration.map(Json.toJson(_).toString)
     val details: Option[String] = d.details.map(_.toString)
     for {
-      _ <- run(
-        sqlu"""insert into webknossos.dataSets(_id, _dataStore, _organization, _publication, _uploader, _folder, inboxSourceHash, defaultViewConfiguration, adminViewConfiguration, description, displayName,
+      _ <- run(sqlu"""insert into webknossos.dataSets(_id, _dataStore, _organization, _publication, _uploader, _folder, inboxSourceHash, defaultViewConfiguration, adminViewConfiguration, description, displayName,
                                                              isPublic, isUsable, name, scale, status, sharingToken, sortingKey, details, tags, created, isDeleted)
                values(${d._id}, ${d._dataStore}, ${d._organization}, ${d._publication},
                ${d._uploader}, ${d._folder},
                 #${optionLiteral(d.inboxSourceHash.map(_.toString))}, #${optionLiteral(
-          defaultViewConfiguration.map(sanitize))}, #${optionLiteral(adminViewConfiguration.map(sanitize))},
+        defaultViewConfiguration.map(sanitize))}, #${optionLiteral(adminViewConfiguration.map(sanitize))},
                 ${d.description}, ${d.displayName}, ${d.isPublic}, ${d.isUsable},
                       ${d.name}, #${optionLiteral(d.scale.map(s => writeScaleLiteral(s)))}, ${d.status
-          .take(1024)}, ${d.sharingToken}, ${new java.sql.Timestamp(d.sortingKey)}, #${optionLiteral(details.map(
-          sanitize))}, '#${writeArrayTuple(d.tags.toList)}', ${new java.sql.Timestamp(d.created)}, ${d.isDeleted})
+        .take(1024)}, ${d.sharingToken}, ${d.sortingKey}, #${optionLiteral(details.map(sanitize))}, '#${writeArrayTuple(
+        d.tags.toList)}', ${d.created}, ${d.isDeleted})
             """)
     } yield ()
   }
@@ -549,13 +550,13 @@ class DataSetDataLayerDAO @Inject()(sqlClient: SQLClient, dataSetResolutionsDAO:
 
 class DataSetLastUsedTimesDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
     extends SimpleSQLDAO(sqlClient) {
-  def findForDataSetAndUser(dataSetId: ObjectId, userId: ObjectId): Fox[Long] =
+  def findForDataSetAndUser(dataSetId: ObjectId, userId: ObjectId): Fox[Instant] =
     for {
       rList <- run(
         sql"select lastUsedTime from webknossos.dataSet_lastUsedTimes where _dataSet = $dataSetId and _user = $userId"
-          .as[java.sql.Timestamp])
+          .as[Instant])
       r <- rList.headOption.toFox
-    } yield r.getTime
+    } yield r
 
   def updateForDataSetAndUser(dataSetId: ObjectId, userId: ObjectId): Fox[Unit] = {
     val clearQuery =

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -1,6 +1,7 @@
 package models.binary
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.JsonHelper.box2Option
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.{
@@ -257,13 +258,13 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
       dataStore <- dataStoreFor(dataSet)
     } yield new WKRemoteDataStoreClient(dataStore, dataSet, rpc)
 
-  def lastUsedTimeFor(_dataSet: ObjectId, userOpt: Option[User]): Fox[Long] =
+  def lastUsedTimeFor(_dataSet: ObjectId, userOpt: Option[User]): Fox[Instant] =
     userOpt match {
       case Some(user) =>
         (for {
           lastUsedTime <- dataSetLastUsedTimesDAO.findForDataSetAndUser(_dataSet, user._id).futureBox
-        } yield lastUsedTime.toOption.getOrElse(0L)).toFox
-      case _ => Fox.successful(0L)
+        } yield lastUsedTime.toOption.getOrElse(Instant(0L))).toFox
+      case _ => Fox.successful(Instant(0L))
     }
 
   def allLayersFor(dataSet: DataSet): Fox[List[DataLayer]] =

--- a/app/models/binary/DataSetService.scala
+++ b/app/models/binary/DataSetService.scala
@@ -263,8 +263,8 @@ class DataSetService @Inject()(organizationDAO: OrganizationDAO,
       case Some(user) =>
         (for {
           lastUsedTime <- dataSetLastUsedTimesDAO.findForDataSetAndUser(_dataSet, user._id).futureBox
-        } yield lastUsedTime.toOption.getOrElse(Instant(0L))).toFox
-      case _ => Fox.successful(Instant(0L))
+        } yield lastUsedTime.toOption.getOrElse(Instant.zero)).toFox
+      case _ => Fox.successful(Instant.zero)
     }
 
   def allLayersFor(dataSet: DataSet): Fox[List[DataLayer]] =

--- a/app/models/binary/Publication.scala
+++ b/app/models/binary/Publication.scala
@@ -1,8 +1,10 @@
 package models.binary
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables._
+
 import javax.inject.Inject
 import models.annotation.{AnnotationDAO, AnnotationService}
 import play.api.http.Status.NOT_FOUND
@@ -15,11 +17,11 @@ import utils.{ObjectId, SQLClient, SQLDAO}
 import scala.concurrent.ExecutionContext
 
 case class Publication(_id: ObjectId,
-                       publicationDate: Option[Long],
+                       publicationDate: Option[Instant],
                        imageUrl: Option[String],
                        title: Option[String],
                        description: Option[String],
-                       created: Long = System.currentTimeMillis(),
+                       created: Instant = Instant.now,
                        isDeleted: Boolean = false)
 
 class PublicationService @Inject()(dataSetService: DataSetService,
@@ -62,11 +64,11 @@ class PublicationDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionConte
     Fox.successful(
       Publication(
         ObjectId(r._Id),
-        r.publicationdate.map(_.getTime),
+        r.publicationdate.map(Instant.fromSql),
         r.imageurl,
         r.title,
         r.description,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       )
     )
@@ -87,8 +89,6 @@ class PublicationDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionConte
     for {
       _ <- run(
         sqlu"""insert into webknossos.publications(_id, publicationDate, imageUrl, title, description, created, isDeleted)
-                         values(${p._id.id}, ${p.publicationDate
-          .map(new java.sql.Timestamp(_))}, ${p.imageUrl}, ${p.title}, ${p.description}, ${new java.sql.Timestamp(
-          p.created)}, ${p.isDeleted})""")
+                         values(${p._id.id}, ${p.publicationDate}, ${p.imageUrl}, ${p.title}, ${p.description}, ${p.created}, ${p.isDeleted})""")
     } yield ()
 }

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -1,10 +1,10 @@
 package models.job
 
-import java.sql.Timestamp
 import akka.actor.ActorSystem
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.geometry.BoundingBox
 import com.scalableminds.util.mvc.Formatter
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.schema.Tables._
 import com.typesafe.scalalogging.LazyLogging
@@ -40,7 +40,7 @@ case class Job(
     returnValue: Option[String] = None,
     started: Option[Long] = None,
     ended: Option[Long] = None,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 ) {
   def isEnded: Boolean = {
@@ -115,7 +115,7 @@ class JobDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         r.returnvalue,
         r.started.map(_.getTime),
         r.ended.map(_.getTime),
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       )
     }
@@ -196,7 +196,7 @@ class JobDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
                           #${optionLiteralSanitized(j.returnValue)},
                           #${optionLiteral(j.started.map(_.toString))},
                           #${optionLiteral(j.ended.map(_.toString))},
-                          ${new java.sql.Timestamp(j.created)}, ${j.isDeleted})""")
+                          ${j.created}, ${j.isDeleted})""")
     } yield ()
 
   def updateManualState(id: ObjectId, manualState: JobState)(implicit ctx: DBAccessContext): Fox[Unit] =
@@ -205,20 +205,16 @@ class JobDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       _ <- run(sqlu"""update webknossos.jobs set manualState = '#${manualState.toString}' where _id = $id""")
     } yield ()
 
-  def updateStatus(jobId: ObjectId, s: JobStatus): Fox[Unit] = {
-    val format = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
-    val startedTimestamp = s.started.map(started => format.format(new Timestamp(started)))
-    val endedTimestamp = s.ended.map(ended => format.format(new Timestamp(ended)))
+  def updateStatus(jobId: ObjectId, s: JobStatus): Fox[Unit] =
     for {
       _ <- run(sqlu"""update webknossos.jobs set
               latestRunId = #${optionLiteralSanitized(s.latestRunId)},
               state = '#${s.state.toString}',
               returnValue = #${optionLiteralSanitized(s.returnValue)},
-              started = #${optionLiteralSanitized(startedTimestamp)},
-              ended = #${optionLiteralSanitized(endedTimestamp)}
+              started = ${s.started},
+              ended = ${s.ended}
               where _id = $jobId""")
     } yield ()
-  }
 
   def reserveNextJob(worker: Worker): Fox[Unit] = {
     val query =

--- a/app/models/job/JobStatus.scala
+++ b/app/models/job/JobStatus.scala
@@ -1,5 +1,6 @@
 package models.job
 
+import com.scalableminds.util.time.Instant
 import models.job.JobState.JobState
 import play.api.libs.json.{Json, OFormat}
 
@@ -7,8 +8,8 @@ case class JobStatus(
     latestRunId: Option[String],
     state: JobState,
     returnValue: Option[String],
-    started: Option[Long],
-    ended: Option[Long],
+    started: Option[Instant],
+    ended: Option[Instant],
 )
 
 object JobStatus {

--- a/app/models/job/Worker.scala
+++ b/app/models/job/Worker.scala
@@ -3,6 +3,7 @@ package models.job
 import akka.actor.ActorSystem
 import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.mvc.Formatter
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.helpers.IntervalScheduler
 import com.scalableminds.webknossos.schema.Tables._
@@ -24,7 +25,7 @@ case class Worker(_id: ObjectId,
                   key: String,
                   maxParallelJobs: Int,
                   lastHeartBeat: Long = 0,
-                  created: Long = System.currentTimeMillis,
+                  created: Instant = Instant.now,
                   isDeleted: Boolean = false)
 
 class WorkerDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
@@ -43,7 +44,7 @@ class WorkerDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         r.key,
         r.maxparalleljobs,
         r.lastheartbeat.getTime,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       )
     )

--- a/app/models/organization/Organization.scala
+++ b/app/models/organization/Organization.scala
@@ -1,8 +1,10 @@
 package models.organization
 
 import com.scalableminds.util.accesscontext.DBAccessContext
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables._
+
 import javax.inject.Inject
 import models.team.PricingPlan
 import models.team.PricingPlan.PricingPlan
@@ -23,7 +25,7 @@ case class Organization(
     newUserMailingList: String = "",
     overTimeMailingList: String = "",
     enableAutoVerify: Boolean = false,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 )
 
@@ -50,7 +52,7 @@ class OrganizationDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionCont
         r.newusermailinglist,
         r.overtimemailinglist,
         r.enableautoverify,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       )
     }
@@ -83,8 +85,8 @@ class OrganizationDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionCont
     for {
       _ <- run(
         sqlu"""insert into webknossos.organizations(_id, name, additionalInformation, logoUrl, displayName, _rootFolder, newUserMailingList, overTimeMailingList, enableAutoVerify, created, isDeleted)
-                  values(${o._id.id}, ${o.name}, ${o.additionalInformation}, ${o.logoUrl}, ${o.displayName}, ${o._rootFolder}, ${o.newUserMailingList}, ${o.overTimeMailingList}, ${o.enableAutoVerify}, ${new java.sql.Timestamp(
-          o.created)}, ${o.isDeleted})
+                  values(${o._id.id}, ${o.name}, ${o.additionalInformation}, ${o.logoUrl}, ${o.displayName}, ${o._rootFolder},
+                   ${o.newUserMailingList}, ${o.overTimeMailingList}, ${o.enableAutoVerify}, ${o.created}, ${o.isDeleted})
             """)
     } yield ()
 

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -1,9 +1,11 @@
 package models.project
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.schema.Tables._
 import com.typesafe.scalalogging.LazyLogging
+
 import javax.inject.Inject
 import models.annotation.{AnnotationState, AnnotationType}
 import models.task.TaskDAO
@@ -27,7 +29,7 @@ case class Project(
     paused: Boolean,
     expectedTime: Option[Long],
     isBlacklistedFromReport: Boolean,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 ) extends FoxImplicits {
 
@@ -71,7 +73,7 @@ class ProjectDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         r.paused,
         r.expectedtime,
         r.isblacklistedfromreport,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       ))
 
@@ -148,7 +150,7 @@ class ProjectDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
                                      paused, expectedTime, isblacklistedfromreport, created, isDeleted)
                          values(${p._id}, $organizationId, ${p._team}, ${p._owner}, ${p.name}, ${p.priority},
                          ${p.paused}, ${p.expectedTime}, ${p.isBlacklistedFromReport},
-                         ${new java.sql.Timestamp(p.created)}, ${p.isDeleted})""")
+                         ${p.created}, ${p.isDeleted})""")
     } yield ()
 
   def updateOne(p: Project)(implicit ctx: DBAccessContext): Fox[Unit] =

--- a/app/models/task/Script.scala
+++ b/app/models/task/Script.scala
@@ -1,6 +1,7 @@
 package models.task
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables._
 import models.user.{UserDAO, UserService}
@@ -17,7 +18,7 @@ case class Script(
     _owner: ObjectId,
     name: String,
     gist: String,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 )
 
@@ -61,14 +62,14 @@ class ScriptDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         ObjectId(r._Owner),
         r.name,
         r.gist,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       ))
 
   def insertOne(s: Script): Fox[Unit] =
     for {
       _ <- run(sqlu"""insert into webknossos.scripts(_id, _owner, name, gist, created, isDeleted)
-                         values(${s._id}, ${s._owner}, ${s.name}, ${s.gist}, ${new java.sql.Timestamp(s.created)}, ${s.isDeleted})""")
+                         values(${s._id}, ${s._owner}, ${s.name}, ${s.gist}, ${s.created}, ${s.isDeleted})""")
     } yield ()
 
   def updateOne(s: Script)(implicit ctx: DBAccessContext): Fox[Unit] =

--- a/app/models/task/TaskType.scala
+++ b/app/models/task/TaskType.scala
@@ -1,6 +1,7 @@
 package models.task
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables._
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType
@@ -12,8 +13,8 @@ import play.api.libs.json._
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.Rep
 import utils.{ObjectId, SQLClient, SQLDAO}
-import javax.inject.Inject
 
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
 case class TaskType(
@@ -24,7 +25,7 @@ case class TaskType(
     settings: AnnotationSettings = AnnotationSettings.defaultFor(TracingType.skeleton),
     recommendedConfiguration: Option[JsValue] = None,
     tracingType: TracingType = TracingType.skeleton,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 )
 
@@ -103,7 +104,7 @@ class TaskTypeDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         ),
         r.recommendedconfiguration.map(Json.parse),
         tracingType,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       )
 
@@ -158,7 +159,7 @@ class TaskTypeDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
                               #${optionLiteral(t.settings.resolutionRestrictions.max.map(_.toString))},
                               #${optionLiteral(t.recommendedConfiguration.map(c => sanitize(Json.toJson(c).toString)))},
                               '#${t.tracingType.toString}',
-                              ${new java.sql.Timestamp(t.created)}, ${t.isDeleted})
+                              ${t.created}, ${t.isDeleted})
                        """)
     } yield ()
 

--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -1,6 +1,7 @@
 package models.team
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.schema.Tables._
 
@@ -25,7 +26,7 @@ case class Team(
     _organization: ObjectId,
     name: String,
     isOrganizationTeam: Boolean = false,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 ) extends FoxImplicits {
 
@@ -109,7 +110,7 @@ class TeamDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         ObjectId(r._Organization),
         r.name,
         r.isorganizationteam,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       ))
 
@@ -184,7 +185,7 @@ class TeamDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
   def insertOne(t: Team): Fox[Unit] =
     for {
       _ <- run(sqlu"""INSERT INTO webknossos.teams(_id, _organization, name, created, isOrganizationTeam, isDeleted)
-                  VALUES(${t._id}, ${t._organization}, ${t.name}, ${new java.sql.Timestamp(t.created)}, ${t.isOrganizationTeam}, ${t.isDeleted})
+                  VALUES(${t._id}, ${t._organization}, ${t.name}, ${t.created}, ${t.isOrganizationTeam}, ${t.isDeleted})
             """)
     } yield ()
 

--- a/app/models/user/Invite.scala
+++ b/app/models/user/Invite.scala
@@ -2,12 +2,13 @@ package models.user
 
 import akka.actor.ActorSystem
 import com.scalableminds.util.accesscontext.DBAccessContext
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.schema.Tables._
 import com.typesafe.scalalogging.LazyLogging
+
 import javax.inject.Inject
 import models.organization.OrganizationDAO
-import org.joda.time.DateTime
 import oxalis.mail.{DefaultMails, Send}
 import oxalis.security.RandomIDGenerator
 import slick.jdbc.PostgresProfile.api._
@@ -21,8 +22,8 @@ case class Invite(
     tokenValue: String,
     _organization: ObjectId,
     autoActivate: Boolean,
-    expirationDateTime: DateTime,
-    created: Long = System.currentTimeMillis(),
+    expirationDateTime: Instant,
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 )
 
@@ -54,7 +55,7 @@ class InviteService @Inject()(conf: WkConf,
         tokenValue,
         organizationID,
         autoActivate,
-        new DateTime(System.currentTimeMillis() + conf.WebKnossos.User.inviteExpiry.toMillis)
+        Instant.in(conf.WebKnossos.User.inviteExpiry)
       )
 
   private def sendInviteMail(recipient: String, sender: User, invite: Invite)(
@@ -96,8 +97,8 @@ class InviteDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         r.tokenvalue,
         ObjectId(r._Organization),
         r.autoactivate,
-        new DateTime(r.expirationdatetime.getTime),
-        r.created.getTime,
+        Instant.fromSql(r.expirationdatetime),
+        Instant.fromSql(r.created),
         r.isdeleted
       ))
 
@@ -113,12 +114,12 @@ class InviteDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       _ <- run(
         sqlu"""insert into webknossos.invites(_id, tokenValue, _organization, autoActivate, expirationDateTime, created, isDeleted)
                     values(${i._id}, ${i.tokenValue}, ${i._organization}, ${i.autoActivate},
-                    ${new java.sql.Timestamp(i.expirationDateTime.getMillis)}, ${new java.sql.Timestamp(i.created)}, ${i.isDeleted})""")
+                    ${i.expirationDateTime}, ${i.created}, ${i.isDeleted})""")
     } yield ()
 
   def deleteAllExpired(): Fox[Unit] = {
     val q = for {
-      row <- collection if notdel(row) && row.expirationdatetime <= new java.sql.Timestamp(System.currentTimeMillis)
+      row <- collection if notdel(row) && row.expirationdatetime <= Instant.now.toSql
     } yield isDeletedColumn(row)
     for { _ <- run(q.update(true)) } yield ()
   }

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -2,11 +2,13 @@ package models.user
 
 import com.mohiva.play.silhouette.api.{Identity, LoginInfo}
 import com.scalableminds.util.accesscontext._
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.JsonHelper.parseAndValidateJson
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.models.datasource.DataSetViewConfiguration.DataSetViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.schema.Tables._
+
 import javax.inject.Inject
 import models.team._
 import play.api.libs.json._
@@ -27,14 +29,14 @@ case class User(
     _organization: ObjectId,
     firstName: String,
     lastName: String,
-    lastActivity: Long = System.currentTimeMillis(),
+    lastActivity: Instant = Instant.now,
     userConfiguration: JsObject,
     loginInfo: LoginInfo,
     isAdmin: Boolean,
     isDatasetManager: Boolean,
     isDeactivated: Boolean,
     isUnlisted: Boolean,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     lastTaskTypeId: Option[ObjectId] = None,
     isDeleted: Boolean = false
 ) extends DBAccessContextPayload
@@ -73,14 +75,14 @@ class UserDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         ObjectId(r._Organization),
         r.firstname,
         r.lastname,
-        r.lastactivity.getTime,
+        Instant.fromSql(r.lastactivity),
         userConfiguration,
         LoginInfo(User.default_login_provider_id, r._Id),
         r.isadmin,
         r.isdatasetmanager,
         r.isdeactivated,
         r.isunlisted,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.lasttasktypeid.map(ObjectId(_)),
         r.isdeleted
       )
@@ -214,16 +216,14 @@ class UserDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
       _ <- run(sqlu"""insert into webknossos.users(_id, _multiUser, _organization, firstName, lastName, lastActivity,
                                             userConfiguration, isDeactivated, isAdmin, isDatasetManager, isUnlisted, created, isDeleted)
                      values(${u._id}, ${u._multiUser}, ${u._organization}, ${u.firstName}, ${u.lastName},
-                            ${new java.sql.Timestamp(u.lastActivity)}, '#${sanitize(
-        Json.toJson(u.userConfiguration).toString)}',
-                     ${u.isDeactivated}, ${u.isAdmin}, ${u.isDatasetManager}, ${u.isUnlisted}, ${new java.sql.Timestamp(
-        u.created)}, ${u.isDeleted})
+                            ${u.lastActivity}, '#${sanitize(Json.toJson(u.userConfiguration).toString)}',
+                     ${u.isDeactivated}, ${u.isAdmin}, ${u.isDatasetManager}, ${u.isUnlisted}, ${u.created}, ${u.isDeleted})
           """)
     } yield ()
 
-  def updateLastActivity(userId: ObjectId, lastActivity: Long = System.currentTimeMillis())(
+  def updateLastActivity(userId: ObjectId, lastActivity: Instant = Instant.now)(
       implicit ctx: DBAccessContext): Fox[Unit] =
-    updateTimestampCol(userId, _.lastactivity, new java.sql.Timestamp(lastActivity))
+    updateTimestampCol(userId, _.lastactivity, lastActivity)
 
   def updateUserConfiguration(userId: ObjectId, userConfiguration: JsObject)(implicit ctx: DBAccessContext): Fox[Unit] =
     for {

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -7,6 +7,7 @@ import com.mohiva.play.silhouette.api.util.PasswordInfo
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.security.SCrypt
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.models.datasource.DataSetViewConfiguration.DataSetViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
@@ -18,6 +19,7 @@ import oxalis.security.TokenDAO
 import play.api.i18n.{Messages, MessagesProvider}
 import play.api.libs.json._
 import utils.{ObjectId, WkConf}
+
 import javax.inject.Inject
 import models.organization.OrganizationDAO
 import net.liftweb.common.Box
@@ -103,7 +105,7 @@ class UserService @Inject()(conf: WkConf,
         organizationId,
         firstName,
         lastName,
-        System.currentTimeMillis(),
+        Instant.now,
         Json.obj(),
         LoginInfo(CredentialsProvider.ID, newUserId.id),
         isAdmin,
@@ -142,13 +144,13 @@ class UserService @Inject()(conf: WkConf,
         _id = newUserId,
         _organization = organizationId,
         loginInfo = loginInfo,
-        lastActivity = System.currentTimeMillis(),
+        lastActivity = Instant.now,
         isAdmin = isAdmin,
         isDatasetManager = false,
         isDeactivated = !autoActivate,
         lastTaskTypeId = None,
         isUnlisted = isUnlisted,
-        created = System.currentTimeMillis()
+        created = Instant.now
       )
       _ <- userDAO.insertOne(user)
       _ <- Fox.combined(teamMemberships.map(userTeamRolesDAO.insertTeamMembership(user._id, _)))

--- a/app/models/user/time/Interval.scala
+++ b/app/models/user/time/Interval.scala
@@ -1,35 +1,28 @@
 package models.user.time
 
+import com.scalableminds.util.time.Instant
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.libs.json.{Json, OFormat}
 
 trait Interval {
-  def start: DateTime
+  def start: Instant
 
-  def end: DateTime
+  def end: Instant
 }
 
 case class Month(month: Int, year: Int) extends Interval with Ordered[Month] {
 
   def compare(p: Month): Int = 12 * (year - p.year) + (month - p.month)
 
-  override def <(that: Month): Boolean = (this compare that) < 0
-
-  override def >(that: Month): Boolean = (this compare that) > 0
-
-  override def <=(that: Month): Boolean = (this compare that) <= 0
-
-  override def >=(that: Month): Boolean = (this compare that) >= 0
-
   override def toString = f"$year%d-$month%02d"
 
-  def start: DateTime =
-    jodaMonth.dayOfMonth().withMinimumValue().millisOfDay().withMinimumValue()
+  def start: Instant =
+    Instant.fromJoda(jodaMonth.dayOfMonth().withMinimumValue().millisOfDay().withMinimumValue())
+
+  def end: Instant =
+    Instant.fromJoda(jodaMonth.dayOfMonth().withMaximumValue().millisOfDay().withMaximumValue())
 
   private def jodaMonth: DateTime = new DateTime().withYear(year).withMonthOfYear(month)
-
-  def end: DateTime =
-    jodaMonth.dayOfMonth().withMaximumValue().millisOfDay().withMaximumValue()
 }
 
 object Month {
@@ -39,24 +32,15 @@ object Month {
 case class Week(week: Int, year: Int) extends Interval with Ordered[Week] {
 
   def compare(p: Week): Int = 53 * (year - p.year) + (week - p.week)
-
-  override def <(that: Week): Boolean = (this compare that) < 0
-
-  override def >(that: Week): Boolean = (this compare that) > 0
-
-  override def <=(that: Week): Boolean = (this compare that) <= 0
-
-  override def >=(that: Week): Boolean = (this compare that) >= 0
-
   override def toString = f"$year%d-W$week%02d"
 
-  def start: DateTime =
-    jodaWeek.withDayOfWeek(DateTimeConstants.MONDAY).millisOfDay().withMinimumValue()
+  def start: Instant =
+    Instant.fromJoda(jodaWeek.withDayOfWeek(DateTimeConstants.MONDAY).millisOfDay().withMinimumValue())
+
+  def end: Instant =
+    Instant.fromJoda(jodaWeek.dayOfWeek().withMaximumValue().millisOfDay().withMaximumValue())
 
   private def jodaWeek: DateTime = new DateTime().withYear(year).withWeekOfWeekyear(week)
-
-  def end: DateTime =
-    jodaWeek.dayOfWeek().withMaximumValue().millisOfDay().withMaximumValue()
 }
 
 object Week {
@@ -67,23 +51,15 @@ case class Day(day: Int, month: Int, year: Int) extends Interval with Ordered[Da
 
   def compare(p: Day): Int = 500 * (year - p.year) + 40 * (month - p.month) + (day - p.day)
 
-  override def <(that: Day): Boolean = (this compare that) < 0
-
-  override def >(that: Day): Boolean = (this compare that) > 0
-
-  override def <=(that: Day): Boolean = (this compare that) <= 0
-
-  override def >=(that: Day): Boolean = (this compare that) >= 0
-
   override def toString = f"$year%d-$month%02d-$day%02d"
 
-  def start: DateTime =
-    jodaDay.millisOfDay().withMinimumValue()
+  def start: Instant =
+    Instant.fromJoda(jodaDay.millisOfDay().withMinimumValue())
+
+  def end: Instant =
+    Instant.fromJoda(jodaDay.millisOfDay().withMaximumValue())
 
   private def jodaDay = new DateTime().withDate(year, month, day)
-
-  def end: DateTime =
-    jodaDay.millisOfDay().withMaximumValue()
 }
 
 object Day {

--- a/app/models/user/time/TimeSpan.scala
+++ b/app/models/user/time/TimeSpan.scala
@@ -1,7 +1,9 @@
 package models.user.time
 
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables._
+
 import javax.inject.Inject
 import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json, OFormat}
@@ -11,7 +13,7 @@ import utils.{ObjectId, SQLClient, SQLDAO}
 
 import scala.concurrent.ExecutionContext
 
-case class TimeSpanRequest(users: List[String], start: Long, end: Long)
+case class TimeSpanRequest(users: List[String], start: Instant, end: Instant)
 object TimeSpanRequest { implicit val timeSpanRequest: OFormat[TimeSpanRequest] = Json.format[TimeSpanRequest] }
 
 case class TimeSpan(
@@ -19,14 +21,14 @@ case class TimeSpan(
     _user: ObjectId,
     _annotation: Option[ObjectId],
     time: Long,
-    lastUpdate: Long,
+    lastUpdate: Instant,
     numberOfUpdates: Long = 0,
-    created: Long = System.currentTimeMillis(),
+    created: Instant = Instant.now,
     isDeleted: Boolean = false
 ) {
   def createdAsDateTime = new DateTime(created)
 
-  def addTime(duration: Long, timestamp: Long): TimeSpan =
+  def addTime(duration: Long, timestamp: Instant): TimeSpan =
     this.copy(lastUpdate = timestamp, time = time + duration, numberOfUpdates = this.numberOfUpdates + 1)
 }
 
@@ -44,14 +46,18 @@ object TimeSpan {
         timeSpan.createdAsDateTime.getYear)
 
   def fromTimestamp(timestamp: Long, _user: ObjectId, _annotation: Option[ObjectId]): TimeSpan =
-    TimeSpan(ObjectId.generate, _user, _annotation, time = 0L, lastUpdate = timestamp, created = timestamp)
+    TimeSpan(ObjectId.generate,
+             _user,
+             _annotation,
+             time = 0L,
+             lastUpdate = Instant(timestamp),
+             created = Instant(timestamp))
 
 }
 
 class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
     extends SQLDAO[TimeSpan, TimespansRow, Timespans](sqlClient) {
   val collection = Timespans
-  val MAX_TIMESTAMP = 253370761200000L
 
   def idColumn(x: Timespans): Rep[String] = x._Id
   def isDeletedColumn(x: Timespans): Rep[Boolean] = x.isdeleted
@@ -63,27 +69,28 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         ObjectId(r._User),
         r._Annotation.map(ObjectId(_)),
         r.time,
-        r.lastupdate.getTime,
+        Instant.fromSql(r.lastupdate),
         r.numberofupdates,
-        r.created.getTime,
+        Instant.fromSql(r.created),
         r.isdeleted
       ))
 
-  def findAllByUser(userId: ObjectId, start: Option[Long], end: Option[Long]): Fox[List[TimeSpan]] =
+  def findAllByUser(userId: ObjectId, start: Option[Instant], end: Option[Instant]): Fox[List[TimeSpan]] =
     for {
       r <- run(
         Timespans
-          .filter(r =>
-            notdel(r) && r._User === userId.id && (r.created >= new java.sql.Timestamp(start.getOrElse(0))) && r.created <= new java.sql.Timestamp(
-              end.getOrElse(MAX_TIMESTAMP)))
+          .filter(
+            r =>
+              notdel(r) && r._User === userId.id && (r.created >= start.getOrElse(Instant(0)).toSql) && r.created <= end
+                .getOrElse(Instant.max)
+                .toSql)
           .result)
       parsed <- Fox.combined(r.toList.map(parse))
     } yield parsed
 
-  def findAllByUserWithTask(userId: ObjectId, start: Option[Long], end: Option[Long]): Fox[JsValue] =
+  def findAllByUserWithTask(userId: ObjectId, start: Option[Instant], end: Option[Instant]): Fox[JsValue] =
     for {
-      tuples <- run(
-        sql"""select ts.time, ts.created, a._id, ts._id, t._id, p.name, tt._id, tt.summary
+      tuples <- run(sql"""select ts.time, ts.created, a._id, ts._id, t._id, p.name, tt._id, tt.summary
                         from webknossos.timespans_ ts
                         join webknossos.annotations_ a on ts._annotation = a._id
                         join webknossos.tasks_ t on a._task = t._id
@@ -91,15 +98,14 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
                         join webknossos.taskTypes_ tt on t._taskType = tt._id
                         where ts._user = ${userId.id}
                         and ts.time > 0
-                        and ts.created >= ${new java.sql.Timestamp(start.getOrElse(0))}
-                        and ts.created < ${new java.sql.Timestamp(end.getOrElse(MAX_TIMESTAMP))}"""
-          .as[(Long, java.sql.Timestamp, String, String, String, String, String, String)])
+                        and ts.created >= ${start.getOrElse(Instant(0))}
+                        and ts.created < ${end
+        .getOrElse(Instant.max)}""".as[(Long, Instant, String, String, String, String, String, String)])
     } yield formatTimespanTuples(tuples)
 
-  private def formatTimespanTuples(
-      tuples: Vector[(Long, java.sql.Timestamp, String, String, String, String, String, String)]) = {
+  private def formatTimespanTuples(tuples: Vector[(Long, Instant, String, String, String, String, String, String)]) = {
 
-    def formatTimespanTuple(tuple: (Long, java.sql.Timestamp, String, String, String, String, String, String)) = {
+    def formatTimespanTuple(tuple: (Long, Instant, String, String, String, String, String, String)) = {
       def formatDuration(millis: Long): String = {
         // example: P3Y6M4DT12H30M5S = 3 years + 9 month + 4 days + 12 hours + 30 min + 5 sec
         // only hours, min and sec are important in this scenario
@@ -112,7 +118,7 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
 
       Json.obj(
         "time" -> formatDuration(tuple._1),
-        "timestamp" -> tuple._2.getTime,
+        "timestamp" -> tuple._2,
         "annotation" -> tuple._3,
         "_id" -> tuple._4,
         "task_id" -> tuple._5,
@@ -124,24 +130,24 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
     Json.toJson(tuples.map(formatTimespanTuple))
   }
 
-  def findAllByAnnotation(annotationId: ObjectId, start: Option[Long], end: Option[Long]): Fox[List[TimeSpan]] =
+  def findAllByAnnotation(annotationId: ObjectId, start: Option[Instant], end: Option[Instant]): Fox[List[TimeSpan]] =
     for {
       r <- run(
         Timespans
           .filter(
             r =>
-              notdel(r) && r._Annotation === annotationId.id && (r.created >= new java.sql.Timestamp(
-                start.getOrElse(0))) && r.created <= new java.sql.Timestamp(end.getOrElse(MAX_TIMESTAMP)))
+              notdel(r) && r._Annotation === annotationId.id && (r.created >= start
+                .getOrElse(Instant(0))
+                .toSql) && r.created <= end.getOrElse(Instant.max).toSql)
           .result)
       parsed <- Fox.combined(r.toList.map(parse))
     } yield parsed
 
-  def findAll(start: Option[Long], end: Option[Long], organizationId: ObjectId): Fox[List[TimeSpan]] =
+  def findAll(start: Option[Instant], end: Option[Instant], organizationId: ObjectId): Fox[List[TimeSpan]] =
     for {
       r <- run(sql"""select #${columnsWithPrefix("t.")} from #$existingCollectionName t
               join webknossos.users u on t._user = u._id
-              where t.created >= ${new java.sql.Timestamp(start.getOrElse(0))} and t.created <= ${new java.sql.Timestamp(
-        end.getOrElse(MAX_TIMESTAMP))}
+              where t.created >= ${start.getOrElse(Instant(0))} and t.created <= ${end.getOrElse(Instant.max)}
               and u._organization = $organizationId
           """.as[TimespansRow])
       parsed <- Fox.combined(r.toList.map(parse))
@@ -151,8 +157,8 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
     for {
       _ <- run(
         sqlu"""insert into webknossos.timespans(_id, _user, _annotation, time, lastUpdate, numberOfUpdates, created, isDeleted)
-                values(${t._id.id}, ${t._user.id}, ${t._annotation.map(_.id)}, ${t.time}, ${new java.sql.Timestamp(
-          t.lastUpdate)}, ${t.numberOfUpdates}, ${new java.sql.Timestamp(t.created)}, ${t.isDeleted})""")
+                values(${t._id.id}, ${t._user.id}, ${t._annotation.map(_.id)}, ${t.time}, ${t.lastUpdate},
+                ${t.numberOfUpdates}, ${t.created}, ${t.isDeleted})""")
     } yield ()
 
   def updateOne(t: TimeSpan): Fox[Unit] =
@@ -162,7 +168,7 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
                   _user = ${t._user.id},
                   _annotation = ${t._annotation.map(_.id)},
                   time = ${t.time},
-                  lastUpdate = ${new java.sql.Timestamp(t.lastUpdate)},
+                  lastUpdate = ${t.lastUpdate},
                   numberOfUpdates = ${t.numberOfUpdates},
                   isDeleted = ${t.isDeleted}
                 where _id = ${t._id.id}

--- a/app/models/user/time/TimeSpan.scala
+++ b/app/models/user/time/TimeSpan.scala
@@ -71,9 +71,9 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
         Timespans
           .filter(
             r =>
-              notdel(r) && r._User === userId.id && (r.created >= start.getOrElse(Instant(0)).toSql) && r.created <= end
-                .getOrElse(Instant.max)
-                .toSql)
+              notdel(r) && r._User === userId.id && (r.created >= start
+                .getOrElse(Instant.zero)
+                .toSql) && r.created <= end.getOrElse(Instant.max).toSql)
           .result)
       parsed <- Fox.combined(r.toList.map(parse))
     } yield parsed
@@ -88,7 +88,7 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
                         join webknossos.taskTypes_ tt on t._taskType = tt._id
                         where ts._user = ${userId.id}
                         and ts.time > 0
-                        and ts.created >= ${start.getOrElse(Instant(0))}
+                        and ts.created >= ${start.getOrElse(Instant.zero)}
                         and ts.created < ${end
         .getOrElse(Instant.max)}""".as[(Long, Instant, String, String, String, String, String, String)])
     } yield formatTimespanTuples(tuples)
@@ -127,7 +127,7 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
           .filter(
             r =>
               notdel(r) && r._Annotation === annotationId.id && (r.created >= start
-                .getOrElse(Instant(0))
+                .getOrElse(Instant.zero)
                 .toSql) && r.created <= end.getOrElse(Instant.max).toSql)
           .result)
       parsed <- Fox.combined(r.toList.map(parse))
@@ -137,7 +137,7 @@ class TimeSpanDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)
     for {
       r <- run(sql"""select #${columnsWithPrefix("t.")} from #$existingCollectionName t
               join webknossos.users u on t._user = u._id
-              where t.created >= ${start.getOrElse(Instant(0))} and t.created <= ${end.getOrElse(Instant.max)}
+              where t.created >= ${start.getOrElse(Instant.zero)} and t.created <= ${end.getOrElse(Instant.max)}
               and u._organization = $organizationId
           """.as[TimespansRow])
       parsed <- Fox.combined(r.toList.map(parse))

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -32,14 +32,12 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
                                 conf: WkConf)(implicit ec: ExecutionContext)
     extends FoxImplicits
     with LazyLogging {
-  private val MaxTracingPauseMillis =
-    conf.WebKnossos.User.timeTrackingPause.toMillis
 
-  def logUserInteraction(timestamp: Long, user: User, annotation: Annotation)(
+  def logUserInteraction(timestamp: Instant, user: User, annotation: Annotation)(
       implicit ctx: DBAccessContext): Fox[Unit] =
     logUserInteraction(Seq(timestamp), user, annotation)
 
-  def logUserInteraction(timestamps: Seq[Long], user: User, annotation: Annotation)(
+  def logUserInteraction(timestamps: Seq[Instant], user: User, annotation: Annotation)(
       implicit ctx: DBAccessContext): Fox[Unit] =
     trackTime(timestamps, user._id, annotation)
 
@@ -91,7 +89,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
   private val lastUserActivities = mutable.HashMap.empty[ObjectId, TimeSpan]
 
   @SuppressWarnings(Array("TraversableHead", "TraversableLast")) // Only functions call this which put at least one timestamp in the seq
-  private def trackTime(timestamps: Seq[Long], _user: ObjectId, _annotation: Annotation)(
+  private def trackTime(timestamps: Seq[Instant], _user: ObjectId, _annotation: Annotation)(
       implicit ctx: DBAccessContext): Fox[Unit] =
     if (timestamps.isEmpty) {
       logger.warn("Timetracking called with empty timestamps list.")
@@ -102,19 +100,19 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
       val start = timestamps.head
 
       var timeSpansToInsert: List[TimeSpan] = List()
-      var timeSpansToUpdate: List[(TimeSpan, Long)] = List()
+      var timeSpansToUpdate: List[(TimeSpan, Instant)] = List()
 
-      def createNewTimeSpan(timestamp: Long, _user: ObjectId, annotation: Option[Annotation]) = {
+      def createNewTimeSpan(timestamp: Instant, _user: ObjectId, annotation: Option[Annotation]) = {
         val timeSpan = TimeSpan.fromTimestamp(timestamp, _user, annotation.map(_._id))
         timeSpansToInsert = timeSpan :: timeSpansToInsert
         timeSpan
       }
 
-      def updateTimeSpan(timeSpan: TimeSpan, timestamp: Long) = {
-        val duration = timestamp - timeSpan.lastUpdate.epochMillis
-        if (duration >= 0) {
+      def updateTimeSpan(timeSpan: TimeSpan, timestamp: Instant) = {
+        val duration: FiniteDuration = timestamp - timeSpan.lastUpdate
+        if (duration.toMillis >= 0) {
           timeSpansToUpdate = (timeSpan, timestamp) :: timeSpansToUpdate
-          timeSpan.addTime(duration, Instant(timestamp))
+          timeSpan.addTime(duration, timestamp)
         } else {
           // Negative duration. This is expected when updating an annotation with multiple layers.
           // Each layer reports updates that can overlap time-wise. We do not update the timespan with the negative duration.
@@ -140,7 +138,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
         val start = pair.head
         val end = pair.last
         val duration = end - start
-        if (duration >= MaxTracingPauseMillis) {
+        if (duration >= conf.WebKnossos.User.timeTrackingPause) {
           updateTimeSpan(current, start)
           current = createNewTimeSpan(end, _user, annotation)
         }
@@ -151,19 +149,19 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
       flushToDb(timeSpansToInsert, timeSpansToUpdate)(ctx)
     }
 
-  private def isNotInterrupted(current: Long, last: TimeSpan) = {
-    val duration = current - last.lastUpdate.epochMillis
-    if (duration < 0) {
+  private def isNotInterrupted(current: Instant, last: TimeSpan) = {
+    val duration = current - last.lastUpdate
+    if (duration.toMillis < 0) {
       logger.info(
         s"Negative timespan duration $duration ms to previous entry. (user ${last._user}, last timespan id ${last._id}, this=$this)")
     }
-    duration < MaxTracingPauseMillis
+    duration < conf.WebKnossos.User.timeTrackingPause
   }
 
   private def belongsToSameTracing(last: TimeSpan, annotation: Option[Annotation]) =
     last._annotation.map(_.id) == annotation.map(_.id)
 
-  private def logTimeToAnnotation(duration: Long, annotation: Option[ObjectId]): Fox[Unit] =
+  private def logTimeToAnnotation(duration: FiniteDuration, annotation: Option[ObjectId]): Fox[Unit] =
     // Log time to annotation
     annotation match {
       case Some(a: ObjectId) =>
@@ -173,7 +171,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
       // do nothing, this is not a stored annotation
     }
 
-  def signalOverTime(time: Long, annotationOpt: Option[Annotation])(implicit ctx: DBAccessContext): Fox[_] =
+  def signalOverTime(time: FiniteDuration, annotationOpt: Option[Annotation])(implicit ctx: DBAccessContext): Fox[_] =
     for {
       annotation <- annotationOpt.toFox
       user <- userService.findOneById(annotation._user, useCache = true)(GlobalAccessContext)
@@ -183,13 +181,13 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
       timeLimit <- project.expectedTime ?~> "no project.expectedTime"
       organization <- organizationDAO.findOne(user._organization)(GlobalAccessContext)
     } yield {
-      if (annotationTime >= timeLimit && annotationTime - time < timeLimit) {
+      if (annotationTime >= timeLimit && annotationTime - time.toMillis < timeLimit) {
         brainTracing.Mailer ! Send(
           defaultMails.overLimitMail(user, project.name, task._id.toString, annotation.id, organization))
       }
     }
 
-  private def logTimeToTask(duration: Long, annotation: Option[Annotation]) =
+  private def logTimeToTask(duration: FiniteDuration, annotation: Option[Annotation]) =
     annotation.flatMap(_._task) match {
       case Some(taskId) =>
         for {
@@ -212,7 +210,7 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
     }
 
   @SuppressWarnings(Array("TryGet")) // This is okay because we check the failure case before using the try
-  private def flushToDb(timespansToInsert: List[TimeSpan], timespansToUpdate: List[(TimeSpan, Long)])(
+  private def flushToDb(timespansToInsert: List[TimeSpan], timespansToUpdate: List[(TimeSpan, Instant)])(
       implicit ctx: DBAccessContext) = {
     val updateResult = for {
       _ <- Fox.serialCombined(timespansToInsert)(t => timeSpanDAO.insertOne(t))
@@ -227,9 +225,9 @@ class TimeSpanService @Inject()(annotationDAO: AnnotationDAO,
     updateResult
   }
 
-  private def updateTimeSpanInDb(timeSpan: TimeSpan, timestamp: Long)(implicit ctx: DBAccessContext) = {
-    val duration = timestamp - timeSpan.lastUpdate.epochMillis
-    val updated = timeSpan.addTime(duration, Instant(timestamp))
+  private def updateTimeSpanInDb(timeSpan: TimeSpan, timestamp: Instant)(implicit ctx: DBAccessContext) = {
+    val duration = timestamp - timeSpan.lastUpdate
+    val updated = timeSpan.addTime(duration, timestamp)
 
     for {
       _ <- timeSpanDAO.updateOne(updated) ?~> "FAILED: TimeSpanDAO.updateOne"

--- a/app/models/voxelytics/ElasticsearchClient.scala
+++ b/app/models/voxelytics/ElasticsearchClient.scala
@@ -68,7 +68,7 @@ class ElasticsearchClient @Inject()(wkConf: WkConf, rpc: RPC, val system: ActorS
     for {
       _ <- bool2Fox(enabled) ?~> "Elasticsearch is not enabled."
       _ = logger.info("Waiting for Elasticsearch to become available.")
-      _ <- pollUntilServerStartedUp(Instant.now + conf.startupTimeout) ~> 500
+      _ <- pollUntilServerStartedUp(Instant.in(conf.startupTimeout)) ~> 500
       _ <- bootstrapIndexOnServer
     } yield ()
   }

--- a/app/models/voxelytics/VoxelyticsService.scala
+++ b/app/models/voxelytics/VoxelyticsService.scala
@@ -1,12 +1,12 @@
 package models.voxelytics
 
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import models.user.User
 import models.voxelytics.VoxelyticsRunState.VoxelyticsRunState
 import play.api.libs.json.{JsObject, Json, OFormat}
 import utils.ObjectId
 
-import java.time.Instant
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.util.Try

--- a/app/models/voxelytics/WorkflowEvents.scala
+++ b/app/models/voxelytics/WorkflowEvents.scala
@@ -1,9 +1,8 @@
 package models.voxelytics
 
+import com.scalableminds.util.time.Instant
 import models.voxelytics.VoxelyticsRunState.VoxelyticsRunState
 import play.api.libs.json._
-
-import java.time.Instant
 
 trait WorkflowEvent {}
 

--- a/app/oxalis/mail/MailchimpTicker.scala
+++ b/app/oxalis/mail/MailchimpTicker.scala
@@ -47,7 +47,7 @@ class MailchimpTicker @Inject()(val lifecycle: ApplicationLifecycle,
     for {
       isActivated <- multiUserDAO.hasAtLeastOneActiveUser(multiUser._id) ?~> "Could not determine isActivated"
       lastActivity <- if (isActivated) multiUserDAO.lastActivity(multiUser._id) ?~> "Could not determine lastActivity"
-      else Fox.successful(Instant(0L))
+      else Fox.successful(Instant.zero)
       registeredAtLeast21DaysAgo = (multiUser.created + (21 days)).isPast
       registeredAtMost22DaysAgo = !(multiUser.created + (22 days)).isPast
       shouldBeTaggedNow = isActivated && registeredAtLeast21DaysAgo && registeredAtMost22DaysAgo

--- a/app/utils/SQLHelpers.scala
+++ b/app/utils/SQLHelpers.scala
@@ -48,6 +48,10 @@ trait SQLTypeImplicits {
   implicit object GetInstant extends GetResult[Instant] {
     override def apply(v1: PositionedResult): Instant = Instant.fromSql(v1.<<)
   }
+
+  implicit object GetInstantOpt extends GetResult[Option[Instant]] {
+    override def apply(v1: PositionedResult): Option[Instant] = v1.nextTimestampOption().map(Instant.fromSql)
+  }
 }
 
 class SimpleSQLDAO @Inject()(sqlClient: SQLClient)(implicit ec: ExecutionContext)

--- a/app/utils/SQLHelpers.scala
+++ b/app/utils/SQLHelpers.scala
@@ -1,6 +1,7 @@
 package utils
 
 import com.scalableminds.util.accesscontext.DBAccessContext
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.typesafe.scalalogging.LazyLogging
 import models.user.User
@@ -34,6 +35,14 @@ trait SQLTypeImplicits {
 
   implicit object GetObjectId extends GetResult[ObjectId] {
     override def apply(v1: PositionedResult): ObjectId = ObjectId(v1.<<)
+  }
+
+  implicit object SetInstant extends SetParameter[Instant] {
+    def apply(v: Instant, pp: PositionedParameters): Unit = pp.setTimestamp(v.toSql)
+  }
+
+  implicit object GetInstant extends GetResult[Instant] {
+    override def apply(v1: PositionedResult): Instant = Instant.fromSql(v1.<<)
   }
 }
 

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -29,7 +29,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
 
     object User {
       val timeTrackingPause: FiniteDuration = get[FiniteDuration]("webKnossos.user.timeTrackingPause")
-      val inviteExpiry: Duration = get[Duration]("webKnossos.user.inviteExpiry")
+      val inviteExpiry: FiniteDuration = get[FiniteDuration]("webKnossos.user.inviteExpiry")
       val ssoKey: String = get[String]("webKnossos.user.ssoKey")
     }
 
@@ -129,10 +129,11 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
 
   object Silhouette {
     object TokenAuthenticator {
-      val resetPasswordExpiry: Duration = get[Duration]("silhouette.tokenAuthenticator.resetPasswordExpiry")
-      val dataStoreExpiry: Duration = get[Duration]("silhouette.tokenAuthenticator.dataStoreExpiry")
-      val authenticatorExpiry: Duration = get[Duration]("silhouette.tokenAuthenticator.authenticatorExpiry")
-      val authenticatorIdleTimeout: Duration = get[Duration]("silhouette.tokenAuthenticator.authenticatorIdleTimeout")
+      val resetPasswordExpiry: FiniteDuration = get[FiniteDuration]("silhouette.tokenAuthenticator.resetPasswordExpiry")
+      val dataStoreExpiry: FiniteDuration = get[FiniteDuration]("silhouette.tokenAuthenticator.dataStoreExpiry")
+      val authenticatorExpiry: FiniteDuration = get[FiniteDuration]("silhouette.tokenAuthenticator.authenticatorExpiry")
+      val authenticatorIdleTimeout: FiniteDuration =
+        get[FiniteDuration]("silhouette.tokenAuthenticator.authenticatorIdleTimeout")
     }
 
     object CookieAuthenticator {
@@ -141,8 +142,9 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
       val secureCookie: Boolean = get[Boolean]("silhouette.cookieAuthenticator.secureCookie")
       val httpOnlyCookie: Boolean = get[Boolean]("silhouette.cookieAuthenticator.httpOnlyCookie")
       val useFingerprinting: Boolean = get[Boolean]("silhouette.cookieAuthenticator.useFingerprinting")
-      val authenticatorExpiry: Duration = get[Duration]("silhouette.cookieAuthenticator.authenticatorExpiry")
-      val cookieMaxAge: Duration = get[Duration]("silhouette.cookieAuthenticator.cookieMaxAge")
+      val authenticatorExpiry: FiniteDuration =
+        get[FiniteDuration]("silhouette.cookieAuthenticator.authenticatorExpiry")
+      val cookieMaxAge: FiniteDuration = get[FiniteDuration]("silhouette.cookieAuthenticator.cookieMaxAge")
       val signerSecret: String = get[String]("silhouette.cookieAuthenticator.signerSecret")
     }
 

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -109,7 +109,7 @@ function TaskStateTag({ taskInfo }: { taskInfo: VoxelyticsTaskInfo }) {
         </Tag>
       );
     case VoxelyticsRunState.RUNNING: {
-      const currentDuration = Date.now() - taskInfo.beginTime.getTime();
+      const currentDuration = Date.now() - taskInfo.beginTime;
       if (taskInfo.chunksFinished > 0) {
         const estimatedRemainingDuration =
           (currentDuration / taskInfo.chunksFinished) * taskInfo.chunksTotal - currentDuration;
@@ -580,8 +580,8 @@ export default function TaskListView({
 
 function aggregateTimes(taskInfos: Array<VoxelyticsTaskInfo>): [Date, Date] {
   return [
-    new Date(taskInfos.reduce((r, a) => Math.min(r, a.beginTime?.getTime() ?? Infinity), Infinity)),
-    new Date(taskInfos.reduce((r, a) => Math.max(r, a.endTime?.getTime() ?? -Infinity), -Infinity)),
+    new Date(taskInfos.reduce((r, a) => Math.min(r, a.beginTime ?? Infinity), Infinity)),
+    new Date(taskInfos.reduce((r, a) => Math.max(r, a.endTime ?? -Infinity), -Infinity)),
   ];
 }
 

--- a/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
@@ -17,8 +17,8 @@ import { VX_POLLING_INTERVAL } from "./workflow_view";
 function parseTaskInfo(taskInfo: VoxelyticsTaskInfo): VoxelyticsTaskInfo {
   return {
     ...taskInfo,
-    beginTime: taskInfo.beginTime != null ? new Date(taskInfo.beginTime) : null,
-    endTime: taskInfo.endTime != null ? new Date(taskInfo.endTime) : null,
+    beginTime: taskInfo.beginTime != null ? taskInfo.beginTime : null,
+    endTime: taskInfo.endTime != null ? taskInfo.endTime : null,
   } as VoxelyticsTaskInfo;
 }
 
@@ -26,19 +26,17 @@ function parseRunInfo(runInfo: VoxelyticsRunInfo): VoxelyticsRunInfo {
   return {
     ...runInfo,
     tasks: runInfo.tasks.map(parseTaskInfo),
-    beginTime: new Date(runInfo.beginTime),
-    endTime: runInfo.endTime != null ? new Date(runInfo.endTime) : null,
+    beginTime: runInfo.beginTime,
+    endTime: runInfo.endTime != null ? runInfo.endTime : null,
   } as any as VoxelyticsRunInfo;
 }
 
 function parseWorkflowInfo(workflowInfo: VoxelyticsWorkflowInfo): VoxelyticsWorkflowInfo {
   return {
     ...workflowInfo,
-    beginTime: new Date(workflowInfo.beginTime),
-    endTime: workflowInfo.endTime != null ? new Date(workflowInfo.endTime) : null,
-    runs: workflowInfo.runs
-      .map(parseRunInfo)
-      .sort((a, b) => b.beginTime.getTime() - a.beginTime.getTime()),
+    beginTime: workflowInfo.beginTime,
+    endTime: workflowInfo.endTime != null ? workflowInfo.endTime : null,
+    runs: workflowInfo.runs.map(parseRunInfo).sort((a, b) => b.beginTime - a.beginTime),
   };
 }
 
@@ -70,9 +68,7 @@ function aggregateTasks(runs: Array<VoxelyticsRunInfo>): Array<VoxelyticsTaskInf
           const taskMaybe = run.tasks.find((t) => t.taskName === task.taskName);
           return taskMaybe != null ? [taskMaybe] : [];
         })
-        .sort(
-          (a, b) => (b.beginTime?.getTime() ?? -Infinity) - (a.beginTime?.getTime() ?? -Infinity),
-        ),
+        .sort((a, b) => (b.beginTime ?? -Infinity) - (a.beginTime ?? -Infinity)),
     ),
   );
   return combinedTaskRuns;
@@ -245,14 +241,14 @@ export default function WorkflowListView() {
             key: "begin",
             defaultSortOrder: "descend",
             sorter: (a: RenderRunInfo, b: RenderRunInfo) =>
-              (a.beginTime?.getTime() ?? Infinity) - (b.beginTime?.getTime() ?? Infinity),
+              (a.beginTime ?? Infinity) - (b.beginTime ?? Infinity),
             render: (run: RenderRunInfo) => run.beginTime && formatDateMedium(run.beginTime),
           },
           {
             title: "End",
             key: "end",
             sorter: (a: RenderRunInfo, b: RenderRunInfo) =>
-              (a.endTime?.getTime() ?? Infinity) - (b.endTime?.getTime() ?? Infinity),
+              (a.endTime ?? Infinity) - (b.endTime ?? Infinity),
             render: (run: RenderRunInfo) => run.endTime && formatDateMedium(run.endTime),
           },
         ]}

--- a/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
@@ -17,8 +17,6 @@ import { VX_POLLING_INTERVAL } from "./workflow_view";
 function parseTaskInfo(taskInfo: VoxelyticsTaskInfo): VoxelyticsTaskInfo {
   return {
     ...taskInfo,
-    beginTime: taskInfo.beginTime != null ? taskInfo.beginTime : null,
-    endTime: taskInfo.endTime != null ? taskInfo.endTime : null,
   } as VoxelyticsTaskInfo;
 }
 
@@ -26,16 +24,12 @@ function parseRunInfo(runInfo: VoxelyticsRunInfo): VoxelyticsRunInfo {
   return {
     ...runInfo,
     tasks: runInfo.tasks.map(parseTaskInfo),
-    beginTime: runInfo.beginTime,
-    endTime: runInfo.endTime != null ? runInfo.endTime : null,
   } as any as VoxelyticsRunInfo;
 }
 
 function parseWorkflowInfo(workflowInfo: VoxelyticsWorkflowInfo): VoxelyticsWorkflowInfo {
   return {
     ...workflowInfo,
-    beginTime: workflowInfo.beginTime,
-    endTime: workflowInfo.endTime != null ? workflowInfo.endTime : null,
     runs: workflowInfo.runs.map(parseRunInfo).sort((a, b) => b.beginTime - a.beginTime),
   };
 }

--- a/frontend/javascripts/libs/format_utils.ts
+++ b/frontend/javascripts/libs/format_utils.ts
@@ -174,7 +174,7 @@ export function formatHash(id: string): string {
   return id.slice(-6);
 }
 
-export function formatDateMedium(date: Date): string {
+export function formatDateMedium(date: Date | number): string {
   return moment(date).format("lll");
 }
 export function formatDistance(start: Date | number, end: Date | number): string {

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -762,7 +762,7 @@ export type VoxelyticsTaskConfigWithHierarchy =
 export type VoxelyticsArtifactConfig = {
   fileSize: number;
   inodeCount: number;
-  createdAt: Date;
+  createdAt: number;
   path: string;
   version: string;
   metadata: {
@@ -775,7 +775,7 @@ export type VoxelyticsArtifactConfig = {
 export type VoxelyticsRunInfo = (
   | {
       state: VoxelyticsRunState.RUNNING;
-      beginTime: Date;
+      beginTime: number;
       endTime: null;
     }
   | {
@@ -784,8 +784,8 @@ export type VoxelyticsRunInfo = (
         | VoxelyticsRunState.FAILED
         | VoxelyticsRunState.CANCELLED
         | VoxelyticsRunState.STALE;
-      beginTime: Date;
-      endTime: Date;
+      beginTime: number;
+      endTime: number;
     }
 ) & {
   id: string;
@@ -823,7 +823,7 @@ export type VoxelyticsTaskInfo = {
     }
   | {
       state: VoxelyticsRunState.RUNNING;
-      beginTime: Date;
+      beginTime: number;
       endTime: null;
     }
   | {
@@ -832,8 +832,8 @@ export type VoxelyticsTaskInfo = {
         | VoxelyticsRunState.FAILED
         | VoxelyticsRunState.CANCELLED
         | VoxelyticsRunState.STALE;
-      beginTime: Date;
-      endTime: Date;
+      beginTime: number;
+      endTime: number;
     }
 );
 
@@ -866,8 +866,8 @@ export type VoxelyticsWorkflowReport = {
 export type VoxelyticsWorkflowInfo = {
   name: string;
   hash: string;
-  beginTime: Date;
-  endTime: Date | null;
+  beginTime: number;
+  endTime: number | null;
   state: VoxelyticsRunState;
   runs: Array<VoxelyticsRunInfo>;
 };
@@ -883,8 +883,8 @@ export type VoxelyticsChunkStatistics = {
   executionId: string;
   countTotal: number;
   countFinished: number;
-  beginTime: Date | null;
-  endTime: Date | null;
+  beginTime: number | null;
+  endTime: number | null;
   memory: Statistics | null;
   cpuUser: Statistics | null;
   cpuSystem: Statistics | null;

--- a/util/src/main/scala/com/scalableminds/util/time/Instant.scala
+++ b/util/src/main/scala/com/scalableminds/util/time/Instant.scala
@@ -5,7 +5,7 @@ import play.api.libs.json._
 
 import java.time.format.DateTimeFormatter
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationLong, FiniteDuration}
 
 case class Instant(epochMillis: Long) extends Ordered[Instant] {
   override def toString: String = DateTimeFormatter.ISO_INSTANT.format(toJavaInstant)
@@ -17,12 +17,20 @@ case class Instant(epochMillis: Long) extends Ordered[Instant] {
   def +(duration: FiniteDuration): Instant = Instant(epochMillis + duration.toMillis)
   def -(duration: FiniteDuration): Instant = Instant(epochMillis - duration.toMillis)
 
+  def -(other: Instant): FiniteDuration = (epochMillis - other.epochMillis) milliseconds
+
   def isPast: Boolean = this < Instant.now
 
   override def compare(that: Instant): Int =
     if (this.epochMillis < that.epochMillis) -1
     else if (this.epochMillis > that.epochMillis) 1
     else 0
+
+  def dayOfMonth: Int = toJodaDateTime.getDayOfMonth
+  def monthOfYear: Int = toJodaDateTime.getMonthOfYear
+  def year: Int = toJodaDateTime.getYear
+  def weekOfWeekyear: Int = toJodaDateTime.getWeekOfWeekyear
+  def weekyear: Int = toJodaDateTime.getWeekyear
 }
 
 object Instant extends FoxImplicits {

--- a/util/src/main/scala/com/scalableminds/util/time/Instant.scala
+++ b/util/src/main/scala/com/scalableminds/util/time/Instant.scala
@@ -22,9 +22,7 @@ case class Instant(epochMillis: Long) extends Ordered[Instant] {
   def isPast: Boolean = this < Instant.now
 
   override def compare(that: Instant): Int =
-    if (this.epochMillis < that.epochMillis) -1
-    else if (this.epochMillis > that.epochMillis) 1
-    else 0
+    this.epochMillis.compare(that.epochMillis)
 
   def dayOfMonth: Int = toJodaDateTime.getDayOfMonth
   def monthOfYear: Int = toJodaDateTime.getMonthOfYear
@@ -36,11 +34,13 @@ case class Instant(epochMillis: Long) extends Ordered[Instant] {
 object Instant extends FoxImplicits {
   def now: Instant = Instant(System.currentTimeMillis())
   def max: Instant = Instant(253370761200000L)
+  def zero: Instant = Instant(0L)
   def in(duration: FiniteDuration): Instant = now + duration
   def fromString(instantLiteral: String)(implicit ec: ExecutionContext): Fox[Instant] =
     fromStringSync(instantLiteral).toFox
   def fromJoda(jodaDateTime: org.joda.time.DateTime): Instant = Instant(jodaDateTime.getMillis)
   def fromSql(sqlTime: java.sql.Timestamp): Instant = Instant(sqlTime.getTime)
+  def fromCalendar(calendarTime: java.util.Calendar) = Instant(calendarTime.getTimeInMillis)
   private def fromStringSync(instantLiteral: String): Option[Instant] =
     tryo(java.time.Instant.parse(instantLiteral).toEpochMilli).toOption.map(timestamp => Instant(timestamp))
 

--- a/util/src/main/scala/com/scalableminds/util/time/Instant.scala
+++ b/util/src/main/scala/com/scalableminds/util/time/Instant.scala
@@ -1,0 +1,56 @@
+package com.scalableminds.util.time
+import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import net.liftweb.common.Box.tryo
+import play.api.libs.json._
+
+import java.time.format.DateTimeFormatter
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+case class Instant(epochMillis: Long) extends Ordered[Instant] {
+  override def toString: String = DateTimeFormatter.ISO_INSTANT.format(toJavaInstant)
+
+  def toJavaInstant: java.time.Instant = java.time.Instant.ofEpochMilli(epochMillis)
+  def toJodaDateTime: org.joda.time.DateTime = new org.joda.time.DateTime(epochMillis)
+  def toSql: java.sql.Timestamp = new java.sql.Timestamp(epochMillis)
+
+  def +(duration: FiniteDuration): Instant = Instant(epochMillis + duration.toMillis)
+
+  def isPast: Boolean = this < Instant.now
+
+  override def compare(that: Instant): Int =
+    if (this.epochMillis < that.epochMillis) -1
+    else if (this.epochMillis > that.epochMillis) 1
+    else 0
+}
+
+object Instant extends FoxImplicits {
+  def now: Instant = Instant(System.currentTimeMillis())
+  def in(duration: FiniteDuration): Instant = now + duration
+  def fromString(instantLiteral: String)(implicit ec: ExecutionContext): Fox[Instant] =
+    fromStringSync(instantLiteral).toFox
+  def fromJoda(jodaDateTime: org.joda.time.DateTime): Instant = Instant(jodaDateTime.getMillis)
+  def fromSql(sqlTime: java.sql.Timestamp): Instant = Instant(sqlTime.getTime)
+  private def fromStringSync(instantLiteral: String): Option[Instant] =
+    tryo(java.time.Instant.parse(instantLiteral).toEpochMilli).toOption.map(timestamp => Instant(timestamp))
+
+  implicit object InstantFormat extends Format[Instant] {
+    override def reads(json: JsValue): JsResult[Instant] =
+      json
+        .validate[String]
+        .flatMap { instantString =>
+          val parsedOpt = fromStringSync(instantString)
+          parsedOpt match {
+            case Some(parsed) => JsSuccess(parsed)
+            case None         => JsError(f"instant.invalid: $instantString")
+          }
+        }
+        .orElse {
+          json.validate[Long].flatMap { instantLong =>
+            JsSuccess(Instant(instantLong))
+          }
+        }
+
+    override def writes(i: Instant): JsValue = JsNumber(i.epochMillis)
+  }
+}

--- a/util/src/main/scala/com/scalableminds/util/time/Instant.scala
+++ b/util/src/main/scala/com/scalableminds/util/time/Instant.scala
@@ -15,6 +15,7 @@ case class Instant(epochMillis: Long) extends Ordered[Instant] {
   def toSql: java.sql.Timestamp = new java.sql.Timestamp(epochMillis)
 
   def +(duration: FiniteDuration): Instant = Instant(epochMillis + duration.toMillis)
+  def -(duration: FiniteDuration): Instant = Instant(epochMillis - duration.toMillis)
 
   def isPast: Boolean = this < Instant.now
 
@@ -26,6 +27,7 @@ case class Instant(epochMillis: Long) extends Ordered[Instant] {
 
 object Instant extends FoxImplicits {
   def now: Instant = Instant(System.currentTimeMillis())
+  def max: Instant = Instant(253370761200000L)
   def in(duration: FiniteDuration): Instant = now + duration
   def fromString(instantLiteral: String)(implicit ec: ExecutionContext): Fox[Instant] =
     fromStringSync(instantLiteral).toFox

--- a/util/src/main/scala/com/scalableminds/util/time/Instant.scala
+++ b/util/src/main/scala/com/scalableminds/util/time/Instant.scala
@@ -47,17 +47,17 @@ object Instant extends FoxImplicits {
   implicit object InstantFormat extends Format[Instant] {
     override def reads(json: JsValue): JsResult[Instant] =
       json
-        .validate[String]
-        .flatMap { instantString =>
-          val parsedOpt = fromStringSync(instantString)
-          parsedOpt match {
-            case Some(parsed) => JsSuccess(parsed)
-            case None         => JsError(f"instant.invalid: $instantString")
-          }
+        .validate[Long]
+        .flatMap { instantLong =>
+          JsSuccess(Instant(instantLong))
         }
         .orElse {
-          json.validate[Long].flatMap { instantLong =>
-            JsSuccess(Instant(instantLong))
+          json.validate[String].flatMap { instantString =>
+            val parsedOpt = fromStringSync(instantString)
+            parsedOpt match {
+              case Some(parsed) => JsSuccess(parsed)
+              case None         => JsError(f"instant.invalid: $instantString")
+            }
           }
         }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -1,13 +1,11 @@
 package com.scalableminds.webknossos.datastore.services
 
-import java.io.{File, FileWriter}
-import java.nio.file.{Files, Path, Paths}
-
 import akka.actor.ActorSystem
 import com.google.inject.Inject
 import com.google.inject.name.Named
 import com.scalableminds.util.io.PathUtils
 import com.scalableminds.util.io.PathUtils.ensureDirectoryBox
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
 import com.scalableminds.webknossos.datastore.DataStoreConfig
 import com.scalableminds.webknossos.datastore.dataformats.MappingProvider
@@ -17,11 +15,11 @@ import com.scalableminds.webknossos.datastore.models.datasource._
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.{InboxDataSource, UnusableDataSource}
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common._
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
 
+import java.io.{File, FileWriter}
+import java.nio.file.{Files, Path, Paths}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.io.Source
@@ -180,9 +178,8 @@ class DataSourceService @Inject()(
     } else {
       "<empty>"
     }
-    val timestamp = ISODateTimeFormat.dateTime.print(new DateTime())
     val outputForLogfile =
-      f"Contents of $propertiesFileName were changed by webKnossos at $timestamp. Old content: \n\n$previousContentOrEmpty\n\n"
+      f"Contents of $propertiesFileName were changed by webKnossos at ${Instant.now}. Old content: \n\n$previousContentOrEmpty\n\n"
     val logfilePath = dataSourcePath.resolve(logFileName)
     try {
       val fileWriter = new FileWriter(logfilePath.toString, true)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteWebKnossosClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteWebKnossosClient.scala
@@ -2,6 +2,7 @@ package com.scalableminds.webknossos.tracingstore
 
 import com.google.inject.Inject
 import com.scalableminds.util.cache.AlfuFoxCache
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.models.datasource.{DataSourceId, DataSourceLike}
 import com.scalableminds.webknossos.datastore.rpc.RPC
@@ -20,7 +21,7 @@ import play.api.libs.ws.WSResponse
 import scala.concurrent.ExecutionContext
 
 case class TracingUpdatesReport(tracingId: String,
-                                timestamps: List[Long],
+                                timestamps: List[Instant],
                                 statistics: Option[JsObject],
                                 significantChangesCount: Int,
                                 viewChangesCount: Int,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -1,5 +1,6 @@
 package com.scalableminds.webknossos.tracingstore.controllers
 
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.JsonHelper.{boxFormat, optionFormat}
 import com.scalableminds.webknossos.datastore.controllers.Controller
@@ -12,8 +13,8 @@ import com.scalableminds.webknossos.tracingstore.tracings.{
   UpdateActionGroup
 }
 import com.scalableminds.webknossos.tracingstore.{
-  TracingStoreAccessTokenService,
   TSRemoteWebKnossosClient,
+  TracingStoreAccessTokenService,
   TracingUpdatesReport
 }
 import play.api.i18n.Messages
@@ -194,7 +195,7 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
     val currentVersion = tracingService.currentVersion(tracingId)
     val report = TracingUpdatesReport(
       tracingId,
-      timestamps = updateGroups.map(_.timestamp),
+      timestamps = updateGroups.map(g => Instant(g.timestamp)),
       statistics = updateGroups.flatMap(_.stats).lastOption,
       significantChangesCount = updateGroups.map(_.significantChangesCount).sum,
       viewChangesCount = updateGroups.map(_.viewChangesCount).sum,


### PR DESCRIPTION
Introducing Instant, a case class representing a point in time in UTC. It replaces our mixed usages of Long, java.time.Instant, java.time.LocalDateTime, org.joda.time.DateTime and java.sql.Timestamp. I probably did not catch all usages of Long, but those can be replaced step by step. I searched for the others and they remain only where really needed.

I first wanted to go with java.time.Instant everywhere, but unfortunately backwards compatibility forbids it, since it serializes as ISO time string, while our API expects epochMillis numbers in jsons. Adding our own case class has a couple of other benefits, though, like nice integration with FiniteDuration.

Note that voxelytics reports expected an ISO time string, so to unify this with the rest of our API, i changed the types in the frontend there, to also expect number.

### URL of deployed dev instance (used for testing):
- https://instant.webknossos.xyz

### Steps to test:
- Test task annotating, time tracking report (staticstics view + time tracking view)
- Test Voxelytics Reporting (both running a workflow and then viewing its report)
- Test around different functionalities, annotating, worker job, edit a task type, etc

### Issues:
- fixes #6456 

------
- [x] Needs datastore update after deployment
- [x] Ready for review
