### PR TITLE
Fix exploring datasets via http (without s)

### DIFF
--- a/app/models/binary/credential/CredentialService.scala
+++ b/app/models/binary/credential/CredentialService.scala
@@ -24,7 +24,7 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO) {
                           userId: ObjectId,
                           organizationId: ObjectId): Option[FileSystemCredential] =
     uri.getScheme match {
-      case FileSystemsHolder.schemeHttps =>
+      case FileSystemsHolder.schemeHttps | FileSystemsHolder.schemeHttp =>
         credentialIdentifier.map(
           username =>
             HttpBasicAuthCredential(uri.toString,

--- a/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_zarr_view.tsx
@@ -322,7 +322,7 @@ function AddZarrLayer({
   };
 
   function validateUrls(userInput: string) {
-    if (userInput.startsWith("https://")) {
+    if (userInput.startsWith("https://") || userInput.startsWith("http://")) {
       setSelectedProtocol("https");
     } else if (userInput.startsWith("s3://")) {
       setSelectedProtocol("s3");
@@ -330,7 +330,7 @@ function AddZarrLayer({
       setSelectedProtocol("gs");
     } else {
       throw new Error(
-        "Dataset URL must employ one of the following protocols: https://, s3:// or gs://",
+        "Dataset URL must employ one of the following protocols: https://, http://, s3:// or gs://",
       );
     }
   }


### PR DESCRIPTION
The FileSystemProviders already support this, there was just some checks in the frontend and the createCredential codepath that didn’t handle http without s.

@philippotto Do you think the front-end fix is ok? I did not add http as a selectedProtocol, but rather reuse https in that case.

### Steps to test:
- Insert http (not https) uri in the Add Remote Dataset view
- Should work
