### PR TITLE
Fix antd deprecation warning for <Modal open/visible>

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where deleting a dataset would fail if its representation on disk was already missing. [#6720](https://github.com/scalableminds/webknossos/pull/6720)
 - Fixed a bug where a user with multiple organizations could not log in anymore after one of their organization accounts got deactivated. [#6719](https://github.com/scalableminds/webknossos/pull/6719)
 - Fixed rare crash in new Datasets tab in dashboard. [#6750](https://github.com/scalableminds/webknossos/pull/6750) and [#6753](https://github.com/scalableminds/webknossos/pull/6753)
+- Fixed deprecation warnings for antd <Modal> props. [#6765](https://github.com/scalableminds/webknossos/pull/6765)
 
 ### Removed
 

--- a/frontend/javascripts/admin/auth/accept_invite_view.tsx
+++ b/frontend/javascripts/admin/auth/accept_invite_view.tsx
@@ -22,7 +22,7 @@ export default function AcceptInviteView({
   activeUser: APIUser | null | undefined;
 }) {
   const history = useHistory();
-  const [isAuthenticationModalVisible, setIsAuthenticationModalVisible] = useState(false);
+  const [isAuthenticationModalOpen, setIsAuthenticationModalOpen] = useState(false);
   const [targetOrganization, exception] = useFetch(
     async () => {
       try {
@@ -78,7 +78,7 @@ export default function AcceptInviteView({
         Join this Organization
       </AsyncButton>
     ) : (
-      <Button type="primary" onClick={() => setIsAuthenticationModalVisible(true)} size="large">
+      <Button type="primary" onClick={() => setIsAuthenticationModalOpen(true)} size="large">
         Log in / Register
       </Button>
     );
@@ -94,7 +94,7 @@ export default function AcceptInviteView({
         alertMessage={`Please register or login to join ${targetOrganizationName}.`}
         inviteToken={token}
         onLoggedIn={async (userJustRegistered) => {
-          setIsAuthenticationModalVisible(false);
+          setIsAuthenticationModalOpen(false);
 
           if (!userJustRegistered) {
             await onClickJoin();
@@ -104,8 +104,8 @@ export default function AcceptInviteView({
             onSuccessfulJoin(userJustRegistered);
           }
         }}
-        onCancel={() => setIsAuthenticationModalVisible(false)}
-        visible={isAuthenticationModalVisible}
+        onCancel={() => setIsAuthenticationModalOpen(false)}
+        isOpen={isAuthenticationModalOpen}
       />
       <Spin spinning={targetOrganization == null}>
         <Result

--- a/frontend/javascripts/admin/auth/authentication_modal.tsx
+++ b/frontend/javascripts/admin/auth/authentication_modal.tsx
@@ -11,14 +11,14 @@ import LoginForm from "./login_form";
 type Props = {
   onLoggedIn: (userJustRegistered: boolean) => unknown;
   onCancel: () => void;
-  visible: boolean;
+  isOpen: boolean;
   alertMessage: string;
   inviteToken?: string;
 };
 export default function AuthenticationModal({
   onLoggedIn,
   onCancel,
-  visible,
+  isOpen,
   alertMessage,
   inviteToken,
 }: Props) {
@@ -47,7 +47,7 @@ export default function AuthenticationModal({
       <RegistrationForm onRegistered={onRegistered} inviteToken={inviteToken} />
     );
   return (
-    <Modal title={step} onCancel={onCancel} visible={visible} footer={null} maskClosable={false}>
+    <Modal title={step} onCancel={onCancel} open={isOpen} footer={null} maskClosable={false}>
       <Alert
         message={alertMessage}
         type="info"
@@ -81,7 +81,7 @@ export function withAuthentication<P, C extends ComponentType<P>>(
   WrappedComponent: C,
 ): ComponentType<AuthenticationProps<P>> {
   return function Wrapper(props: AuthenticationProps<P>) {
-    const [isAuthenticationModalVisible, setIsAuthenticationModalVisible] = useState(false);
+    const [isAuthenticationModalOpen, setIsAuthenticationModalOpen] = useState(false);
     const { activeUser, authenticationMessage, onClick: originalOnClick, ...rest } = props;
 
     if (activeUser != null) {
@@ -91,15 +91,15 @@ export function withAuthentication<P, C extends ComponentType<P>>(
       return (
         <>
           {/* @ts-expect-error ts-migrate(2322) FIXME: Type 'Omit<AuthenticationProps<P>, "activeUser" | ... Remove this comment to see the full error message */}
-          <WrappedComponent {...rest} onClick={() => setIsAuthenticationModalVisible(true)} />
+          <WrappedComponent {...rest} onClick={() => setIsAuthenticationModalOpen(true)} />
           <AuthenticationModal
             alertMessage={authenticationMessage}
             onLoggedIn={() => {
-              setIsAuthenticationModalVisible(false);
+              setIsAuthenticationModalOpen(false);
               originalOnClick();
             }}
-            onCancel={() => setIsAuthenticationModalVisible(false)}
-            visible={isAuthenticationModalVisible}
+            onCancel={() => setIsAuthenticationModalOpen(false)}
+            isOpen={isAuthenticationModalOpen}
           />
         </>
       );

--- a/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
@@ -176,7 +176,7 @@ function DatasetAddZarrView(props: Props) {
           <Modal
             title="Add Layer"
             width={800}
-            visible={showAddLayerModal}
+            open={showAddLayerModal}
             footer={null}
             onCancel={() => setShowAddLayerModal(false)}
           >

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -433,7 +433,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
     const { isRetrying, isFinishing, uploadProgress, isUploading } = this.state;
     return (
       <Modal
-        visible={isUploading}
+        open={isUploading}
         keyboard={false}
         maskClosable={false}
         className="no-footer-modal"

--- a/frontend/javascripts/admin/onboarding.tsx
+++ b/frontend/javascripts/admin/onboarding.tsx
@@ -220,7 +220,7 @@ type InviteUsersModalState = {
 
 export class InviteUsersModal extends React.Component<
   {
-    visible?: boolean;
+    isOpen?: boolean;
     handleVisibleChange?: (...args: Array<any>) => any;
     destroy?: (...args: Array<any>) => any;
     organizationName: string;
@@ -311,7 +311,7 @@ export class InviteUsersModal extends React.Component<
 
     return (
       <Modal
-        open={this.props.visible == null ? true : this.props.visible}
+        open={this.props.isOpen == null ? true : this.props.isOpen}
         title={
           <>
             <UserAddOutlined /> Invite Users
@@ -497,7 +497,7 @@ class OnboardingView extends React.PureComponent<Props, State> {
     >
       {this.state.isDatasetUploadModalVisible && (
         <Modal
-          visible
+          open
           width="85%"
           footer={null}
           maskClosable={false}
@@ -609,7 +609,7 @@ class OnboardingView extends React.PureComponent<Props, State> {
           </LinkButton>{" "}
           <InviteUsersModal
             organizationName={this.state.organizationName}
-            visible={this.state.isInviteModalVisible}
+            isOpen={this.state.isInviteModalVisible}
             handleVisibleChange={(isInviteModalVisible) =>
               this.setState({
                 isInviteModalVisible,

--- a/frontend/javascripts/admin/project/transfer_all_tasks_modal.tsx
+++ b/frontend/javascripts/admin/project/transfer_all_tasks_modal.tsx
@@ -129,7 +129,7 @@ class TransferAllTasksModal extends React.PureComponent<Props, State> {
 
     if (!project) {
       return (
-        <Modal title="Error" visible onOk={this.props.onCancel} onCancel={this.props.onCancel}>
+        <Modal title="Error" open onOk={this.props.onCancel} onCancel={this.props.onCancel}>
           <p>{messages["project.none_selected"]}</p>
         </Modal>
       );
@@ -138,7 +138,7 @@ class TransferAllTasksModal extends React.PureComponent<Props, State> {
       return (
         <Modal
           title={title}
-          visible
+          open
           onCancel={this.props.onCancel}
           // @ts-expect-error ts-migrate(2322) FIXME: Type '{ children: (string | Element)[]; title: str... Remove this comment to see the full error message
           pagination="false"

--- a/frontend/javascripts/admin/task/task_annotation_view.tsx
+++ b/frontend/javascripts/admin/task/task_annotation_view.tsx
@@ -40,7 +40,7 @@ type StateProps = {
 };
 type Props = OwnProps & StateProps;
 type State = {
-  isTransferModalVisible: boolean;
+  isTransferModalOpen: boolean;
   annotations: Array<APIAnnotation>;
   currentAnnotation: APIAnnotation | null | undefined;
 };
@@ -48,7 +48,7 @@ type State = {
 class TaskAnnotationView extends React.PureComponent<Props, State> {
   state: State = {
     currentAnnotation: null,
-    isTransferModalVisible: false,
+    isTransferModalOpen: false,
     annotations: [],
   };
 
@@ -94,7 +94,7 @@ class TaskAnnotationView extends React.PureComponent<Props, State> {
 
   updateAnnotationState = (updatedAnnotation: APIAnnotation) => {
     this.setState((prevState) => ({
-      isTransferModalVisible: false,
+      isTransferModalOpen: false,
       annotations: prevState.annotations.map((a) =>
         a.id === updatedAnnotation.id ? updatedAnnotation : a,
       ),
@@ -131,7 +131,7 @@ class TaskAnnotationView extends React.PureComponent<Props, State> {
           onClick={() =>
             this.setState({
               currentAnnotation: annotation,
-              isTransferModalVisible: true,
+              isTransferModalOpen: true,
             })
           }
         >
@@ -219,11 +219,11 @@ class TaskAnnotationView extends React.PureComponent<Props, State> {
         </table>
         {this.state.currentAnnotation?.owner ? (
           <TransferTaskModal
-            visible={this.state.isTransferModalVisible}
+            isOpen={this.state.isTransferModalOpen}
             annotationId={this.state.currentAnnotation.id}
             onCancel={() =>
               this.setState({
-                isTransferModalVisible: false,
+                isTransferModalOpen: false,
               })
             }
             onChange={this.updateAnnotationState}

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -46,7 +46,7 @@ type State = {
   users: APIUser[];
   searchQuery: string;
   selectedUserIdForAssignment: string | null;
-  isAnonymousTaskLinkModalVisible: boolean;
+  isAnonymousTaskLinkModalOpen: boolean;
 };
 const typeHint: Array<APITask> = [];
 const persistence = new Persistence<Pick<State, "searchQuery">>(
@@ -63,7 +63,7 @@ class TaskListView extends React.PureComponent<Props, State> {
     users: [],
     searchQuery: "",
     selectedUserIdForAssignment: null,
-    isAnonymousTaskLinkModalVisible: Utils.hasUrlParam("showAnonymousLinks"),
+    isAnonymousTaskLinkModalOpen: Utils.hasUrlParam("showAnonymousLinks"),
   };
 
   componentDidMount() {
@@ -200,7 +200,7 @@ class TaskListView extends React.PureComponent<Props, State> {
   getAnonymousTaskLinkModal() {
     const anonymousTaskId = Utils.getUrlParamValue("showAnonymousLinks");
 
-    if (!this.state.isAnonymousTaskLinkModalVisible) {
+    if (!this.state.isAnonymousTaskLinkModalOpen) {
       return null;
     }
 
@@ -211,18 +211,18 @@ class TaskListView extends React.PureComponent<Props, State> {
     return (
       <Modal
         title={`Anonymous Task Links for Task ${anonymousTaskId}`}
-        visible={this.state.isAnonymousTaskLinkModalVisible}
+        open={this.state.isAnonymousTaskLinkModalOpen}
         onOk={() => {
           navigator.clipboard
             .writeText(tasksString)
             .then(() => Toast.success("Links copied to clipboard"));
           this.setState({
-            isAnonymousTaskLinkModalVisible: false,
+            isAnonymousTaskLinkModalOpen: false,
           });
         }}
         onCancel={() =>
           this.setState({
-            isAnonymousTaskLinkModalVisible: false,
+            isAnonymousTaskLinkModalOpen: false,
           })
         }
       >

--- a/frontend/javascripts/admin/team/create_team_modal_view.tsx
+++ b/frontend/javascripts/admin/team/create_team_modal_view.tsx
@@ -7,10 +7,10 @@ const FormItem = Form.Item;
 type Props = {
   onOk: (...args: Array<any>) => any;
   onCancel: (...args: Array<any>) => any;
-  isVisible: boolean;
+  isOpen: boolean;
 };
 
-function CreateTeamModalForm({ onOk: onOkCallback, onCancel, isVisible }: Props) {
+function CreateTeamModalForm({ onOk: onOkCallback, onCancel, isOpen }: Props) {
   const [form] = Form.useForm();
 
   const onOk = async () => {
@@ -32,7 +32,7 @@ function CreateTeamModalForm({ onOk: onOkCallback, onCancel, isVisible }: Props)
   };
 
   return (
-    <Modal visible={isVisible} title="Add a New Team" okText="Ok" onCancel={onCancel} onOk={onOk}>
+    <Modal open={isOpen} title="Add a New Team" okText="Ok" onCancel={onCancel} onOk={onOk}>
       <Shortcut keys="enter" onTrigger={onOk} supportInputElements />
 
       <Form layout="vertical" form={form}>

--- a/frontend/javascripts/admin/team/team_list_view.tsx
+++ b/frontend/javascripts/admin/team/team_list_view.tsx
@@ -193,7 +193,7 @@ class TeamListView extends React.PureComponent<Props, State> {
           <CreateTeamModal
             // @ts-expect-error ts-migrate(2322) FIXME: Type '{ teams: never[]; isVisible: boolean; onOk: ... Remove this comment to see the full error message
             teams={this.state.teams}
-            isVisible={this.state.isTeamCreationModalVisible}
+            isOpen={this.state.isTeamCreationModalVisible}
             onOk={this.createTeam}
             onCancel={() =>
               this.setState({

--- a/frontend/javascripts/admin/user/experience_modal_view.tsx
+++ b/frontend/javascripts/admin/user/experience_modal_view.tsx
@@ -26,7 +26,7 @@ type TableEntry = {
 type Props = {
   onChange: (arg0: Array<APIUser>) => void;
   onCancel: () => void;
-  visible: boolean;
+  isOpen: boolean;
   selectedUsers: Array<APIUser>;
   initialDomainToEdit: string | null | undefined;
 };
@@ -230,7 +230,7 @@ class ExperienceModalView extends React.PureComponent<Props, State> {
   render() {
     const selectedUsersCount = this.props.selectedUsers.length;
 
-    if (!this.props.visible && selectedUsersCount === 0) {
+    if (!this.props.isOpen && selectedUsersCount === 0) {
       return null;
     }
 
@@ -244,7 +244,7 @@ class ExperienceModalView extends React.PureComponent<Props, State> {
             ? `Change Experiences of ${selectedUsersCount} Users`
             : `Change Experiences for ${this.props.selectedUsers[0].firstName} ${this.props.selectedUsers[0].lastName}`
         }
-        visible={this.props.visible}
+        open={this.props.isOpen}
         onCancel={this.props.onCancel}
         width={multipleUsers ? 800 : 600}
         maskClosable={false}

--- a/frontend/javascripts/admin/user/permissions_and_teams_modal_view.tsx
+++ b/frontend/javascripts/admin/user/permissions_and_teams_modal_view.tsx
@@ -23,7 +23,7 @@ enum PERMISSIONS {
 type TeamRoleModalProp = {
   onChange: (...args: Array<any>) => any;
   onCancel: (...args: Array<any>) => any;
-  visible: boolean;
+  isOpen: boolean;
   selectedUserIds: Key[];
   users: Array<APIUser>;
   activeUser: APIUser;
@@ -340,7 +340,7 @@ class PermissionsAndTeamsModalView extends React.PureComponent<TeamRoleModalProp
       <Modal
         maskClosable={false}
         closable={false}
-        visible={this.props.visible}
+        open={this.props.isOpen}
         onCancel={this.props.onCancel}
         footer={
           <div>

--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -51,9 +51,9 @@ type State = {
   isLoading: boolean;
   users: Array<APIUser>;
   selectedUserIds: Key[];
-  isExperienceModalVisible: boolean;
-  isTeamRoleModalVisible: boolean;
-  isInviteModalVisible: boolean;
+  isExperienceModalOpen: boolean;
+  isTeamRoleModalOpen: boolean;
+  isInviteModalOpen: boolean;
   singleSelectedUser: APIUser | null | undefined;
   activationFilter: Array<"true" | "false">;
   searchQuery: string;
@@ -73,9 +73,9 @@ class UserListView extends React.PureComponent<Props, State> {
     isLoading: true,
     users: [],
     selectedUserIds: [],
-    isExperienceModalVisible: false,
-    isTeamRoleModalVisible: false,
-    isInviteModalVisible: false,
+    isExperienceModalOpen: false,
+    isTeamRoleModalOpen: false,
+    isInviteModalOpen: false,
     activationFilter: ["true"],
     searchQuery: "",
     singleSelectedUser: null,
@@ -90,7 +90,7 @@ class UserListView extends React.PureComponent<Props, State> {
 
     if (location.hash === "#invite") {
       this.setState({
-        isInviteModalVisible: true,
+        isInviteModalOpen: true,
       });
     }
   }
@@ -131,7 +131,7 @@ class UserListView extends React.PureComponent<Props, State> {
         this.setState({
           users: newUsers,
           selectedUserIds: [selectedUser.id],
-          isTeamRoleModalVisible: isActive,
+          isTeamRoleModalOpen: isActive,
         });
       },
       () => {}, // Do nothing, change did not succeed
@@ -169,8 +169,8 @@ class UserListView extends React.PureComponent<Props, State> {
   handleUsersChange = (updatedUsers: Array<APIUser>): void => {
     this.setState({
       users: updatedUsers,
-      isExperienceModalVisible: false,
-      isTeamRoleModalVisible: false,
+      isExperienceModalOpen: false,
+      isTeamRoleModalOpen: false,
     });
   };
 
@@ -178,7 +178,7 @@ class UserListView extends React.PureComponent<Props, State> {
     const updatedUsersMap = _.keyBy(updatedUsers, (u) => u.id);
 
     this.setState((prevState) => ({
-      isExperienceModalVisible: false,
+      isExperienceModalOpen: false,
       users: prevState.users.map((user) => updatedUsersMap[user.id] || user),
       singleSelectedUser: null,
       selectedUserIds: prevState.singleSelectedUser == null ? [] : prevState.selectedUserIds,
@@ -246,7 +246,7 @@ class UserListView extends React.PureComponent<Props, State> {
   renderInviteUsersAlert() {
     const inviteUsersCallback = () =>
       this.setState({
-        isInviteModalVisible: true,
+        isInviteModalOpen: true,
       });
 
     const noUsersMessage = (
@@ -359,7 +359,7 @@ class UserListView extends React.PureComponent<Props, State> {
           <Button
             onClick={() =>
               this.setState({
-                isTeamRoleModalVisible: true,
+                isTeamRoleModalOpen: true,
               })
             }
             icon={<TeamOutlined />}
@@ -371,7 +371,7 @@ class UserListView extends React.PureComponent<Props, State> {
           <Button
             onClick={() => {
               this.setState({
-                isExperienceModalVisible: true,
+                isExperienceModalOpen: true,
               });
             }}
             icon={<TrophyOutlined />}
@@ -386,7 +386,7 @@ class UserListView extends React.PureComponent<Props, State> {
             style={marginRight}
             onClick={() =>
               this.setState({
-                isInviteModalVisible: true,
+                isInviteModalOpen: true,
               })
             }
           >
@@ -395,11 +395,11 @@ class UserListView extends React.PureComponent<Props, State> {
           <InviteUsersModal
             currentUserCount={getActiveUserCount(this.state.users)}
             maxUserCountPerOrganization={this.state.maxUserCountPerOrganization}
-            visible={this.state.isInviteModalVisible}
+            isOpen={this.state.isInviteModalOpen}
             organizationName={this.props.activeUser.organization}
             handleVisibleChange={(visible) => {
               this.setState({
-                isInviteModalVisible: visible,
+                isInviteModalOpen: visible,
               });
             }}
           />
@@ -518,7 +518,7 @@ class UserListView extends React.PureComponent<Props, State> {
                           // If no user is selected, set singleSelectedUser. Otherwise,
                           // open the modal so that all selected users are edited.
                           singleSelectedUser: prevState.selectedUserIds.length > 0 ? null : user,
-                          isExperienceModalVisible: true,
+                          isExperienceModalOpen: true,
                           domainToEdit: domain,
                         }));
                       }}
@@ -643,9 +643,9 @@ class UserListView extends React.PureComponent<Props, State> {
             />
           </Table>
         </Spin>
-        {this.state.isExperienceModalVisible ? (
+        {this.state.isExperienceModalOpen ? (
           <ExperienceModalView
-            visible={this.state.isExperienceModalVisible}
+            isOpen={this.state.isExperienceModalOpen}
             selectedUsers={
               this.state.singleSelectedUser
                 ? [this.state.singleSelectedUser]
@@ -655,7 +655,7 @@ class UserListView extends React.PureComponent<Props, State> {
             onChange={this.closeExperienceModal}
             onCancel={() =>
               this.setState({
-                isExperienceModalVisible: false,
+                isExperienceModalOpen: false,
                 singleSelectedUser: null,
                 domainToEdit: null,
               })
@@ -663,13 +663,13 @@ class UserListView extends React.PureComponent<Props, State> {
           />
         ) : null}
         <PermissionsAndTeamsModalView
-          visible={this.state.isTeamRoleModalVisible}
+          isOpen={this.state.isTeamRoleModalOpen}
           selectedUserIds={this.state.selectedUserIds}
           users={this.state.users}
           onChange={this.handleUsersChange}
           onCancel={() =>
             this.setState({
-              isTeamRoleModalVisible: false,
+              isTeamRoleModalOpen: false,
             })
           }
           activeUser={this.props.activeUser}

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -65,7 +65,7 @@ type Props = OwnProps & StateProps;
 type State = {
   showFinishedTasks: boolean;
   isLoading: boolean;
-  isTransferModalVisible: boolean;
+  isTransferModalOpen: boolean;
   currentAnnotationId: string | null | undefined;
   finishedModeState: TaskModeState;
   unfinishedModeState: TaskModeState;
@@ -110,7 +110,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
   state: State = {
     showFinishedTasks: false,
     isLoading: false,
-    isTransferModalVisible: false,
+    isTransferModalOpen: false,
     currentAnnotationId: null,
     finishedModeState: {
       tasks: [],
@@ -223,7 +223,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
 
   openTransferModal(annotationId: string) {
     this.setState({
-      isTransferModalVisible: true,
+      isTransferModalOpen: true,
       currentAnnotationId: annotationId,
     });
   }
@@ -374,7 +374,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
 
   handleTransferredTask() {
     this.setState({
-      isTransferModalVisible: false,
+      isTransferModalOpen: false,
     });
 
     const removeTransferredTask = (
@@ -554,11 +554,11 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
           ) : null}
         </div>
         <TransferTaskModal
-          visible={this.state.isTransferModalVisible}
+          isOpen={this.state.isTransferModalOpen}
           annotationId={this.state.currentAnnotationId}
           onCancel={() =>
             this.setState({
-              isTransferModalVisible: false,
+              isTransferModalOpen: false,
             })
           }
           onChange={() => this.handleTransferredTask()}

--- a/frontend/javascripts/dashboard/transfer_task_modal.tsx
+++ b/frontend/javascripts/dashboard/transfer_task_modal.tsx
@@ -9,7 +9,7 @@ type Props = {
   onChange: (updatedAnnotation: APIAnnotation) => void;
   annotationId: string | null | undefined;
   onCancel: (...args: Array<any>) => any;
-  visible: boolean;
+  isOpen: boolean;
 };
 type State = {
   currentUserIdValue: string;
@@ -42,14 +42,14 @@ class TransferTaskModal extends React.PureComponent<Props, State> {
   };
 
   render() {
-    if (!this.props.visible) {
+    if (!this.props.isOpen) {
       return null;
     }
 
     return (
       <Modal
         title="Transfer a Task"
-        visible={this.props.visible}
+        open={this.props.isOpen}
         onCancel={this.props.onCancel}
         footer={
           <div>

--- a/frontend/javascripts/libs/react_helpers.tsx
+++ b/frontend/javascripts/libs/react_helpers.tsx
@@ -69,17 +69,17 @@ export function usePolledState(callback: (arg0: OxalisState) => void, interval: 
   }, interval);
 }
 
-export function makeComponentLazy<T extends { isVisible: boolean }>(
+export function makeComponentLazy<T extends { isOpen: boolean }>(
   ComponentFn: React.ComponentType<T>,
 ): React.ComponentType<T> {
   return function LazyModalWrapper(props: T) {
     const [hasBeenInitialized, setHasBeenInitialized] = useState(false);
-    const isVisible = props.isVisible;
+    const isOpen = props.isOpen;
     useEffect(() => {
-      setHasBeenInitialized(hasBeenInitialized || isVisible);
-    }, [isVisible]);
+      setHasBeenInitialized(hasBeenInitialized || isOpen);
+    }, [isOpen]);
 
-    if (isVisible || hasBeenInitialized) {
+    if (isOpen || hasBeenInitialized) {
       return <ComponentFn {...props} />;
     }
     return null;

--- a/frontend/javascripts/oxalis/view/action-bar/add_new_layout_modal.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/add_new_layout_modal.tsx
@@ -1,8 +1,9 @@
 import { Input, Modal } from "antd";
 import * as React from "react";
+
 type Props = {
   addLayout: (arg0: string) => void;
-  open: boolean;
+  isOpen: boolean;
   onCancel: () => void;
 };
 type State = {
@@ -25,7 +26,7 @@ class AddNewLayoutModal extends React.PureComponent<Props, State> {
     return (
       <Modal
         title="Add a new layout"
-        open={this.props.open}
+        open={this.props.isOpen}
         onOk={this.onConfirm}
         onCancel={this.props.onCancel}
       >

--- a/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
@@ -27,7 +27,7 @@ const CheckboxGroup = Checkbox.Group;
 const { TabPane } = Tabs;
 const { Paragraph, Text } = Typography;
 type Props = {
-  isVisible: boolean;
+  isOpen: boolean;
   onClose: () => void;
   annotationType: APIAnnotationType;
   annotationId: string;
@@ -124,7 +124,7 @@ function Footer({
 }
 
 function _DownloadModalView(props: Props): JSX.Element {
-  const { isVisible, onClose, annotationType, annotationId, hasVolumeFallback } = props;
+  const { isOpen, onClose, annotationType, annotationId, hasVolumeFallback } = props;
 
   const [activeTabKey, setActiveTabKey] = useState("download");
   const [includeVolumeData, setIncludeVolumeData] = useState(true);
@@ -298,7 +298,7 @@ with wk.webknossos_context(
   return (
     <Modal
       title="Download this annotation"
-      visible={isVisible}
+      open={isOpen}
       width={600}
       footer={[
         <Footer

--- a/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/merge_modal_view.tsx
@@ -27,7 +27,7 @@ type ProjectInfo = {
   label: string;
 };
 type OwnProps = {
-  isVisible: boolean;
+  isOpen: boolean;
   onOk: () => void;
 };
 type StateProps = {
@@ -232,7 +232,7 @@ class _MergeModalView extends PureComponent<Props, MergeModalViewState> {
     return (
       <Modal
         title="Merge"
-        visible={this.props.isVisible}
+        open={this.props.isOpen}
         onCancel={this.props.onOk}
         className="merge-modal"
         width={800}

--- a/frontend/javascripts/oxalis/view/action-bar/private_links_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/private_links_view.tsx
@@ -404,11 +404,11 @@ function PrivateLinksView({ annotationId }: { annotationId: string }) {
 }
 
 export function _PrivateLinksModal({
-  isVisible,
+  isOpen,
   onOk,
   annotationId,
 }: {
-  isVisible: boolean;
+  isOpen: boolean;
   onOk: () => void;
   annotationId: string;
 }) {
@@ -420,7 +420,7 @@ export function _PrivateLinksModal({
   return (
     <Modal
       title="Manage Zarr Links"
-      visible={isVisible}
+      open={isOpen}
       width={800}
       onCancel={onOk}
       onOk={onOk}

--- a/frontend/javascripts/oxalis/view/action-bar/python_client_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/python_client_modal_view.tsx
@@ -9,12 +9,12 @@ import type { OxalisState } from "oxalis/store";
 import { CopyableCodeSnippet, MoreInfoHint } from "./download_modal_view";
 const { Paragraph, Text } = Typography;
 type Props = {
-  isVisible: boolean;
+  isOpen: boolean;
   onClose: () => void;
 };
 
 function _PythonClientModalView(props: Props): JSX.Element {
-  const { isVisible, onClose } = props;
+  const { isOpen, onClose } = props;
   const activeUser = useSelector((state: OxalisState) => state.activeUser);
   const dataset = useSelector((state: OxalisState) => state.dataset);
 
@@ -78,7 +78,7 @@ with wk.webknossos_context(token="${authToken || "<insert token here>"}"${contex
   return (
     <Modal
       title="Python Client"
-      visible={isVisible}
+      open={isOpen}
       width={800}
       footer={null}
       onCancel={onClose}

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -48,7 +48,7 @@ import { AsyncButton } from "components/async_clickables";
 const RadioGroup = Radio.Group;
 const sharingActiveNode = true;
 type Props = {
-  isVisible: boolean;
+  isOpen: boolean;
   onOk: () => void;
   annotationType: APIAnnotationType;
   annotationId: string;
@@ -168,7 +168,7 @@ export function ShareButton(props: { dataset: APIDataset; style?: Record<string,
 }
 
 function _ShareModalView(props: Props) {
-  const { isVisible, onOk, annotationType, annotationId } = props;
+  const { isOpen, onOk, annotationType, annotationId } = props;
   const dataset = useSelector((state: OxalisState) => state.dataset);
   const tracing = useSelector((state: OxalisState) => state.tracing);
   const activeUser = useSelector((state: OxalisState) => state.activeUser);
@@ -333,7 +333,7 @@ function _ShareModalView(props: Props) {
   return (
     <Modal
       title="Share this annotation"
-      visible={isVisible}
+      open={isOpen}
       width={800}
       onOk={onOk}
       onCancel={onOk}
@@ -349,7 +349,7 @@ function _ShareModalView(props: Props) {
           Sharing Link
         </Col>
         <Col span={18}>
-          <CopyableSharingLink isVisible={isVisible} longUrl={longUrl} />
+          <CopyableSharingLink isVisible={isOpen} longUrl={longUrl} />
           <Hint
             style={{
               margin: "4px 9px 12px 4px",

--- a/frontend/javascripts/oxalis/view/action-bar/share_view_dataset_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_view_dataset_modal_view.tsx
@@ -11,12 +11,12 @@ import { useZarrLinkMenu } from "./private_links_view";
 const sharingActiveNode = false;
 
 type Props = {
-  isVisible: boolean;
+  isOpen: boolean;
   onOk: () => any;
 };
 
 function _ShareViewDatasetModalView(props: Props) {
-  const { isVisible, onOk } = props;
+  const { isOpen, onOk } = props;
   const dataset = useSelector((state: OxalisState) => state.dataset);
   const sharingToken = useDatasetSharingToken(dataset);
   const longUrl = getUrl(sharingToken, !dataset.isPublic);
@@ -26,7 +26,7 @@ function _ShareViewDatasetModalView(props: Props) {
   return (
     <Modal
       title="Share this Dataset"
-      visible={isVisible}
+      open={isOpen}
       width={800}
       okText="Ok"
       onOk={onOk}
@@ -42,7 +42,7 @@ function _ShareViewDatasetModalView(props: Props) {
           Sharing Link
         </Col>
         <Col span={18}>
-          <CopyableSharingLink isVisible={isVisible} longUrl={longUrl} />
+          <CopyableSharingLink isVisible={isOpen} longUrl={longUrl} />
 
           <div
             style={{

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
@@ -573,7 +573,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
       modals.push(
         <DownloadModalView
           key="download-modal"
-          isVisible={this.props.isDownloadModalOpen}
+          isOpen={this.props.isDownloadModalOpen}
           onClose={this.handleDownloadClose}
           annotationType={annotationType}
           annotationId={annotationId}
@@ -601,7 +601,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     modals.push(
       <ShareModalView
         key="share-modal"
-        isVisible={this.props.isShareModalOpen}
+        isOpen={this.props.isShareModalOpen}
         onOk={this.handleShareClose}
         annotationType={annotationType}
         annotationId={annotationId}
@@ -610,7 +610,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     modals.push(
       <PrivateLinksModal
         key="private-links-modal"
-        isVisible={this.state.isZarrPrivateLinksModalOpen}
+        isOpen={this.state.isZarrPrivateLinksModalOpen}
         onOk={() => this.setState({ isZarrPrivateLinksModalOpen: false })}
         annotationId={annotationId}
       />,
@@ -633,7 +633,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
     modals.push(
       <UserScriptsModalView
         key="user-scripts-modal"
-        isVisible={this.state.isUserScriptsModalOpen}
+        isOpen={this.state.isUserScriptsModalOpen}
         onOK={this.handleUserScriptsClose}
       />,
     );
@@ -648,7 +648,7 @@ class TracingActionsView extends React.PureComponent<Props, State> {
       modals.push(
         <MergeModalView
           key="merge-modal"
-          isVisible={this.state.isMergeModalOpen}
+          isOpen={this.state.isMergeModalOpen}
           onOk={this.handleMergeClose}
         />,
       );

--- a/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/user_scripts_modal_view.tsx
@@ -13,7 +13,7 @@ const { TextArea } = Input;
 
 type UserScriptsModalViewProps = {
   onOK: (...args: Array<any>) => any;
-  isVisible: boolean;
+  isOpen: boolean;
 };
 type State = {
   code: string;
@@ -116,7 +116,7 @@ class _UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProp
   render() {
     return (
       <Modal
-        visible={this.props.isVisible}
+        open={this.props.isOpen}
         title="Add User Script"
         okText="Add"
         cancelText="Close"

--- a/frontend/javascripts/oxalis/view/action-bar/view_dataset_actions_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/view_dataset_actions_view.tsx
@@ -33,13 +33,13 @@ export default function ViewDatasetActionsView(props: Props) {
   );
   const shareDatasetModal = (
     <ShareViewDatasetModalView
-      isVisible={isShareModalOpen}
+      isOpen={isShareModalOpen}
       onOk={() => Store.dispatch(setShareModalVisibilityAction(false))}
     />
   );
   const pythonClientModal = (
     <PythonClientModalView
-      isVisible={isPythonClientModalOpen}
+      isOpen={isPythonClientModalOpen}
       onClose={() => Store.dispatch(setPythonClientModalVisibilityAction(false))}
     />
   );

--- a/frontend/javascripts/oxalis/view/action_bar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action_bar_view.tsx
@@ -55,12 +55,12 @@ type OwnProps = {
 };
 type Props = OwnProps & StateProps;
 type State = {
-  isNewLayoutModalVisible: boolean;
+  isNewLayoutModalOpen: boolean;
 };
 
 class ActionBarView extends React.PureComponent<Props, State> {
   state: State = {
-    isNewLayoutModalVisible: false,
+    isNewLayoutModalOpen: false,
   };
 
   handleResetLayout = () => {
@@ -77,7 +77,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
 
   addNewLayout = (layoutName: string) => {
     this.setState({
-      isNewLayoutModalVisible: false,
+      isNewLayoutModalOpen: false,
     });
     const configForLayout = getLayoutConfig(
       this.props.layoutProps.layoutKey,
@@ -155,7 +155,7 @@ class ActionBarView extends React.PureComponent<Props, State> {
         key="layout-menu"
         addNewLayout={() => {
           this.setState({
-            isNewLayoutModalVisible: true,
+            isNewLayoutModalOpen: true,
           });
         }}
         onResetLayout={this.handleResetLayout}
@@ -179,10 +179,10 @@ class ActionBarView extends React.PureComponent<Props, State> {
         </div>
         <AddNewLayoutModal
           addLayout={this.addNewLayout}
-          open={this.state.isNewLayoutModalVisible}
+          isOpen={this.state.isNewLayoutModalOpen}
           onCancel={() =>
             this.setState({
-              isNewLayoutModalVisible: false,
+              isNewLayoutModalOpen: false,
             })
           }
         />

--- a/frontend/javascripts/oxalis/view/components/editable_text_label.tsx
+++ b/frontend/javascripts/oxalis/view/components/editable_text_label.tsx
@@ -149,7 +149,7 @@ class EditableTextLabel extends React.PureComponent<EditableTextLabelProp, State
           ) : (
             <MarkdownModal
               source={this.state.value}
-              visible={this.state.isEditing}
+              isOpen={this.state.isEditing}
               onChange={this.handleInputChange}
               onOk={this.handleOnChange}
               label={this.props.label}

--- a/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
+++ b/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
@@ -24,14 +24,14 @@ export function MarkdownWrapper({ source, singleLine }: { source: string; single
 }
 export function MarkdownModal({
   source,
-  visible,
+  isOpen,
   onOk,
   onChange,
   label,
 }: {
   source: string;
   label: string;
-  visible?: boolean;
+  isOpen?: boolean;
   onOk: () => void;
   onChange: (arg0: React.SyntheticEvent) => void;
 }) {
@@ -39,7 +39,7 @@ export function MarkdownModal({
     <Modal
       key="comment-markdown-modal"
       title={<span>{`Edit ${label}`}</span>}
-      visible={visible}
+      open={isOpen}
       onCancel={onOk}
       closable={false}
       width={700}

--- a/frontend/javascripts/oxalis/view/new_task_description_modal.tsx
+++ b/frontend/javascripts/oxalis/view/new_task_description_modal.tsx
@@ -9,13 +9,13 @@ type Props = {
 };
 type State = {
   mayClose: boolean;
-  visible: boolean;
+  isOpen: boolean;
 };
 export default class NewTaskDescriptionModal extends React.Component<Props, State> {
   timeoutId: ReturnType<typeof setTimeout> | undefined;
   state: State = {
     mayClose: false,
-    visible: true,
+    isOpen: true,
   };
 
   componentDidMount() {
@@ -45,7 +45,7 @@ export default class NewTaskDescriptionModal extends React.Component<Props, Stat
     }
 
     this.setState({
-      visible: false,
+      isOpen: false,
     });
     this.props.destroy();
   };
@@ -54,7 +54,7 @@ export default class NewTaskDescriptionModal extends React.Component<Props, Stat
     return (
       <Modal
         maskClosable={false}
-        visible={this.state.visible}
+        open={this.state.isOpen}
         title={this.props.title}
         onOk={this.handleOk}
         onCancel={this.handleOk}

--- a/frontend/javascripts/oxalis/view/recommended_configuration_modal.tsx
+++ b/frontend/javascripts/oxalis/view/recommended_configuration_modal.tsx
@@ -24,11 +24,11 @@ type Props = {
   destroy: () => void;
 };
 type State = {
-  visible: boolean;
+  isOpen: boolean;
 };
 export default class RecommendedConfigurationModal extends React.Component<Props, State> {
   state: State = {
-    visible: true,
+    isOpen: true,
   };
 
   handleOk = () => {
@@ -38,7 +38,7 @@ export default class RecommendedConfigurationModal extends React.Component<Props
 
   hide = () => {
     this.setState({
-      visible: false,
+      isOpen: false,
     });
     this.props.destroy();
   };
@@ -56,7 +56,7 @@ export default class RecommendedConfigurationModal extends React.Component<Props
     return (
       <Modal
         maskClosable={false}
-        visible={this.state.visible}
+        open={this.state.isOpen}
         title="Recommended Configuration"
         okText="Accept"
         cancelText="Decline"

--- a/frontend/javascripts/oxalis/view/remove_tree_modal.tsx
+++ b/frontend/javascripts/oxalis/view/remove_tree_modal.tsx
@@ -10,12 +10,12 @@ type Props = {
 };
 type State = {
   shouldNotWarnAgain: boolean;
-  visible: boolean;
+  isOpen: boolean;
 };
 export default class TreeRemovalModal extends React.Component<Props, State> {
   state = {
     shouldNotWarnAgain: false,
-    visible: true,
+    isOpen: true,
   };
 
   handleCheckboxChange = (event: CheckboxChangeEvent) => {
@@ -26,7 +26,7 @@ export default class TreeRemovalModal extends React.Component<Props, State> {
 
   hide = () => {
     this.setState({
-      visible: false,
+      isOpen: false,
     });
     if (this.props.destroy) this.props.destroy();
   };
@@ -45,7 +45,7 @@ export default class TreeRemovalModal extends React.Component<Props, State> {
         title={messages["tracing.delete_tree"]}
         onOk={this.handleOk}
         onCancel={this.hide}
-        visible={this.state.visible}
+        open={this.state.isOpen}
       >
         <Checkbox onChange={this.handleCheckboxChange} checked={this.state.shouldNotWarnAgain}>
           Do not warn me again. (Remember, accidentally deleted trees can always be restored using

--- a/frontend/javascripts/oxalis/view/right-border-tabs/comment_tab/comment_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/comment_tab/comment_tab_view.tsx
@@ -88,7 +88,7 @@ type CommentTabState = {
   isSortedAscending: boolean;
   sortBy: SortByEnumType;
   collapsedTreeIds: Record<number, boolean>;
-  isMarkdownModalVisible: boolean;
+  isMarkdownModalOpen: boolean;
 };
 const RELEVANT_ACTIONS_FOR_COMMENTS = [
   "updateTree",
@@ -142,7 +142,7 @@ class CommentTabView extends React.Component<PropsWithSkeleton, CommentTabState>
     isSortedAscending: true,
     sortBy: SortByEnum.NAME,
     collapsedTreeIds: {},
-    isMarkdownModalVisible: false,
+    isMarkdownModalOpen: false,
   };
 
   componentDidMount() {
@@ -311,7 +311,7 @@ class CommentTabView extends React.Component<PropsWithSkeleton, CommentTabState>
 
   setMarkdownModalVisibility = (visible: boolean) => {
     this.setState({
-      isMarkdownModalVisible: visible,
+      isMarkdownModalOpen: visible,
     });
   };
 
@@ -328,7 +328,7 @@ class CommentTabView extends React.Component<PropsWithSkeleton, CommentTabState>
         <MarkdownModal
           key={comment.nodeId}
           source={comment.content}
-          visible={this.state.isMarkdownModalVisible}
+          isOpen={this.state.isMarkdownModalOpen}
           onChange={this.handleChangeInput}
           onOk={onOk}
           label="Comment"
@@ -420,7 +420,7 @@ class CommentTabView extends React.Component<PropsWithSkeleton, CommentTabState>
       >
         <DomVisibilityObserver targetId={commentTabId}>
           {(isVisibleInDom) => {
-            if (!isVisibleInDom && !this.state.isMarkdownModalVisible) {
+            if (!isVisibleInDom && !this.state.isMarkdownModalOpen) {
               return null;
             }
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/skeleton_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/skeleton_tab_view.tsx
@@ -800,7 +800,7 @@ class SkeletonTabView extends React.PureComponent<Props, State> {
             !isVisibleInDom ? null : (
               <React.Fragment>
                 <Modal
-                  visible={this.state.isDownloading || this.state.isUploading}
+                  open={this.state.isDownloading || this.state.isUploading}
                   title={title}
                   closable={false}
                   footer={null}


### PR DESCRIPTION
I received a lot of `antd` deprecation warning/erros in my developer console about a `<Modal>` components' `visible` props. The prop has been renamed to `open`.
This PR refactors a bunch of wk modals to use the new `open` prop name. Wherever possible is also renamed of props/state accordingly. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Run type checker/linter
- Open as many modals as you can think of

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
