### PR TITLE
Fix exploring remote datasets with no credentials

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where deleting a dataset would fail if its representation on disk was already missing. [#6720](https://github.com/scalableminds/webknossos/pull/6720)
 - Fixed a bug where a user with multiple organizations could not log in anymore after one of their organization accounts got deactivated. [#6719](https://github.com/scalableminds/webknossos/pull/6719)
 - Fixed rare crash in new Datasets tab in dashboard. [#6750](https://github.com/scalableminds/webknossos/pull/6750) and [#6753](https://github.com/scalableminds/webknossos/pull/6753)
+- Fixed a bug where remote datasets without authentication could not be explored. [#6762](https://github.com/scalableminds/webknossos/pull/6762)
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,7 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where deleting a dataset would fail if its representation on disk was already missing. [#6720](https://github.com/scalableminds/webknossos/pull/6720)
 - Fixed a bug where a user with multiple organizations could not log in anymore after one of their organization accounts got deactivated. [#6719](https://github.com/scalableminds/webknossos/pull/6719)
 - Fixed rare crash in new Datasets tab in dashboard. [#6750](https://github.com/scalableminds/webknossos/pull/6750) and [#6753](https://github.com/scalableminds/webknossos/pull/6753)
-- Fixed a bug where remote datasets without authentication could not be explored. [#6762](https://github.com/scalableminds/webknossos/pull/6762)
+- Fixed a bug where remote datasets without authentication could not be explored. [#6764](https://github.com/scalableminds/webknossos/pull/6764)
 
 ### Removed
 

--- a/app/models/binary/explore/ExploreRemoteLayerService.scala
+++ b/app/models/binary/explore/ExploreRemoteLayerService.scala
@@ -144,11 +144,12 @@ class ExploreRemoteLayerService @Inject()(credentialService: CredentialService) 
       requestingUser: User)(implicit ec: ExecutionContext): Fox[List[(DataLayer, Vec3Double)]] =
     for {
       remoteSource <- tryo(RemoteSourceDescriptor(new URI(normalizeUri(layerUri)), user, password)).toFox ?~> s"Received invalid URI: $layerUri"
-      credentialId <- credentialService.createCredential(new URI(normalizeUri(layerUri)),
-                                                         user,
-                                                         password,
-                                                         requestingUser._id.toString,
-                                                         requestingUser._organization.toString)
+      credentialId <- credentialService.createCredential(
+        new URI(normalizeUri(layerUri)),
+        user,
+        password,
+        requestingUser._id.toString,
+        requestingUser._organization.toString) ?~> "Failed to set up remote file system credentaial"
       fileSystem <- FileSystemsHolder.getOrCreate(remoteSource).toFox ?~> "Failed to set up remote file system"
       remotePath <- tryo(fileSystem.getPath(remoteSource.remotePath)) ?~> "Failed to get remote path"
       layersWithVoxelSizes <- exploreRemoteLayersForRemotePath(

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/FileSystemsHolder.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/FileSystemsHolder.scala
@@ -18,9 +18,9 @@ class FileSystemsProvidersCache(val maxEntries: Int) extends LRUConcurrentCache[
 
 object FileSystemsHolder extends LazyLogging {
 
-  private val schemeS3 = "s3"
-  private val schemeHttps = "https"
-  private val schemeHttp = "http"
+  val schemeS3: String = "s3"
+  val schemeHttps: String = "https"
+  val schemeHttp: String = "http"
 
   private val fileSystemsCache = new FileSystemsCache(maxEntries = 100)
   private val fileSystemsProvidersCache = new FileSystemsProvidersCache(maxEntries = 100)


### PR DESCRIPTION
`Fox.successful(None)` encodes that the result is valid, but does not contain credentials. `Fox.empty` stopped the calling function’s for comprehension.

Also cleaned up some magic strings.

### URL of deployed dev instance (used for testing):
- https://exploreremotefixanonymous.webknossos.xyz

### Steps to test:
- Try exploring remote dataset with and without credentials

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
