### PR TITLE
Add evolutions 99,100 to migration guide

### DIFF
--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -11,3 +11,6 @@ User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 - WEBKNOSSOS now requires Node.js not only for development and building, but also for execution. The prebuilt Docker images already contain this dependency. If you're using these, nothing needs to be changed. [#6803](https://github.com/scalableminds/webknossos/pull/6803)
 
 ### Postgres Evolutions:
+
+- [099-rename-credential-types.sql](conf/evolutions/099-rename-credential-types.sql)
+- [100-annotation-mutexes.sql](conf/evolutions/100-annotation-mutexes.sql)


### PR DESCRIPTION
Someone (me) missed adding these to the migration guide. Luckily, they did not yet make it into releases, so this should not have caused harm