### PR TITLE
Fix basicauth for exploring remote http datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed saving allowed teams in dataset settings. [#6817](https://github.com/scalableminds/webknossos/pull/6817)
 - Fixed log streaming in Voxelytics workflow reports. [#6828](https://github.com/scalableminds/webknossos/pull/6828) [#6831](https://github.com/scalableminds/webknossos/pull/6831)
 - Fixed some layouting issues with line breaks in segment list/dataset info tab [#6799](https://github.com/scalableminds/webknossos/pull/6799)
+- Fixed basic auth for exploring remote http datasets [#6866](https://github.com/scalableminds/webknossos/pull/6866)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/httpsfilesystem/HttpsFileSystemProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/httpsfilesystem/HttpsFileSystemProvider.scala
@@ -15,7 +15,7 @@ object HttpsFileSystemProvider {
 
   def fileSystemKey(uri: URI, basicAuthCredentials: Option[HttpBasicAuthCredential]): String = {
     val uriWithUser = basicAuthCredentials.map { c =>
-      new URI(uri.getScheme, c.user, uri.getHost, uri.getPort, uri.getPath, uri.getQuery, uri.getFragment)
+      new URI(uri.getScheme, c.username, uri.getHost, uri.getPort, uri.getPath, uri.getQuery, uri.getFragment)
     }.getOrElse(uri)
     uriWithUser.toString
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/httpsfilesystem/HttpsSeekableByteChannel.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/httpsfilesystem/HttpsSeekableByteChannel.scala
@@ -25,7 +25,7 @@ class HttpsSeekableByteChannel(path: HttpsPath, openOptions: util.Set[_ <: OpenO
     path.getBasicAuthCredential.map { credential =>
       Http(uri.toString)
         .timeout(connTimeoutMs = connectionTimeout.toMillis.toInt, readTimeoutMs = readTimeout.toMillis.toInt)
-        .auth(credential.user, credential.password)
+        .auth(credential.username, credential.password)
         .asBytes
     }.getOrElse(Http(uri.toString)
       .timeout(connTimeoutMs = connectionTimeout.toMillis.toInt, readTimeoutMs = readTimeout.toMillis.toInt)


### PR DESCRIPTION
The credentials also have “user” which is the webknossos user id. That is not what is supposed to be passed to http basicauth…

### Steps to test:
- Explore a remote dataset with basic auth

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
