### PR TITLE
Fix superUser being wrongly marked as organization owners

### DIFF
--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -157,6 +157,7 @@ class UserService @Inject()(conf: WkConf,
         isDatasetManager = false,
         isDeactivated = !autoActivate,
         lastTaskTypeId = None,
+        isOrganizationOwner = false,
         isUnlisted = isUnlisted,
         created = Instant.now
       )


### PR DESCRIPTION
### Steps to test:
- as super user and organization owner, switch to a new orga
- you should not be an owner there