### PR TITLE
fixes infinite loop in getLineCount

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed import of remote datasets with multiple layers and differing resolution pyramid. #[6670](https://github.com/scalableminds/webknossos/pull/6670)
 - Fixed broken Get-new-Task button in task dashboard. [#6677](https://github.com/scalableminds/webknossos/pull/6677)
 - Fixed access of remote datasets using the Amazon S3 protocol [#6679](https://github.com/scalableminds/webknossos/pull/6679)
+- Fixed a bug in line measurement that would lead to an infinite loop. [#6689](https://github.com/scalableminds/webknossos/pull/6689)
 
 ### Removed
 

--- a/frontend/javascripts/admin/voxelytics/log_tab.tsx
+++ b/frontend/javascripts/admin/voxelytics/log_tab.tsx
@@ -53,18 +53,20 @@ function findBreakableCharFromRight(str: string, position: number): number {
   }
   return -1;
 }
+
 function getLineCount(str: string, wrapLength: number): number {
   // Inspired by https://stackoverflow.com/a/857770
-  const trimmedStr = str.trim();
-  if (trimmedStr.length <= wrapLength) {
-    return 1;
-  } else {
+  let trimmedStr = str.trim();
+  let counter = 1;
+  while (trimmedStr.length > wrapLength) {
     let splitIdx = findBreakableCharFromRight(trimmedStr, wrapLength);
-    if (splitIdx === -1) {
+    if (splitIdx < 1) {
       splitIdx = wrapLength;
     }
-    return 1 + getLineCount(trimmedStr.substring(splitIdx), wrapLength);
+    trimmedStr = trimmedStr.substring(splitIdx).trim();
+    counter++;
   }
+  return counter;
 }
 
 function LogContent({


### PR DESCRIPTION
Fixes a bug in `getLineCount` that would result in an infinite loop.

### Steps to test:
- Call `getLineCount('DEBUG    voxelytics.commons.workflow.resumable_executor.resumable_executor Looking for checkpoint: artifacts/xxxxxxxx-xxxx-xx-xx-xxxxx/compute_segment_stats/segment_stats__xxxxxxxxxx/resumable_executions/main/step/xxxxxx,xxxxxx,xxxx,xxxx,xx,xxx/checkpoint. Exists: True', 110)` (should result in `4`)
------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
