### PR TITLE
When merging volume tracings, also merge segment lists

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed a bug where merging multiple volume annotations would result in inconsistent segment lists. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
+- Fixed a bug where uploading multiple annotations with volume layers at once would fail. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
 
 ### Removed
 

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -23,7 +23,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   SegmentationLayer
 }
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType
-import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeTracingDefaults
+import com.scalableminds.webknossos.tracingstore.tracings.volume.{VolumeTracingDefaults, VolumeTracingDownsampling}
 import com.typesafe.scalalogging.LazyLogging
 import io.swagger.annotations._
 
@@ -280,7 +280,9 @@ Expects:
       fallbackLayer = fallbackLayerOpt.map(_.name),
       largestSegmentId =
         annotationService.combineLargestSegmentIdsByPrecedence(volumeTracing.largestSegmentId,
-                                                               fallbackLayerOpt.map(_.largestSegmentId))
+                                                               fallbackLayerOpt.map(_.largestSegmentId)),
+      resolutions =
+        VolumeTracingDownsampling.resolutionsForVolumeTracing(dataSource, fallbackLayerOpt).map(vec3IntToProto)
     )
   }
 

--- a/app/controllers/JobsController.scala
+++ b/app/controllers/JobsController.scala
@@ -272,9 +272,10 @@ class JobsController @Inject()(jobDAO: JobDAO,
     sil.SecuredAction.async { implicit request =>
       log(Some(slackNotificationService.noticeFailedJobRequest)) {
         for {
-          organization <- organizationDAO.findOneByName(organizationName) ?~> Messages("organization.notFound",
-                                                                                       organizationName)
-          _ <- bool2Fox(request.identity._organization == organization._id) ?~> "job.applyMergerMode.notAllowed.organization" ~> FORBIDDEN
+          organization <- organizationDAO.findOneByName(organizationName)(GlobalAccessContext) ?~> Messages(
+            "organization.notFound",
+            organizationName)
+          _ <- bool2Fox(request.identity._organization == organization._id) ?~> "job.materializeVolumeAnnotation.notAllowed.organization" ~> FORBIDDEN
           dataSet <- dataSetDAO.findOneByNameAndOrganization(dataSetName, organization._id) ?~> Messages(
             "dataSet.notFound",
             dataSetName) ~> NOT_FOUND

--- a/conf/messages
+++ b/conf/messages
@@ -292,7 +292,7 @@ job.inferNuclei.notAllowed.organization = Currently nuclei inferral is only allo
 job.inferNeurons.notAllowed.organization = Currently neuron inferral is only allowed for datasets of your own organization.
 job.meshFile.notAllowed.organization = Calculating mesh files is only allowed for datasets of your own organization.
 job.globalizeFloodfill.notAllowed.organization = Globalizing floodfills is only allowed for datasets of your own organization.
-job.applyMergerMode.notAllowed.organization = Applying merger mode tracings is only allowed for datasets of your own organization.
+job.materializeVolumeAnnotation.notAllowed.organization = Materializing volume annotations is only allowed for datasets of your own organization.
 job.noWorkerForDatastore = Processing jobs are not available for the datastore this dataset belongs to.
 
 voxelytics.disabled = Voxelytics workflow reporting and logging are not enabled for this WEBKNOSSOS instance.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataFormatHelper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataFormatHelper.scala
@@ -70,6 +70,7 @@ trait WKWDataFormatHelper {
     path match {
       case headerRx(_, resolutionStr) =>
         Vec3Int.fromMagLiteral(resolutionStr, allowScalar = true)
+      case _ => None
     }
   }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -7,6 +7,7 @@ import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, 
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
 import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton._
+import com.scalableminds.webknossos.tracingstore.tracings.volume.MergedVolumeStats
 import com.scalableminds.webknossos.tracingstore.{TSRemoteWebKnossosClient, TracingStoreAccessTokenService}
 import play.api.i18n.Messages
 import play.api.libs.json.Json
@@ -38,7 +39,7 @@ class SkeletonTracingController @Inject()(val tracingService: SkeletonTracingSer
       log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos, urlOrHeaderToken(token, request)) {
           val tracings: List[Option[SkeletonTracing]] = request.body
-          val mergedTracing = tracingService.merge(tracings.flatten)
+          val mergedTracing = tracingService.merge(tracings.flatten, MergedVolumeStats.empty)
           val processedTracing = tracingService.remapTooLargeTreeIds(mergedTracing)
           for {
             newId <- tracingService.save(processedTracing, None, processedTracing.version, toCache = !persist)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -245,7 +245,6 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
                                                                 newId,
                                                                 newVersion = 0L,
                                                                 toCache = !persist)
-            // TODO: pass resolution list, largest segment id, label maps for remapping segment list
             mergedTracing = tracingService.merge(tracings, mergedVolumeStats)
             _ <- tracingService.save(mergedTracing, Some(newId), version = 0, toCache = !persist)
           } yield {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -18,6 +18,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.editablemapping.{
   MinCutParameters
 }
 import com.scalableminds.webknossos.tracingstore.tracings.volume.{
+  MergedVolumeStats,
   ResolutionRestrictions,
   UpdateMappingNameAction,
   VolumeTracingService
@@ -91,7 +92,7 @@ class VolumeTracingController @Inject()(
       log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos, urlOrHeaderToken(token, request)) {
           val tracings: List[Option[VolumeTracing]] = request.body
-          val mergedTracing = tracingService.merge(tracings.flatten)
+          val mergedTracing = tracingService.merge(tracings.flatten, MergedVolumeStats.empty)
           tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist).map { newId =>
             Ok(Json.toJson(newId))
           }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -92,7 +92,11 @@ class VolumeTracingController @Inject()(
       log() {
         accessTokenService.validateAccess(UserAccessRequest.webknossos, urlOrHeaderToken(token, request)) {
           val tracings: List[Option[VolumeTracing]] = request.body
-          val mergedTracing = tracingService.merge(tracings.flatten, MergedVolumeStats.empty)
+          val mergedTracing =
+            tracingService
+              .merge(tracings.flatten, MergedVolumeStats.empty)
+              // segment lists for multi-volume uploads are not supported yet, compare https://github.com/scalableminds/webknossos/issues/6887
+              .copy(segments = List.empty)
           tracingService.save(mergedTracing, None, mergedTracing.version, toCache = !persist).map { newId =>
             Ok(Json.toJson(newId))
           }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingService.scala
@@ -3,6 +3,7 @@ package com.scalableminds.webknossos.tracingstore.tracings
 import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
 import com.scalableminds.webknossos.tracingstore.TracingStoreRedisStore
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType.TracingType
+import com.scalableminds.webknossos.tracingstore.tracings.volume.MergedVolumeStats
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json._
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
@@ -178,14 +179,14 @@ trait TracingService[T <: GeneratedMessage]
   def handledGroupIdStoreContains(tracingId: String, transactionId: String, version: Long): Fox[Boolean] =
     handledGroupIdStore.contains(handledGroupKey(tracingId, transactionId, version))
 
-  def merge(tracings: Seq[T]): T
+  def merge(tracings: Seq[T], mergedVolumeStats: MergedVolumeStats): T
 
   def remapTooLargeTreeIds(tracing: T): T = tracing
 
   def mergeVolumeData(tracingSelectors: Seq[TracingSelector],
                       tracings: Seq[T],
                       newId: String,
-                      newTracing: T,
-                      toCache: Boolean): Fox[Unit]
+                      newVersion: Long,
+                      toCache: Boolean): Fox[MergedVolumeStats]
 
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -10,6 +10,7 @@ import com.scalableminds.webknossos.tracingstore.TracingStoreRedisStore
 import com.scalableminds.webknossos.tracingstore.tracings.UpdateAction.SkeletonUpdateAction
 import com.scalableminds.webknossos.tracingstore.tracings.{TracingType, _}
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating._
+import com.scalableminds.webknossos.tracingstore.tracings.volume.MergedVolumeStats
 import net.liftweb.common.{Empty, Full}
 import play.api.libs.json.{JsObject, JsValue, Json}
 
@@ -158,7 +159,7 @@ class SkeletonTracingService @Inject()(
     save(finalTracing, None, finalTracing.version)
   }
 
-  def merge(tracings: Seq[SkeletonTracing]): SkeletonTracing =
+  def merge(tracings: Seq[SkeletonTracing], mergedVolumeStats: MergedVolumeStats): SkeletonTracing =
     tracings
       .reduceLeft(mergeTwo)
       .copy(
@@ -196,8 +197,8 @@ class SkeletonTracingService @Inject()(
   def mergeVolumeData(tracingSelectors: Seq[TracingSelector],
                       tracings: Seq[SkeletonTracing],
                       newId: String,
-                      newTracing: SkeletonTracing,
-                      toCache: Boolean): Fox[Unit] = Fox.successful(())
+                      newVersion: Long,
+                      toCache: Boolean): Fox[MergedVolumeStats] = Fox.successful(MergedVolumeStats.empty)
 
   def updateActionLog(tracingId: String, newestVersion: Option[Long], oldestVersion: Option[Long]): Fox[JsValue] = {
     def versionedTupleToJson(tuple: (Long, List[SkeletonUpdateAction])): JsObject =

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -170,9 +170,9 @@ class VolumeTracingService @Inject()(
         val resolutionSet = resolutionSetFromZipfile(dataZip)
         if (resolutionSet.nonEmpty) resolutionSets.add(resolutionSet)
       }
-      // if none of the tracings contained any volume data do not save buckets, use full resolution list
+      // if none of the tracings contained any volume data do not save buckets, use full resolution list, as alraedy initialized on wk-side
       if (resolutionSets.isEmpty)
-        getRequiredMags(tracing, tracingId).map(_.toSet)
+        Fox.successful(tracing.resolutions.map(vec3IntFromProto).toSet)
       else {
         val resolutionsDoMatch = resolutionSets.headOption.forall { head =>
           resolutionSets.forall(_ == head)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -170,7 +170,7 @@ class VolumeTracingService @Inject()(
         val resolutionSet = resolutionSetFromZipfile(dataZip)
         if (resolutionSet.nonEmpty) resolutionSets.add(resolutionSet)
       }
-      // if none of the tracings contained any volume data do not save buckets, use full resolution list, as alraedy initialized on wk-side
+      // if none of the tracings contained any volume data do not save buckets, use full resolution list, as already initialized on wk-side
       if (resolutionSets.isEmpty)
         Fox.successful(tracing.resolutions.map(vec3IntFromProto).toSet)
       else {


### PR DESCRIPTION
When merging volume annotations, their segment lists are now also merged. This needs information from the actual data merging (now passed as MergedVolumeStats) because the segment ids are changed during the merge process.

The PR also adresses a bug where initialDataMultiple failed, because it tried looking up the resolution list from uploaded zipfiles, which failed due to a match error on path regex, and then it tried to look up the resolution list remotely, which failed because postgres does at that time not yet have an entry for the currently created annotation.

Also slipped in here, sorry for the small unrelated change: GlobalAccessContext in JobsController to yield a readable error message when a user tries to run a globalizeFloodfill job on a dataset of a different organization.

### URL of deployed dev instance (used for testing):
- https://mergevolumesegmentlist.webknossos.xyz

### Steps to test:
- Create two volume annotations for the same dataset (without fallback layer is easier to test)
- Draw some segments
- From one of the annotations, merge the other in (menu→merge, select annotation id, UNCHECK the »merge into active« checkbox), result should have segment list from both annotations, ids should be uniqueified
- Download two volume annotations for the same dataset, reupload both together (drag’n’drop in dashboard)
- Result should show data, but no segment list, compare #6887

### Issues:
- fixes #6877

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
