### PR TITLE
Include wkw file path when logging java internal error

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -80,9 +80,9 @@ class BinaryDataService(val dataBaseDir: Path,
       val readInstruction =
         DataReadInstruction(dataBaseDir, request.dataSource, request.dataLayer, bucket, request.settings.version)
       request.dataLayer.bucketProvider.load(readInstruction, cache).futureBox.flatMap {
-        case Failure(_, Full(e: InternalError), _) =>
+        case Failure(msg, Full(e: InternalError), _) =>
           applicationHealthService.foreach(a => a.pushError(e))
-          logger.warn(s"Caught internal error: $e")
+          logger.warn(s"Caught internal error: $msg")
           Fox.failure(e.getMessage)
         case other => other.toFox
       }


### PR DESCRIPTION
Note that not every internal error was thrown in the wkw read data codepath (some happened during array allocation in unrelated code, etc). But those are currently the only ones we catch.

### Steps to test:
- add `throw new InternalError("hi")` in wkw bucket provider
- hit reload button next to layer histogram
- logging should show wkw file paths

------
- [x] Needs datastore update after deployment
- [x] Ready for review
