### PR TITLE
Purge last usages of SqlToken.raw with user input

### DIFF
--- a/app/models/binary/DataSet.scala
+++ b/app/models/binary/DataSet.scala
@@ -189,8 +189,7 @@ class DataSetDAO @Inject()(sqlClient: SqlClient,
       case None => q"${true}"
       case Some(searchQuery) =>
         val queryTokens = searchQuery.toLowerCase.trim.split(" +")
-        SqlToken.raw(
-          queryTokens.map(queryToken => s"POSITION(${escapeLiteral(queryToken)} IN LOWER(name)) > 0").mkString(" AND "))
+        SqlToken.joinBySeparator(queryTokens.map(queryToken => q"POSITION($queryToken IN LOWER(name)) > 0"), " AND ")
     }
 
   def countByFolder(folderId: ObjectId): Fox[Int] =

--- a/app/utils/sql/SqlInterpolation.scala
+++ b/app/utils/sql/SqlInterpolation.scala
@@ -86,8 +86,8 @@ object SqlToken {
 
   def raw(s: String): SqlToken = SqlToken(s)
 
-  def joinBySeparator(tokens: Iterable[SqlToken], sepator: String): SqlToken =
-    SqlToken(sql = tokens.map(_.sql).mkString(sepator), values = tokens.flatMap(_.values).toList)
+  def joinBySeparator(tokens: Iterable[SqlToken], separator: String): SqlToken =
+    SqlToken(sql = tokens.map(_.sql).mkString(separator), values = tokens.flatMap(_.values).toList)
 
   def empty: SqlToken = raw("")
 

--- a/app/utils/sql/SqlInterpolation.scala
+++ b/app/utils/sql/SqlInterpolation.scala
@@ -106,6 +106,9 @@ object SqlToken {
 
   def raw(s: String): SqlToken = SqlToken(s)
 
+  def joinBySeparator(tokens: Iterable[SqlToken], sepator: String): SqlToken =
+    SqlToken(sql = tokens.map(_.sql).mkString(sepator), values = tokens.flatMap(_.values).toList)
+
   def empty: SqlToken = raw("")
 
   def identifier(id: String): SqlToken = raw('"' + id + '"')

--- a/app/utils/sql/SqlInterpolation.scala
+++ b/app/utils/sql/SqlInterpolation.scala
@@ -74,26 +74,6 @@ case class SqlToken(sql: String, values: List[SqlValue] = List()) {
 }
 
 object SqlToken {
-  def join(values: List[Either[SqlValue, SqlToken]], sep: String): SqlToken = {
-    val outputSql = mutable.StringBuilder.newBuilder
-    val outputValues = ListBuffer[SqlValue]()
-    for (i <- values.indices) {
-      val value = values(i)
-      value match {
-        case Left(x) =>
-          outputSql ++= x.placeholder
-          outputValues += x
-        case Right(x) =>
-          outputSql ++= x.sql
-          outputValues ++= x.values
-      }
-      if (i < values.length - 1) {
-        outputSql ++= sep
-      }
-    }
-    SqlToken(sql = outputSql.toString, values = outputValues.toList)
-  }
-
   def tupleFromList(values: List[SqlValue]): SqlToken =
     SqlToken(sql = s"(${values.map(_.placeholder).mkString(", ")})", values = values)
 


### PR DESCRIPTION
- Introduces two new enum classes to pass to sql (note that they are not used in the scala models as their usages are in library code, which expects strings)
- Introducs `SqlToken.joinBySeparator` which is here used with the separator AND to construct the dataset search query
- The remaining usages of SqlToken.raw contain no user-supplied data (construction of column lists, sql view name existingCollectionName)

### URL of deployed dev instance (used for testing):
- https://avoidsqlraw.webknossos.xyz

### Steps to test:
- Search for a dataset
- Register a new user
- Should work

------
- [x] Ready for review
