### PR TITLE
Remove <Textarea> from <InputComponent>

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Limit paid team sharing features to respective organization plans. [#6767](https://github.com/scalableminds/webknossos/pull/6776)
 - Rewrite the database tools in `tools/postgres` to JavaScript and adding support for non-default Postgres username-password combinations. [#6803](https://github.com/scalableminds/webknossos/pull/6803)
 - Added owner name to organization page. [#6811](https://github.com/scalableminds/webknossos/pull/6811)
+- Remove multiline <TextArea> support from <InputComponent>. [#6839](https://github.com/scalableminds/webknossos/pull/6839)
 
 ### Fixed
 - Fixed saving allowed teams in dataset settings. [#6817](https://github.com/scalableminds/webknossos/pull/6817)

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -657,7 +657,7 @@ export function DatasetTags({
     updatedDataset: APIMaybeUnimportedDataset,
     shouldAddTag: boolean,
     tag: string,
-    event: React.MouseEvent,
+    event: React.SyntheticEvent,
   ): void => {
     event.stopPropagation(); // prevent the onClick event
 

--- a/frontend/javascripts/libs/vector_input.tsx
+++ b/frontend/javascripts/libs/vector_input.tsx
@@ -2,13 +2,11 @@ import * as React from "react";
 import _ from "lodash";
 import type { ServerBoundingBoxTypeTuple } from "types/api_flow_types";
 import type { Vector3, Vector6 } from "oxalis/constants";
-import InputComponent, {
-  InputComponentCommonProps,
-  InputElementProps,
-} from "oxalis/view/components/input_component";
+import InputComponent from "oxalis/view/components/input_component";
 import * as Utils from "libs/utils";
+import { InputProps } from "antd";
 
-type BaseProps<T> = Omit<InputComponentCommonProps & InputElementProps, "value" | "onChange"> & {
+type BaseProps<T> = Omit<InputProps, "value" | "onChange"> & {
   value: T | string;
   onChange: (value: T) => void;
   changeOnlyOnBlur?: boolean;
@@ -139,7 +137,6 @@ class BaseVector<T extends Vector3 | Vector6> extends React.PureComponent<BasePr
           autoSize ? { ...style, width: this.getText(this.state.text).length * 8 + 25 } : style
         }
         {...props}
-        isTextArea={false}
       />
     );
   }
@@ -151,7 +148,7 @@ export class Vector3Input extends BaseVector<Vector3> {
 export class Vector6Input extends BaseVector<Vector6> {
   defaultValue: Vector6 = [0, 0, 0, 0, 0, 0];
 }
-type BoundingBoxInputProps = Omit<InputComponentCommonProps & InputElementProps, "value"> & {
+type BoundingBoxInputProps = Omit<InputProps, "value"> & {
   value: ServerBoundingBoxTypeTuple;
   onChange: (arg0: ServerBoundingBoxTypeTuple) => void;
 };

--- a/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.tsx
@@ -22,18 +22,21 @@ type Props = {
   dataset: APIDataset;
   task: Task | null | undefined;
 };
-const positionIconStyle = {
+const positionIconStyle: React.CSSProperties = {
   transform: "rotate(-45deg)",
 };
-const warningColors = {
+const warningColors: React.CSSProperties = {
   color: "rgb(255, 155, 85)",
   borderColor: "rgb(241, 122, 39)",
 };
-const iconErrorStyle = { ...warningColors };
-const positionInputDefaultStyle = {
+const iconErrorStyle: React.CSSProperties = { ...warningColors };
+const positionInputDefaultStyle: React.CSSProperties = {
   textAlign: "center",
 };
-const positionInputErrorStyle = { ...positionInputDefaultStyle, ...warningColors };
+const positionInputErrorStyle: React.CSSProperties = {
+  ...positionInputDefaultStyle,
+  ...warningColors,
+};
 
 class DatasetPositionView extends PureComponent<Props> {
   copyPositionToClipboard = async () => {
@@ -131,7 +134,6 @@ class DatasetPositionView extends PureComponent<Props> {
             value={position}
             onChange={this.handleChangePosition}
             autoSize
-            // @ts-expect-error ts-migrate(2322) FIXME: Type '{ textAlign: string; }' is not assignable to... Remove this comment to see the full error message
             style={positionInputStyle}
             allowDecimals
           />

--- a/frontend/javascripts/oxalis/view/components/editable_text_icon.tsx
+++ b/frontend/javascripts/oxalis/view/components/editable_text_icon.tsx
@@ -1,11 +1,11 @@
 import { Input } from "antd";
-// @ts-expect-error ts-migrate(2724) FIXME: '"react"' has no exported member named 'Element'. ... Remove this comment to see the full error message
-import type { Element } from "react";
 import React from "react";
+
 type Props = {
-  icon: Element<any>;
-  onChange: (...args: Array<any>) => any;
+  icon: React.ReactElement;
+  onChange: (value: string, event: React.SyntheticEvent<HTMLInputElement>) => void;
 };
+
 type State = {
   isEditing: boolean;
   value: string;
@@ -17,14 +17,13 @@ class EditableTextIcon extends React.PureComponent<Props, State> {
     value: "",
   };
 
-  handleInputChange = (event: React.SyntheticEvent) => {
+  handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'EventTarg... Remove this comment to see the full error message
       value: event.target.value,
     });
   };
 
-  handleInputSubmit = (event: React.SyntheticEvent) => {
+  handleInputSubmit = (event: React.SyntheticEvent<HTMLInputElement>) => {
     const { value } = this.state;
 
     if (value !== "") {

--- a/frontend/javascripts/oxalis/view/components/input_component.tsx
+++ b/frontend/javascripts/oxalis/view/components/input_component.tsx
@@ -1,38 +1,6 @@
 import { Input, InputProps, Tooltip } from "antd";
 import * as React from "react";
 import _ from "lodash";
-import TextArea, { TextAreaProps } from "antd/lib/input/TextArea";
-
-export type InputComponentProps = InputComponentCommonProps &
-  (InputElementProps | TextAreaElementProps);
-
-export type InputComponentCommonProps = {
-  value: React.InputHTMLAttributes<HTMLInputElement>["value"];
-  title?: React.ReactNode;
-  style?: React.InputHTMLAttributes<HTMLInputElement>["style"];
-  placeholder?: React.InputHTMLAttributes<HTMLInputElement>["placeholder"];
-  disabled?: React.InputHTMLAttributes<HTMLInputElement>["disabled"];
-  size?: InputProps["size"];
-};
-
-export type InputElementProps = {
-  // The discriminated union
-  isTextArea?: false;
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
-  onBlur?: React.FocusEventHandler<HTMLInputElement>;
-  onFocus?: React.FocusEventHandler<HTMLInputElement>;
-  onPressEnter?: React.KeyboardEventHandler<HTMLInputElement>;
-};
-
-type TextAreaElementProps = {
-  isTextArea: true;
-  autoSize: TextAreaProps["autoSize"];
-  rows: TextAreaProps["rows"];
-  onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
-  onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
-  onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
-  onPressEnter?: React.KeyboardEventHandler<HTMLTextAreaElement>;
-};
 
 type InputComponentState = {
   isFocused: boolean;
@@ -48,14 +16,12 @@ type InputComponentState = {
  * @class
  */
 
-class InputComponent extends React.PureComponent<InputComponentProps, InputComponentState> {
-  static defaultProps: InputComponentProps = {
+class InputComponent extends React.PureComponent<InputProps, InputComponentState> {
+  static defaultProps: InputProps = {
     onChange: _.noop,
-    onPressEnter: undefined,
     placeholder: "",
     value: "",
     style: {},
-    isTextArea: false,
   };
 
   state = {
@@ -63,7 +29,7 @@ class InputComponent extends React.PureComponent<InputComponentProps, InputCompo
     currentValue: this.props.value,
   };
 
-  componentDidUpdate(prevProps: InputComponentProps) {
+  componentDidUpdate(prevProps: InputProps) {
     if (!this.state.isFocused && prevProps.value !== this.props.value) {
       this.setState({
         currentValue: this.props.value,
@@ -71,36 +37,33 @@ class InputComponent extends React.PureComponent<InputComponentProps, InputCompo
     }
   }
 
-  handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({
       currentValue: e.target.value,
     });
 
     if (this.props.onChange) {
-      // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
       this.props.onChange(e);
     }
   };
 
-  handleFocus = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     this.setState({
       isFocused: true,
     });
 
     if (this.props.onFocus) {
-      // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
       this.props.onFocus(e);
     }
   };
 
-  handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     this.setState(
       {
         isFocused: false,
       },
       () => {
         if (this.props.onBlur) {
-          // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
           this.props.onBlur(e);
         }
       },
@@ -118,19 +81,8 @@ class InputComponent extends React.PureComponent<InputComponentProps, InputCompo
   };
 
   render() {
-    const { isTextArea, onPressEnter, title, style, ...inputProps } = this.props;
-    const input = isTextArea ? (
-      <TextArea
-        {...inputProps}
-        style={title == null ? style : undefined}
-        onChange={this.handleChange}
-        onFocus={this.handleFocus}
-        onBlur={this.handleBlur}
-        value={this.state.currentValue}
-        onPressEnter={onPressEnter}
-        onKeyDown={this.blurOnEscape}
-      />
-    ) : (
+    const { title, style, ...inputProps } = this.props;
+    const input = (
       <Input
         {...inputProps}
         style={title == null ? style : undefined}
@@ -138,7 +90,6 @@ class InputComponent extends React.PureComponent<InputComponentProps, InputCompo
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         value={this.state.currentValue}
-        onPressEnter={onPressEnter != null ? onPressEnter : this.blurYourself}
         onKeyDown={this.blurOnEscape}
       />
     );

--- a/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
+++ b/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
@@ -78,14 +78,6 @@ export function MarkdownModal({
               minRows: 5,
               maxRows: 20,
             }}
-
-            // style={title == null ? style : undefined}
-            // onChange={this.handleChange}
-            // onFocus={this.handleFocus}
-            // onBlur={this.handleBlur}
-            // value={this.state.currentValue}
-            // onPressEnter={onPressEnter}
-            // onKeyDown={this.blurOnEscape}
           />
         </Col>
         <Col

--- a/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
+++ b/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
@@ -2,7 +2,7 @@ import { Alert, Modal, Button, Row, Col } from "antd";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import Markdown from "react-remarkable";
 import * as React from "react";
-import InputComponent from "oxalis/view/components/input_component";
+import TextArea from "antd/lib/input/TextArea";
 
 function getFirstLine(comment: string) {
   const newLineIndex = comment.indexOf("\n");
@@ -22,6 +22,7 @@ export function MarkdownWrapper({ source, singleLine }: { source: string; single
     />
   );
 }
+
 export function MarkdownModal({
   source,
   isOpen,
@@ -68,7 +69,7 @@ export function MarkdownModal({
       />
       <Row gutter={16}>
         <Col span={12}>
-          <InputComponent
+          <TextArea
             value={source}
             placeholder={`Add ${label}`}
             onChange={onChange}
@@ -77,7 +78,14 @@ export function MarkdownModal({
               minRows: 5,
               maxRows: 20,
             }}
-            isTextArea
+
+            // style={title == null ? style : undefined}
+            // onChange={this.handleChange}
+            // onFocus={this.handleFocus}
+            // onBlur={this.handleBlur}
+            // value={this.state.currentValue}
+            // onPressEnter={onPressEnter}
+            // onKeyDown={this.blurOnEscape}
           />
         </Col>
         <Col

--- a/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
+++ b/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
@@ -407,8 +407,7 @@ export class UserBoundingBoxInput extends React.PureComponent<UserBoundingBoxInp
     });
   };
 
-  handleChange = (evt: React.SyntheticEvent) => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'EventTarg... Remove this comment to see the full error message
+  handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const text = evt.target.value;
     // only numbers, commas and whitespace is allowed
     const isValidInput = /^[\d\s,]*$/g.test(text);
@@ -591,8 +590,7 @@ export class ColorSetting extends React.PureComponent<ColorSettingPropTypes> {
     disabled: false,
   };
 
-  onColorChange = (evt: React.SyntheticEvent) => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'EventTarg... Remove this comment to see the full error message
+  onColorChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     this.props.onChange(Utils.hexToRgb(evt.target.value));
   };
 

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -2,7 +2,7 @@ import { CopyOutlined } from "@ant-design/icons";
 import type { Dispatch } from "redux";
 import { Dropdown, Empty, Menu, notification, Tooltip, Popover, Input, MenuItemProps } from "antd";
 import { connect, useDispatch, useSelector } from "react-redux";
-import React, { createContext, useContext, useEffect } from "react";
+import React, { createContext, MouseEvent, useContext, useEffect } from "react";
 import type {
   APIConnectomeFile,
   APIDataset,
@@ -578,8 +578,7 @@ function getBoundingBoxMenuOptions({
     setBoundingBoxName(clickedBoundingBoxId, evt.target.value);
   };
 
-  // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'evt' implicitly has an 'any' type.
-  const preventContextMenuFromClosing = (evt) => {
+  const preventContextMenuFromClosing = (evt: MouseEvent) => {
     evt.stopPropagation();
   };
 
@@ -638,8 +637,7 @@ function getBoundingBoxMenuOptions({
             top: 0,
             opacity: 0,
           }}
-          onChange={(evt: React.SyntheticEvent) => {
-            // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'EventTarg... Remove this comment to see the full error message
+          onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
             let color = hexToRgb(evt.target.value);
             color = color.map((colorPart) => colorPart / 255) as any as Vector3;
             setBoundingBoxColor(clickedBoundingBoxId, color);

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -1058,9 +1058,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
           <>
             <Divider />
             <Row justify="center" align="middle">
-              <Button
-                onClick={this.showAddVolumeLayerModal}
-              >
+              <Button onClick={this.showAddVolumeLayerModal}>
                 <PlusOutlined />
                 Add Volume Annotation Layer
               </Button>

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -1060,9 +1060,6 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             <Row justify="center" align="middle">
               <Button
                 onClick={this.showAddVolumeLayerModal}
-                style={{
-                  width: 235,
-                }}
               >
                 <PlusOutlined />
                 Add Volume Annotation Layer

--- a/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/modals/add_volume_layer_modal.tsx
@@ -125,7 +125,7 @@ export default function AddVolumeLayerModal({
   const datasetResolutionInfo = getDatasetResolutionInfo(dataset);
   const [resolutionIndices, setResolutionIndices] = useState([0, 10000]);
 
-  const handleSetNewLayerName = (evt: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+  const handleSetNewLayerName = (evt: React.ChangeEvent<HTMLInputElement>) =>
     setNewLayerName(evt.target.value);
 
   const segmentationLayers = getSegmentationLayers(dataset);
@@ -199,7 +199,7 @@ export default function AddVolumeLayerModal({
       width={500}
       maskClosable={false}
       onCancel={onCancel}
-      visible
+      open
     >
       Layer Name:{" "}
       <InputComponent

--- a/frontend/javascripts/oxalis/view/right-border-tabs/skeleton_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/skeleton_tab_view.tsx
@@ -390,7 +390,7 @@ class SkeletonTabView extends React.PureComponent<Props, State> {
     },
   );
 
-  handleChangeTreeName = (evt: React.SyntheticEvent) => {
+  handleChangeTreeName = (evt: React.ChangeEvent<HTMLInputElement>) => {
     if (!this.props.skeletonTracing) {
       return;
     }
@@ -398,10 +398,8 @@ class SkeletonTabView extends React.PureComponent<Props, State> {
     const { activeGroupId } = this.props.skeletonTracing;
 
     if (activeGroupId != null) {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'EventTarg... Remove this comment to see the full error message
       api.tracing.renameGroup(activeGroupId, evt.target.value);
     } else {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'value' does not exist on type 'EventTarg... Remove this comment to see the full error message
       this.props.onChangeTreeName(evt.target.value);
     }
   };


### PR DESCRIPTION
ATM, our custom `<InputComponent>` supports rendering antd's `<Input>`and `<TextArea>` which leads to very questionable TS types. It turns out that `<TextArea>` is really only used in location, so I extracted it from `<InputComponent>`.

Comments in `<InputComponent>` that React 16 might have fixed the jumping cursors bug and that no custom wrapper for `<Input>` is necessary. I tried that and still had jumping cursors :-/ So, I guess the `<InputComponent>` will be around for a little longer but with simpler typing.

I also updated/fixed some generic types here and there to more specific events.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Perhaps try the annotation description Markdown modal.
- Run typechecker 

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [(unreleased) changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [(unreleased) migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Needs datastore update after deployment
- [x] Ready for review
