### PR TITLE
Prevent merging/splitting with segment 0

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -40,6 +40,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where the dataset folders view would not list public datasets if the requesting user could not also access the dataset for other reasons, like being admin. [#6759](https://github.com/scalableminds/webknossos/pull/6759)
 - Fixed a bug where zarr-streamed datasets would produce (very rare) rendering errors. [#6782](https://github.com/scalableminds/webknossos/pull/6782)
 - Fixed a bug where publicly shared annotations were not viewable by users without an account. [#6784](https://github.com/scalableminds/webknossos/pull/6784)
+- Fixed that the proofreading tool allowed to split/merge with segment 0 which led to an inconsistent state. [#6793](https://github.com/scalableminds/webknossos/pull/6793)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -639,6 +639,13 @@ function* getPartnerAgglomerateIds(
     yield* put(setBusyBlockingInfoAction(false));
     return null;
   }
+  if (sourceAgglomerateId == 0 || targetAgglomerateId == 0) {
+    Toast.warning(
+      "One of the selected segments has the id 0 which is the background. Cannot merge/split.",
+    );
+    yield* put(setBusyBlockingInfoAction(false));
+    return null;
+  }
   return {
     volumeTracingWithEditableMapping: { ...volumeTracingWithEditableMapping, mappingName },
     sourceAgglomerateId,

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -639,7 +639,7 @@ function* getPartnerAgglomerateIds(
     yield* put(setBusyBlockingInfoAction(false));
     return null;
   }
-  if (sourceAgglomerateId == 0 || targetAgglomerateId == 0) {
+  if ([sourceAgglomerateId, targetAgglomerateId, unmappedSourceId, unmappedTargetId].includes(0)) {
     Toast.warning(
       "One of the selected segments has the id 0 which is the background. Cannot merge/split.",
     );


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://preventmerge.webknossos.xyz

### Steps to test:
- create an annotation for the test-agglomerate-file DS
- select the proofreading tool
- ensure that segment 0 cannot be selected (worked before, too)
- activate a segment
- try to merge/split with/from segment 0
- a warning toast should appear and nothing should happen
- save and reload -> should still be valid

### Issues:
- see https://scm.slack.com/archives/C02H5T8Q08P/p1675151659552189

------
(Please delete unneeded items, merge only when none are left open)
- [X] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
