### PR TITLE
Fix proofreading when mag 1 doesn't exist for segmentation layer

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -40,6 +40,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where the dataset folders view would not list public datasets if the requesting user could not also access the dataset for other reasons, like being admin. [#6759](https://github.com/scalableminds/webknossos/pull/6759)
 - Fixed a bug where zarr-streamed datasets would produce (very rare) rendering errors. [#6782](https://github.com/scalableminds/webknossos/pull/6782)
 - Fixed a bug where publicly shared annotations were not viewable by users without an account. [#6784](https://github.com/scalableminds/webknossos/pull/6784)
+- Fixed proofreading when mag 1 doesn't exist for segmentation layer [#6795](https://github.com/scalableminds/webknossos/pull/6795)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -1549,10 +1549,12 @@ class DataApi {
     topLeft: Vector3,
     bottomRight: Vector3,
     token: string,
+    resolution?: Vector3,
   ): string {
     const { dataset } = Store.getState();
-    const resolutionInfo = getDatasetResolutionInfo(dataset);
-    const resolution = resolutionInfo.getLowestResolution();
+    const resolutionInfo = getResolutionInfo(getLayerByName(dataset, layerName).resolutions);
+    resolution = resolution || resolutionInfo.getLowestResolution();
+
     const magString = resolution.join("-");
     return (
       `${dataset.dataStore.url}/data/datasets/${dataset.owningOrganization}/${dataset.name}/layers/${layerName}/data?mag=${magString}&` +
@@ -1591,6 +1593,7 @@ class DataApi {
     layerName: string,
     topLeft: Vector3,
     bottomRight: Vector3,
+    resolution?: Vector3,
   ): Promise<ArrayBuffer> {
     return doWithToken((token) => {
       const downloadUrl = this._getDownloadUrlForRawDataCuboid(
@@ -1598,6 +1601,7 @@ class DataApi {
         topLeft,
         bottomRight,
         token,
+        resolution,
       );
       return Request.receiveArraybuffer(downloadUrl);
     });

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -692,6 +692,7 @@ function* createGetUnmappedDataValueFn(
       fallbackLayerName,
       nodePosition,
       V3.add(nodePosition, mag),
+      mag,
     );
 
     return Number(new TypedArrayClass(buffer)[0]);


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I duplicated the test-agglomerate-ds, added another color layer (which has mag 1), downsampled the seg layer and removed mag 1 so that only mag 2 exists (therefore, color exists in mag 1 but the segmentation layer only in mag 2)
- then I used the proofreading tool to merge segments (didn't work before in this constellation)
- I also doublechecked that one cannot merge with segment 0

### Issues:
- see https://scm.slack.com/archives/C02H5T8Q08P/p1675179308527579?thread_ts=1675151659.552189&cid=C02H5T8Q08P

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Ready for review
