### PR TITLE
Send Cache-Control: no-cache for most routes

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -45,13 +45,15 @@ class Application @Inject()(multiUserDAO: MultiUserDAO,
       schemaVersion <- releaseInformationDAO.getSchemaVersion.futureBox
     } yield {
       addRemoteOriginHeaders(
-        Ok(Json.obj(
-          "webknossos" -> webknossos.BuildInfo.toMap.mapValues(_.toString),
-          "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString),
-          "schemaVersion" -> schemaVersion.toOption,
-          "localDataStoreEnabled" -> storeModules.localDataStoreEnabled,
-          "localTracingStoreEnabled" -> storeModules.localTracingStoreEnabled
-        )))
+        addNoCacheHeaderFallback(
+          Ok(Json.obj(
+            "webknossos" -> webknossos.BuildInfo.toMap.mapValues(_.toString),
+            "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString),
+            "schemaVersion" -> schemaVersion.toOption,
+            "localDataStoreEnabled" -> storeModules.localDataStoreEnabled,
+            "localTracingStoreEnabled" -> storeModules.localTracingStoreEnabled
+          )))
+      )
     }
   }
 
@@ -66,12 +68,13 @@ class Application @Inject()(multiUserDAO: MultiUserDAO,
 
   @ApiOperation(hidden = true, value = "")
   def features: Action[AnyContent] = sil.UserAwareAction {
-    Ok(conf.raw.underlying.getConfig("features").resolve.root.render(ConfigRenderOptions.concise()))
+    addNoCacheHeaderFallback(
+      Ok(conf.raw.underlying.getConfig("features").resolve.root.render(ConfigRenderOptions.concise())))
   }
 
   @ApiOperation(value = "Health endpoint")
   def health: Action[AnyContent] = Action {
-    Ok("Ok")
+    addNoCacheHeaderFallback(Ok("Ok"))
   }
 
   @ApiOperation(hidden = true, value = "")

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -45,14 +45,14 @@ class Application @Inject()(multiUserDAO: MultiUserDAO,
       schemaVersion <- releaseInformationDAO.getSchemaVersion.futureBox
     } yield {
       addRemoteOriginHeaders(
-        addNoCacheHeaderFallback(
-          Ok(Json.obj(
+        Ok(
+          Json.obj(
             "webknossos" -> webknossos.BuildInfo.toMap.mapValues(_.toString),
             "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString),
             "schemaVersion" -> schemaVersion.toOption,
             "localDataStoreEnabled" -> storeModules.localDataStoreEnabled,
             "localTracingStoreEnabled" -> storeModules.localTracingStoreEnabled
-          )))
+          ))
       )
     }
   }

--- a/app/controllers/ConfigurationController.scala
+++ b/app/controllers/ConfigurationController.scala
@@ -23,7 +23,7 @@ class ConfigurationController @Inject()(
 
   def read: Action[AnyContent] = sil.UserAwareAction { implicit request =>
     val config = request.identity.map(_.userConfiguration).getOrElse(Json.obj())
-    Ok(Json.toJson(config))
+    addNoCacheHeaderFallback(Ok(Json.toJson(config)))
   }
 
   def update: Action[JsValue] = sil.SecuredAction.async(parse.json(maxLength = 20480)) { implicit request =>

--- a/app/controllers/OrganizationController.scala
+++ b/app/controllers/OrganizationController.scala
@@ -88,16 +88,17 @@ class OrganizationController @Inject()(organizationDAO: OrganizationDAO,
   }
 
   def getOperatorData: Action[AnyContent] = Action {
-    Ok(Json.toJson(conf.WebKnossos.operatorData))
+    addNoCacheHeaderFallback(Ok(Json.toJson(conf.WebKnossos.operatorData)))
   }
 
   def getTermsOfService: Action[AnyContent] = Action {
-    Ok(
-      Json.obj(
-        "version" -> conf.WebKnossos.TermsOfService.version,
-        "enabled" -> conf.WebKnossos.TermsOfService.enabled,
-        "url" -> conf.WebKnossos.TermsOfService.url
-      ))
+    addNoCacheHeaderFallback(
+      Ok(
+        Json.obj(
+          "version" -> conf.WebKnossos.TermsOfService.version,
+          "enabled" -> conf.WebKnossos.TermsOfService.enabled,
+          "url" -> conf.WebKnossos.TermsOfService.url
+        )))
   }
 
   def termsOfServiceAcceptanceNeeded: Action[AnyContent] = sil.SecuredAction.async { implicit request =>

--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -67,7 +67,7 @@ trait BoxToResultHelpers extends I18nSupport with Formatter with RemoteOriginHel
       addRemoteOriginHeaders(result)
     } else result
 
-  private def addNoCacheHeaderFallback(result: Result): Result =
+  def addNoCacheHeaderFallback(result: Result): Result =
     if (result.header.headers.contains(CACHE_CONTROL)) {
       result
     } else result.withHeaders(CACHE_CONTROL -> "no-cache")

--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -34,7 +34,7 @@ trait BoxToResultHelpers extends I18nSupport with Formatter with RemoteOriginHel
       case Empty =>
         new JsonResult(NOT_FOUND)("Couldn't find the requested resource.")
     }
-    allowRemoteOriginIfSelected(result)
+    allowRemoteOriginIfSelected(addNoCacheHeader(result))
   }
 
   private def formatChainOpt(chain: Box[Failure])(implicit messages: MessagesProvider): Option[String] = chain match {
@@ -66,6 +66,9 @@ trait BoxToResultHelpers extends I18nSupport with Formatter with RemoteOriginHel
     if (allowRemoteOrigin) {
       addRemoteOriginHeaders(result)
     } else result
+
+  private def addNoCacheHeader(result: Result): Result =
+    result.withHeaders("Cache-Control" -> "no-cache")
 
 }
 

--- a/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ExtendedController.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common._
 import net.liftweb.util.Helpers.tryo
 import play.api.http.Status._
-import play.api.http.{HttpEntity, Status, Writeable}
+import play.api.http.{HeaderNames, HttpEntity, Status, Writeable}
 import play.api.i18n.{I18nSupport, Messages, MessagesProvider}
 import play.api.libs.json._
 import play.api.mvc.Results.BadRequest
@@ -17,7 +17,7 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 import java.io.FileInputStream
 import scala.concurrent.{ExecutionContext, Future}
 
-trait BoxToResultHelpers extends I18nSupport with Formatter with RemoteOriginHelpers {
+trait BoxToResultHelpers extends I18nSupport with Formatter with RemoteOriginHelpers with HeaderNames {
 
   protected def defaultErrorCode: Int = BAD_REQUEST
 
@@ -34,7 +34,7 @@ trait BoxToResultHelpers extends I18nSupport with Formatter with RemoteOriginHel
       case Empty =>
         new JsonResult(NOT_FOUND)("Couldn't find the requested resource.")
     }
-    allowRemoteOriginIfSelected(addNoCacheHeader(result))
+    allowRemoteOriginIfSelected(addNoCacheHeaderFallback(result))
   }
 
   private def formatChainOpt(chain: Box[Failure])(implicit messages: MessagesProvider): Option[String] = chain match {
@@ -67,9 +67,10 @@ trait BoxToResultHelpers extends I18nSupport with Formatter with RemoteOriginHel
       addRemoteOriginHeaders(result)
     } else result
 
-  private def addNoCacheHeader(result: Result): Result =
-    result.withHeaders("Cache-Control" -> "no-cache")
-
+  private def addNoCacheHeaderFallback(result: Result): Result =
+    if (result.header.headers.contains(CACHE_CONTROL)) {
+      result
+    } else result.withHeaders(CACHE_CONTROL -> "no-cache")
 }
 
 trait RemoteOriginHelpers {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -286,7 +286,8 @@ Expects:
     accessTokenService.validateAccessForSyncBlock(
       UserAccessRequest.readDataSources(DataSourceId(dataSetName, organizationName)),
       urlOrHeaderToken(token, request)) {
-      Ok(Json.toJson(dataSourceService.exploreMappings(organizationName, dataSetName, dataLayerName)))
+      addNoCacheHeaderFallback(
+        Ok(Json.toJson(dataSourceService.exploreMappings(organizationName, dataSetName, dataLayerName))))
     }
   }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/StandaloneDatastore.scala
@@ -8,12 +8,12 @@ import javax.inject.Inject
 class StandaloneDatastore @Inject()() extends Controller {
 
   def buildInfo: Action[AnyContent] = Action {
-    addRemoteOriginHeaders(
-      Ok(
-        Json.obj(
+    addNoCacheHeaderFallback(
+      addRemoteOriginHeaders(
+        Ok(Json.obj(
           "webknossosDatastore" -> webknossosDatastore.BuildInfo.toMap.mapValues(_.toString),
           "webknossos-wrap" -> webknossoswrap.BuildInfo.toMap.mapValues(_.toString)
         ))
-    )
+      ))
   }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/StandaloneTracingstore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/StandaloneTracingstore.scala
@@ -9,11 +9,12 @@ import javax.inject.Inject
 class StandaloneTracingstore @Inject()() extends Controller {
 
   def buildInfo: Action[AnyContent] = Action {
-    addRemoteOriginHeaders(
-      Ok(
-        Json.obj(
-          "webknossosTracingstore" -> webknossosTracingstore.BuildInfo.toMap.mapValues(_.toString)
-        )
-      ))
+    addNoCacheHeaderFallback(
+      addRemoteOriginHeaders(
+        Ok(
+          Json.obj(
+            "webknossosTracingstore" -> webknossosTracingstore.BuildInfo.toMap.mapValues(_.toString)
+          )
+        )))
   }
 }


### PR DESCRIPTION
Adds `Cache-Control: no-cache` header to most routes. 
Routes that go via the box-to-result codepath get it there.
Routes that don’t do that now have an explicit `addNoCacheHeaderFallback` wrapper.
Asset routes are not affected, neither are routes that already set the Cache-Control header in their implementation (e.g. thumbnail route)
Note that routes rejected by silhouette with 401 unauthenticated will not have the header set. But I assume no reasonable browser caches 401 responses anyway.

### URL of deployed dev instance (used for testing):
- https://nocache.webknossos.xyz

### Steps to test:
- In browser’s network tab, check that api responses have the header as expected, but asset responses don’t.

### Issues:
- fixes #6701 

------
- [x] Needs datastore update after deployment
