### PR TITLE
add license checker

### DIFF
--- a/project/license.sbt
+++ b/project/license.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")


### PR DESCRIPTION
Adds a license checker for the backend. It can be run with `sbt dumpLicenseReport` (not sure where to document this). The frontend already has that in the form of `yarn licenses ls`. 

------
- [x] Ready for review
