### PR TITLE
Fix saving allowed teams in dataset settings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed a benign error message which briefly appeared after logging in. [#6810](https://github.com/scalableminds/webknossos/pull/6810)
+- Fixed saving allowed teams in dataset settings [#6817](https://github.com/scalableminds/webknossos/pull/6817)
 
 ### Removed
 

--- a/frontend/javascripts/components/pricing_enforcers.tsx
+++ b/frontend/javascripts/components/pricing_enforcers.tsx
@@ -78,11 +78,26 @@ export const PricingEnforcedButton: React.FunctionComponent<RequiredPricingProps
 export const PricingEnforcedBlur: React.FunctionComponent<RequiredPricingProps> = ({
   children,
   requiredPricingPlan,
+  ...restProps
 }) => {
   const activeOrganization = useSelector((state: OxalisState) => state.activeOrganization);
   const isFeatureAllowed = isFeatureAllowedByPricingPlan(activeOrganization, requiredPricingPlan);
 
-  if (isFeatureAllowed) return <>{children}</>;
+  if (isFeatureAllowed)
+    // Spread additional props to the children (required since antd's form implementation
+    // typically fills value and onChange props on children of FormItems).
+    return (
+      <>
+        {React.Children.map(children, (child) => {
+          if (!React.isValidElement(child)) {
+            return child;
+          }
+          return React.cloneElement(child, {
+            ...restProps,
+          });
+        })}
+      </>
+    );
 
   return (
     <Tooltip title={messages["organization.plan.feature_not_available"](requiredPricingPlan)}>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open the settings for a dataset
- add an allowed team in the sharing tab
- save
- ensure that the saving worked

### Issues:
- follow-up to #6776 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [X] Ready for review
