### PR TITLE
adds URL to help email

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -75,11 +75,12 @@ class Application @Inject()(multiUserDAO: MultiUserDAO,
   }
 
   @ApiOperation(hidden = true, value = "")
-  def helpEmail(message: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
+  def helpEmail(message: String, currentUrl: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
       organization <- organizationDAO.findOne(request.identity._organization)
       userEmail <- userService.emailFor(request.identity)
-      _ = Mailer ! Send(defaultMails.helpMail(request.identity, userEmail, organization.displayName, message))
+      _ = Mailer ! Send(
+        defaultMails.helpMail(request.identity, userEmail, organization.displayName, message, currentUrl))
     } yield Ok
   }
 

--- a/app/oxalis/mail/DefaultMails.scala
+++ b/app/oxalis/mail/DefaultMails.scala
@@ -1,14 +1,13 @@
 package oxalis.mail
 
-import java.net.URL
-
-import javax.inject.Inject
 import models.organization.Organization
 import models.user.User
 import play.api.i18n.Messages
 import utils.WkConf
 import views._
 
+import java.net.URL
+import javax.inject.Inject
 import scala.util.Try
 
 class DefaultMails @Inject()(conf: WkConf) {
@@ -93,11 +92,15 @@ class DefaultMails @Inject()(conf: WkConf) {
     )
   }
 
-  def helpMail(user: User, userEmail: String, organizationDisplayName: String, message: String): Mail =
+  def helpMail(user: User,
+               userEmail: String,
+               organizationDisplayName: String,
+               message: String,
+               currentUrl: String): Mail =
     Mail(
       from = defaultSender,
       subject = "Help requested // Feedback provided",
-      bodyHtml = html.mail.help(user.name, organizationDisplayName, message).body,
+      bodyHtml = html.mail.help(user.name, organizationDisplayName, message, currentUrl).body,
       recipients = List("hello@webknossos.org", userEmail)
     )
 

--- a/app/views/mail/help.scala.html
+++ b/app/views/mail/help.scala.html
@@ -1,4 +1,4 @@
-@( name: String, organizationDisplayName: String, message: String)
+@( name: String, organizationDisplayName: String, message: String, currentUrl: String)
 
 @emailBaseTemplate() {
 <p>Hi WEBKNOSSOS team</p>
@@ -6,6 +6,8 @@
 <p>
   @{message}
 </p>
+
+<p>Current URL: @{currentUrl}</p>
 
 <p>With best regards,<br />@{name} from @{organizationDisplayName}</p>
 }

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -6,7 +6,7 @@ GET           /buildinfo                                                        
 GET           /features                                                                 controllers.Application.features
 GET           /health                                                                   controllers.Application.health
 POST          /analytics/:eventType                                                     controllers.Application.trackAnalyticsEvent(eventType)
-POST          /helpEmail                                                                controllers.Application.helpEmail(message: String)
+POST          /helpEmail                                                                controllers.Application.helpEmail(message: String, currentUrl: String)
 POST          /triggers/initialData                                                     controllers.InitialDataController.triggerInsert
 GET           /maintenance                                                              controllers.MaintenanceController.info
 POST          /maintenance                                                              controllers.MaintenanceController.initMaintenance

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -2460,9 +2460,15 @@ export function getVoxelyticsArtifactChecksums(
 
 // ### Help / Feedback userEmail
 export function sendHelpEmail(message: string) {
-  return Request.receiveJSON(`/api/helpEmail?message=${encodeURIComponent(message)}`, {
-    method: "POST",
-  });
+  return Request.receiveJSON(
+    `/api/helpEmail?${new URLSearchParams({
+      message,
+      currentUrl: window.location.href,
+    })}`,
+    {
+      method: "POST",
+    },
+  );
 }
 
 export function requestSingleSignOnLogin() {

--- a/frontend/javascripts/oxalis/view/help_modal.tsx
+++ b/frontend/javascripts/oxalis/view/help_modal.tsx
@@ -76,6 +76,9 @@ export function HelpModal(props: HelpModalProps) {
         await sendHelpEmail(helpText);
         setHelpText("");
         message.success("Message has been sent. We'll reply via email shortly.");
+      } catch (err) {
+        message.error("Sorry, we could not send the help message. Please try again later.");
+        throw err;
       } finally {
         setSending(false);
       }

--- a/frontend/javascripts/oxalis/view/help_modal.tsx
+++ b/frontend/javascripts/oxalis/view/help_modal.tsx
@@ -66,13 +66,13 @@ type HelpModalProps = {
 
 export function HelpModal(props: HelpModalProps) {
   const [helpText, setHelpText] = useState("");
-  const [sending, setSending] = useState(false);
+  const [isSending, setIsSending] = useState(false);
   const positionStyle: CSSProperties = { right: 10, bottom: 40, top: "auto", position: "fixed" };
 
   const sendHelp = async () => {
     if (helpText.length > 0) {
       try {
-        setSending(true);
+        setIsSending(true);
         await sendHelpEmail(helpText);
         setHelpText("");
         message.success("Message has been sent. We'll reply via email shortly.");
@@ -80,7 +80,7 @@ export function HelpModal(props: HelpModalProps) {
         message.error("Sorry, we could not send the help message. Please try again later.");
         throw err;
       } finally {
-        setSending(false);
+        setIsSending(false);
       }
     }
     props.onCancel();
@@ -93,7 +93,7 @@ export function HelpModal(props: HelpModalProps) {
       open={props.isModalOpen}
       onOk={sendHelp}
       onCancel={props.onCancel}
-      confirmLoading={sending}
+      confirmLoading={isSending}
       mask={props.centeredLayout}
       okText="Send"
       width={300}

--- a/frontend/javascripts/oxalis/view/help_modal.tsx
+++ b/frontend/javascripts/oxalis/view/help_modal.tsx
@@ -1,5 +1,5 @@
 import { sendHelpEmail, updateNovelUserExperienceInfos } from "admin/admin_rest_api";
-import { Modal, Input, Alert } from "antd";
+import { Modal, Input, Alert, message } from "antd";
 import { setActiveUserAction } from "oxalis/model/actions/user_actions";
 import { OxalisState } from "oxalis/store";
 import React, { CSSProperties, useState } from "react";
@@ -66,14 +66,21 @@ type HelpModalProps = {
 
 export function HelpModal(props: HelpModalProps) {
   const [helpText, setHelpText] = useState("");
+  const [sending, setSending] = useState(false);
   const positionStyle: CSSProperties = { right: 10, bottom: 40, top: "auto", position: "fixed" };
 
-  const sendHelp = () => {
-    props.onCancel();
-
+  const sendHelp = async () => {
     if (helpText.length > 0) {
-      sendHelpEmail(helpText);
+      try {
+        setSending(true);
+        await sendHelpEmail(helpText);
+        setHelpText("");
+        message.success("Message has been sent. We'll reply via email shortly.");
+      } finally {
+        setSending(false);
+      }
     }
+    props.onCancel();
   };
 
   return (
@@ -83,6 +90,7 @@ export function HelpModal(props: HelpModalProps) {
       open={props.isModalOpen}
       onOk={sendHelp}
       onCancel={props.onCancel}
+      confirmLoading={sending}
       mask={props.centeredLayout}
       okText="Send"
       width={300}


### PR DESCRIPTION
Adds the user's current URL to the help email for better debug support.
Improves the UI a bit (thank you message, loading indicator).

### Steps to test:
- Set `features.isDemoInstance = true`
- Configure an SMTP
- Send a test mail

### Issues:
- fixes #6842
