### PR TITLE
Log dataset id on Internal Error even when Failure msg does not include path

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
@@ -18,6 +18,7 @@ class WKWCubeHandle(wkwFile: WKWFile, wkwFilePath: Path) extends DataCubeHandle 
     val blockOffsetY = bucket.bucketY % numBlocksPerCubeDimension
     val blockOffsetZ = bucket.bucketZ % numBlocksPerCubeDimension
     try {
+      throw new InternalError("hi")
       wkwFile.readBlock(blockOffsetX, blockOffsetY, blockOffsetZ)
     } catch {
       case e: InternalError =>

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
@@ -18,7 +18,6 @@ class WKWCubeHandle(wkwFile: WKWFile, wkwFilePath: Path) extends DataCubeHandle 
     val blockOffsetY = bucket.bucketY % numBlocksPerCubeDimension
     val blockOffsetZ = bucket.bucketZ % numBlocksPerCubeDimension
     try {
-      throw new InternalError("hi")
       wkwFile.readBlock(blockOffsetX, blockOffsetY, blockOffsetZ)
     } catch {
       case e: InternalError =>

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -82,7 +82,8 @@ class BinaryDataService(val dataBaseDir: Path,
       request.dataLayer.bucketProvider.load(readInstruction, cache).futureBox.flatMap {
         case Failure(msg, Full(e: InternalError), _) =>
           applicationHealthService.foreach(a => a.pushError(e))
-          logger.warn(s"Caught internal error: $msg")
+          logger.warn(
+            s"Caught internal error: $msg while loading a bucket for layer ${request.dataLayer.name} of dataset ${request.dataSource.id}")
           Fox.failure(e.getMessage)
         case other => other.toFox
       }


### PR DESCRIPTION
We saw occurences of this error catching but the msg was not written with paths. Either way, we should be able to log the dataset name, orga and layer

- [x] Needs datastore update after deployment
- [x] Ready for review
