### PR TITLE
Catch Malformed Json Exceptions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed import of remote datasets with multiple layers and differing resolution pyramid. #[6670](https://github.com/scalableminds/webknossos/pull/6670)
 - Fixed broken Get-new-Task button in task dashboard. [#6677](https://github.com/scalableminds/webknossos/pull/6677)
 - Fixed access of remote datasets using the Amazon S3 protocol [#6679](https://github.com/scalableminds/webknossos/pull/6679)
+- Fixed a bug where malformed json files could lead to uncaught exceptions.[#6691](https://github.com/scalableminds/webknossos/pull/6691)
 
 ### Removed
 

--- a/app/models/binary/explore/RemoteLayerExplorer.scala
+++ b/app/models/binary/explore/RemoteLayerExplorer.scala
@@ -26,7 +26,7 @@ trait RemoteLayerExplorer extends FoxImplicits {
   protected def parseJsonFromPath[T: Reads](path: Path): Fox[T] =
     for {
       fileAsString <- tryo(new String(Files.readAllBytes(path), StandardCharsets.UTF_8)).toFox ?~> "Failed to read remote file"
-      parsed <- JsonHelper.parseAndValidateJson[T](fileAsString) ?~> "Failed to validate json against data schema"
+      parsed <- JsonHelper.parseAndValidateJson[T](fileAsString) ?~> "Failed to parse or validate json against data schema"
     } yield parsed
 
   protected def looksLikeSegmentationLayer(layerName: String, elementClass: ElementClass.Value): Boolean =

--- a/util/src/main/scala/com/scalableminds/util/tools/JsonHelper.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/JsonHelper.scala
@@ -2,16 +2,16 @@ package com.scalableminds.util.tools
 
 import java.io.FileNotFoundException
 import java.nio.file._
-
 import com.scalableminds.util.io.FileIO
 import com.typesafe.scalalogging.LazyLogging
+import net.liftweb.common.Box.tryo
 import net.liftweb.common._
 import play.api.i18n.Messages
 import play.api.libs.json._
 import play.api.libs.json.Reads._
 import play.api.libs.json.Writes._
-import scala.concurrent.ExecutionContext.Implicits._
 
+import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration._
 import scala.io.{BufferedSource, Source}
 
@@ -103,7 +103,7 @@ object JsonHelper extends BoxImplicits with LazyLogging {
   }
 
   def parseAndValidateJson[T: Reads](s: String): Box[T] =
-    validateJsValue[T](Json.parse(s))
+    tryo(Json.parse(s)).flatMap(parsed => validateJsValue[T](parsed))
 
   def validateJsValue[T: Reads](o: JsValue): Box[T] =
     o.validate[T] match {


### PR DESCRIPTION
Turns out the Json.parse wasn’t yet wrapped in tryo, letting the exception bubble.

### Issues:
- fixes #6690

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
