### PR TITLE
Update linter to Rome v11.0.0

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Implements statistics from combined worflow runs in the Voxelytics reporting. [#6732](https://github.com/scalableminds/webknossos/pull/6732)
 - Limit paid task/project management features to respective organization plans. [6767](https://github.com/scalableminds/webknossos/pull/6767)
 - The dataset list route `GET api/datasets` no longer respects the isEditable filter. [#6759](https://github.com/scalableminds/webknossos/pull/6759)
+- Upgrade linter to Rome v11.0.0. [#6785](https://github.com/scalableminds/webknossos/pull/6785)
 
 ### Fixed
 - Fixed node selection and context menu for node ids greater than 130813. [#6724](https://github.com/scalableminds/webknossos/pull/6724) and [#6731](https://github.com/scalableminds/webknossos/pull/6731)

--- a/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
@@ -349,7 +349,7 @@ function AddZarrLayer({
     let existingDatasource;
     try {
       existingDatasource = JSON.parse(datasourceConfigStr);
-    } catch (e) {
+    } catch (_e) {
       Toast.error(
         "The current datasource config contains invalid JSON. Cannot add the new Zarr/N5 data.",
       );

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -1,17 +1,4 @@
-import {
-  Popover,
-  Avatar,
-  Form,
-  Button,
-  Col,
-  Row,
-  Tooltip,
-  Modal,
-  Progress,
-  Alert,
-  List,
-  Spin,
-} from "antd";
+import { Popover, Avatar, Form, Button, Col, Row, Modal, Progress, Alert, List, Spin } from "antd";
 import { Location as HistoryLocation, Action as HistoryAction } from "history";
 import { InfoCircleOutlined, FileOutlined, FolderOutlined, InboxOutlined } from "@ant-design/icons";
 import { connect } from "react-redux";
@@ -34,8 +21,6 @@ import {
   startConvertToWkwJob,
   sendAnalyticsEvent,
   sendFailedRequestAnalyticsEvent,
-  updateDataset,
-  getDataset,
 } from "admin/admin_rest_api";
 import Toast from "libs/toast";
 import * as Utils from "libs/utils";

--- a/frontend/javascripts/admin/project/transfer_all_tasks_modal.tsx
+++ b/frontend/javascripts/admin/project/transfer_all_tasks_modal.tsx
@@ -77,7 +77,7 @@ class TransferAllTasksModal extends React.PureComponent<Props, State> {
       }
 
       this.props.onComplete();
-    } catch (e) {
+    } catch (_e) {
       Toast.error(messages["project.unsuccessful_active_tasks_transfer"]);
     }
   };

--- a/frontend/javascripts/admin/statistic/open_tasks_report_view.tsx
+++ b/frontend/javascripts/admin/statistic/open_tasks_report_view.tsx
@@ -84,7 +84,7 @@ class OpenTasksReportView extends React.PureComponent<{}, State> {
             <Column
               title=""
               key="content"
-              render={(text, item) =>
+              render={(_text, item) =>
                 // @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.
                 Object.keys(item.assignmentsByProjects)
                   // @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.

--- a/frontend/javascripts/admin/statistic/project_progress_report_view.tsx
+++ b/frontend/javascripts/admin/statistic/project_progress_report_view.tsx
@@ -48,7 +48,7 @@ class ProjectProgressReportView extends React.PureComponent<{}, State> {
           updatedAt: Date.now(),
         });
         Toast.close(errorToastKey);
-      } catch (err) {
+      } catch (_err) {
         Toast.error(messages["project.report.failed_to_refresh"], {
           sticky: true,
           key: errorToastKey,
@@ -201,7 +201,7 @@ class ProjectProgressReportView extends React.PureComponent<{}, State> {
                 dataIndex="finishedInstances"
                 // @ts-expect-error ts-migrate(2322) FIXME: Type 'Comparator<APIProjectProgressReport>' is not... Remove this comment to see the full error message
                 sorter={Utils.compareBy(typeHint, (project) => project.finishedInstances)}
-                render={(text, item) => ({
+                render={(_text, item) => ({
                   props: {
                     colSpan: 3,
                   },

--- a/frontend/javascripts/admin/task/task_create_form_view.tsx
+++ b/frontend/javascripts/admin/task/task_create_form_view.tsx
@@ -343,6 +343,7 @@ class TaskCreateFormView extends React.PureComponent<Props, State> {
       const validFormValues = _.omitBy(defaultValues, _.isNull);
 
       // The task type is not needed for the form and leads to antd errors if it contains null values
+      // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
       const { type, ...neededFormValues } = validFormValues;
       form.setFieldsValue(neededFormValues);
     }
@@ -454,7 +455,7 @@ class TaskCreateFormView extends React.PureComponent<Props, State> {
                   required: true,
                 },
                 {
-                  validator: async (rule, value) => {
+                  validator: async (_rule, value) => {
                     const newestForm = this.formRef.current;
 
                     if (!newestForm || value === "") {

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -1,5 +1,4 @@
-import type { RouteComponentProps } from "react-router-dom";
-import { Link, withRouter } from "react-router-dom";
+import { Link } from "react-router-dom";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Table, Tag, Spin, Button, Input, Modal, Card, Alert } from "antd";

--- a/frontend/javascripts/admin/task/task_search_form.tsx
+++ b/frontend/javascripts/admin/task/task_search_form.tsx
@@ -3,8 +3,6 @@ import { FormInstance } from "antd/lib/form";
 import { DownloadOutlined, DownOutlined, RetweetOutlined } from "@ant-design/icons";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
-import type { RouteComponentProps } from "react-router-dom";
-import { withRouter } from "react-router-dom";
 import React from "react";
 import _ from "lodash";
 import messages from "messages";

--- a/frontend/javascripts/admin/tasktype/task_type_create_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_create_view.tsx
@@ -33,7 +33,7 @@ type State = {
 };
 
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'rule' implicitly has an 'any' type.
-function isValidMagnification(rule, value) {
+function isValidMagnification(_rule, value) {
   if (value === "" || value == null || (Math.log(value) / Math.log(2)) % 1 === 0) {
     return Promise.resolve();
   } else {

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
@@ -1,4 +1,3 @@
-import type { RouteComponentProps } from "react-router-dom";
 import { Link } from "react-router-dom";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";

--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -30,7 +30,7 @@ import { InviteUsersModal } from "admin/onboarding";
 import type { OxalisState } from "oxalis/store";
 import { enforceActiveUser } from "oxalis/model/accessors/user_accessor";
 import LinkButton from "components/link_button";
-import { getEditableUsers, getOrganization, updateUser } from "admin/admin_rest_api";
+import { getEditableUsers, updateUser } from "admin/admin_rest_api";
 import { stringToColor } from "libs/format_utils";
 import EditableTextLabel from "oxalis/view/components/editable_text_label";
 import ExperienceModalView from "admin/user/experience_modal_view";
@@ -442,7 +442,7 @@ class UserListView extends React.PureComponent<Props, State> {
             style={{
               marginTop: 30,
             }}
-            onChange={(pagination, filters) =>
+            onChange={(_pagination, filters) =>
               this.setState({
                 // @ts-expect-error ts-migrate(2322) FIXME: Type 'FilterValue' is not assignable to type '("tr... Remove this comment to see the full error message
                 activationFilter: filters.isActive != null ? filters.isActive : [],

--- a/frontend/javascripts/admin/voxelytics/artifacts_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/artifacts_view.tsx
@@ -118,7 +118,7 @@ function ArtifactsView({
       a.href = URL.createObjectURL(new Blob([csv], { type: "text/csv" }));
       a.download = `${workflowHash}_${taskName}_${artifactName}_checksums.csv`;
       a.click();
-    } catch (error) {
+    } catch (_error) {
       message.error("Could not download artifact checksums.");
     }
   }

--- a/frontend/javascripts/admin/voxelytics/log_tab.tsx
+++ b/frontend/javascripts/admin/voxelytics/log_tab.tsx
@@ -41,7 +41,7 @@ export function formatLog(
 function LogContent({ logText }: { logText: Array<string> }) {
   return (
     <div className="log-content">
-      {logText.map((line, index) => (
+      {logText.map((_line, index) => (
         // rome-ignore lint/suspicious/noArrayIndexKey: log lines are indexed uniquely
         <div className={`log-line log-line-${index % 2 ? "odd" : "even"}`} key={index}>
           <div className="log-line-number">{index + 1}</div>
@@ -143,7 +143,7 @@ export default function LogTab({
       a.href = URL.createObjectURL(new Blob([logText], { type: "plain/text" }));
       a.download = `${workflowHash}_${runId}_${taskName}.log`;
       a.click();
-    } catch (error) {
+    } catch (_error) {
       message.error("Could not fetch log for download.");
     }
   }

--- a/frontend/javascripts/admin/voxelytics/log_tab.tsx
+++ b/frontend/javascripts/admin/voxelytics/log_tab.tsx
@@ -42,6 +42,7 @@ function LogContent({ logText }: { logText: Array<string> }) {
   return (
     <div className="log-content">
       {logText.map((line, index) => (
+        // rome-ignore lint/suspicious/noArrayIndexKey: log lines are indexed uniquely
         <div className={`log-line log-line-${index % 2 ? "odd" : "even"}`} key={index}>
           <div className="log-line-number">{index + 1}</div>
           <Ansi linkify>{logText[index]}</Ansi>

--- a/frontend/javascripts/admin/voxelytics/statistics_tab.tsx
+++ b/frontend/javascripts/admin/voxelytics/statistics_tab.tsx
@@ -37,7 +37,6 @@ export default function StatisticsTab({
   workflowHash,
   runId,
   taskName,
-  isRunning,
 }: {
   workflowHash: string;
   runId: string | null;

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -332,8 +332,9 @@ export default function TaskListView({
   }
 
   function copyAllArtifactPaths() {
-    const artifactPaths = Object.values(report.artifacts)
-      .flatMap((artifactObject) => Object.values(artifactObject).map((artifact) => artifact.path));
+    const artifactPaths = Object.values(report.artifacts).flatMap((artifactObject) =>
+      Object.values(artifactObject).map((artifact) => artifact.path),
+    );
 
     navigator.clipboard.writeText(artifactPaths.join("\n")).then(
       () => notification.success({ message: "All artifacts path were copied to the clipboard" }),
@@ -362,7 +363,7 @@ export default function TaskListView({
       );
       a.download = `${report.workflow.name}.yaml`;
       a.click();
-    } catch (error) {
+    } catch (_error) {
       message.error("Could not find YAML file for download.");
     }
   }

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -333,8 +333,7 @@ export default function TaskListView({
 
   function copyAllArtifactPaths() {
     const artifactPaths = Object.values(report.artifacts)
-      .map((artifactObject) => Object.values(artifactObject).map((artifact) => artifact.path))
-      .flat();
+      .flatMap((artifactObject) => Object.values(artifactObject).map((artifact) => artifact.path));
 
     navigator.clipboard.writeText(artifactPaths.join("\n")).then(
       () => notification.success({ message: "All artifacts path were copied to the clipboard" }),

--- a/frontend/javascripts/admin/voxelytics/task_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_view.tsx
@@ -43,7 +43,7 @@ function TaskView({
   taskInfo: VoxelyticsTaskInfo;
   onSelectTask: (id: string) => void;
 }) {
-  const shouldExpandNode = (keyPath: Array<string | number>, data: any) =>
+  const shouldExpandNode = (_keyPath: Array<string | number>, data: any) =>
     // Expand all with at most 10 keys
     (data.length || 0) <= 10;
 

--- a/frontend/javascripts/admin/voxelytics/utils.ts
+++ b/frontend/javascripts/admin/voxelytics/utils.ts
@@ -1,13 +1,9 @@
-import { getVoxelyticsLogs } from "admin/admin_rest_api";
 import { message } from "antd";
-import { LOG_LEVELS } from "oxalis/constants";
 import { OxalisState } from "oxalis/store";
 import { useSelector } from "react-redux";
-import { VoxelyticsLogLine, VoxelyticsRunState } from "types/api_flow_types";
+import { VoxelyticsRunState } from "types/api_flow_types";
 
 export const VX_POLLING_INTERVAL = null; // disabled for now. 30 * 1000; // 30s
-const LOG_ENTRY_BATCH_SIZE = 5000;
-const LOG_TIME_BATCH_INTERVAL = 7 * 24 * 60 * 60 * 1000; // 7 days
 const LOG_TIME_PADDING = 60 * 1000; // 1 minute
 
 export type Result<T> =

--- a/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
@@ -6,7 +6,6 @@ import { getVoxelyticsWorkflows } from "admin/admin_rest_api";
 import {
   VoxelyticsWorkflowListingRun,
   VoxelyticsRunState,
-  VoxelyticsTaskInfo,
   VoxelyticsWorkflowListing,
 } from "types/api_flow_types";
 import { usePolling } from "libs/react_hooks";

--- a/frontend/javascripts/components/highlightable_row.tsx
+++ b/frontend/javascripts/components/highlightable_row.tsx
@@ -17,7 +17,7 @@ export default class HighlightableRow extends React.PureComponent<Props, State> 
   };
 
   render() {
-    const { shouldHighlight, style, ...restProps } = this.props;
+    const { style, ...restProps } = this.props;
     return (
       <tr
         {...restProps}

--- a/frontend/javascripts/components/highlightable_row.tsx
+++ b/frontend/javascripts/components/highlightable_row.tsx
@@ -17,7 +17,8 @@ export default class HighlightableRow extends React.PureComponent<Props, State> 
   };
 
   render() {
-    const { style, ...restProps } = this.props;
+    // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
+    const { shouldHighlight, style, ...restProps } = this.props;
     return (
       <tr
         {...restProps}

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -1,12 +1,7 @@
 import { FolderOpenOutlined, PlusOutlined, WarningOutlined } from "@ant-design/icons";
 import { Link } from "react-router-dom";
 import { Dropdown, Table, Tag, Tooltip } from "antd";
-import type {
-  FilterValue,
-  SorterResult,
-  TableCurrentDataSource,
-  TablePaginationConfig,
-} from "antd/lib/table/interface";
+import type { FilterValue, SorterResult, TablePaginationConfig } from "antd/lib/table/interface";
 import * as React from "react";
 import _ from "lodash";
 import { diceCoefficient as dice } from "dice-coefficient";
@@ -537,7 +532,7 @@ class DatasetTable extends React.PureComponent<Props, State> {
             width={280}
             sorter={Utils.localeCompareBy(typeHint, (dataset) => dataset.name)}
             sortOrder={sortedInfo.columnKey === "name" ? sortedInfo.order : undefined}
-            render={(name: string, dataset: APIMaybeUnimportedDataset) => (
+            render={(_name: string, dataset: APIMaybeUnimportedDataset) => (
               <>
                 <Link
                   to={`/datasets/${dataset.owningOrganization}/${dataset.name}/view`}
@@ -560,7 +555,7 @@ class DatasetTable extends React.PureComponent<Props, State> {
             dataIndex="tags"
             key="tags"
             sortOrder={sortedInfo.columnKey === "name" ? sortedInfo.order : undefined}
-            render={(tags: Array<string>, dataset: APIMaybeUnimportedDataset) =>
+            render={(_tags: Array<string>, dataset: APIMaybeUnimportedDataset) =>
               dataset.isActive ? (
                 <DatasetTags
                   dataset={dataset}
@@ -612,7 +607,7 @@ class DatasetTable extends React.PureComponent<Props, State> {
                 }
                 return dataset.allowedTeams.some((team) => team.name === value);
               }}
-              render={(teams: APITeam[], dataset: APIMaybeUnimportedDataset) => (
+              render={(_teams: APITeam[], dataset: APIMaybeUnimportedDataset) => (
                 <TeamTags dataset={dataset} />
               )}
             />

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -9,8 +9,7 @@ import {
   TeamOutlined,
   UserAddOutlined,
 } from "@ant-design/icons";
-import type { RouteComponentProps } from "react-router-dom";
-import { Link, withRouter } from "react-router-dom";
+import { Link } from "react-router-dom";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { connect } from "react-redux";
@@ -363,7 +362,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
           ]),
         },
       }));
-    } catch (ex) {
+    } catch (_ex) {
       // catch exception so that promise does not fail and the modal will close
     } finally {
       this.setState({

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
@@ -470,7 +470,7 @@ function SimpleLayerForm({
               },
               {
                 warningOnly: true,
-                validator: (rule, value) =>
+                validator: (_rule, value) =>
                   value == null || value === ""
                     ? Promise.reject(
                         new Error(
@@ -519,7 +519,7 @@ function SimpleLayerForm({
                   }
                   rules={[
                     {
-                      validator: (rule, value) =>
+                      validator: (_rule, value) =>
                         value == null || value === "" || (value > 0 && value < 2 ** bitDepth)
                           ? Promise.resolve()
                           : Promise.reject(
@@ -530,7 +530,7 @@ function SimpleLayerForm({
                     },
                     {
                       warningOnly: true,
-                      validator: (rule, value) =>
+                      validator: (_rule, value) =>
                         value == null || value === ""
                           ? Promise.reject(
                               new Error(

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -610,7 +610,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
         const dataSource = JSON.parse(form.getFieldValue("dataSourceJson"));
         const didNotEditDatasource = !this.didDatasourceChange(dataSource);
         return didNotEditDatasource;
-      } catch (e) {
+      } catch (_e) {
         return false;
       }
     }
@@ -768,7 +768,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
     );
   }
 
-  onValuesChange = (changedValues: FormData, allValues: FormData) => {
+  onValuesChange = (_changedValues: FormData, _allValues: FormData) => {
     this.setState({
       hasUnsavedChanges: true,
     });

--- a/frontend/javascripts/dashboard/dataset/team_selection_component.tsx
+++ b/frontend/javascripts/dashboard/dataset/team_selection_component.tsx
@@ -53,7 +53,7 @@ class TeamSelectionComponent extends React.PureComponent<Props, State> {
       if (this.props.afterFetchedTeams != null) {
         this.props.afterFetchedTeams(possibleTeams);
       }
-    } catch (exception) {
+    } catch (_exception) {
       console.error("Could not load teams.");
     }
   }

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -608,7 +608,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
           width={280}
           dataIndex="name"
           sorter={Utils.localeCompareBy(typeHint, (annotation) => annotation.name)}
-          render={(name: string, tracing: APIAnnotationCompact) =>
+          render={(_name: string, tracing: APIAnnotationCompact) =>
             this.renderNameWithDescription(tracing)
           }
         />

--- a/frontend/javascripts/libs/drawing.ts
+++ b/frontend/javascripts/libs/drawing.ts
@@ -154,7 +154,7 @@ class Drawing {
         bufX1[y] = x;
       });
     } else {
-      this.drawLine2d(x1, y1, x2, y2, (x: number, y: number) => {
+      this.drawLine2d(x1, y1, x2, y2, (_x: number, y: number) => {
         bufX0[y] = minX;
         bufX1[y] = maxX;
       });

--- a/frontend/javascripts/libs/gist.ts
+++ b/frontend/javascripts/libs/gist.ts
@@ -28,7 +28,7 @@ export async function fetchGistContent(url: string, name: string): Promise<strin
 
   try {
     gist = (await Request.receiveJSON(`https://api.github.com/gists/${gistId}`)) as GithubGist;
-  } catch (e) {
+  } catch (_e) {
     handleError(name);
     return "";
   }

--- a/frontend/javascripts/libs/request.ts
+++ b/frontend/javascripts/libs/request.ts
@@ -316,7 +316,7 @@ class Request {
 
               /* eslint-disable-next-line prefer-promise-reject-errors */
               return Promise.reject({ ...json, url: requestedUrl });
-            } catch (jsonError) {
+            } catch (_jsonError) {
               if (showErrorToast) Toast.error(text);
 
               /* eslint-disable-next-line prefer-promise-reject-errors */

--- a/frontend/javascripts/libs/resizable_buffer.ts
+++ b/frontend/javascripts/libs/resizable_buffer.ts
@@ -1,5 +1,5 @@
 const GROW_MULTIPLIER = 1.3;
-type Class<T> = new (...args: any[]) => T;
+type Class<T> = new (..._args: any[]) => T;
 
 class ResizableBuffer<T extends Float32Array> {
   elementLength: number;

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -137,7 +137,7 @@ export function parseAsMaybe(str: string | null | undefined): Maybe<any> {
     } else {
       return Maybe.Nothing();
     }
-  } catch (exception) {
+  } catch (_exception) {
     return Maybe.Nothing();
   }
 }
@@ -145,7 +145,7 @@ export function parseAsMaybe(str: string | null | undefined): Maybe<any> {
 export async function tryToAwaitPromise<T>(promise: Promise<T>): Promise<T | null | undefined> {
   try {
     return await promise;
-  } catch (exception) {
+  } catch (_exception) {
     return null;
   }
 }
@@ -740,7 +740,7 @@ const areEventListenerOptionsSupported = _.once(() => {
     window.addEventListener("test", options, options);
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'removeEventListener' does not exist on t... Remove this comment to see the full error message
     window.removeEventListener("test", options, options);
-  } catch (err) {
+  } catch (_err) {
     passiveSupported = false;
   }
 
@@ -1000,7 +1000,7 @@ export function convertBufferToImage(
 export function getIsInIframe() {
   try {
     return window.self !== window.top;
-  } catch (e) {
+  } catch (_e) {
     return true;
   }
 }

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -57,7 +57,7 @@ async function loadActiveUser() {
       queryClient: reactQueryClient,
       persister: localStoragePersister,
     });
-  } catch (e) {
+  } catch (_e) {
     // pass
   }
 }
@@ -67,7 +67,7 @@ async function loadHasOrganizations() {
   try {
     const hasOrganizations = await checkAnyOrganizationExists();
     Store.dispatch(setHasOrganizationsAction(hasOrganizations));
-  } catch (e) {
+  } catch (_e) {
     // pass
   }
 }

--- a/frontend/javascripts/oxalis/controller/combinations/bounding_box_handlers.ts
+++ b/frontend/javascripts/oxalis/controller/combinations/bounding_box_handlers.ts
@@ -225,7 +225,7 @@ export function getClosestHoveredBoundingBox(
   return [primaryEdge, secondaryEdge];
 }
 export const highlightAndSetCursorOnHoveredBoundingBox = _.throttle(
-  (delta: Point2, position: Point2, planeId: OrthoView) => {
+  (_delta: Point2, position: Point2, planeId: OrthoView) => {
     const hoveredEdgesInfo = getClosestHoveredBoundingBox(position, planeId);
     // Access the parent element as that is where the cursor style property is set
     const inputCatcher = document.getElementById(`inputcatcher_${planeId}`)?.parentElement;

--- a/frontend/javascripts/oxalis/controller/combinations/skeleton_handlers.ts
+++ b/frontend/javascripts/oxalis/controller/combinations/skeleton_handlers.ts
@@ -102,7 +102,7 @@ export function handleSelectNode(
 
   return false;
 }
-export function handleCreateNode(planeView: PlaneView, position: Point2, ctrlPressed: boolean) {
+export function handleCreateNode(_planeView: PlaneView, position: Point2, ctrlPressed: boolean) {
   const state = Store.getState();
 
   if (isMagRestrictionViolated(state)) {

--- a/frontend/javascripts/oxalis/controller/combinations/tool_controls.ts
+++ b/frontend/javascripts/oxalis/controller/combinations/tool_controls.ts
@@ -212,7 +212,7 @@ export class SkeletonTool {
 
     let draggingNodeId: number | null | undefined = null;
     return {
-      leftMouseDown: (pos: Point2, plane: OrthoView, event: MouseEvent, isTouch: boolean) => {
+      leftMouseDown: (pos: Point2, plane: OrthoView, _event: MouseEvent, isTouch: boolean) => {
         const { useLegacyBindings } = Store.getState().userConfiguration;
 
         if (useLegacyBindings) {
@@ -235,7 +235,7 @@ export class SkeletonTool {
       },
       leftDownMove: (
         delta: Point2,
-        pos: Point2,
+        _pos: Point2,
         _id: string | null | undefined,
         event: MouseEvent,
       ) => {
@@ -290,7 +290,7 @@ export class SkeletonTool {
           showNodeContextMenuAt,
         );
       },
-      middleClick: (pos: Point2, plane: OrthoView, event: MouseEvent) => {
+      middleClick: (pos: Point2, _plane: OrthoView, event: MouseEvent) => {
         if (event.shiftKey) {
           handleAgglomerateSkeletonAtClick(pos);
         }
@@ -350,7 +350,7 @@ export class DrawTool {
     showNodeContextMenuAt: ShowContextMenuFunction,
   ): any {
     return {
-      leftDownMove: (delta: Point2, pos: Point2) => {
+      leftDownMove: (_delta: Point2, pos: Point2) => {
         VolumeHandlers.handleMoveForDrawOrErase(pos);
       },
       leftMouseDown: (pos: Point2, plane: OrthoView, event: MouseEvent) => {
@@ -369,7 +369,7 @@ export class DrawTool {
       leftMouseUp: () => {
         VolumeHandlers.handleEndForDrawOrErase();
       },
-      rightDownMove: (delta: Point2, pos: Point2) => {
+      rightDownMove: (_delta: Point2, pos: Point2) => {
         const { useLegacyBindings } = Store.getState().userConfiguration;
 
         if (!useLegacyBindings) {
@@ -404,7 +404,7 @@ export class DrawTool {
 
         VolumeHandlers.handleEndForDrawOrErase();
       },
-      leftClick: (pos: Point2, plane: OrthoView, event: MouseEvent) => {
+      leftClick: (pos: Point2, _plane: OrthoView, event: MouseEvent) => {
         const shouldPickCell = event.shiftKey && !event.ctrlKey;
         const shouldErase = event.shiftKey && event.ctrlKey;
 
@@ -467,7 +467,7 @@ export class EraseTool {
     showNodeContextMenuAt: ShowContextMenuFunction,
   ): any {
     return {
-      leftDownMove: (delta: Point2, pos: Point2) => {
+      leftDownMove: (_delta: Point2, pos: Point2) => {
         VolumeHandlers.handleMoveForDrawOrErase(pos);
       },
       leftMouseDown: (pos: Point2, plane: OrthoView, _event: MouseEvent) => {
@@ -643,7 +643,7 @@ export class BoundingBoxTool {
 
 export class QuickSelectTool {
   static getPlaneMouseControls(
-    planeId: OrthoView,
+    _planeId: OrthoView,
     planeView: PlaneView,
     showNodeContextMenuAt: ShowContextMenuFunction,
   ): any {

--- a/frontend/javascripts/oxalis/controller/td_controller.tsx
+++ b/frontend/javascripts/oxalis/controller/td_controller.tsx
@@ -199,7 +199,7 @@ class TDController extends React.PureComponent<Props> {
       },
       // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'delta' implicitly has an 'any' type.
       pinch: (delta) => this.zoomTDView(delta, true),
-      mouseMove: (delta: Point2, position: Point2) => {
+      mouseMove: (_delta: Point2, position: Point2) => {
         if (this.props.planeView == null) {
           return;
         }

--- a/frontend/javascripts/oxalis/controller/url_manager.ts
+++ b/frontend/javascripts/oxalis/controller/url_manager.ts
@@ -342,12 +342,12 @@ export function updateTypeAndId(
   if (maybeCompoundType == null) {
     return baseUrl.replace(
       /^(.*\/annotations)\/([^/?]*)(\/?.*)$/,
-      (all, base, id, rest) => `${base}/${annotationId}${rest}`,
+      (_all, base, _id, rest) => `${base}/${annotationId}${rest}`,
     );
   } else {
     return baseUrl.replace(
       /^(.*\/annotations)\/(.*?)\/([^/?]*)(\/?.*)$/,
-      (all, base, type, id, rest) => `${base}/${maybeCompoundType}/${annotationId}${rest}`,
+      (_all, base, _type, _id, rest) => `${base}/${maybeCompoundType}/${annotationId}${rest}`,
     );
   }
 }

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -584,10 +584,7 @@ export function getDatasetExtentAsString(
   const extent = getDatasetExtentInLength(dataset);
   return formatExtentWithLength(extent, formatNumberToLength);
 }
-export function determineAllowedModes(
-  dataset: APIDataset,
-  settings?: Settings,
-): {
+export function determineAllowedModes(settings?: Settings): {
   preferredMode: APIAllowedMode | null | undefined;
   allowedModes: Array<APIAllowedMode>;
 } {

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/polyhedron_rasterizer.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/polyhedron_rasterizer.ts
@@ -387,8 +387,7 @@ class PolyhedronRasterizer {
     // edges of that polygon is then drawn into the buffer.
     // After that, we know all line segments that belong to
     // the polyhedron.
-    // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
-    const { deltaX, deltaY, deltaZ, shiftZ, buffer, pointsBuffer } = this;
+    const { deltaY, deltaZ, shiftZ, buffer, pointsBuffer } = this;
 
     // build and rasterize convex hull of all xy-planes
     for (let z = 0; z < deltaZ; z++) {

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/polyhedron_rasterizer.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/polyhedron_rasterizer.ts
@@ -387,7 +387,7 @@ class PolyhedronRasterizer {
     // edges of that polygon is then drawn into the buffer.
     // After that, we know all line segments that belong to
     // the polyhedron.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
     const { deltaX, deltaY, deltaZ, shiftZ, buffer, pointsBuffer } = this;
 
     // build and rasterize convex hull of all xy-planes

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/pushqueue.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/pushqueue.ts
@@ -104,7 +104,7 @@ class PushQueue {
     try {
       // wait here
       await this.compressionTaskQueue.join();
-    } catch (error) {
+    } catch (_error) {
       alert("We've encountered a permanent issue while saving. Please try to reload the page.");
     }
   };

--- a/frontend/javascripts/oxalis/model/reducers/annotation_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/annotation_reducer.ts
@@ -178,8 +178,8 @@ function AnnotationReducer(state: OxalisState, action: Action): OxalisState {
       const mergedUserBoundingBoxes = _.uniqWith(
         [...tracing.userBoundingBoxes, ...additionalUserBoundingBoxes],
         (bboxWithId1, bboxWithId2) => {
-          const { id: id1, ...bbox1 } = bboxWithId1;
-          const { id: id2, ...bbox2 } = bboxWithId2;
+          const { id: _id1, ...bbox1 } = bboxWithId1;
+          const { id: _id2, ...bbox2 } = bboxWithId2;
           return _.isEqual(bbox1, bbox2);
         },
       );

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
@@ -704,21 +704,20 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
           const { timestamp, nodeId, treeId } = action;
           return getNodeAndTree(skeletonTracing, nodeId, treeId)
             .chain(([tree, node]) =>
-              createBranchPoint(skeletonTracing, tree, node, timestamp, restrictions).map(
-                (branchPoint) =>
-                  update(state, {
-                    tracing: {
-                      skeleton: {
-                        trees: {
-                          [tree.treeId]: {
-                            branchPoints: {
-                              $push: [branchPoint],
-                            },
+              createBranchPoint(tree, node, timestamp, restrictions).map((branchPoint) =>
+                update(state, {
+                  tracing: {
+                    skeleton: {
+                      trees: {
+                        [tree.treeId]: {
+                          branchPoints: {
+                            $push: [branchPoint],
                           },
                         },
                       },
                     },
-                  }),
+                  },
+                }),
               ),
             )
             .getOrElse(state);

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer_helpers.ts
@@ -407,7 +407,6 @@ function splitTreeByNodes(
 }
 
 export function createBranchPoint(
-  skeletonTracing: SkeletonTracing,
   tree: Tree,
   node: Node,
   timestamp: number,
@@ -684,7 +683,7 @@ export function shuffleTreeColor(
   return setTreeColorIndex(skeletonTracing, tree, randomId);
 }
 export function setTreeColorIndex(
-  skeletonTracing: SkeletonTracing,
+  _skeletonTracing: SkeletonTracing,
   tree: Tree,
   colorIndex: number,
 ): Maybe<[Tree, number]> {
@@ -696,7 +695,7 @@ export function setTreeColorIndex(
   return Maybe.Just([newTree, tree.treeId]);
 }
 export function createComment(
-  skeletonTracing: SkeletonTracing,
+  _skeletonTracing: SkeletonTracing,
   tree: Tree,
   node: Node,
   commentText: string,
@@ -712,7 +711,7 @@ export function createComment(
   return Maybe.Just(newComments);
 }
 export function deleteComment(
-  skeletonTracing: SkeletonTracing,
+  _skeletonTracing: SkeletonTracing,
   tree: Tree,
   node: Node,
 ): Maybe<Array<CommentType>> {

--- a/frontend/javascripts/oxalis/model/sagas/handle_mesh_changes.ts
+++ b/frontend/javascripts/oxalis/model/sagas/handle_mesh_changes.ts
@@ -89,7 +89,7 @@ function* handleRemoteUpdateMesh(action: UpdateRemoteMeshMetaDataAction): Saga<v
     }),
   );
 
-  /* eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }] */
+  // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
   const { isVisible, isLoaded, isLoading, ...remoteMetadata } = meshMetaData;
   yield* call(updateMeshMetaData, remoteMetadata);
   yield* put(

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
@@ -3,11 +3,11 @@ import _ from "lodash";
 import { V3 } from "libs/mjs";
 import { sleep } from "libs/utils";
 import ErrorHandling from "libs/error_handling";
-import type { APIDataLayer, APIMeshFile, APISegmentationLayer } from "types/api_flow_types";
+import type { APIMeshFile, APISegmentationLayer } from "types/api_flow_types";
 import { mergeVertices } from "libs/BufferGeometryUtils";
 import Deferred from "libs/deferred";
 
-import Store, { OxalisState } from "oxalis/store";
+import Store from "oxalis/store";
 import {
   ResolutionInfo,
   getResolutionInfo,
@@ -64,7 +64,6 @@ import {
   getActiveSegmentationTracing,
   getEditableMappingForVolumeTracingId,
   getTracingForSegmentationLayer,
-  hasEditableMapping,
 } from "oxalis/model/accessors/volumetracing_accessor";
 import { saveNowAction } from "oxalis/model/actions/save_actions";
 import Toast from "libs/toast";

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
@@ -35,7 +35,6 @@ import {
   deleteBranchPointAction,
   setTreeNameAction,
   addTreesAndGroupsAction,
-  deleteTreeAction,
 } from "oxalis/model/actions/skeletontracing_actions";
 import {
   generateTreeName,

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -209,7 +209,7 @@ export async function initialize(
     initializeTracing(annotation, serverTracings, editableMappings);
   } else {
     // In view only tracings we need to set the view mode too.
-    const { allowedModes } = determineAllowedModes(dataset);
+    const { allowedModes } = determineAllowedModes();
     const mode = UrlManager.initialState.mode || allowedModes[0];
     Store.dispatch(setViewModeAction(mode));
   }
@@ -285,7 +285,7 @@ function initializeTracing(
   // This method is not called for the View mode
   const { dataset } = Store.getState();
   let annotation = _annotation;
-  const { allowedModes, preferredMode } = determineAllowedModes(dataset, annotation.settings);
+  const { allowedModes, preferredMode } = determineAllowedModes(annotation.settings);
 
   _.extend(annotation.settings, {
     allowedModes,

--- a/frontend/javascripts/oxalis/store.ts
+++ b/frontend/javascripts/oxalis/store.ts
@@ -1,4 +1,3 @@
-import type { Dispatch } from "redux";
 import { createStore, applyMiddleware } from "redux";
 import { enableBatching } from "redux-batched-actions";
 import createSagaMiddleware, { Saga } from "redux-saga";

--- a/frontend/javascripts/oxalis/view/action-bar/private_links_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/private_links_view.tsx
@@ -91,7 +91,7 @@ function useUpdatePrivateLink(annotationId: string) {
       return { previousLink };
     },
     // If the mutation fails, use the context returned from onMutate to roll back
-    onError: (err, _updatedLinkItem, context) => {
+    onError: (_err, _updatedLinkItem, context) => {
       Toast.error("Could not update link.");
       if (context) {
         queryClient.setQueryData(mutationKey, context.previousLink);

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -49,7 +49,7 @@ import {
   InterpolationMode,
 } from "oxalis/constants";
 import { Model } from "oxalis/singletons";
-import Store, { OxalisState, VolumeTracing } from "oxalis/store";
+import Store, { OxalisState } from "oxalis/store";
 
 import features from "features";
 import { getInterpolationInfo } from "oxalis/model/sagas/volume/volume_interpolation_saga";

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
@@ -123,7 +123,6 @@ export function LayoutMenu(props: LayoutMenuProps) {
     autoSaveLayouts,
     setAutoSaveLayouts,
     saveCurrentLayout,
-    setCurrentLayout,
     ...others
   } = props;
   const layoutMissingHelpTitle = (

--- a/frontend/javascripts/oxalis/view/components/categorization_label.tsx
+++ b/frontend/javascripts/oxalis/view/components/categorization_label.tsx
@@ -46,7 +46,7 @@ export function CategorizationSearch({
       try {
         const loadedSearchTags = JSON.parse(searchTagString);
         setTags(loadedSearchTags);
-      } catch (error) {
+      } catch (_error) {
         // pass
       }
     }

--- a/frontend/javascripts/oxalis/view/layouting/layout_persistence.ts
+++ b/frontend/javascripts/oxalis/view/layouting/layout_persistence.ts
@@ -61,7 +61,7 @@ function readStoredLayoutConfigs() {
     }
 
     return defaultLayoutConfig;
-  } catch (ex) {
+  } catch (_ex) {
     // This should only happen if someone tinkers with localStorage manually
     console.warn("Layout config could not be deserialized.");
   }

--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -57,12 +57,7 @@ import { connect } from "react-redux";
 // @ts-expect-error ts-migrate(2305) FIXME: Module '"react-router-dom"' has no exported member... Remove this comment to see the full error message
 import type { ContextRouter, RouteProps } from "react-router-dom";
 import { Redirect, Route, Router, Switch } from "react-router-dom";
-import {
-  APICompoundTypeEnum,
-  APIPricingPlanStatus,
-  APIUser,
-  TracingTypeEnum,
-} from "types/api_flow_types";
+import { APICompoundTypeEnum, APIUser, TracingTypeEnum } from "types/api_flow_types";
 
 import ErrorBoundary from "components/error_boundary";
 
@@ -199,7 +194,7 @@ class ReactRouter extends React.Component<Props> {
     try {
       const annotationInformation = await getAnnotationInformation(match.params.id || "");
       return annotationInformation.visibility === "Public";
-    } catch (ex) {
+    } catch (_ex) {
       // Annotation could not be found
     }
 
@@ -254,7 +249,7 @@ class ReactRouter extends React.Component<Props> {
               <SecuredRouteWithErrorBoundary
                 isAuthenticated={isAuthenticated}
                 path="/dashboard/datasets/:folderIdWithName"
-                render={({ match }: ContextRouter) => {
+                render={() => {
                   const initialTabKey = "datasets";
                   return (
                     <DashboardView

--- a/frontend/javascripts/test/api/api_skeleton_latest.spec.ts
+++ b/frontend/javascripts/test/api/api_skeleton_latest.spec.ts
@@ -162,7 +162,7 @@ test("Utils Api: registerKeyHandler should register a key handler and return a h
 test("Utils Api: registerOverwrite should overwrite an existing function", (t) => {
   const { api } = t.context;
   let bool = false;
-  api.utils.registerOverwrite("SET_ACTIVE_NODE", (store, call, action) => {
+  api.utils.registerOverwrite("SET_ACTIVE_NODE", (_store, call, action) => {
     bool = true;
     call(action);
   });

--- a/frontend/javascripts/test/api/api_v2.spec.ts
+++ b/frontend/javascripts/test/api/api_v2.spec.ts
@@ -134,7 +134,7 @@ test("registerKeyHandler should register a key handler and return a handler to u
 test("registerOverwrite should overwrite newAddNode", (t) => {
   const api = t.context.api;
   let bool = false;
-  api.utils.registerOverwrite("SET_ACTIVE_NODE", (store, call, action) => {
+  api.utils.registerOverwrite("SET_ACTIVE_NODE", (_store, call, action) => {
     bool = true;
     call(action);
   });
@@ -147,7 +147,7 @@ test("registerOverwrite should overwrite newAddNode", (t) => {
 test("registerOverwrite should overwrite deleteActiveNode", (t) => {
   const api = t.context.api;
   let bool = false;
-  api.utils.registerOverwrite("DELETE_NODE", (store, call, action) => {
+  api.utils.registerOverwrite("DELETE_NODE", (_store, call, action) => {
     bool = true;
     call(action);
   });

--- a/frontend/javascripts/test/controller/url_manager.spec.ts
+++ b/frontend/javascripts/test/controller/url_manager.spec.ts
@@ -60,7 +60,7 @@ test("UrlManager should parse csv url hash without optional values", (t) => {
     rotation: [40.45, 13.65, 0.8],
     activeNode: 2,
   };
-  const { rotation, ...stateWithoutRotation } = state;
+  const { ...stateWithoutRotation } = state;
   location.hash = `#${[
     ...state.position,
     ViewModeValues.indexOf(state.mode),
@@ -68,7 +68,7 @@ test("UrlManager should parse csv url hash without optional values", (t) => {
     state.activeNode,
   ].join(",")}`;
   t.deepEqual(UrlManager.parseUrlHash(), stateWithoutRotation);
-  const { activeNode, ...stateWithoutActiveNode } = state;
+  const { ...stateWithoutActiveNode } = state;
   location.hash = `#${[
     ...state.position,
     ViewModeValues.indexOf(state.mode),
@@ -133,10 +133,10 @@ test("UrlManager should parse incomplete json url hash", (t) => {
     rotation: [40.45, 13.65, 0.8],
     activeNode: 2,
   };
-  const { rotation, ...stateWithoutRotation } = state;
+  const { ...stateWithoutRotation } = state;
   location.hash = `#${encodeUrlHash(JSON.stringify(stateWithoutRotation))}`;
   t.deepEqual(UrlManager.parseUrlHash(), stateWithoutRotation);
-  const { activeNode, ...stateWithoutActiveNode } = state;
+  const { ...stateWithoutActiveNode } = state;
   location.hash = `#${encodeUrlHash(JSON.stringify(stateWithoutActiveNode))}`;
   t.deepEqual(UrlManager.parseUrlHash(), stateWithoutActiveNode);
 });

--- a/frontend/javascripts/test/controller/url_manager.spec.ts
+++ b/frontend/javascripts/test/controller/url_manager.spec.ts
@@ -6,6 +6,7 @@ import { location } from "libs/window";
 import Constants, { ViewModeValues } from "oxalis/constants";
 import defaultState from "oxalis/default_state";
 import update from "immutability-helper";
+
 test("UrlManager should replace tracing in url", (t) => {
   // Without annotationType (Explorational and Task don't appear in the URL)
   t.is(
@@ -35,6 +36,7 @@ test("UrlManager should replace tracing in url", (t) => {
     "abc/def/annotations/CompoundProject/newAnnotationId/readOnly",
   );
 });
+
 test("UrlManager should parse full csv url hash", (t) => {
   const state = {
     position: [555, 278, 482],
@@ -52,6 +54,7 @@ test("UrlManager should parse full csv url hash", (t) => {
   ].join(",")}`;
   t.deepEqual(UrlManager.parseUrlHash(), state);
 });
+
 test("UrlManager should parse csv url hash without optional values", (t) => {
   const state = {
     position: [555, 278, 482],
@@ -60,7 +63,8 @@ test("UrlManager should parse csv url hash without optional values", (t) => {
     rotation: [40.45, 13.65, 0.8],
     activeNode: 2,
   };
-  const { ...stateWithoutRotation } = state;
+  // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
+  const { rotation, ...stateWithoutRotation } = state;
   location.hash = `#${[
     ...state.position,
     ViewModeValues.indexOf(state.mode),
@@ -68,7 +72,8 @@ test("UrlManager should parse csv url hash without optional values", (t) => {
     state.activeNode,
   ].join(",")}`;
   t.deepEqual(UrlManager.parseUrlHash(), stateWithoutRotation);
-  const { ...stateWithoutActiveNode } = state;
+  // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
+  const { activeNode, ...stateWithoutActiveNode } = state;
   location.hash = `#${[
     ...state.position,
     ViewModeValues.indexOf(state.mode),
@@ -82,6 +87,7 @@ test("UrlManager should parse csv url hash without optional values", (t) => {
   )}`;
   t.deepEqual(UrlManager.parseUrlHash(), stateWithoutOptionalValues);
 });
+
 test("UrlManager should build csv url hash and parse it again", (t) => {
   const mode = Constants.MODE_ARBITRARY;
   const urlState = {
@@ -101,6 +107,7 @@ test("UrlManager should build csv url hash and parse it again", (t) => {
   location.hash = `#${hash}`;
   t.deepEqual(UrlManager.parseUrlHash(), urlState);
 });
+
 test("UrlManager should parse url hash with comment links", (t) => {
   const state = {
     position: [555, 278, 482],
@@ -114,6 +121,7 @@ test("UrlManager should parse url hash with comment links", (t) => {
     });
   }
 });
+
 test("UrlManager should parse json url hash", (t) => {
   const state = {
     position: [555, 278, 482],
@@ -125,6 +133,7 @@ test("UrlManager should parse json url hash", (t) => {
   location.hash = `#${encodeUrlHash(JSON.stringify(state))}`;
   t.deepEqual(UrlManager.parseUrlHash(), state);
 });
+
 test("UrlManager should parse incomplete json url hash", (t) => {
   const state = {
     position: [555, 278, 482],
@@ -133,13 +142,16 @@ test("UrlManager should parse incomplete json url hash", (t) => {
     rotation: [40.45, 13.65, 0.8],
     activeNode: 2,
   };
-  const { ...stateWithoutRotation } = state;
+  // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
+  const { rotation, ...stateWithoutRotation } = state;
   location.hash = `#${encodeUrlHash(JSON.stringify(stateWithoutRotation))}`;
   t.deepEqual(UrlManager.parseUrlHash(), stateWithoutRotation);
-  const { ...stateWithoutActiveNode } = state;
+  // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
+  const { activeNode, ...stateWithoutActiveNode } = state;
   location.hash = `#${encodeUrlHash(JSON.stringify(stateWithoutActiveNode))}`;
   t.deepEqual(UrlManager.parseUrlHash(), stateWithoutActiveNode);
 });
+
 test("UrlManager should build json url hash and parse it again", (t) => {
   const mode = Constants.MODE_ARBITRARY;
   const urlState = {
@@ -159,6 +171,7 @@ test("UrlManager should build json url hash and parse it again", (t) => {
   location.hash = `#${hash}`;
   t.deepEqual(UrlManager.parseUrlHash(), urlState);
 });
+
 test("UrlManager should build default url in csv format", (t) => {
   UrlManager.initialize();
   const url = UrlManager.buildUrl();

--- a/frontend/javascripts/test/helpers/apiHelpers.ts
+++ b/frontend/javascripts/test/helpers/apiHelpers.ts
@@ -33,7 +33,7 @@ const Request = {
   always: () => Promise.resolve(),
 };
 export function createBucketResponseFunction(TypedArrayClass, fillValue, delay = 0) {
-  return async function getBucketData(payload) {
+  return async function getBucketData(_url, payload) {
     const bucketCount = payload.data.length;
     await sleep(delay);
     return {

--- a/frontend/javascripts/test/helpers/apiHelpers.ts
+++ b/frontend/javascripts/test/helpers/apiHelpers.ts
@@ -33,7 +33,7 @@ const Request = {
   always: () => Promise.resolve(),
 };
 export function createBucketResponseFunction(TypedArrayClass, fillValue, delay = 0) {
-  return async function getBucketData(url, payload) {
+  return async function getBucketData(payload) {
     const bucketCount = payload.data.length;
     await sleep(delay);
     return {
@@ -131,7 +131,7 @@ const modelData = {
 
 const { default: Store, startSagas } = require("oxalis/store");
 const rootSaga = require("oxalis/model/sagas/root_saga").default;
-const { setStore, setModel, setApi } = require("oxalis/singletons");
+const { setStore, setModel } = require("oxalis/singletons");
 const { setupApi } = require("oxalis/api/internal_api");
 
 setModel(Model);

--- a/frontend/javascripts/test/helpers/chainReducer.ts
+++ b/frontend/javascripts/test/helpers/chainReducer.ts
@@ -21,7 +21,7 @@ class ChainReducerClass<S, A> {
     // @ts-expect-error ts-migrate(2322) FIXME: Type 'A | ((arg0: S) => A)' is not assignable to t... Remove this comment to see the full error message
     return actionGetters.reduce(
       // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
-      (acc, currentActionGetter) => this.apply(reducer, currentActionGetter),
+      (_acc, currentActionGetter) => this.apply(reducer, currentActionGetter),
       this,
     );
   }

--- a/frontend/javascripts/test/libs/task_pool.spec.ts
+++ b/frontend/javascripts/test/libs/task_pool.spec.ts
@@ -43,7 +43,7 @@ test.serial(
     try {
       await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
       t.fail("processTaskWithPool should fail");
-    } catch (exception) {
+    } catch (_exception) {
       t.deepEqual(protocol, [1]);
     }
   },

--- a/frontend/javascripts/test/reducers/volumetracing_reducer.spec.ts
+++ b/frontend/javascripts/test/reducers/volumetracing_reducer.spec.ts
@@ -176,7 +176,7 @@ test("VolumeTracing should update its lastLabelActions", (t) => {
   });
 });
 
-const prepareContourListTest = (t, state) => {
+const prepareContourListTest = (state) => {
   const contourList = [
     [4, 6, 9],
     [1, 2, 3],
@@ -193,7 +193,7 @@ const prepareContourListTest = (t, state) => {
 };
 
 test("VolumeTracing should add values to the contourList", (t) => {
-  const { newState, contourList } = prepareContourListTest(t, initialState);
+  const { newState, contourList } = prepareContourListTest(initialState);
   t.not(newState, initialState);
   getFirstVolumeTracingOrFail(newState.tracing).map((tracing) => {
     t.deepEqual(tracing.contourList, contourList);
@@ -208,7 +208,7 @@ test("VolumeTracing should add values to the contourList even if getRequestLogZo
     },
   });
   t.true(getRequestLogZoomStep(alteredState) > 1);
-  const { newState, contourList } = prepareContourListTest(t, alteredState);
+  const { newState, contourList } = prepareContourListTest(alteredState);
   t.not(newState, initialState);
   getFirstVolumeTracingOrFail(newState.tracing).map((tracing) => {
     t.deepEqual(tracing.contourList, contourList);

--- a/frontend/javascripts/test/reducers/volumetracing_reducer.spec.ts
+++ b/frontend/javascripts/test/reducers/volumetracing_reducer.spec.ts
@@ -176,7 +176,7 @@ test("VolumeTracing should update its lastLabelActions", (t) => {
   });
 });
 
-const prepareContourListTest = (state) => {
+const prepareContourListTest = (_t, state) => {
   const contourList = [
     [4, 6, 9],
     [1, 2, 3],
@@ -193,7 +193,7 @@ const prepareContourListTest = (state) => {
 };
 
 test("VolumeTracing should add values to the contourList", (t) => {
-  const { newState, contourList } = prepareContourListTest(initialState);
+  const { newState, contourList } = prepareContourListTest(t, initialState);
   t.not(newState, initialState);
   getFirstVolumeTracingOrFail(newState.tracing).map((tracing) => {
     t.deepEqual(tracing.contourList, contourList);
@@ -208,7 +208,7 @@ test("VolumeTracing should add values to the contourList even if getRequestLogZo
     },
   });
   t.true(getRequestLogZoomStep(alteredState) > 1);
-  const { newState, contourList } = prepareContourListTest(alteredState);
+  const { newState, contourList } = prepareContourListTest(t, alteredState);
   t.not(newState, initialState);
   getFirstVolumeTracingOrFail(newState.tracing).map((tracing) => {
     t.deepEqual(tracing.contourList, contourList);

--- a/frontend/javascripts/test/sagas/saga_integration.spec.ts
+++ b/frontend/javascripts/test/sagas/saga_integration.spec.ts
@@ -67,8 +67,7 @@ test.serial(
     );
     // Reset the info field which is just for debugging purposes
     const actualSaveQueue = state.save.queue.skeleton.map((entry) => {
-      const { info, ...rest } = entry;
-      return { ...rest, info: "[]" };
+      return { ...entry, info: "[]" };
     });
     // Once the updateTree update action is in the save queue, we're good.
     // This means the setTreeName action was dispatched, the diffing ran, and the change will be persisted.

--- a/frontend/javascripts/test/sagas/saga_integration.spec.ts
+++ b/frontend/javascripts/test/sagas/saga_integration.spec.ts
@@ -67,7 +67,9 @@ test.serial(
     );
     // Reset the info field which is just for debugging purposes
     const actualSaveQueue = state.save.queue.skeleton.map((entry) => {
-      return { ...entry, info: "[]" };
+      // rome-ignore lint/correctness/noUnusedVariables: underscore prefix does not work with object destructuring
+      const { info, ...rest } = entry;
+      return { ...rest, info: "[]" };
     });
     // Once the updateTree update action is in the save queue, we're good.
     // This means the setTreeName action was dispatched, the diffing ran, and the change will be persisted.

--- a/frontend/javascripts/types/validation.ts
+++ b/frontend/javascripts/types/validation.ts
@@ -34,7 +34,7 @@ const validateWithSchemaSync = (type: string, value: string) => {
   }
 };
 
-const validateWithSchema = (type: string) => (rule: Record<string, any>, value: string) => {
+const validateWithSchema = (type: string) => (_rule: Record<string, any>, value: string) => {
   try {
     return Promise.resolve(validateWithSchemaSync(type, value));
   } catch (e) {
@@ -68,11 +68,11 @@ export const isValidJSON = (json: string) => {
   try {
     JSON.parse(json);
     return true;
-  } catch (ex) {
+  } catch (_ex) {
     return false;
   }
 };
 export function syncValidator<T>(validateValueFn: (arg0: T) => boolean, errMessage: string) {
-  return (rule: Record<string, any>, value: T) =>
+  return (_rule: Record<string, any>, value: T) =>
     validateValueFn(value) ? Promise.resolve() : Promise.reject(new Error(errMessage));
 }

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "redux-batched-actions": "^0.4.1",
     "redux-saga": "^1.0.0",
     "resumablejs": "^1.1.0",
-    "rome": "^10.0.0",
+    "rome": "^11.0.0",
     "saxophone": "^0.8.0",
     "strip-ansi": "^7.0.1",
     "terser-webpack-plugin": "^5.3.0",

--- a/rome.json
+++ b/rome.json
@@ -30,6 +30,7 @@
         "noDelete": "off"
       },
       "correctness": {
+        "noUnusedVariables": "error",
         "noRenderReturnValue": "off"
       },
       "suspicious": {

--- a/rome.json
+++ b/rome.json
@@ -26,11 +26,16 @@
         "useValidAnchor": "off",
         "useKeyWithClickEvents": "off"
       },
+      "performance": {
+        "noDelete": "off"
+      },
       "correctness": {
-        "noDelete": "off",
-        "noShadowRestrictedNames": "off",
-        "noRenderReturnValue": "off",
-        "noAsyncPromiseExecutor": "off"
+        "noRenderReturnValue": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noAsyncPromiseExecutor": "off",
+        "noShadowRestrictedNames": "off"
       }
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,35 +797,35 @@
   dependencies:
     react "^16.13.1"
 
-"@rometools/cli-darwin-arm64@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-arm64/-/cli-darwin-arm64-10.0.0.tgz#c219bbdc8a9d53a845b18f6df2affbff5b887b0b"
-  integrity sha512-JT7JccEtKyFDHXy0MxhwHN4Zc94s/kW+0aTczb1ChAoCStfjj5jWzv/yQnm+HFw5Vf3ukAocLsDNRN6d9gQYbQ==
+"@rometools/cli-darwin-arm64@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-arm64/-/cli-darwin-arm64-11.0.0.tgz#8f916df0580fede2325434a50ed5b1f2cf972696"
+  integrity sha512-F3vkdY+s3FLIEnAjSbyHTuIPB88cLpccimW4ecid5I7S6GzGG3iUJI4xT00JhH73K4P/qW20/9r+kH1T9Du8Xg==
 
-"@rometools/cli-darwin-x64@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-x64/-/cli-darwin-x64-10.0.0.tgz#dbf8284c5013d61dbca25ab92027398274ee2e3a"
-  integrity sha512-HORYhz8eM3L3XePPNBhU44zFpTVfhpuO4B7fjdfho7z9kwTW22M0fVvuPrxxPauxmin7gHM8lxCD2jHxabg34Q==
+"@rometools/cli-darwin-x64@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-x64/-/cli-darwin-x64-11.0.0.tgz#1393a5bba26e8c5352737270a1a98f2759f40d14"
+  integrity sha512-X6jhtS6Iml4GOzgNtnLwIp/KXXhSdqeVyfv69m/AHnIzx3gQAjPZ7BPnJLvTCbhe4SKHL+uTZYFSCJpkUUKE6w==
 
-"@rometools/cli-linux-arm64@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-arm64/-/cli-linux-arm64-10.0.0.tgz#50b3fd210054fc68f2c92494f304d26ab5a8a7b1"
-  integrity sha512-/L3jxo9RUwJ+uvDvAPCquAw10ccpZDuzADfZff5tHd6Fzv28cAToC3JrN/2miGpur0Fx/NIZIPbAsdI4NWGIRA==
+"@rometools/cli-linux-arm64@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-arm64/-/cli-linux-arm64-11.0.0.tgz#efbfd36013455fc5d940b24b1b195a43aba87bcb"
+  integrity sha512-dktTJJlTpmycBZ2TwhJBcAO8ztK8DdevdyZnFFxdYRvtmJgTjIsC2UFayf/SbKew8B8q1IhI0it+D6ihAeIpeg==
 
-"@rometools/cli-linux-x64@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-x64/-/cli-linux-x64-10.0.0.tgz#5cd3611dc23fcefafaf642791950bc3c940b172d"
-  integrity sha512-KC6CDeSR4haRfxmfrvCn8+NzQ7X31pDjFgD+m+PAbSXOeMr/KHmU7eDsjC3d47ORYYkYXqhx9VxHe1w3IEShMg==
+"@rometools/cli-linux-x64@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-x64/-/cli-linux-x64-11.0.0.tgz#675532d9f603b88ab0686da800ec711b45d22085"
+  integrity sha512-WVcnXPNdWGUWo0p4NU8YzuthjYR7q+b4vRcjdxtP1DlpphZmSsoC/RSE85nEqRAz8hChcKUansVzOPM8BSsuGA==
 
-"@rometools/cli-win32-arm64@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-arm64/-/cli-win32-arm64-10.0.0.tgz#6dfb064de3b9a4c35a89bf32635ba4e675ea85c6"
-  integrity sha512-8XWjx7Z1dMp9q4Lvi+ax4+Y8vkbp7JHVdfrTSMQTyUA9ofaW6ah1h9iGPuKic057VTZGX66/KazC5qNTbrlckQ==
+"@rometools/cli-win32-arm64@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-arm64/-/cli-win32-arm64-11.0.0.tgz#4d50f446acf2bc126cb58b5cff5a4d53b7c6a378"
+  integrity sha512-tPj6RThQzS7Q45jqQll7NlTYvNcsg/BEP3LYiiazqSh9FAFnMkrV6ewUcMPKWyAfiyLs7jlz4rRvdNRUSygzfQ==
 
-"@rometools/cli-win32-x64@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-x64/-/cli-win32-x64-10.0.0.tgz#1c5132eb96bac7ba5da59ed7cddac32d33bc933b"
-  integrity sha512-mAf3f32oE919cZ86KVMR/X0VOs+C16jEUyt1ww2UPw/rKUmm0DNfuT6/m4FQW8GEHdCBC8z3zdRVCd05VK7UJg==
+"@rometools/cli-win32-x64@11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-x64/-/cli-win32-x64-11.0.0.tgz#c6d48db5ea52b393dae7fe04bfe803ad8cee71a5"
+  integrity sha512-bmBai8WHxYjsGk1+je7ZTfCUCWq30WJI3pQM8pzTA674lfGTZ9ymJoZwTaIMSO4rL5V9mlO6uLunsBKso9VqOg==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
@@ -11808,17 +11808,17 @@ rimraf@^2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rome@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/rome/-/rome-10.0.0.tgz#ae1e291f4b3546881c1709597f7e2e679546fc56"
-  integrity sha512-dQnIlzgHDt94N4JoFaqe9e2aDAZfdmyGOW4UaefMztDph41mt75Mg0aeJ/C7JgcIOLbp9D4LD+omyUB5YFUUPw==
+rome@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/rome/-/rome-11.0.0.tgz#cd2f00fadfd3611399eba9a2f87612e1f3299a23"
+  integrity sha512-rRo6JOwpMLc3OkeTDRXkrmrDqnxDvZ75GS4f0jLDBNmRgDXWbu0F8eVnJoRn+VbK2AE7vWvhVOMBjnWowcopkQ==
   optionalDependencies:
-    "@rometools/cli-darwin-arm64" "10.0.0"
-    "@rometools/cli-darwin-x64" "10.0.0"
-    "@rometools/cli-linux-arm64" "10.0.0"
-    "@rometools/cli-linux-x64" "10.0.0"
-    "@rometools/cli-win32-arm64" "10.0.0"
-    "@rometools/cli-win32-x64" "10.0.0"
+    "@rometools/cli-darwin-arm64" "11.0.0"
+    "@rometools/cli-darwin-x64" "11.0.0"
+    "@rometools/cli-linux-arm64" "11.0.0"
+    "@rometools/cli-linux-x64" "11.0.0"
+    "@rometools/cli-win32-arm64" "11.0.0"
+    "@rometools/cli-win32-x64" "11.0.0"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
I was looking for a lint rule to detect unused imports. In the process I update to the latest version of Rome linter v11.0.0 in the hopes that they might have added this rule. Unfortunately, that is not the case, but I updated anyways to have access to their latest rules.
[Rome v11 Announcement and Summary Blog Post](https://rome.tools/blog/2022/12/06/rome11/)

PR changes
- Update Rome to latest version, v11.0.0
- Fix rome config / new sections for some rules
- Disabled new [`noExplicitAny` rule](https://docs.rome.tools/lint/rules/noexplicitany/)
- Applied fixes for new rule [`useFlatMap`](https://docs.rome.tools/lint/rules/useflatmap/) 
- Enabled and applied fixes for rule [`noUnusedVariables`](https://docs.rome.tools/lint/rules/nounusedvariables/ 

### Steps to test:
- yarn install
- yarn lint

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
