### PR TITLE
fix reversion being linked in MIGRATIONS.released.md

### DIFF
--- a/MIGRATIONS.released.md
+++ b/MIGRATIONS.released.md
@@ -18,8 +18,8 @@ None.
 
 ### Postgres Evolutions:
 
-- [094-pricing-plans.sql](conf/evolutions/reversions/094-pricing-plans.sql)
-- [095-constraint-naming.sql](conf/evolutions/reversions/095-constraint-naming.sql)
+- [094-pricing-plans.sql](conf/evolutions/094-pricing-plans.sql)
+- [095-constraint-naming.sql](conf/evolutions/095-constraint-naming.sql)
 - [096-storage.sql](conf/evolutions/096-storage.sql)
 - [097-credentials.sql](conf/evolutions/097-credentials.sql)
 - [098-voxelytics-states.sql](conf/evolutions/098-voxelytics-states.sql)


### PR DESCRIPTION
The MIGRATIONS.released.md had a significant flaw in it, the listed migrations were instead the database evolution needed to revert the migration for 94 and 95, this seems to have been missed in both 14dbb479fb and 6bedf79da4.

I have corrected the file here (and rolled back my database from backups).