### PR TITLE
Add line break before dataset tags

### DIFF
--- a/frontend/javascripts/dashboard/folders/details_sidebar.tsx
+++ b/frontend/javascripts/dashboard/folders/details_sidebar.tsx
@@ -80,7 +80,7 @@ function DatasetDetails({ selectedDataset }: { selectedDataset: APIMaybeUnimport
       </h4>
       {selectedDataset.isActive && (
         <div>
-          <span className="sidebar-label">Voxel Size & Extent</span>
+          <div className="sidebar-label">Voxel Size & Extent</div>
           <div className="info-tab-block" style={{ marginTop: -3 }}>
             <table
               style={{
@@ -97,22 +97,21 @@ function DatasetDetails({ selectedDataset }: { selectedDataset: APIMaybeUnimport
       )}
       {selectedDataset.description && (
         <div style={{ marginBottom: 4 }}>
-          <span className="sidebar-label">Description</span>
+          <div className="sidebar-label">Description</div>
           <div>{selectedDataset.description}</div>
         </div>
       )}
       <div style={{ marginBottom: 4 }}>
-        <span className="sidebar-label">Access Permissions</span>
-        <br />
+        <div className="sidebar-label">Access Permissions</div>
         <TeamTags dataset={selectedDataset} emptyValue="Administrators & Dataset Managers" />
       </div>
       <div style={{ marginBottom: 4 }}>
-        <span className="sidebar-label">Layers</span>
-        <br /> <DatasetLayerTags dataset={selectedDataset} />
+        <div className="sidebar-label">Layers</div>
+        <DatasetLayerTags dataset={selectedDataset} />
       </div>
       {selectedDataset.isActive ? (
         <div style={{ marginBottom: 4 }}>
-          <span className="sidebar-label">Tags</span>
+          <div className="sidebar-label">Tags</div>
           <DatasetTags dataset={selectedDataset} updateDataset={context.updateCachedDataset} />
         </div>
       ) : null}
@@ -195,8 +194,7 @@ function FolderDetails({
             </Tooltip>
             . {maybeSelectMsg}
           </p>
-          <span className="sidebar-label">Access Permissions</span>
-          <br />
+          <div className="sidebar-label">Access Permissions</div>
           <FolderTeamTags folder={folder} />
         </div>
       ) : error ? (

--- a/frontend/javascripts/oxalis/view/components/editable_text_icon.tsx
+++ b/frontend/javascripts/oxalis/view/components/editable_text_icon.tsx
@@ -1,4 +1,4 @@
-import { Input } from "antd";
+import { Button, Input } from "antd";
 import React from "react";
 
 type Props = {
@@ -37,10 +37,6 @@ class EditableTextIcon extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const iconStyle = {
-      cursor: "pointer",
-    };
-
     if (this.state.isEditing) {
       return (
         <Input
@@ -55,15 +51,20 @@ class EditableTextIcon extends React.PureComponent<Props, State> {
           autoFocus
         />
       );
-    } else {
-      return React.cloneElement(this.props.icon, {
-        style: iconStyle,
-        onClick: () =>
+    }
+
+    return (
+      <Button
+        size="small"
+        icon={this.props.icon}
+        style={{ height: 22, width: 22 }}
+        onClick={() =>
           this.setState({
             isEditing: true,
-          }),
-      });
-    }
+          })
+        }
+      />
+    );
   }
 }
 


### PR DESCRIPTION
Small PR to improve styling of dataset list / tags. Moves tags to a new line. Also turns the "PlusIcon" for new tags into an actual `antd` button to make it easier to spot it as a clickable UI element. 

<img width="1615" alt="image" src="https://user-images.githubusercontent.com/1105056/218477539-008a14f8-eff6-4cf6-9f8c-da87c1582320.png">


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open ine browser and check that lay outing works
- Nothing special, really

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
