### PR TITLE
Fix dbtool schema scheck stderr capturing

### DIFF
--- a/app/Startup.scala
+++ b/app/Startup.scala
@@ -96,21 +96,22 @@ class Startup @Inject()(actorSystem: ActorSystem,
 
     val errorMessageBuilder = mutable.ListBuffer[String]()
     val capturingProcessLogger =
-      ProcessLogger((o: String) => errorMessageBuilder.append(o), (e: String) => logger.error(e))
+      ProcessLogger((o: String) => errorMessageBuilder.append(o), (e: String) => errorMessageBuilder.append(e))
 
     val result = Process("./tools/postgres/dbtool.js check-db-schema", None, "POSTGRES_URL" -> postgresUrl) ! capturingProcessLogger
     if (result == 0) {
       logger.info("Database schema is up to date.")
     } else {
       val errorMessage = errorMessageBuilder.toList.mkString("\n")
-      logger.error(errorMessage)
+      logger.error("dbtool: " + errorMessage)
       slackNotificationService.warn("SQL schema mismatch", errorMessage)
     }
   }
 
   private def ensurePostgresDatabase(): Unit = {
     logger.info(s"Ensuring Postgres database…")
-    val processLogger = ProcessLogger((o: String) => logger.info(o), (e: String) => logger.error(e))
+    val processLogger =
+      ProcessLogger((o: String) => logger.info(s"dbtool: $o"), (e: String) => logger.error(s"dbtool: $e"))
 
     // this script is copied to the stage directory in AssetCompilation
     val result = Process("./tools/postgres/dbtool.js ensure-db", None, "POSTGRES_URL" -> postgresUrl) ! processLogger


### PR DESCRIPTION
This should restore the schema difference output to the slack notification.
Also: clarify in logging which output comes from the dbtool (otherwise the bare `Startup - ✨✨ Done` was misleading)

### Steps to test:
- Create a schema mismatch by messing with your local db schema, e.g. inserting a new table
- This difference should be included in the error logging on wk startup

### Issues:
- fixes #6822
