### PR TITLE
Gracefully handle failing breadcrumb generation

### DIFF
--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -548,7 +548,8 @@ class DatasetTable extends React.PureComponent<Props, State> {
                 </Link>
                 <br />
 
-                {"getBreadcrumbs" in this.props.context ? (
+                {"getBreadcrumbs" in this.props.context &&
+                this.props.context.globalSearchQuery != null ? (
                   <BreadcrumbsTag parts={this.props.context.getBreadcrumbs(dataset)} />
                 ) : (
                   <Tag color={stringToColor(dataset.dataStore.name)}>{dataset.dataStore.name}</Tag>

--- a/frontend/javascripts/dashboard/dataset/dataset_collection_context.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_collection_context.tsx
@@ -165,10 +165,18 @@ export default function DatasetCollectionContextProvider({
     }
     const { itemById } = folderHierarchyQuery.data;
 
-    let currentFolder = itemById[dataset.folderId];
+    let currentFolder = itemById.get(dataset.folderId);
+    if (currentFolder == null) {
+      console.warn("Breadcrumbs could not be computed.");
+      return [];
+    }
     const breadcrumbs = [currentFolder.title];
     while (currentFolder?.parent != null) {
-      currentFolder = itemById[currentFolder.parent];
+      currentFolder = itemById.get(currentFolder.parent);
+      if (currentFolder == null) {
+        console.warn("Breadcrumbs could not be computed.");
+        return [];
+      }
       breadcrumbs.unshift(currentFolder.title);
     }
 

--- a/frontend/javascripts/dashboard/dataset/queries.tsx
+++ b/frontend/javascripts/dashboard/dataset/queries.tsx
@@ -537,13 +537,13 @@ function getUnobtrusivelyUpdatedDatasets(
 
 type FolderHierarchy = {
   tree: FolderItem[];
-  itemById: Record<string, FolderItem>;
+  itemById: Map<string, FolderItem>;
   flatItems: FlatFolderTreeItem[];
 };
 
 export function getFolderHierarchy(folderTree: FlatFolderTreeItem[]): FolderHierarchy {
   const roots: FolderItem[] = [];
-  const itemById: Record<string, FolderItem> = {};
+  const itemById: Map<string, FolderItem> = new Map();
   for (const folderTreeItem of folderTree) {
     const treeItem = {
       key: folderTreeItem.id,
@@ -555,18 +555,25 @@ export function getFolderHierarchy(folderTree: FlatFolderTreeItem[]): FolderHier
     if (folderTreeItem.parent == null) {
       roots.push(treeItem);
     }
-    itemById[folderTreeItem.id] = treeItem;
+    itemById.set(folderTreeItem.id, treeItem);
   }
+
+  // Satisfy TypeScript
+  const get = (id: string): FolderItem =>
+    Utils.enforceValue(
+      itemById.get(id),
+      "Unexpected error during initialization of folder structure",
+    );
 
   for (const folderTreeItem of folderTree) {
     if (folderTreeItem.parent != null) {
-      itemById[folderTreeItem.parent].children.push(itemById[folderTreeItem.id]);
+      get(folderTreeItem.parent).children.push(get(folderTreeItem.id));
     }
   }
 
   for (const folderTreeItem of folderTree) {
     if (folderTreeItem.parent != null) {
-      itemById[folderTreeItem.parent].children.sort((a, b) => a.title.localeCompare(b.title));
+      get(folderTreeItem.parent).children.sort((a, b) => a.title.localeCompare(b.title));
     }
   }
 

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -124,6 +124,13 @@ export function enforce<A, B>(fn: (arg0: A) => B): (arg0: A | null | undefined) 
   };
 }
 
+export function enforceValue<T>(val: T | null, msg?: string): NonNullable<T> {
+  if (val == null) {
+    throw new Error(msg || "Unexpected null value");
+  }
+  return val;
+}
+
 export function maybe<A, B>(fn: (arg0: A) => B): (arg0: A | null | undefined) => Maybe<B> {
   return (nullableA: A | null | undefined) => Maybe.fromNullable(nullableA).map(fn);
 }


### PR DESCRIPTION
Also: don't show breadcrubs in non-search view

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open folder view
- check that breadcrumbs are not rendered (instead, the datastore is rendered now; should I remove this in the folders tab?)
- search for a dataset --> breadcrumbs should be rendered

### Issues:
- contributes to #6669 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
