### PR TITLE
Disable compression for development proxy

### DIFF
--- a/tools/proxy/proxy.js
+++ b/tools/proxy/proxy.js
@@ -105,6 +105,14 @@ function toWebpackDev(req, res) {
   proxy.web(req, res, { target: `http://127.0.0.1:${PORT + 2}` });
 }
 
+proxy.on("proxyReq", function (proxyReq, req, res, options) {
+  if (req.url.match(/\/assets\/bundle\/.+\.js/)) {
+    // Disable compression for JS files, as the performance penalty of the compression
+    // isn't worth the size gain.
+    proxyReq.setHeader("Accept-Encoding", "");
+  }
+});
+
 app.all("/assets/bundle/*", toWebpackDev);
 app.all("/*", toBackend);
 

--- a/tools/proxy/proxy.js
+++ b/tools/proxy/proxy.js
@@ -105,11 +105,11 @@ function toWebpackDev(req, res) {
   proxy.web(req, res, { target: `http://127.0.0.1:${PORT + 2}` });
 }
 
-proxy.on("proxyReq", function (proxyReq, req, res, options) {
+proxy.on("proxyReq", (proxyReq, req) => {
   if (req.url.match(/\/assets\/bundle\/.+\.js/)) {
     // Disable compression for JS files, as the performance penalty of the compression
     // isn't worth the size gain.
-    proxyReq.setHeader("Accept-Encoding", "");
+    proxyReq.removeHeader("Accept-Encoding");
   }
 });
 


### PR DESCRIPTION
I noticed that the vendors and main js file took quite a while to load in the dev setup (TTFB was almost 2 seconds). I traced this down to the compression. Since the source files are quite big (e.g., > 30 MB) due to source maps, the compression penalty is quite high and not worth it the size reduction.

- [X] Ready for review
