### PR TITLE
Automatically open (and close) quick select settings when labeling in…

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - webKnossos is now able to recover from a lost webGL context. [#6663](https://github.com/scalableminds/webknossos/pull/6663)
 - Bulk task creation now needs the taskTypeId, the task type summary will no longer be accepted. [#6640](https://github.com/scalableminds/webknossos/pull/6640)
 - Error handling and reporting is more robust now. [#6700](https://github.com/scalableminds/webknossos/pull/6700)
+- The Quick-Select settings are opened (and closed) automatically when labeling with the preview mode. That way, bulk labelings with preview mode don't require constantly opening the settings manually. [#6706](https://github.com/scalableminds/webknossos/pull/6706)
 
 ### Fixed
 - Fixed import of N5 datasets. [#6668](https://github.com/scalableminds/webknossos/pull/6668)

--- a/frontend/javascripts/oxalis/default_state.ts
+++ b/frontend/javascripts/oxalis/default_state.ts
@@ -234,6 +234,7 @@ const defaultState: OxalisState = {
       isBusy: false,
     },
     isQuickSelectActive: false,
+    areQuickSelectSettingsOpen: false,
   },
   localSegmentationData: {},
 };

--- a/frontend/javascripts/oxalis/model/actions/ui_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/ui_actions.ts
@@ -18,6 +18,7 @@ type SetPythonClientModalVisibilityAction = ReturnType<typeof setPythonClientMod
 export type EnterAction = ReturnType<typeof enterAction>;
 export type EscapeAction = ReturnType<typeof escapeAction>;
 export type SetIsQuickSelectActiveAction = ReturnType<typeof setIsQuickSelectActiveAction>;
+type ShowQuickSelectSettingsAction = ReturnType<typeof showQuickSelectSettingsAction>;
 
 export type UiAction =
   | SetDropzoneModalVisibilityAction
@@ -36,7 +37,8 @@ export type UiAction =
   | SetBusyBlockingInfoAction
   | EnterAction
   | EscapeAction
-  | SetIsQuickSelectActiveAction;
+  | SetIsQuickSelectActiveAction
+  | ShowQuickSelectSettingsAction;
 
 export const setDropzoneModalVisibilityAction = (visible: boolean) =>
   ({
@@ -123,4 +125,10 @@ export const setIsQuickSelectActiveAction = (isActive: boolean) =>
   ({
     type: "SET_IS_QUICK_SELECT_ACTIVE",
     isActive,
+  } as const);
+
+export const showQuickSelectSettingsAction = (isOpen: boolean) =>
+  ({
+    type: "SET_ARE_QUICK_SELECT_SETTINGS_OPEN",
+    isOpen,
   } as const);

--- a/frontend/javascripts/oxalis/model/reducers/ui_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/ui_reducer.ts
@@ -114,6 +114,12 @@ function UiReducer(state: OxalisState, action: Action): OxalisState {
       });
     }
 
+    case "SET_ARE_QUICK_SELECT_SETTINGS_OPEN": {
+      return updateKey(state, "uiInformation", {
+        areQuickSelectSettingsOpen: action.isOpen,
+      });
+    }
+
     default:
       return state;
   }

--- a/frontend/javascripts/oxalis/store.ts
+++ b/frontend/javascripts/oxalis/store.ts
@@ -482,6 +482,7 @@ type UiInformation = {
   readonly theme: Theme;
   readonly busyBlockingInfo: BusyBlockingInfo;
   readonly isQuickSelectActive: boolean;
+  readonly areQuickSelectSettingsOpen: boolean;
 };
 type BaseIsosurfaceInformation = {
   readonly segmentId: number;

--- a/frontend/javascripts/oxalis/view/action-bar/quick_select_settings.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/quick_select_settings.tsx
@@ -12,13 +12,14 @@ import Shortcut from "libs/shortcut_component";
 import { Radio, RadioChangeEvent } from "antd";
 import { NumberSliderSetting, SwitchSetting } from "../components/setting_input_views";
 import ButtonComponent from "../components/button_component";
+import { showQuickSelectSettingsAction } from "oxalis/model/actions/ui_actions";
 
 const OPTIONS_WITH_DISABLED = [
   { label: "Dark Segment", value: "dark" },
   { label: "Light Segment", value: "light" },
 ];
 
-export function QuickSelectControls({ setIsOpen }: { setIsOpen: (val: boolean) => void }) {
+export function QuickSelectControls() {
   const isQuickSelectActive = useSelector(
     (state: OxalisState) => state.uiInformation.isQuickSelectActive,
   );
@@ -78,11 +79,11 @@ export function QuickSelectControls({ setIsOpen }: { setIsOpen: (val: boolean) =
 
   const onDiscard = () => {
     dispatch(cancelQuickSelectAction());
-    setIsOpen(false);
+    dispatch(showQuickSelectSettingsAction(false));
   };
   const onConfirm = () => {
     dispatch(confirmQuickSelectAction());
-    setIsOpen(false);
+    dispatch(showQuickSelectSettingsAction(false));
   };
 
   return (

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -28,7 +28,7 @@ import {
   getDisabledInfoForTools,
   adaptActiveToolToShortcuts,
 } from "oxalis/model/accessors/tool_accessor";
-import { setToolAction } from "oxalis/model/actions/ui_actions";
+import { setToolAction, showQuickSelectSettingsAction } from "oxalis/model/actions/ui_actions";
 import { toNullable } from "libs/utils";
 import { updateUserSettingAction } from "oxalis/model/actions/settings_actions";
 import { usePrevious, useKeyPress } from "libs/react_hooks";
@@ -970,17 +970,19 @@ function ToolSpecificSettings({
 }
 
 function QuickSelectSettingsPopover() {
-  const [isOpen, setIsOpen] = useState(false);
-  const isQuickSelectActive = useSelector(
-    (state: OxalisState) => state.uiInformation.isQuickSelectActive,
+  const dispatch = useDispatch();
+  const { isQuickSelectActive, areQuickSelectSettingsOpen } = useSelector(
+    (state: OxalisState) => state.uiInformation,
   );
   return (
     <Popover
       trigger="click"
       placement="bottom"
-      open={isOpen}
-      content={<QuickSelectControls setIsOpen={setIsOpen} />}
-      onOpenChange={(open: boolean) => setIsOpen(open)}
+      open={areQuickSelectSettingsOpen}
+      content={<QuickSelectControls />}
+      onOpenChange={(open: boolean) => {
+        dispatch(showQuickSelectSettingsAction(open));
+      }}
     >
       <ButtonComponent
         title="Configure Quick Select"


### PR DESCRIPTION
… preview mode. That way, bulk labelings with preview mode don't require constantly opening the settings manually.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- use quick select tool with and without preview mode and check usability of settings

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
