### PR TITLE
Respect mail.smtp.auth setting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed import of remote datasets with multiple layers and differing resolution pyramid. #[6670](https://github.com/scalableminds/webknossos/pull/6670)
 - Fixed broken Get-new-Task button in task dashboard. [#6677](https://github.com/scalableminds/webknossos/pull/6677)
 - Fixed access of remote datasets using the Amazon S3 protocol [#6679](https://github.com/scalableminds/webknossos/pull/6679)
+- Respect the config value mail.smtp.auth (used to be ignored, always using true) [#6692](https://github.com/scalableminds/webknossos/pull/6692)
 
 ### Removed
 

--- a/app/Startup.scala
+++ b/app/Startup.scala
@@ -117,6 +117,7 @@ class Startup @Inject()(actorSystem: ActorSystem,
       conf.Mail.Smtp.host,
       conf.Mail.Smtp.port,
       conf.Mail.Smtp.tls,
+      conf.Mail.Smtp.auth,
       conf.Mail.Smtp.user,
       conf.Mail.Smtp.pass,
     )

--- a/app/oxalis/mail/Mailer.scala
+++ b/app/oxalis/mail/Mailer.scala
@@ -20,6 +20,7 @@ case class MailerConfig(
     smtpHost: String,
     smtpPort: Int,
     smtpTls: Boolean,
+    smtpAuth: Boolean,
     smtpUser: String,
     smtpPass: String,
 )
@@ -54,7 +55,9 @@ class Mailer(conf: MailerConfig) extends Actor with LazyLogging {
       multiPartMail.setHostName(conf.smtpHost)
       multiPartMail.setSmtpPort(conf.smtpPort)
       multiPartMail.setStartTLSEnabled(conf.smtpTls)
-      multiPartMail.setAuthenticator(new DefaultAuthenticator(conf.smtpUser, conf.smtpPass))
+      if (conf.smtpAuth) {
+        multiPartMail.setAuthenticator(new DefaultAuthenticator(conf.smtpUser, conf.smtpPass))
+      }
       multiPartMail.setDebug(false)
       multiPartMail.getMailSession.getProperties.put("mail.smtp.ssl.protocols", "TLSv1.2")
 

--- a/app/oxalis/mail/Mailer.scala
+++ b/app/oxalis/mail/Mailer.scala
@@ -72,7 +72,7 @@ class Mailer(conf: MailerConfig) extends Actor with LazyLogging {
   /**
     * Extracts an email address from the given string and passes to the enclosed method.
     */
-  private def setAddress(emailAddress: String)(setter: (String, String) => _) {
+  private def setAddress(emailAddress: String)(setter: (String, String) => _): Unit =
     try {
       val iAddress = new InternetAddress(emailAddress)
       val address = iAddress.getAddress
@@ -80,9 +80,8 @@ class Mailer(conf: MailerConfig) extends Actor with LazyLogging {
 
       setter(address, name)
     } catch {
-      case _: Exception => ()
+      case e: Exception => logger.warn(s"Failed to set email address: $e")
     }
-  }
 
   /**
     * Creates an appropriate email object based on the content type.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -181,7 +181,6 @@ mail {
     pass = ""
   }
   defaultSender = "webKnossos <no-reply@webknossos.org>"
-  reply = "webKnossos <no-reply@webknossos.org>"
   mailchimp {
     host = ""
     listId = ""


### PR DESCRIPTION
As reported in #6688 the wk setting mail.smtp.auth was not respected. I added an if-condition to only set the auth fields if this is enabled.
The PR also adds some logging if email adresses could not be set.

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
