### PR TITLE
Small fixes for organization page

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -37,7 +37,7 @@ organization.list.failed=Failed to retrieve list of organizations.
 organization.name.invalid=This organization name contains illegal characters. Please only use letters and numbers.
 organization.name.alreadyInUse=This name is already claimed by a different organization and not available anymore. Please choose a different name.
 organization.alreadyJoined=Your account is already associated with the selected organization.
-organization.users.userLimitReached=Cannot add user because it would exceed the limit of included users in this plan.
+organization.users.userLimitReached=Cannot add new user to this organization because it would exceed the organization’s user limit. Please ask the organization owner to upgrade. 
 organization.pricingUpgrades.notAuthorized=You are not authorized to request any changes to your organization WEBKNOSSOS plan. Please ask the organization owner for permission.
 
 termsOfService.versionMismatch=Terms of service version mismatch. Current version is {0}, received acceptance for {1}

--- a/frontend/javascripts/admin/organization/organization_cards.tsx
+++ b/frontend/javascripts/admin/organization/organization_cards.tsx
@@ -135,7 +135,6 @@ export function PlanUpgradeCard({ organization }: { organization: APIOrganizatio
           "linear-gradient(rgba(9, 109, 217,  0.8), rgba(9, 109, 217,  0.7)), url(/assets/images/pricing/background_neuron_meshes.jpeg) 10% center / 120% no-repeat",
         color: "white",
       }}
-      headStyle={{ backgroundColor: "rgb(250, 250, 250)" }}
     >
       <p>
         Upgrading your WEBKNOSSOS plan will unlock more advanced features and increase your user and


### PR DESCRIPTION
Two small fixes for the orga page:
- Removed a CSS background color for a card which looked weird in dark mode. Fallback is the default antd colors
- Rephrased an error message when trying to join an organization and going over the user limit

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- No testing required

### Issues:
- no issue

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
