### PR TITLE
Fix datastore file system watcher

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,7 +153,7 @@ datastore {
   watchFileSystem {
     enabled = true
     interval = 1 minute
-    initialDelay = 10 seconds
+    initialDelay = 5 seconds
   }
   reportUsedStorage.enabled = false
   cache {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -33,10 +33,10 @@ class DataSourceService @Inject()(
     with LazyLogging
     with FoxImplicits {
 
-  override protected val enabled: Boolean = config.Datastore.WatchFileSystem.enabled
-  protected lazy val tickerInterval: FiniteDuration = config.Datastore.WatchFileSystem.interval
+  override protected def enabled: Boolean = config.Datastore.WatchFileSystem.enabled
+  override protected def tickerInterval: FiniteDuration = config.Datastore.WatchFileSystem.interval
 
-  override protected val tickerInitialDelay: FiniteDuration = config.Datastore.WatchFileSystem.initialDelay
+  override protected def tickerInitialDelay: FiniteDuration = config.Datastore.WatchFileSystem.initialDelay
 
   val dataBaseDir: Path = Paths.get(config.Datastore.baseFolder)
 

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -42,7 +42,7 @@ datastore {
   watchFileSystem {
     enabled = true
     interval = 1 minute
-    initialDelay = 10 seconds
+    initialDelay = 5 seconds
   }
   cache {
     dataCube.maxEntries = 1000


### PR DESCRIPTION
Fixes regression introduced in #6788 – apparently the execution order caused this override value to be unset, leading the ticker to be disabled. Changing this from val to def fixes it. I like this better than the `lazy val` this was before, as the superclass also has this as def.

I also decided to lower the default delay from 10s to 5s for this to shorten the time the datasources are unavailable.

### Steps to test:
- run wk with default config, should log `Scanning inbox (binaryData)...` shortly after startup

------
- [x] Needs datastore update after deployment
- [x] Ready for review
