### PR TITLE
Remove debug logging in editable mapping logic

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMapping.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMapping.scala
@@ -8,7 +8,7 @@ case class EditableMapping(
     agglomerateToGraph: Map[Long, AgglomerateGraph],
     createdTimestamp: Long,
 ) {
-  override def toString: String = f"EditableMapping(agglomerates:${agglomerateToGraph.keySet})"
+  override def toString: String = f"EditableMapping(${agglomerateToGraph.size} agglomerates)"
 
   def toProto: EditableMappingProto =
     EditableMappingProto(


### PR DESCRIPTION
This logic has been in production long enough that we don’t need the debug logging anymore to validate its logic.
Also, with larger production mappings, the logging got quite extensive (lots of ids printed) so it spammed server logs.

Should we ever need to debug this stuff again, we can copy the logging statemenets back in from here.

-----
- [x] Needs datastore update after deployment
- [x] Ready for review
