### PR TITLE
Add explicit name for foreign-key constraint to fix false positives in diff schema

### DIFF
--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -11,3 +11,4 @@ User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 ### Postgres Evolutions:
 
 - [094-pricing-plans.sql](conf/evolutions/reversions/094-pricing-plans.sql)
+- [095-constraint-naming.sql](conf/evolutions/reversions/095-constraint-naming.sql)

--- a/conf/evolutions/095-constraint-naming.sql
+++ b/conf/evolutions/095-constraint-naming.sql
@@ -1,7 +1,7 @@
 START TRANSACTION;
 
-ALTER TABLE webknossos.webknossos.voxelytics_runs DROP CONSTRAINT IF EXISTS voxelytics_runs__organization_workflow_hash_fkey;
-ALTER TABLE webknossos.webknossos.voxelytics_runs DROP CONSTRAINT IF EXISTS voxelytics_runs__organization_fkey1;
+ALTER TABLE webknossos.voxelytics_runs DROP CONSTRAINT IF EXISTS voxelytics_runs__organization_workflow_hash_fkey;
+ALTER TABLE webknossos.voxelytics_runs DROP CONSTRAINT IF EXISTS voxelytics_runs__organization_fkey1;
 
 ALTER TABLE webknossos.voxelytics_runs ADD CONSTRAINT voxelytics_runs__organization_workflow_hash_fkey FOREIGN KEY (_organization, workflow_hash) REFERENCES webknossos.voxelytics_workflows(_organization, hash) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
 

--- a/conf/evolutions/095-constraint-naming.sql
+++ b/conf/evolutions/095-constraint-naming.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+ALTER TABLE webknossos.webknossos.voxelytics_runs DROP CONSTRAINT IF EXISTS voxelytics_runs__organization_workflow_hash_fkey;
+ALTER TABLE webknossos.webknossos.voxelytics_runs DROP CONSTRAINT IF EXISTS voxelytics_runs__organization_fkey1;
+
+ALTER TABLE webknossos.voxelytics_runs ADD CONSTRAINT voxelytics_runs__organization_workflow_hash_fkey FOREIGN KEY (_organization, workflow_hash) REFERENCES webknossos.voxelytics_workflows(_organization, hash) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 95;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/095-constraint-naming.sql
+++ b/conf/evolutions/reversions/095-constraint-naming.sql
@@ -1,0 +1,7 @@
+START TRANSACTION;
+
+-- nothing to revert
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 94;
+
+COMMIT TRANSACTION;

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -19,7 +19,7 @@ START TRANSACTION;
 CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(94);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(95);
 COMMIT TRANSACTION;
 
 
@@ -706,7 +706,8 @@ ALTER TABLE webknossos.voxelytics_artifacts
   ADD FOREIGN KEY (_task) REFERENCES webknossos.voxelytics_tasks(_id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
 ALTER TABLE webknossos.voxelytics_runs
   ADD FOREIGN KEY (_organization) REFERENCES webknossos.organizations(_id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE,
-  ADD FOREIGN KEY (_organization, workflow_hash) REFERENCES webknossos.voxelytics_workflows(_organization, hash) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+  -- explicit naming for this constraint, as different postgres versions give different names to tuple key constraints
+  ADD CONSTRAINT voxelytics_runs__organization_workflow_hash_fkey FOREIGN KEY (_organization, workflow_hash) REFERENCES webknossos.voxelytics_workflows(_organization, hash) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
 ALTER TABLE webknossos.voxelytics_tasks
   ADD FOREIGN KEY (_run) REFERENCES webknossos.voxelytics_runs(_id) ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
 ALTER TABLE webknossos.voxelytics_chunks


### PR DESCRIPTION
After a postgres upgrade the automatic naming for tuple foreign keys was changed, resulting in false positives in the schema difference detection.

### Steps to test:
- the foreign key constraint referencing `webknossos.voxelytics_workflows(_organization, hash)` in the `voxelytics_runs` table should be named `voxelytics_runs__organization_workflow_hash_fkey` regardless of postgres version

------
- [x] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Ready for review
