### PR TITLE
Fix race condition which could disable saving

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where merging multiple volume annotations would result in inconsistent segment lists. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
 - Fixed a bug where uploading multiple annotations with volume layers at once would fail. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
 - Fixed a bug where dates were formatted incorrectly in Voxelytics reports. [#6908](https://github.com/scalableminds/webknossos/pull/6908)
+- Fixed a rare bug which could cause an incorrectly initialized annotation so that changes were not changed in the current session. [#6914](https://github.com/scalableminds/webknossos/pull/6914)
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where merging multiple volume annotations would result in inconsistent segment lists. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
 - Fixed a bug where uploading multiple annotations with volume layers at once would fail. [#6882](https://github.com/scalableminds/webknossos/pull/6882)
 - Fixed a bug where dates were formatted incorrectly in Voxelytics reports. [#6908](https://github.com/scalableminds/webknossos/pull/6908)
-- Fixed a rare bug which could cause an incorrectly initialized annotation so that changes were not changed in the current session. [#6914](https://github.com/scalableminds/webknossos/pull/6914)
+- Fixed a rare bug which could cause an incorrectly initialized annotation so that changes were not saved in the current session. [#6914](https://github.com/scalableminds/webknossos/pull/6914)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/sagas/annotation_saga.tsx
+++ b/frontend/javascripts/oxalis/model/sagas/annotation_saga.tsx
@@ -7,7 +7,6 @@ import {
   setBlockedByUserAction,
   type SetOthersMayEditForAnnotationAction,
 } from "oxalis/model/actions/annotation_actions";
-import { sleep } from "libs/utils";
 import type { EditableAnnotation } from "admin/admin_rest_api";
 import {
   editAnnotation,
@@ -250,7 +249,6 @@ export function* acquireAnnotationMutexMaybe(): Saga<void> {
     while (shallTryAcquireMutex) {
       if (isInitialRequest) {
         yield* put(setAnnotationAllowUpdateAction(false));
-        yield* call(sleep, 5000);
       }
       try {
         const { canEdit, blockedByUser } = yield* retry(

--- a/frontend/javascripts/oxalis/model/sagas/annotation_saga.tsx
+++ b/frontend/javascripts/oxalis/model/sagas/annotation_saga.tsx
@@ -7,6 +7,7 @@ import {
   setBlockedByUserAction,
   type SetOthersMayEditForAnnotationAction,
 } from "oxalis/model/actions/annotation_actions";
+import { sleep } from "libs/utils";
 import type { EditableAnnotation } from "admin/admin_rest_api";
 import {
   editAnnotation,
@@ -249,6 +250,7 @@ export function* acquireAnnotationMutexMaybe(): Saga<void> {
     while (shallTryAcquireMutex) {
       if (isInitialRequest) {
         yield* put(setAnnotationAllowUpdateAction(false));
+        yield* call(sleep, 5000);
       }
       try {
         const { canEdit, blockedByUser } = yield* retry(

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.ts
@@ -1091,7 +1091,7 @@ export function* setupSavingForTracingType(
     const allowUpdate = yield* select(
       (state) => state.tracing.restrictions.allowUpdate && state.tracing.restrictions.allowSave,
     );
-    if (!allowUpdate) return;
+    if (!allowUpdate) continue;
     const tracing = (yield* select((state) => selectTracing(state, saveQueueType, tracingId))) as
       | VolumeTracing
       | SkeletonTracing;


### PR DESCRIPTION
This fixes a race condition which would affect saving when annotation-sharing was activated. Especially on slow computers, this could lead to a faulty initialization which would mean that nothing was saved.

### URL of deployed dev instance (used for testing):
- https://fixsavingracecondition.webknossos.xyz

### Steps to test:
- the PR adds a sleep to provoke the original bug (without the fix the bug was reliably happening)
- Create an annotation and enable others-may-edit
- reload the annotation and add a tree
- save and reload -> tree should be there

### Issues:
- follow-up to #6819 
- context: https://scm.slack.com/archives/C02H5T8Q08P/p1678178937732359

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
