### PR TITLE
Fix direct task assignment query

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed incorrect loading of precomputed meshes from mesh files that were computed for a specific mapping. [#6771](https://github.com/scalableminds/webknossos/pull/6771)
 - Fixed a bug where remote datasets without authentication could not be explored. [#6764](https://github.com/scalableminds/webknossos/pull/6764)
 - Fixed deprecation warnings for antd <Modal> props. [#6765](https://github.com/scalableminds/webknossos/pull/6765)
+- Fixed a bug where direct task assignment to a single user would fail. [#6777](https://github.com/scalableminds/webknossos/pull/6777)
 
 ### Removed
 

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -180,7 +180,7 @@ class TaskDAO @Inject()(sqlClient: SqlClient, projectDAO: ProjectDAO)(implicit e
       dataset as (select _id from webknossos.datasets_ limit 1)
       insert into webknossos.annotations(_id, _dataSet, _task, _team, _user, description, visibility, name, state, statistics, tags, tracingTime, typ, created, modified, isDeleted)
       select $annotationId, dataset._id, task._id, ${teamIds.headOption}, $userId, '',
-             ${AnnotationVisibility.Internal}, '', ${AnnotationState.Initializing.toString}, '{}', '{}', 0, 'Task', $now, $now, false
+             ${AnnotationVisibility.Internal}, '', ${AnnotationState.Initializing}, '{}', '{}', 0, 'Task', $now, $now, false
       from task, dataset""".asUpdate
 
     for {


### PR DESCRIPTION
Regression introduced in #6734 in the direct (“manual”) task assignment query. Got SQL Errors `ERROR: column "state" is of type webknossos.annotation_state but expression is of type character varying`. Needs to take the enum value directly.

### URL of deployed dev instance (used for testing):
- https://taskassignmentquery.webknossos.xyz

### Steps to test:
- Create a task, assign it directly to a single user
- Should not fail with sql error

------
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
