### PR TITLE
Verbose error logging for storage scan failures, avoid getting stuck

### DIFF
--- a/app/models/organization/Organization.scala
+++ b/app/models/organization/Organization.scala
@@ -186,12 +186,12 @@ class OrganizationDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionCont
       firstRow <- rows.headOption
     } yield firstRow
 
-  def findNotRecentlyScanned(scanInterval: FiniteDuration, limit: Int): Fox[List[Organization]] =
+  def findNotRecentlyScanned(rescanInterval: FiniteDuration, limit: Int): Fox[List[Organization]] =
     for {
       rows <- run(sql"""
                   SELECT #${columns.debugInfo}
                   FROM #${existingCollectionName.debugInfo}
-                  WHERE lastStorageScanTime < ${Instant.now - scanInterval}
+                  WHERE lastStorageScanTime < ${Instant.now - rescanInterval}
                   ORDER BY lastStorageScanTime
                   LIMIT $limit
                   """.as[OrganizationsRow])

--- a/app/models/storage/UsedStorageService.scala
+++ b/app/models/storage/UsedStorageService.scala
@@ -10,8 +10,9 @@ import com.scalableminds.webknossos.datastore.services.DirectoryStorageReport
 import com.typesafe.scalalogging.LazyLogging
 import models.binary.{DataSet, DataSetService, DataStore, DataStoreDAO, WKRemoteDataStoreClient}
 import models.organization.{Organization, OrganizationDAO}
+import net.liftweb.common.{Failure, Full}
 import play.api.inject.ApplicationLifecycle
-import utils.WkConf
+import utils.{ObjectId, WkConf}
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
@@ -28,16 +29,17 @@ class UsedStorageService @Inject()(val system: ActorSystem,
     with IntervalScheduler {
 
   /* Note that not every tick here will scan something, there is additional logic below:
-     Every tick, et most 10 organizations are scanned. But only if their last full scan is was sufficiently long ago
-     The 10 organizations with the most outdated scan are selected each tick. This is to distribute the load.
+     Every tick, et most scansPerTick organizations are scanned.
+     But only if their last full scan is was sufficiently long ago
+     The organizations with the most outdated scan are selected each tick. This is to distribute the load.
    */
-  override protected def tickerInterval: FiniteDuration = 10 minutes
+  override protected def tickerInterval: FiniteDuration = config.WebKnossos.FetchUsedStorage.tickerInterval
   override protected def tickerInitialDelay: FiniteDuration = 1 minute
 
   private val isRunning = new java.util.concurrent.atomic.AtomicBoolean(false)
 
   private val pauseAfterEachOrganization = 5 seconds
-  private val organizationCountToScanPerTick = 10
+  private val organizationCountToScanPerTick = config.WebKnossos.FetchUsedStorage.scansPerTick
 
   implicit private val ctx: DBAccessContext = GlobalAccessContext
 
@@ -50,21 +52,33 @@ class UsedStorageService @Inject()(val system: ActorSystem,
 
   private def tickAsync(): Fox[Unit] =
     for {
-      organizations <- organizationDAO.findNotRecentlyScanned(config.WebKnossos.FetchUsedStorage.interval,
+      organizations <- organizationDAO.findNotRecentlyScanned(config.WebKnossos.FetchUsedStorage.rescanInterval,
                                                               organizationCountToScanPerTick)
       dataStores <- dataStoreDAO.findAllWithStorageReporting
-      _ = logger.info(s"Scanning ${organizations.length} organizations in ${dataStores.length} datastores...")
-      _ <- Fox.serialCombined(organizations)(organization => refreshStorageReports(organization, dataStores))
+      _ = logger.info(s"Scanning used storage for ${organizations.length} organizations (${organizations
+        .map(_._id)}) in ${dataStores.length} datastores (${dataStores.map(_.name)})...")
+      _ <- Fox.serialCombined(organizations)(organization =>
+        tryAndLog(organization._id, refreshStorageReports(organization, dataStores)))
+    } yield ()
+
+  private def tryAndLog(organizationId: ObjectId, result: Fox[Unit]): Fox[Unit] =
+    for {
+      box <- result.futureBox
+      _ = box match {
+        case Full(_)    => ()
+        case f: Failure => logger.error(f"Error during storage scan for organization with id $organizationId: $f")
+        case _          => logger.error(f"Error during storage scan for organization with id $organizationId: Empty")
+      }
     } yield ()
 
   private def refreshStorageReports(organization: Organization, dataStores: List[DataStore]): Fox[Unit] =
     for {
       storageReportsByDataStore <- Fox.serialCombined(dataStores)(dataStore =>
-        refreshStorageReports(dataStore, organization))
-      _ <- organizationDAO.deleteUsedStorage(organization._id)
+        refreshStorageReports(dataStore, organization)) ?~> "Failed to fetch used storage reports"
+      _ <- organizationDAO.deleteUsedStorage(organization._id) ?~> "Failed to delete outdated used storage entries"
       _ <- Fox.serialCombined(storageReportsByDataStore.zip(dataStores))(storageForDatastore =>
-        upsertUsedStorage(organization, storageForDatastore))
-      _ <- organizationDAO.updateLastStorageScanTime(organization._id, Instant.now)
+        upsertUsedStorage(organization, storageForDatastore)) ?~> "Failed to upsert used storage reports into db"
+      _ <- organizationDAO.updateLastStorageScanTime(organization._id, Instant.now) ?~> "Failed to update last storage scan time in db"
       _ = Thread.sleep(pauseAfterEachOrganization.toMillis)
     } yield ()
 

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -63,7 +63,9 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
     }
 
     object FetchUsedStorage {
-      val interval: FiniteDuration = get[FiniteDuration]("webKnossos.fetchUsedStorage.interval")
+      val rescanInterval: FiniteDuration = get[FiniteDuration]("webKnossos.fetchUsedStorage.rescanInterval")
+      val tickerInterval: FiniteDuration = get[FiniteDuration]("webKnossos.fetchUsedStorage.tickerInterval")
+      val scansPerTick: Int = get[Int]("webKnossos.fetchUsedStorage.scansPerTick")
     }
 
     object TermsOfService {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -154,7 +154,7 @@ datastore {
     enabled = true
     interval = 1 minute
   }
-  reportUsedStorage.enabled = true
+  reportUsedStorage.enabled = false
   cache {
     dataCube.maxEntries = 40
     mapping.maxEntries = 5

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,7 +60,9 @@ webKnossos {
     user.timeout = 3 minutes
   }
   fetchUsedStorage {
-    interval = 24 hours # note that this interval works across wk restarts
+    rescanInterval = 24 hours # do not scan organizations whose last scan is more recent than this
+    tickerInterval = 10 minutes # scan some organizations at each tick
+    scansPerTick = 10 # scan x organizations at each tick
   }
   sampleOrganization {
     enabled = true
@@ -101,7 +103,7 @@ features {
   discussionBoard = "https://forum.image.sc/tag/webknossos"
   discussionBoardRequiresAdmin = false
   hideNavbarLogin = false
-  isDemoInstance = false
+  isDemoInstance = true
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
   # to enable jobs for local development, use "yarn enable-jobs" to also activate it in the database
@@ -152,7 +154,7 @@ datastore {
     enabled = true
     interval = 1 minute
   }
-  reportUsedStorage.enabled = false
+  reportUsedStorage.enabled = true
   cache {
     dataCube.maxEntries = 40
     mapping.maxEntries = 5

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -103,7 +103,7 @@ features {
   discussionBoard = "https://forum.image.sc/tag/webknossos"
   discussionBoardRequiresAdmin = false
   hideNavbarLogin = false
-  isDemoInstance = true
+  isDemoInstance = false
   taskReopenAllowedInSeconds = 30
   allowDeleteDatasets = true
   # to enable jobs for local development, use "yarn enable-jobs" to also activate it in the database

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -447,18 +447,20 @@ Expects:
                          organizationName: String,
                          datasetName: Option[String] = None): Action[AnyContent] =
     Action.async { implicit request =>
-      accessTokenService.validateAccess(UserAccessRequest.administrateDataSources(organizationName),
-                                        urlOrHeaderToken(token, request)) {
-        for {
-          before <- Fox.successful(System.currentTimeMillis())
-          usedStorageInBytes: List[DirectoryStorageReport] <- storageUsageService.measureStorage(organizationName,
-                                                                                                 datasetName)
-          after = System.currentTimeMillis()
-          _ = if (after - before > (10 seconds).toMillis) {
-            val datasetLabel = datasetName.map(n => s" dataset $n of").getOrElse("")
-            logger.info(s"Measuring storage for$datasetLabel orga $organizationName took ${after - before} ms.")
-          }
-        } yield Ok(Json.toJson(usedStorageInBytes))
+      log() {
+        accessTokenService.validateAccess(UserAccessRequest.administrateDataSources(organizationName),
+                                          urlOrHeaderToken(token, request)) {
+          for {
+            before <- Fox.successful(System.currentTimeMillis())
+            usedStorageInBytes: List[DirectoryStorageReport] <- storageUsageService.measureStorage(organizationName,
+                                                                                                   datasetName)
+            after = System.currentTimeMillis()
+            _ = if (after - before > (10 seconds).toMillis) {
+              val datasetLabel = datasetName.map(n => s" dataset $n of").getOrElse("")
+              logger.info(s"Measuring storage for$datasetLabel orga $organizationName took ${after - before} ms.")
+            }
+          } yield Ok(Json.toJson(usedStorageInBytes))
+        }
       }
     }
 


### PR DESCRIPTION
- Adds extensive error logging to possible failures during storage scanning.
- Continues with more organizations even if updating one fails.
- Adds more configuration possibilities for the timing/load balancing

### Steps to test:
- set `reportUsedStorage.enabled = true` in datastore config
- add an error somewhere in the stack (e.g. in `updateLastStorageScanTime`, I added `_ <- Fox.failure("nope")` in Organization.scala before line 151)
- Logging should show the error
- In multi-orga setup, the scanning should continue with the next orga, even if inserting the first failed.
- If the error is inserted in the datastore, additional logging with more details should show up there as well

------
- [x] Needs datastore update after deployment
- [x] Ready for review
