### PR TITLE
Fix sql migration links in migration guide

### DIFF
--- a/MIGRATIONS.released.md
+++ b/MIGRATIONS.released.md
@@ -18,8 +18,8 @@ None.
 
 ### Postgres Evolutions:
 
-- [094-pricing-plans.sql](conf/evolutions/reversions/094-pricing-plans.sql)
-- [095-constraint-naming.sql](conf/evolutions/reversions/095-constraint-naming.sql)
+- [094-pricing-plans.sql](conf/evolutions/094-pricing-plans.sql)
+- [095-constraint-naming.sql](conf/evolutions/095-constraint-naming.sql)
 - [096-storage.sql](conf/evolutions/096-storage.sql)
 - [097-credentials.sql](conf/evolutions/097-credentials.sql)
 - [098-voxelytics-states.sql](conf/evolutions/098-voxelytics-states.sql)


### PR DESCRIPTION
Credit goes to thopp-tudelft who authored https://github.com/scalableminds/webknossos/pull/6856 Duplicating that here because the CI does not run for fork PRs and the master branch is protected.

