### PR TITLE
Fix download button for annotations when tiff export is disabled

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
@@ -435,6 +435,10 @@ with wk.webknossos_context(
     activeTabKey === "export" &&
     runningExportJobs.some(([key]) => key === exportKey(selectedLayerInfos, mag));
 
+  const isOkButtonDisabled =
+    activeTabKey === "export" &&
+    (!isExportable || isCurrentlyRunningExportJob || isMergerModeEnabled);
+
   return (
     <Modal
       title="Download this annotation"
@@ -445,7 +449,7 @@ with wk.webknossos_context(
           <Button
             key="ok"
             type="primary"
-            disabled={!isExportable || isCurrentlyRunningExportJob || isMergerModeEnabled}
+            disabled={isOkButtonDisabled}
             onClick={handleOk}
             loading={isCurrentlyRunningExportJob}
           >


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I created an annotation locally and tried to download it (non worker configured)
- without the change, the ok button was disabled.
- with the change, it works.

### Issues:
- follow-up for #6838 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
