### PR TITLE
Fix creating task types with preferred mode

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed an issue with text hints not being visible on the logout page for dark mode users. [#6916](https://github.com/scalableminds/webknossos/pull/6916)
+- Fixed creating task types with a selected preferred mode. [#6928](https://github.com/scalableminds/webknossos/pull/6928)
 
 ### Removed
 

--- a/app/models/annotation/AnnotationSettings.scala
+++ b/app/models/annotation/AnnotationSettings.scala
@@ -13,7 +13,7 @@ object TracingMode extends ExtendedEnumeration {
 
 case class AnnotationSettings(
     allowedModes: List[TracingMode.Value],
-    preferredMode: Option[String] = None,
+    preferredMode: Option[TracingMode.Value] = None,
     branchPointsAllowed: Boolean = true,
     somaClickingAllowed: Boolean = true,
     volumeInterpolationAllowed: Boolean = true,

--- a/app/models/task/TaskType.scala
+++ b/app/models/task/TaskType.scala
@@ -81,6 +81,7 @@ class TaskTypeDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
       settingsAllowedModes <- Fox.combined(
         parseArrayLiteral(r.settingsAllowedmodes)
           .map(TracingMode.fromString(_).toFox)) ?~> "failed to parse tracing mode"
+      settingsPreferredMode = r.settingsPreferredmode.flatMap(TracingMode.fromString)
     } yield
       TaskType(
         ObjectId(r._Id),
@@ -89,7 +90,7 @@ class TaskTypeDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
         r.description,
         AnnotationSettings(
           settingsAllowedModes,
-          r.settingsPreferredmode,
+          settingsPreferredMode,
           r.settingsBranchpointsallowed,
           r.settingsSomaclickingallowed,
           r.settingsVolumeinterpolationallowed,


### PR DESCRIPTION
This field did not yet use the enum type but instead was string.

### URL of deployed dev instance (used for testing):
- https://fixtasktypecreation.webknossos.xyz

### Steps to test:
- Create a task type with and without a selected “preferred mode” each
- Check that you can list both task types in the task types table

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
