### PR TITLE
Fix reload-precomputed-mesh functionality

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed the layouting in the connectome tab. [#6864](https://github.com/scalableminds/webknossos/pull/6864)
 - Fixed that the quick-select and floodfill tool didn't update the segment list. [#6867](https://github.com/scalableminds/webknossos/pull/6867)
 - Fixed deprecation warnings for antd' <Menu> component in Navbar. [#6860](https://github.com/scalableminds/webknossos/pull/6860)
+- Fixed that trying to reload a precomputed mesh via context menu could crash webKnossos. [#6875](https://github.com/scalableminds/webknossos/pull/6875)
 
 ### Removed
 - Removed the old Datasets tab in favor of the Dataset Folders tab. [#6834](https://github.com/scalableminds/webknossos/pull/6834)

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.tsx
@@ -560,7 +560,7 @@ function getRefreshButton(
       />
     );
   } else {
-    return isPrecomputed ? null : (
+    return (
       <Tooltip title="Refresh Mesh">
         <ReloadOutlined
           key="refresh-button"

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.tsx
@@ -304,7 +304,7 @@ function _MeshInfoItem(props: {
             marginLeft: 6,
           }}
         >
-          {getRefreshButton(segment, isPrecomputed, isLoading, props.visibleSegmentationLayer)}
+          {getRefreshButton(segment, isLoading, props.visibleSegmentationLayer)}
           {downloadButton}
           {deleteButton}
         </div>
@@ -542,7 +542,6 @@ const SegmentListItem = React.memo<Props>(_SegmentListItem);
 
 function getRefreshButton(
   segment: Segment,
-  isPrecomputed: boolean,
   isLoading: boolean,
   visibleSegmentationLayer: APISegmentationLayer | null | undefined,
 ) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- load some meshes (precomputed and ad-hoc)
- try to reload them via the sidebar or via the context menu in the 3d viewport
- should not crash

### Issues:
- context: https://scm.slack.com/archives/C02H5T8Q08P/p1677246066474489

------
(Please delete unneeded items, merge only when none are left open)
- [X] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
