### PR TITLE
Readable error message if team name is taken, even if other team is deleted

### DIFF
--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -133,8 +133,7 @@ class TeamDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
   def countByNameAndOrganization(teamName: String, organizationId: ObjectId): Fox[Int] =
     for {
       countList <- run(
-        q"select count(_id) from $existingCollectionName where name = $teamName and _organization = $organizationId"
-          .as[Int])
+        q"SELECT COUNT(*) FROM webknossos.teams WHERE name = $teamName AND _organization = $organizationId".as[Int])
       count <- countList.headOption
     } yield count
 


### PR DESCRIPTION
Names are, unfortunately, also blocked by deleted entities. However, this assertion only checked non-deleted ones. It should count all, though, otherwise the SQL constraint error is passed to the user in raw form.

### Steps to test:
- Create team, delete it
- Create new team of same name
- Should fail with readable error message (no raw SQL error)

### Issues:
- fixes #6787
