### PR TITLE
Followups for OME-TIFF export

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - If an annotation that others are allowed to edit is opened, it will now be automatically locked. This prevents conflicts when multiple users try to edit it at the same time. [#6819](https://github.com/scalableminds/webknossos/pull/6819)
 - Added new mesh-related menu items to the context menu when a mesh is hovered in the 3d viewport. [#](https://github.com/scalableminds/webknossos/pull/6813)
 - Highlight 'organization owner' in Admin>User page. [#6832](https://github.com/scalableminds/webknossos/pull/6832
-- Added OME-TIFF export for bounding boxes. [#6838](https://github.com/scalableminds/webknossos/pull/6838)
+- Added OME-TIFF export for bounding boxes. [#6838](https://github.com/scalableminds/webknossos/pull/6838) [#6874](https://github.com/scalableminds/webknossos/pull/6874)
 - Added functions to get and set segment colors to the frontend API (`api.data.{getSegmentColor,setSegmentColor}`). [#6853](https://github.com/scalableminds/webknossos/pull/6853)
 
 ### Changed

--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -235,7 +235,7 @@ class JobsController @Inject()(jobDAO: JobDAO,
           dataSet <- dataSetDAO.findOneByNameAndOrganizationName(dataSetName, organizationName) ?~> Messages(
             "dataSet.notFound",
             dataSetName) ~> NOT_FOUND
-          _ <- jobService.assertTiffExportBoundingBoxLimits(bbox)
+          _ <- jobService.assertTiffExportBoundingBoxLimits(bbox, mag)
           userAuthToken <- wkSilhouetteEnvironment.combinedAuthenticatorService.findOrCreateToken(
             request.identity.loginInfo)
           command = "export_tiff"

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -369,9 +369,9 @@ class JobService @Inject()(wkConf: WkConf,
     for {
       parsedBoundingBox <- BoundingBox.fromLiteral(boundingBox).toFox ?~> "job.export.tiff.invalidBoundingBox"
       parsedMag <- Vec3Int.fromMagLiteral(mag.getOrElse("1-1-1"), true) ?~> "job.export.tiff.invalidMag"
-      scaledBoundingBox = parsedBoundingBox / parsedMag
-      _ <- bool2Fox(scaledBoundingBox.volume <= wkConf.Features.exportTiffMaxVolumeMVx * 1024 * 1024) ?~> "job.export.tiff.volumeExceeded"
-      _ <- bool2Fox(scaledBoundingBox.dimensions.maxDim <= wkConf.Features.exportTiffMaxEdgeLengthVx) ?~> "job.export.tiff.edgeLengthExceeded"
+      boundingBoxInMag = parsedBoundingBox / parsedMag
+      _ <- bool2Fox(boundingBoxInMag.volume <= wkConf.Features.exportTiffMaxVolumeMVx * 1024 * 1024) ?~> "job.export.tiff.volumeExceeded"
+      _ <- bool2Fox(boundingBoxInMag.dimensions.maxDim <= wkConf.Features.exportTiffMaxEdgeLengthVx) ?~> "job.export.tiff.edgeLengthExceeded"
     } yield ()
 
 }

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -1,7 +1,7 @@
 package models.job
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
-import com.scalableminds.util.geometry.BoundingBox
+import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.util.mvc.Formatter
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
@@ -365,11 +365,13 @@ class JobService @Inject()(wkConf: WkConf,
       _ <- workerDAO.findOneByDataStore(dataStoreName)
     } yield ()
 
-  def assertTiffExportBoundingBoxLimits(bbox: String): Fox[Unit] =
+  def assertTiffExportBoundingBoxLimits(boundingBox: String, mag: Option[String]): Fox[Unit] =
     for {
-      boundingBox <- BoundingBox.fromLiteral(bbox).toFox ?~> "job.export.tiff.invalidBoundingBox"
-      _ <- bool2Fox(boundingBox.volume <= wkConf.Features.exportTiffMaxVolumeMVx * 1024 * 1024) ?~> "job.export.tiff.volumeExceeded"
-      _ <- bool2Fox(boundingBox.dimensions.maxDim <= wkConf.Features.exportTiffMaxEdgeLengthVx) ?~> "job.export.tiff.edgeLengthExceeded"
+      parsedBoundingBox <- BoundingBox.fromLiteral(boundingBox).toFox ?~> "job.export.tiff.invalidBoundingBox"
+      parsedMag <- Vec3Int.fromMagLiteral(mag.getOrElse("1-1-1"), true) ?~> "job.export.tiff.invalidMag"
+      scaledBoundingBox = parsedBoundingBox / parsedMag
+      _ <- bool2Fox(scaledBoundingBox.volume <= wkConf.Features.exportTiffMaxVolumeMVx * 1024 * 1024) ?~> "job.export.tiff.volumeExceeded"
+      _ <- bool2Fox(scaledBoundingBox.dimensions.maxDim <= wkConf.Features.exportTiffMaxEdgeLengthVx) ?~> "job.export.tiff.edgeLengthExceeded"
     } yield ()
 
 }

--- a/conf/messages
+++ b/conf/messages
@@ -285,6 +285,7 @@ job.disabled = Long-running jobs are not enabled for this WEBKNOSSOS instance.
 job.worker.notFound = Could not find this worker in the database.
 job.export.fileNotFound = Exported file not found. The link may be expired.
 job.export.tiff.invalidBoundingBox = The selected bounding box could not be parsed, must be x,y,z,width,height,depth
+job.export.tiff.invalidMag = The selected mag could not be parsed, must be x-y-z
 job.export.tiff.volumeExceeded = The volume of the selected bounding box is too large.
 job.export.tiff.edgeLengthExceeded = An edge length of the selected bounding box is too large.
 job.inferNuclei.notAllowed.organization = Currently nuclei inferral is only allowed for datasets of your own organization.

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -985,6 +985,27 @@ export function convertToHybridTracing(
   });
 }
 
+export async function downloadWithFilename(downloadUrl: string) {
+  const { buffer, headers } = await Request.receiveArraybuffer(downloadUrl, {
+    extractHeaders: true,
+  });
+
+  // Using headers to determine the name and type of the file.
+  const contentDispositionHeader = headers["content-disposition"];
+  const filenameStartingPart = 'filename="';
+  const filenameStartingPosition =
+    contentDispositionHeader.indexOf(filenameStartingPart) + filenameStartingPart.length;
+  const filenameEndPosition = contentDispositionHeader.indexOf('"', filenameStartingPosition + 1);
+  const filename = contentDispositionHeader.substring(
+    filenameStartingPosition,
+    filenameEndPosition,
+  );
+  const blob = new Blob([buffer], {
+    type: headers["content-type"],
+  });
+  saveAs(blob, filename);
+}
+
 export async function downloadAnnotation(
   annotationId: string,
   annotationType: APIAnnotationType,
@@ -1005,24 +1026,7 @@ export async function downloadAnnotation(
   const maybeAmpersand = possibleVersionString === "" && !includeVolumeData ? "" : "&";
 
   const downloadUrl = `/api/annotations/${annotationType}/${annotationId}/download?${possibleVersionString}${maybeAmpersand}${skipVolumeDataString}`;
-  const { buffer, headers } = await Request.receiveArraybuffer(downloadUrl, {
-    extractHeaders: true,
-  });
-
-  // Using headers to determine the name and type of the file.
-  const contentDispositionHeader = headers["content-disposition"];
-  const filenameStartingPart = 'filename="';
-  const filenameStartingPosition =
-    contentDispositionHeader.indexOf(filenameStartingPart) + filenameStartingPart.length;
-  const filenameEndPosition = contentDispositionHeader.indexOf('"', filenameStartingPosition + 1);
-  const filename = contentDispositionHeader.substring(
-    filenameStartingPosition,
-    filenameEndPosition,
-  );
-  const blob = new Blob([buffer], {
-    type: headers["content-type"],
-  });
-  saveAs(blob, filename);
+  await downloadWithFilename(downloadUrl);
 }
 
 // When the annotation is open, please use the corresponding method

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -1,4 +1,3 @@
-import { saveAs } from "file-saver";
 import ResumableJS from "resumablejs";
 import _ from "lodash";
 import dayjs from "dayjs";
@@ -986,24 +985,12 @@ export function convertToHybridTracing(
 }
 
 export async function downloadWithFilename(downloadUrl: string) {
-  const { buffer, headers } = await Request.receiveArraybuffer(downloadUrl, {
-    extractHeaders: true,
-  });
-
-  // Using headers to determine the name and type of the file.
-  const contentDispositionHeader = headers["content-disposition"];
-  const filenameStartingPart = 'filename="';
-  const filenameStartingPosition =
-    contentDispositionHeader.indexOf(filenameStartingPart) + filenameStartingPart.length;
-  const filenameEndPosition = contentDispositionHeader.indexOf('"', filenameStartingPosition + 1);
-  const filename = contentDispositionHeader.substring(
-    filenameStartingPosition,
-    filenameEndPosition,
-  );
-  const blob = new Blob([buffer], {
-    type: headers["content-type"],
-  });
-  saveAs(blob, filename);
+  const link = document.createElement("a");
+  link.href = downloadUrl;
+  link.rel = "noopener";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
 }
 
 export async function downloadAnnotation(

--- a/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
@@ -10,6 +10,7 @@ import features from "features";
 import {
   doWithToken,
   downloadAnnotation,
+  downloadWithFilename,
   getAuthToken,
   startExportTiffJob,
 } from "admin/admin_rest_api";
@@ -41,7 +42,6 @@ import {
 import { formatBytes, formatScale } from "libs/format_utils";
 import { BoundingBoxType, Vector3 } from "oxalis/constants";
 import { useStartAndPollJob } from "admin/job/job_hooks";
-import { saveAs } from "file-saver";
 const CheckboxGroup = Checkbox.Group;
 const { TabPane } = Tabs;
 const { Paragraph, Text } = Typography;
@@ -290,7 +290,7 @@ function _DownloadModalView({
     async onSuccess(job) {
       if (job.resultLink != null) {
         const token = await doWithToken(async (t) => t);
-        saveAs(`${job.resultLink}?token=${token}`);
+        downloadWithFilename(`${job.resultLink}?token=${token}`);
       }
     },
     onFailure() {

--- a/test/backend/MathTestSuite.scala
+++ b/test/backend/MathTestSuite.scala
@@ -1,0 +1,19 @@
+package backend
+
+import com.scalableminds.util.tools.Math.ceilDiv
+import org.scalatestplus.play.PlaySpec
+
+class MathTestSuite extends PlaySpec {
+  "Math" should {
+    "ceilDiv correctly" in {
+      assert(ceilDiv(5, 2) == 3)
+      assert(ceilDiv(-5, 2) == -3)
+      assert(ceilDiv(5, -2) == -3)
+      assert(ceilDiv(-5, -2) == 3)
+      assert(ceilDiv(4, 2) == 2)
+
+      assert(ceilDiv(5L, 2L) == 3L)
+      assert(ceilDiv(4L, 2L) == 2L)
+    }
+  }
+}

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -57,6 +57,7 @@ case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
     BoundingBox(topLeft * that, width * that.x, height * that.y, depth * that.z)
 
   def /(that: Vec3Int): BoundingBox =
+    // Since floorDiv is used for topLeft, ceilDiv is used for the size to avoid voxels being lost at the border
     BoundingBox(topLeft / that, ceilDiv(width, that.x), ceilDiv(height, that.y), ceilDiv(depth, that.z))
 
   def toSql: List[Int] =

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -25,9 +25,9 @@ case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
     if (newTopLeft.x < newBottomRight.x && newTopLeft.y < newBottomRight.y && newTopLeft.z < newBottomRight.z) {
       Some(
         BoundingBox(newTopLeft,
-          newBottomRight.x - newTopLeft.x,
-          newBottomRight.y - newTopLeft.y,
-          newBottomRight.z - newTopLeft.z))
+                    newBottomRight.x - newTopLeft.x,
+                    newBottomRight.y - newTopLeft.y,
+                    newBottomRight.z - newTopLeft.z))
     } else None
   }
 

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -25,9 +25,9 @@ case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
     if (newTopLeft.x < newBottomRight.x && newTopLeft.y < newBottomRight.y && newTopLeft.z < newBottomRight.z) {
       Some(
         BoundingBox(newTopLeft,
-                    newBottomRight.x - newTopLeft.x,
-                    newBottomRight.y - newTopLeft.y,
-                    newBottomRight.z - newTopLeft.z))
+          newBottomRight.x - newTopLeft.x,
+          newBottomRight.y - newTopLeft.y,
+          newBottomRight.z - newTopLeft.z))
     } else None
   }
 
@@ -54,6 +54,8 @@ case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
 
   def *(that: Vec3Int): BoundingBox =
     BoundingBox(topLeft * that, width * that.x, height * that.y, depth * that.z)
+
+  def /(that: Vec3Int): BoundingBox = BoundingBox(topLeft / that, width / that.x, height / that.y, depth / that.z)
 
   def toSql: List[Int] =
     List(topLeft.x, topLeft.y, topLeft.z, width, height, depth)

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -1,5 +1,6 @@
 package com.scalableminds.util.geometry
 
+import com.scalableminds.util.tools.Math.ceilDiv
 import net.liftweb.common.Full
 
 case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
@@ -55,7 +56,8 @@ case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
   def *(that: Vec3Int): BoundingBox =
     BoundingBox(topLeft * that, width * that.x, height * that.y, depth * that.z)
 
-  def /(that: Vec3Int): BoundingBox = BoundingBox(topLeft / that, width / that.x, height / that.y, depth / that.z)
+  def /(that: Vec3Int): BoundingBox =
+    BoundingBox(topLeft / that, ceilDiv(width, that.x), ceilDiv(height, that.y), ceilDiv(depth, that.z))
 
   def toSql: List[Int] =
     List(topLeft.x, topLeft.y, topLeft.z, width, height, depth)

--- a/util/src/main/scala/com/scalableminds/util/geometry/Vec3Int.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Vec3Int.scala
@@ -14,6 +14,9 @@ case class Vec3Int(x: Int, y: Int, z: Int) {
   def *(that: Int): Vec3Int =
     Vec3Int(x * that, y * that, z * that)
 
+  def /(that: Vec3Int): Vec3Int =
+    Vec3Int(x / that.x, y / that.y, z / that.z)
+
   def scale(s: Float): Vec3Int =
     Vec3Int((x * s).toInt, (y * s).toInt, (z * s).toInt)
 

--- a/util/src/main/scala/com/scalableminds/util/tools/Math.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Math.scala
@@ -30,4 +30,14 @@ object Math {
 
   def stdDev[T: Numeric](xs: Iterable[T]): Double = math.sqrt(variance(xs))
 
+  def ceilDiv(num: Long, divisor: Long): Long = {
+    val sign = num.signum * divisor.signum
+    sign * (num.abs + divisor.abs - 1) / divisor.abs
+  }
+
+  def ceilDiv(num: Int, divisor: Int): Int = {
+    val sign = num.signum * divisor.signum
+    sign * (num.abs + divisor.abs - 1) / divisor.abs
+  }
+
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- Fixes download filename
- Fixes backend error when requesting larger bounding boxes (wasn't scaled by mag)

### Steps to test:
- Set a smaller `exportTiffMaxVolumeMVx`
- Try to download some data of a large bbox (e.g. full layer) in a high mag
- Should download the file with a proper filename: `date__dataset__layer.ome.tiff`

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)