### PR TITLE
Fix error message when trying to join an orga you are already in

### DIFF
--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -72,9 +72,9 @@ class UserService @Inject()(conf: WkConf,
       user <- userDAO.findOneByOrgaAndMultiUser(organizationId, multiUser._id)
     } yield user
 
-  def assertNotInOrgaYet(multiUserId: ObjectId, organizationId: ObjectId)(implicit ctx: DBAccessContext): Fox[Unit] =
+  def assertNotInOrgaYet(multiUserId: ObjectId, organizationId: ObjectId): Fox[Unit] =
     for {
-      userBox <- userDAO.findOneByOrgaAndMultiUser(organizationId, multiUserId).futureBox
+      userBox <- userDAO.findOneByOrgaAndMultiUser(organizationId, multiUserId)(GlobalAccessContext).futureBox
       _ <- bool2Fox(userBox.isEmpty) ?~> "organization.alreadyJoined"
     } yield ()
 


### PR DESCRIPTION
When this assertion runs with the requesting user’s access context, it is possible they are not able to see the organization, leading the assertion to not fail. This was caught by the SQL constraints, but this fix gives the user a readable error message again.

- [x] Ready for review
