### PR TITLE
adds dedicated explore method for zarr datasets with a datasource-properties.json

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Highlight 'organization owner' in Admin>User page. [#6832](https://github.com/scalableminds/webknossos/pull/6832
 - Added OME-TIFF export for bounding boxes. [#6838](https://github.com/scalableminds/webknossos/pull/6838) [#6874](https://github.com/scalableminds/webknossos/pull/6874)
 - Added functions to get and set segment colors to the frontend API (`api.data.{getSegmentColor,setSegmentColor}`). [#6853](https://github.com/scalableminds/webknossos/pull/6853)
+- Added support for remote Zarr datasets with a `datasource-properties.json` as created by the WEBKNOSSOS Python library. [#6879](https://github.com/scalableminds/webknossos/pull/6879)
 
 ### Changed
 - Limit paid team sharing features to respective organization plans. [#6767](https://github.com/scalableminds/webknossos/pull/6776)

--- a/app/models/binary/explore/ExploreRemoteLayerService.scala
+++ b/app/models/binary/explore/ExploreRemoteLayerService.scala
@@ -171,6 +171,7 @@ class ExploreRemoteLayerService @Inject()(credentialService: CredentialService) 
         reportMutable,
         List(new ZarrArrayExplorer,
              new NgffExplorer,
+             new WebknossosZarrExplorer,
              new N5ArrayExplorer,
              new N5MultiscalesExplorer,
              new PrecomputedExplorer)

--- a/app/models/binary/explore/WebknossosZarrExplorer.scala
+++ b/app/models/binary/explore/WebknossosZarrExplorer.scala
@@ -20,9 +20,9 @@ class WebknossosZarrExplorer extends RemoteLayerExplorer {
       zarrLayers <- Fox.serialCombined(dataSource.dataLayers) {
         case l: ZarrSegmentationLayer =>
           for {
-            zarrLayers <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
+            zarrLayersFromNgff <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
           } yield
-            zarrLayers.map(
+            zarrLayersFromNgff.map(
               zarrLayer =>
                 (ZarrSegmentationLayer(zarrLayer._1.name,
                                        l.boundingBox,
@@ -32,9 +32,9 @@ class WebknossosZarrExplorer extends RemoteLayerExplorer {
                  zarrLayer._2))
         case l: ZarrDataLayer =>
           for {
-            zarrLayers <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
+            zarrLayersFromNgff <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
           } yield
-            zarrLayers.map(
+            zarrLayersFromNgff.map(
               zarrLayer =>
                 (ZarrDataLayer(zarrLayer._1.name,
                                Category.color,

--- a/app/models/binary/explore/WebknossosZarrExplorer.scala
+++ b/app/models/binary/explore/WebknossosZarrExplorer.scala
@@ -1,0 +1,49 @@
+package models.binary.explore
+
+import com.scalableminds.util.geometry.Vec3Double
+import com.scalableminds.util.tools.Fox
+import com.scalableminds.webknossos.datastore.dataformats.zarr.{ZarrDataLayer, ZarrLayer, ZarrSegmentationLayer}
+import com.scalableminds.webknossos.datastore.models.datasource.{Category, DataSource}
+
+import java.nio.file.Path
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class WebknossosZarrExplorer extends RemoteLayerExplorer {
+
+  override def name: String = "WEBKNOSSOS-based Zarr"
+
+  override def explore(remotePath: Path, credentialId: Option[String]): Fox[List[(ZarrLayer, Vec3Double)]] =
+    for {
+      dataSourcePropertiesPath <- Fox.successful(remotePath.resolve("datasource-properties.json"))
+      dataSource <- parseJsonFromPath[DataSource](dataSourcePropertiesPath)
+      ngffExplorer = new NgffExplorer
+      zarrLayers <- Fox.serialCombined(dataSource.dataLayers) {
+        case l: ZarrSegmentationLayer =>
+          for {
+            zarrLayers <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
+          } yield
+            zarrLayers.map(
+              zarrLayer =>
+                (ZarrSegmentationLayer(zarrLayer._1.name,
+                                       l.boundingBox,
+                                       zarrLayer._1.elementClass,
+                                       zarrLayer._1.mags,
+                                       largestSegmentId = l.largestSegmentId),
+                 zarrLayer._2))
+        case l: ZarrDataLayer =>
+          for {
+            zarrLayers <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
+          } yield
+            zarrLayers.map(
+              zarrLayer =>
+                (ZarrDataLayer(zarrLayer._1.name,
+                               Category.color,
+                               l.boundingBox,
+                               zarrLayer._1.elementClass,
+                               zarrLayer._1.mags),
+                 zarrLayer._2))
+        case layer => Fox.failure(s"Only remote Zarr layers are supported, got ${layer.getClass}.")
+      }
+    } yield zarrLayers.flatten
+
+}

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -157,6 +157,7 @@ class UserService @Inject()(conf: WkConf,
         isDatasetManager = false,
         isDeactivated = !autoActivate,
         lastTaskTypeId = None,
+        isOrganizationOwner = false,
         isUnlisted = isUnlisted,
         created = Instant.now
       )

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -46,7 +46,9 @@ Once the data is uploaded (and potentially converted), you can further configure
 WEBKNOSSOS supports loading and remotely streaming [Zarr](https://zarr.dev), [Neuroglancer precomputed format](https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed) and [N5](https://github.com/saalfeldlab/n5) datasets from a remote source, e.g. Cloud storage (S3) or HTTP server. 
 WEBKNOSSOS supports loading Zarr datasets according to the [OME NGFF v0.4 spec](https://ngff.openmicroscopy.org/latest/).
 
-WEBKNOSSOS can load several remote sources and assemble them into a WEBKNOSSOS dataset with several layers, e.g. one Zarr file/source for the `color` layer and one Zarr file/source for a `segmentation` layer.
+WEBKNOSSOS can load several remote sources and assemble them into a WEBKNOSSOS dataset with several layers, e.g. one Zarr file/source for the `color` layer and one Zarr file/source for a `segmentation` layer. 
+If you create the remote Zarr dataset with the [WEBKNOSSOS Python library](https://docs.webknossos.org/api/webknossos/dataset/dataset.html), all layers will be automatically detected. 
+With other converters, you may need to add the layers separately.
 
 1. From the *Datasets* tab in the user dashboard, click the *Add Dataset* button.
 2. Select the *Add Remote Dataset* tab
@@ -59,10 +61,10 @@ WEBKNOSSOS can load several remote sources and assemble them into a WEBKNOSSOS d
 6. Click `Import` to finish
 
 WEBKNOSSOS will NOT download/copy any data from these third-party data providers. 
-Rather, any data viewed in WEBKNOSSOS will be streamed read-only and directly from the remote source. 
+Rather, any data viewed in WEBKNOSSOS will be streamed read-only from the remote source. 
 Any other WEBKNOSSOS feature, e.g., annotations, and access rights, will be stored in WEBKNOSSOS and do not affect these services. 
 
-Note that data streaming may count against any usage limits or minutes as defined by these third-party services. Check with the service provider or dataset owner.
+Note that data streaming may incur costs and count against any usage limits or minutes as defined by these third-party services. Check with the service provider or dataset owner.
 
 Hint: If you happen to have any Zarr dataset locally that you would like to view in WEBKNOSSOS, consider running an HTTP server locally to serve the dataset. Then WEBKNOSSOS can easily stream the data.
 Alternatively, convert the dataset to wkw using [webknossos-libs](https://github.com/scalableminds/webknossos-libs/).

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -60,14 +60,15 @@ With other converters, you may need to add the layers separately.
   Consider setting the dataset `name` property and double-check all other properties for correctness.
 6. Click `Import` to finish
 
-WEBKNOSSOS will NOT download/copy any data from these third-party data providers. 
+WEBKNOSSOS will NOT download or copy datasets in full from these third-party data providers. 
 Rather, any data viewed in WEBKNOSSOS will be streamed read-only from the remote source. 
+These remote datasets will not count against your storage quota on WEBKNOSSOS. 
 Any other WEBKNOSSOS feature, e.g., annotations, and access rights, will be stored in WEBKNOSSOS and do not affect these services. 
 
 Note that data streaming may incur costs and count against any usage limits or minutes as defined by these third-party services. Check with the service provider or dataset owner.
 
-Hint: If you happen to have any Zarr dataset locally that you would like to view in WEBKNOSSOS, consider running an HTTP server locally to serve the dataset. Then WEBKNOSSOS can easily stream the data.
-Alternatively, convert the dataset to wkw using [webknossos-libs](https://github.com/scalableminds/webknossos-libs/).
+Hint: If you happen to have any Zarr dataset locally that you would like to view in WEBKNOSSOS, consider running an HTTP server locally to serve the dataset. 
+Then WEBKNOSSOS can easily stream the data.
 
 ### Working with Neuroglancer and BossDB datasets on webknossos.org
 webknossos.org supports loading and remotely streaming datasets in the [Neuroglancer precomputed format](https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed) stored in the Google Cloud or datasets served from [BossDB](https://bossdb.org).
@@ -137,7 +138,7 @@ Any dataset uploaded through the web interface at [webknossos.org](https://webkn
 For manual conversion, we provide the following software tools and libraries:
 
 - The [WEBKNOSSOS Cuber](https://docs.webknossos.org/wkcuber/index.html) is a CLI tool that can convert many formats to WKW. 
-- For other file formats, the [Python WEBKNOSSOS library](https://docs.webknossos.org/webknossos-py/index.html) can be an option for custom scripting.
+- For other file formats, the [WEBKNOSSOS Python library](https://docs.webknossos.org/webknossos-py/index.html) can be an option for custom scripting.
 
 See the page on [software tooling](./tooling.md) for more.
 

--- a/frontend/javascripts/admin/dataset/dataset_add_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_view.tsx
@@ -29,6 +29,13 @@ const fetchCategorizedDatastores = async (): Promise<{
   };
 };
 
+enum DatasetAddViewTabs {
+  UPLOAD = "upload",
+  REMOTE = "remote",
+  NEUROGLANCER = "neuroglancer",
+  BOSSDB = "bossdb",
+}
+
 function DatasetAddView({ history }: RouteComponentProps) {
   const datastores = useFetch(
     fetchCategorizedDatastores,
@@ -115,11 +122,18 @@ function DatasetAddView({ history }: RouteComponentProps) {
     );
   };
 
+  const defaultActiveTabFromHash = location.hash.substring(1);
+  const defaultActiveKey = Object.values(DatasetAddViewTabs).includes(
+    defaultActiveTabFromHash as DatasetAddViewTabs,
+  )
+    ? (defaultActiveTabFromHash as DatasetAddViewTabs)
+    : DatasetAddViewTabs.UPLOAD;
+
   return (
     <React.Fragment>
       <Layout>
         <Content>
-          <Tabs defaultActiveKey="1" className="container">
+          <Tabs defaultActiveKey={defaultActiveKey} className="container">
             <TabPane
               tab={
                 <span>
@@ -127,7 +141,7 @@ function DatasetAddView({ history }: RouteComponentProps) {
                   Upload Dataset
                 </span>
               }
-              key="1"
+              key={DatasetAddViewTabs.UPLOAD}
             >
               <DatasetUploadView datastores={datastores.own} onUploaded={handleDatasetAdded} />
             </TabPane>
@@ -138,7 +152,7 @@ function DatasetAddView({ history }: RouteComponentProps) {
                   Add Remote Dataset
                 </span>
               }
-              key="2"
+              key={DatasetAddViewTabs.REMOTE}
             >
               <DatasetAddZarrView
                 datastores={datastores.own}
@@ -154,7 +168,7 @@ function DatasetAddView({ history }: RouteComponentProps) {
                     Add Remote Neuroglancer Dataset
                   </span>
                 }
-                key="3"
+                key={DatasetAddViewTabs.NEUROGLANCER}
               >
                 <DatasetAddNeuroglancerView
                   datastores={datastores.wkConnect}
@@ -171,7 +185,7 @@ function DatasetAddView({ history }: RouteComponentProps) {
                     Add Remote BossDB Dataset
                   </span>
                 }
-                key="4"
+                key={DatasetAddViewTabs.BOSSDB}
               >
                 <DatasetAddBossView
                   datastores={datastores.wkConnect}


### PR DESCRIPTION
- Added support for remote Zarr datasets with a `datasource-properties.json` as created by the webknossos-libs.

### Steps to test:
- Import `https://example.cloud.scm.io/l4_sample`

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [documentation](../blob/master/docs) if applicable
