### PR TITLE
expose datastore file system watcher initial delay to config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,6 +153,7 @@ datastore {
   watchFileSystem {
     enabled = true
     interval = 1 minute
+    initialDelay = 10 seconds
   }
   reportUsedStorage.enabled = false
   cache {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -24,6 +24,7 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
     object WatchFileSystem {
       val enabled: Boolean = get[Boolean]("datastore.watchFileSystem.enabled")
       val interval: FiniteDuration = get[FiniteDuration]("datastore.watchFileSystem.interval")
+      val initialDelay: FiniteDuration = get[FiniteDuration]("datastore.watchFileSystem.initialDelay")
     }
     object Cache {
       object DataCube {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -33,10 +33,10 @@ class DataSourceService @Inject()(
     with LazyLogging
     with FoxImplicits {
 
-  override protected lazy val enabled: Boolean = config.Datastore.WatchFileSystem.enabled
+  override protected val enabled: Boolean = config.Datastore.WatchFileSystem.enabled
   protected lazy val tickerInterval: FiniteDuration = config.Datastore.WatchFileSystem.interval
 
-  override val tickerInitialDelay: FiniteDuration = config.Datastore.WatchFileSystem.initialDelay
+  override protected val tickerInitialDelay: FiniteDuration = config.Datastore.WatchFileSystem.initialDelay
 
   val dataBaseDir: Path = Paths.get(config.Datastore.baseFolder)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -36,6 +36,8 @@ class DataSourceService @Inject()(
   override protected lazy val enabled: Boolean = config.Datastore.WatchFileSystem.enabled
   protected lazy val tickerInterval: FiniteDuration = config.Datastore.WatchFileSystem.interval
 
+  override val tickerInitialDelay: FiniteDuration = config.Datastore.WatchFileSystem.initialDelay
+
   val dataBaseDir: Path = Paths.get(config.Datastore.baseFolder)
 
   private val propertiesFileName = Paths.get("datasource-properties.json")

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -42,6 +42,7 @@ datastore {
   watchFileSystem {
     enabled = true
     interval = 1 minute
+    initialDelay = 10 seconds
   }
   cache {
     dataCube.maxEntries = 1000


### PR DESCRIPTION
When developing locally, it may make sense to reduce this initial delay in order to reduce the time until datasources are available after incremental recompilation

------
- [x] Ready for review
