### PR TITLE
Fix publicly shared annotations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where direct task assignment to a single user would fail. [#6777](https://github.com/scalableminds/webknossos/pull/6777)
 - Fixed a bug where the dataset folders view would not list public datasets if the requesting user could not also access the dataset for other reasons, like being admin. [#6759](https://github.com/scalableminds/webknossos/pull/6759)
 - Fixed a bug where zarr-streamed datasets would produce (very rare) rendering errors. [#6782](https://github.com/scalableminds/webknossos/pull/6782)
+- Fixed a bug where publicly shared annotations were not viewable by users without an account. [#6784](https://github.com/scalableminds/webknossos/pull/6784)
 
 ### Removed
 

--- a/frontend/javascripts/components/secured_route.tsx
+++ b/frontend/javascripts/components/secured_route.tsx
@@ -69,10 +69,15 @@ class SecuredRoute extends React.PureComponent<SecuredRouteProps, State> {
             return <LoginView redirect={this.props.location.pathname} />;
           }
 
-          const organization = enforceActiveOrganization(this.props.activeOrganization);
           if (
             this.props.requiredPricingPlan &&
-            !isPricingPlanGreaterEqualThan(organization.pricingPlan, this.props.requiredPricingPlan)
+            !(
+              this.props.activeOrganization &&
+              isPricingPlanGreaterEqualThan(
+                this.props.activeOrganization.pricingPlan,
+                this.props.requiredPricingPlan,
+              )
+            )
           ) {
             return <PageUnavailableForYourPlanView />;
           }

--- a/frontend/javascripts/components/secured_route.tsx
+++ b/frontend/javascripts/components/secured_route.tsx
@@ -9,7 +9,6 @@ import { PageUnavailableForYourPlanView } from "components/pricing_enforcers";
 import type { ComponentType } from "react";
 import type { RouteComponentProps } from "react-router-dom";
 import type { OxalisState } from "oxalis/store";
-import { enforceActiveOrganization } from "oxalis/model/accessors/organization_accessors";
 
 type StateProps = {
   activeOrganization: APIOrganization | null;


### PR DESCRIPTION
PR fixes errors with publicly shared annotations.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Share an annotation publicly (i.e. with token)
- Open annotation without being logged in 
- Everything should work again

### Issues:
- follow-up to #6767

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
