### PR TITLE
Prevent Deactivating Organization Owner

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -37,7 +37,7 @@ organization.list.failed=Failed to retrieve list of organizations.
 organization.name.invalid=This organization name contains illegal characters. Please only use letters and numbers.
 organization.name.alreadyInUse=This name is already claimed by a different organization and not available anymore. Please choose a different name.
 organization.alreadyJoined=Your account is already associated with the selected organization.
-organization.users.userLimitReached=Cannot add new user to this organization because it would exceed the organization’s user limit. Please ask the organization owner to upgrade. 
+organization.users.userLimitReached=Cannot add new user to this organization because it would exceed the organization’s user limit. Please ask the organization owner to upgrade.
 organization.pricingUpgrades.notAuthorized=You are not authorized to request any changes to your organization WEBKNOSSOS plan. Please ask the organization owner for permission.
 
 termsOfService.versionMismatch=Terms of service version mismatch. Current version is {0}, received acceptance for {1}
@@ -46,7 +46,8 @@ user.notFound=User not found
 user.noAdmin=Access denied. Only admin users can execute this operation.
 user.deactivated=Your account has not been activated by an admin yet. Please contact your organization’s admin for help.
 user.noSelfDeactivate=You cannot deactivate yourself. Please contact an admin to do it for you.
-user.lastAdmin=Your account is the last remaining admin in your organzation. You cannot remove admin privileges from your account.
+user.lastAdmin=This user is the last remaining admin in your organzation. You cannot remove admin privileges from this account.
+user.lastOwner=Cannot deactivate the organization owner. Please talk to the WEBKNOSSOS team to transfer organization ownership.
 
 user.email.alreadyInUse=This email address is already in use
 user.email.onlySuperUserCanChange=Only super users can change emails of users with multiple organization accounts


### PR DESCRIPTION
Prevents deactivating the (last) organization owner.

Also slipped in here: Skip unlisted users in annotation contributor list.

### Steps to test:
- Set up two admins, one of whom should be the organization owner
- As the _other_ admin, try to deactivate the owner from the user list view
- Should be denied.
- Set a user as unlisted, set an annotation to shared + multi-user editing, edit as the unlisted user, should not show up in contributors list in annotation view right sidebar

### Issues:
- fixes #6804
- fixes #6790

------
- [x] Ready for review
