### PR TITLE
Fix some login problems

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,9 +13,10 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Added
 
 ### Changed
-- Limit paid team sharing features to respective organization plans. [6767](https://github.com/scalableminds/webknossos/pull/6776)
+- Limit paid team sharing features to respective organization plans. [#6767](https://github.com/scalableminds/webknossos/pull/6776)
 
 ### Fixed
+- Fixed a benign error message which briefly appeared after logging in. [#6810](https://github.com/scalableminds/webknossos/pull/6810)
 
 ### Removed
 

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -142,11 +142,14 @@ export function sendFailedRequestAnalyticsEvent(
 export async function loginUser(formValues: {
   email: string;
   password: string;
-}): Promise<Record<string, any>> {
+}): Promise<[APIUser, APIOrganization]> {
   await Request.sendJSONReceiveJSON("/api/auth/login", {
     data: formValues,
   });
-  return getActiveUser();
+  const activeUser = await getActiveUser();
+  const organization = await getOrganization(activeUser.organization);
+
+  return [activeUser, organization];
 }
 
 export async function getUsers(): Promise<Array<APIUser>> {

--- a/frontend/javascripts/admin/auth/login_form.tsx
+++ b/frontend/javascripts/admin/auth/login_form.tsx
@@ -8,6 +8,7 @@ import { setActiveUserAction } from "oxalis/model/actions/user_actions";
 import Store from "oxalis/store";
 import messages from "messages";
 import features from "features";
+import { setActiveOrganizationAction } from "oxalis/model/actions/organization_actions";
 
 const FormItem = Form.Item;
 const { Password } = Input;
@@ -34,9 +35,9 @@ function LoginForm({ layout, onLoggedIn, hideFooter, style }: Props) {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'formValues' implicitly has an 'any' typ... Remove this comment to see the full error message
   const onFinish = async (formValues) => {
-    const user = await loginUser(formValues);
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'Record<string, any>' is not assi... Remove this comment to see the full error message
+    const [user, organization] = await loginUser(formValues);
     Store.dispatch(setActiveUserAction(user));
+    Store.dispatch(setActiveOrganizationAction(organization));
 
     if (onLoggedIn) {
       onLoggedIn();

--- a/frontend/javascripts/admin/auth/registration_form.tsx
+++ b/frontend/javascripts/admin/auth/registration_form.tsx
@@ -8,6 +8,7 @@ import Request from "libs/request";
 import Store from "oxalis/throttled_store";
 import messages from "messages";
 import { setHasOrganizationsAction } from "oxalis/model/actions/ui_actions";
+import { setActiveOrganizationAction } from "oxalis/model/actions/organization_actions";
 const FormItem = Form.Item;
 const { Password } = Input;
 type Props = {
@@ -38,12 +39,12 @@ function RegistrationForm(props: Props) {
     const tryAutoLogin = props.tryAutoLogin || props.inviteToken != null || autoVerified;
 
     if (tryAutoLogin) {
-      const user = await loginUser({
+      const [user, organization] = await loginUser({
         email: formValues.email,
         password: formValues.password.password1,
       });
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'Record<string, any>' is not assi... Remove this comment to see the full error message
       Store.dispatch(setActiveUserAction(user));
+      Store.dispatch(setActiveOrganizationAction(organization));
     }
 
     props.onRegistered(tryAutoLogin);

--- a/frontend/javascripts/admin/auth/spotlight_registration_form.tsx
+++ b/frontend/javascripts/admin/auth/spotlight_registration_form.tsx
@@ -6,6 +6,7 @@ import { setActiveUserAction } from "oxalis/model/actions/user_actions";
 import Request from "libs/request";
 import Store from "oxalis/throttled_store";
 import messages from "messages";
+import { setActiveOrganizationAction } from "oxalis/model/actions/organization_actions";
 const FormItem = Form.Item;
 const { Password } = Input;
 type Props = {
@@ -40,12 +41,12 @@ function SpotlightRegistrationForm(props: Props) {
         organizationDisplayName: `${formValues.firstName} ${formValues.lastName} Lab`,
       },
     });
-    const user = await loginUser({
+    const [user, organization] = await loginUser({
       email: formValues.email,
       password: formValues.password.password1,
     });
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'Record<string, any>' is not assi... Remove this comment to see the full error message
     Store.dispatch(setActiveUserAction(user));
+    Store.dispatch(setActiveOrganizationAction(organization));
     props.onRegistered(true);
   }
 

--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -61,6 +61,7 @@ import { Redirect, Route, Router, Switch } from "react-router-dom";
 import { APICompoundTypeEnum, APIUser, TracingTypeEnum } from "types/api_flow_types";
 
 import ErrorBoundary from "components/error_boundary";
+import { Store } from "oxalis/singletons";
 
 const { Content } = Layout;
 
@@ -265,7 +266,11 @@ class ReactRouter extends React.Component<Props> {
               <RouteWithErrorBoundary
                 path="/dashboard"
                 render={() => {
-                  if (isAuthenticated) {
+                  // Imperatively access store state to avoid race condition when logging in.
+                  // The `isAuthenticated` prop could be outdated for a short time frame which
+                  // would lead to an unnecessary browser refresh.
+                  const { activeUser } = Store.getState();
+                  if (activeUser) {
                     return <DashboardView userId={null} isAdminView={false} initialTabKey={null} />;
                   }
 

--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -274,7 +274,7 @@ class ReactRouter extends React.Component<Props> {
                     return <DashboardView userId={null} isAdminView={false} initialTabKey={null} />;
                   }
 
-                  // Hard navigate
+                  // Hard navigate so that webknossos.org is shown for the demo instance.
                   window.location.href = "/";
                   return null;
                 }}


### PR DESCRIPTION
This PR fixes two problems:
- after logging in, an error boundary UI briefly showed up, because the active organization wasn't set yet (but was enforced by the dashboard)
- due to the above bug I noticed that there was apparently a hard refresh after logging in which I fixed now since it was unnecessary.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- log in from `/auth/login` and from the navbar (e.g., open a public dataset for that)
- logging in should not show up an error message

### Issues:
- partly related to #6767

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
