### PR TITLE
Check that user does not upload NML in dataset upload view

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -777,6 +777,14 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                 {
                   validator: syncValidator(
                     (files: FileWithPath[]) =>
+                      files.filter((file) => Utils.isFileExtensionEqualTo(file.path, ["nml"]))
+                        .length === 0,
+                    "An NML file is an annotation of a dataset and not an independent dataset. Please upload the NML file into the Annotations page in the dashboard or into an open dataset.",
+                  ),
+                },
+                {
+                  validator: syncValidator(
+                    (files: FileWithPath[]) =>
                       files.filter((file) => Utils.isFileExtensionEqualTo(file.path, ["mrc"]))
                         .length === 0,
                     "MRC files are not supported currently.",

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -497,8 +497,17 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
               const wkwFile = entries.find((entry: Entry) =>
                 Utils.isFileExtensionEqualTo(entry.filename, "wkw"),
               );
-              const hasArchiveWkwFile = wkwFile != null;
-              this.handleNeedsConversionInfo(!hasArchiveWkwFile);
+              const needsConversion = wkwFile == null;
+              this.handleNeedsConversionInfo(!needsConversion);
+
+              const nmlFile = entries.find((entry: Entry) =>
+                Utils.isFileExtensionEqualTo(entry.filename, "nml"),
+              );
+              if (nmlFile) {
+                Modal.error({
+                  content: messages["dataset.upload_zip_with_nml"],
+                });
+              }
             });
           },
           () => {

--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -274,6 +274,8 @@ instead. Only enable this option if you understand its effect. All layers will n
   "dataset.upload_cancel": "The dataset upload was cancelled.",
   "dataset.unsupported_file_type":
     "It looks like the selected file is not supported. WebKnossos only supports uploading zipped WKW datasets or image files.",
+  "dataset.upload_zip_with_nml":
+    "The archive you attached contains an NML file. If the archive is an annotation, please use the Annotations tab in the dashboard to upload it. Uploading annotations here won't succeed.",
   "dataset.upload_invalid_zip":
     "It looks like the selected file is not a valid zip file. Please ensure that your dataset is zipped to a single file and that the format is correct.",
   "dataset.leave_during_upload":


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- enable jobs (otherwise, there will be a warning anyway saying that the NML file needs conversion)
- drag nml file into upload dataset view
- will look like this:

![image](https://user-images.githubusercontent.com/2486553/207062780-e23ae257-68d7-45cd-a47c-13673eac7148.png)

The submit button is apparently always enabled by antd even though the validation fails. I didn't find an easy way to improve this, but 1) couldn't find a quick solution and 2) it shouldn't be big problem and 3) it's been like this before.

### Issues:
- fixes #6694

------
- [X] Ready for review
