### PR TITLE
Add link to imprint and privacy to help menu

### DIFF
--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -382,7 +382,7 @@ function getHelpSubMenu(
   helpSubMenuItems.push({
     key: "imprint",
     label: (
-      <a target="_blank" href="https://webknossos.org/imprint" rel="noopener noreferrer">
+      <a target="_blank" href="/imprint" rel="noopener noreferrer">
         Imprint
       </a>
     ),
@@ -390,7 +390,7 @@ function getHelpSubMenu(
   helpSubMenuItems.push({
     key: "privacy",
     label: (
-      <a target="_blank" href="https://webknossos.org/privacy" rel="noopener noreferrer">
+      <a target="_blank" href="/privacy" rel="noopener noreferrer">
         Privacy
       </a>
     ),

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -379,6 +379,22 @@ function getHelpSubMenu(
       ),
     });
   }
+  helpSubMenuItems.push({
+    key: "imprint",
+    label: (
+      <a target="_blank" href="https://webknossos.org/imprint" rel="noopener noreferrer">
+        Imprint
+      </a>
+    ),
+  });
+  helpSubMenuItems.push({
+    key: "privacy",
+    label: (
+      <a target="_blank" href="https://webknossos.org/privacy" rel="noopener noreferrer">
+        Privacy
+      </a>
+    ),
+  });
 
   if (version !== "")
     helpSubMenuItems.push({
@@ -769,7 +785,11 @@ function Navbar({
 
     if (othersMayEdit && !allowUpdate) {
       trailingNavItems.push(
-        <AnnotationLockedByUserTag blockedByUser={blockedByUser} activeUser={activeUser} />,
+        <AnnotationLockedByUserTag
+          key="locked-by-user-tag"
+          blockedByUser={blockedByUser}
+          activeUser={activeUser}
+        />,
       );
     }
     trailingNavItems.push(<NotificationIcon key="notification-icon" activeUser={loggedInUser} />);


### PR DESCRIPTION
This pr adds a link to the imprint and privacy page to the help menu in the navbar.
It additionally might fix a potential bug where a new menu item added in #6819 did not get a key attribute. See [here](https://github.com/scalableminds/webknossos/pull/6819#discussion_r1115315444).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open any wk page
- open the help menu and click on the two new links to imprint and privacy. 
- Those links should open a new tab with the respective wk.org page

### Issues:
- fixes [#6798](https://github.com/scalableminds/webknossos/issues/6798)

------
(Please delete unneeded items, merge only when none are left open)
- ~[ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~
  - It is nothing really user-facing. Thus I would not add an entry for this.
