### PR TITLE
Fix date formatting for VX reports

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where N5 datasets reading with end-chunks that have a chunk size differing from the metadata-supplied chunk size would fail for some areas. [#6890](https://github.com/scalableminds/webknossos/pull/6890)
 - Fixed a bug where merging multiple volume annotations would result in inconsistent segment lists. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
 - Fixed a bug where uploading multiple annotations with volume layers at once would fail. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
+- Fixed a bug where dates were formatted incorrectly in Voxelytics reports. [#6908](https://github.com/scalableminds/webknossos/pull/6908)
 
 ### Removed
 

--- a/frontend/javascripts/libs/format_utils.ts
+++ b/frontend/javascripts/libs/format_utils.ts
@@ -7,6 +7,7 @@ import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import updateLocale from "dayjs/plugin/updateLocale";
 import relativeTime from "dayjs/plugin/relativeTime";
+import localizedFormat from "dayjs/plugin/localizedFormat";
 import calendar from "dayjs/plugin/calendar";
 import utc from "dayjs/plugin/utc";
 import weekday from "dayjs/plugin/weekday";
@@ -22,6 +23,7 @@ dayjs.extend(utc);
 dayjs.extend(calendar);
 dayjs.extend(weekday);
 dayjs.extend(localeData);
+dayjs.extend(localizedFormat);
 dayjs.updateLocale("en", {
   weekStart: 1,
   calendar: {


### PR DESCRIPTION
This PR fixes date formatting for VX reports. I believe we need to add the "localized format plugin" to dayjs in order to use `days().format("lll")`. See `dayjs` docs on this: https://day.js.org/docs/en/display/format#localized-formats

Before:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/1105056/223973919-2293d72f-2428-49e3-96b6-8575f1859e73.png">
<img width="316" alt="image" src="https://user-images.githubusercontent.com/1105056/223974757-d05411d1-758c-42c8-af96-51062842ca11.png">



### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open any VX report
- Check that the start date under the workflow title is shown as a well formatted string and not just `lll`
- How over the runtime of any task in the list to bring up the tooltip with more information. That should also be fixed.

### Issues:
- related to #6849 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-connect](https://github.com/scalableminds/webknossos-connect) if datastore API changes
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
