### PR TITLE
Support n5 end-chunks with chunksize differing from metadata chunksize

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed a bug where N5 datasets reading with end-chunks that have a chunk size differing from the metadata-supplied chunk size would fail for some areas. [#6890](https://github.com/scalableminds/webknossos/pull/6890)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetHeader.scala
@@ -26,18 +26,15 @@ trait DatasetHeader {
 
   lazy val byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
 
-  lazy val bytesPerChunk: Int = chunkSize.toList.product * bytesPerElementFor(resolvedDataType)
+  lazy val bytesPerElement: Int = bytesPerElementFor(resolvedDataType)
+
+  lazy val bytesPerChunk: Int = chunkSize.toList.product * bytesPerElement
 
   lazy val fillValueNumber: Number =
     fill_value match {
       case Right(n) => n
       case Left(_)  => 0 // parsing fill value from string not currently supported
     }
-
-  lazy val chunkShapeOrdered: Array[Int] =
-    if (order == ArrayOrder.C) {
-      chunkSize
-    } else chunkSize.reverse
 
   def boundingBox(axisOrder: AxisOrder): Option[BoundingBox] =
     if (Math.max(Math.max(axisOrder.x, axisOrder.y), axisOrder.z) >= rank)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5ChunkReader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5ChunkReader.scala
@@ -1,11 +1,6 @@
 package com.scalableminds.webknossos.datastore.datareaders.n5
 
-import com.scalableminds.webknossos.datastore.datareaders.{
-  ChunkReader,
-  DatasetHeader,
-  FileSystemStore,
-  ChunkTyper
-}
+import com.scalableminds.webknossos.datastore.datareaders.{ChunkReader, DatasetHeader, FileSystemStore, ChunkTyper}
 import com.typesafe.scalalogging.LazyLogging
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5DataExtractor.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5DataExtractor.scala
@@ -3,14 +3,14 @@ package com.scalableminds.webknossos.datastore.datareaders.n5
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, InputStream}
 
 class N5DataExtractor {
-  def readBytesAndHeader(data: Array[Byte]): (N5BlockHeader, Option[Array[Byte]]) = {
+  def readBytesAndHeader(data: Array[Byte]): (N5BlockHeader, Array[Byte]) = {
     val in = new ByteArrayInputStream(data)
     val dis = new DataInputStream(in)
 
     val header = extractHeader(dis)
     val buffer = extractData(in)
 
-    (header, Some(buffer))
+    (header, buffer)
   }
 
   private def extractData(in: InputStream): Array[Byte] = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedChunkReader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedChunkReader.scala
@@ -4,13 +4,13 @@ import com.scalableminds.webknossos.datastore.datareaders.{
   ChunkReader,
   DatasetHeader,
   FileSystemStore,
-  TypedChunkReader
+  ChunkTyper
 }
 
 object PrecomputedChunkReader {
   def create(store: FileSystemStore, header: DatasetHeader): ChunkReader =
-    new PrecomputedChunkReader(header, store, ChunkReader.createTypedChunkReader(header))
+    new PrecomputedChunkReader(header, store, ChunkReader.createChunkTyper(header))
 }
 
-class PrecomputedChunkReader(header: DatasetHeader, store: FileSystemStore, typedChunkReader: TypedChunkReader)
+class PrecomputedChunkReader(header: DatasetHeader, store: FileSystemStore, typedChunkReader: ChunkTyper)
     extends ChunkReader(header, store, typedChunkReader) {}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedChunkReader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedChunkReader.scala
@@ -1,11 +1,6 @@
 package com.scalableminds.webknossos.datastore.datareaders.precomputed
 
-import com.scalableminds.webknossos.datastore.datareaders.{
-  ChunkReader,
-  DatasetHeader,
-  FileSystemStore,
-  ChunkTyper
-}
+import com.scalableminds.webknossos.datastore.datareaders.{ChunkReader, DatasetHeader, FileSystemStore, ChunkTyper}
 
 object PrecomputedChunkReader {
   def create(store: FileSystemStore, header: DatasetHeader): ChunkReader =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedHeader.scala
@@ -62,10 +62,10 @@ case class PrecomputedScaleHeader(precomputedScale: PrecomputedScale, precompute
   lazy val voxelOffset: Array[Int] = precomputedScale.voxel_offset.getOrElse(Array(0, 0, 0))
 
   def chunkIndexToNDimensionalBoundingBox(chunkIndex: Array[Int]): Array[(Int, Int)] =
-    chunkIndex.zipWithIndex.map(indices => {
-      val (cIndex, dim) = indices
-      val beginOffset = voxelOffset(dim) + cIndex * precomputedScale.primaryChunkSize(dim)
-      val endOffset = voxelOffset(dim) + ((cIndex + 1) * precomputedScale.primaryChunkSize(dim))
+    chunkIndex.zipWithIndex.map(chunkIndexWithDim => {
+      val (chunkIndexAtDim, dim) = chunkIndexWithDim
+      val beginOffset = voxelOffset(dim) + chunkIndexAtDim * precomputedScale.primaryChunkSize(dim)
+      val endOffset = voxelOffset(dim) + ((chunkIndexAtDim + 1) * precomputedScale.primaryChunkSize(dim))
         .min(precomputedScale.size(dim))
       (beginOffset, endOffset)
     })


### PR DESCRIPTION
Turns out N5 chunks report their own size, which may differ from the chunk size specified in metadata for end-chunks (like, at the edges of the dataset). This PR introduces code into the wk chunk reading process that handles that.

First I tried reusing the chunkSizeAtIndex from our Neuroglancer Precomputed code, but it turns out that for N5 the bounding box is not a reliable source, chunks may or may not be truncated, so the chunk size mentioned in each chunk header should be used as the source of truth here.

Additionally, I renamed the TypedChunkReader to ChunkTyper, because its job is not actually reading anything, but converting a previously read byte array to a typed multi array.

### URL of deployed dev instance (used for testing):
- https://nendchunks.webknossos.xyz

### Steps to test:
- Open an N5-streamed dataset, e.g. via the datasource-properties.json found at https://scm.slack.com/archives/C02H5T8Q08P/p1677765260865059?thread_ts=1677744181.121229&cid=C02H5T8Q08P
- Data should load fine (note: may be pretty slow, note2: is very dark, see histogram, use brightness sliders and gamma correction)
- Zoom in to mag 1 and check dataset borders as well.

### Issues:
- fixes #6888

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
