### PR TITLE
VaultPath no longer extends nio.Path

### DIFF
--- a/app/models/binary/credential/CredentialDAO.scala
+++ b/app/models/binary/credential/CredentialDAO.scala
@@ -2,7 +2,7 @@ package models.binary.credential
 
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.storage.{
-  FileSystemCredential,
+  DataVaultCredential,
   GoogleServiceAccountCredential,
   HttpBasicAuthCredential,
   S3AccessKeyCredential
@@ -79,14 +79,14 @@ class CredentialDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContex
                        values(${_id}, ${CredentialType.GoogleServiceAccount}, ${credential.name}, ${credential.secretJson.toString}, ${credential.user}, ${credential.organization})""".asUpdate)
     } yield ()
 
-  def findOne(id: ObjectId): Fox[FileSystemCredential] =
+  def findOne(id: ObjectId): Fox[DataVaultCredential] =
     for {
       r <- run(q"select $columns from webknossos.credentials_ where _id = $id".as[CredentialsRow])
       firstRow <- r.headOption.toFox
       parsed <- parseAnyCredential(firstRow)
     } yield parsed
 
-  private def parseAnyCredential(r: CredentialsRow): Fox[FileSystemCredential] =
+  private def parseAnyCredential(r: CredentialsRow): Fox[DataVaultCredential] =
     for {
       typeParsed <- CredentialType.fromString(r.`type`).toFox
       parsed <- typeParsed match {

--- a/app/models/binary/credential/CredentialService.scala
+++ b/app/models/binary/credential/CredentialService.scala
@@ -2,7 +2,7 @@ package models.binary.credential
 
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.storage.{
-  FileSystemCredential,
+  DataVaultCredential,
   DataVaultsHolder,
   GoogleServiceAccountCredential,
   HttpBasicAuthCredential,
@@ -22,7 +22,7 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO) {
                           credentialIdentifier: Option[String],
                           credentialSecret: Option[String],
                           userId: ObjectId,
-                          organizationId: ObjectId): Option[FileSystemCredential] =
+                          organizationId: ObjectId): Option[DataVaultCredential] =
     uri.getScheme match {
       case DataVaultsHolder.schemeHttps | DataVaultsHolder.schemeHttp =>
         credentialIdentifier.map(
@@ -45,7 +45,7 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO) {
         } yield GoogleServiceAccountCredential(uri.toString, secretJson, userId.toString, organizationId.toString)
     }
 
-  def insertOne(credential: FileSystemCredential)(implicit ec: ExecutionContext): Fox[ObjectId] = {
+  def insertOne(credential: DataVaultCredential)(implicit ec: ExecutionContext): Fox[ObjectId] = {
     val _id = ObjectId.generate
     for {
       _ <- credential match {

--- a/app/models/binary/explore/ExploreRemoteLayerService.scala
+++ b/app/models/binary/explore/ExploreRemoteLayerService.scala
@@ -162,8 +162,8 @@ class ExploreRemoteLayerService @Inject()(credentialService: CredentialService) 
                                                             requestingUser._id,
                                                             requestingUser._organization)
       remoteSource = RemoteSourceDescriptor(uri, credentialOpt)
-      credentialId <- Fox.runOptional(credentialOpt)(c => credentialService.insertOne(c)) ?~> "remoteFileSystem.credential.insert.failed"
-      remotePath <- DataVaultsHolder.getVaultPath(remoteSource) ?~> "remoteFileSystem.setup.failed"
+      credentialId <- Fox.runOptional(credentialOpt)(c => credentialService.insertOne(c)) ?~> "dataVault.credential.insert.failed"
+      remotePath <- DataVaultsHolder.getVaultPath(remoteSource) ?~> "dataVault.setup.failed"
       layersWithVoxelSizes <- exploreRemoteLayersForRemotePath(
         remotePath,
         credentialId.map(_.toString),

--- a/app/models/binary/explore/ExploreRemoteLayerService.scala
+++ b/app/models/binary/explore/ExploreRemoteLayerService.scala
@@ -10,6 +10,7 @@ import com.scalableminds.webknossos.datastore.dataformats.precomputed.{
 import com.scalableminds.webknossos.datastore.dataformats.zarr._
 import com.scalableminds.webknossos.datastore.datareaders.n5.N5Header
 import com.scalableminds.webknossos.datastore.datareaders.zarr._
+import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource._
 import com.scalableminds.webknossos.datastore.storage.{DataVaultsHolder, RemoteSourceDescriptor}
 import com.typesafe.scalalogging.LazyLogging
@@ -21,7 +22,6 @@ import oxalis.security.WkEnv
 import play.api.libs.json.{Json, OFormat}
 
 import java.net.URI
-import java.nio.file.Path
 import javax.inject.Inject
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
@@ -186,7 +186,7 @@ class ExploreRemoteLayerService @Inject()(credentialService: CredentialService) 
     else uri
 
   private def exploreRemoteLayersForRemotePath(
-      remotePath: Path,
+      remotePath: VaultPath,
       credentialId: Option[String],
       reportMutable: ListBuffer[String],
       explorers: List[RemoteLayerExplorer])(implicit ec: ExecutionContext): Fox[List[(DataLayer, Vec3Double)]] =

--- a/app/models/binary/explore/N5ArrayExplorer.scala
+++ b/app/models/binary/explore/N5ArrayExplorer.scala
@@ -5,19 +5,19 @@ import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.dataformats.n5.{N5DataLayer, N5Layer, N5SegmentationLayer}
 import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.datareaders.n5.N5Header
+import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.Category
 
-import java.nio.file.Path
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class N5ArrayExplorer extends RemoteLayerExplorer {
 
   override def name: String = "N5 Array"
 
-  override def explore(remotePath: Path, credentialId: Option[String]): Fox[List[(N5Layer, Vec3Double)]] =
+  override def explore(remotePath: VaultPath, credentialId: Option[String]): Fox[List[(N5Layer, Vec3Double)]] =
     for {
-      headerPath <- Fox.successful(remotePath.resolve(N5Header.FILENAME_ATTRIBUTES_JSON))
-      name <- guessNameFromPath(remotePath)
+      headerPath <- Fox.successful(remotePath / N5Header.FILENAME_ATTRIBUTES_JSON)
+      name = guessNameFromPath(remotePath)
       n5Header <- parseJsonFromPath[N5Header](headerPath) ?~> s"failed to read n5 header at $headerPath"
       elementClass <- n5Header.elementClass ?~> "failed to read element class from n5 header"
       guessedAxisOrder = AxisOrder.asZyxFromRank(n5Header.rank)

--- a/app/models/binary/explore/PrecomputedExplorer.scala
+++ b/app/models/binary/explore/PrecomputedExplorer.scala
@@ -9,26 +9,26 @@ import com.scalableminds.webknossos.datastore.dataformats.precomputed.{
 }
 import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.datareaders.precomputed.{PrecomputedHeader, PrecomputedScale}
+import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.{Category, ElementClass}
 
-import java.nio.file.Path
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class PrecomputedExplorer extends RemoteLayerExplorer {
   override def name: String = "Neuroglancer Precomputed"
 
-  override def explore(remotePath: Path, credentialId: Option[String]): Fox[List[(PrecomputedLayer, Vec3Double)]] =
+  override def explore(remotePath: VaultPath, credentialId: Option[String]): Fox[List[(PrecomputedLayer, Vec3Double)]] =
     for {
-      infoPath <- Fox.successful(remotePath.resolve(PrecomputedHeader.FILENAME_INFO))
+      infoPath <- Fox.successful(remotePath / PrecomputedHeader.FILENAME_INFO)
       precomputedHeader <- parseJsonFromPath[PrecomputedHeader](infoPath) ?~> s"Failed to read neuroglancer precomputed metadata at $infoPath"
       layerAndVoxelSize <- layerFromPrecomputedHeader(precomputedHeader, remotePath, credentialId)
     } yield List(layerAndVoxelSize)
 
   private def layerFromPrecomputedHeader(precomputedHeader: PrecomputedHeader,
-                                         remotePath: Path,
+                                         remotePath: VaultPath,
                                          credentialId: Option[String]): Fox[(PrecomputedLayer, Vec3Double)] =
     for {
-      name <- guessNameFromPath(remotePath)
+      name <- Fox.successful(guessNameFromPath(remotePath))
       firstScale <- precomputedHeader.scales.headOption.toFox
       boundingBox <- BoundingBox.fromSizeArray(firstScale.size).toFox
       elementClass: ElementClass.Value <- elementClassFromPrecomputedDataType(precomputedHeader.data_type) ?~> "Unknown data type"
@@ -53,16 +53,16 @@ class PrecomputedExplorer extends RemoteLayerExplorer {
 
   private def getMagFromScale(scale: PrecomputedScale,
                               minimalResolution: Array[Int],
-                              remotePath: Path,
+                              remotePath: VaultPath,
                               credentialId: Option[String]): Fox[MagLocator] = {
     val normalizedResolution = (scale.resolution, minimalResolution).zipped.map((r, m) => r / m)
     for {
       mag <- Vec3Int.fromList(normalizedResolution.toList)
-      path = remotePath.resolve(scale.key)
+      path = remotePath / scale.key
 
       // Neuroglancer precomputed specification does not specify axis order, but uses x,y,z implicitly.
       // https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/volume.md#unsharded-chunk-storage
       axisOrder = AxisOrder(0, 1, 2)
-    } yield MagLocator(mag, Some(path.toUri.toString), None, Some(axisOrder), channelIndex = None, credentialId)
+    } yield MagLocator(mag, Some(path.toString), None, Some(axisOrder), channelIndex = None, credentialId)
   }
 }

--- a/app/models/binary/explore/RemoteLayerExplorer.scala
+++ b/app/models/binary/explore/RemoteLayerExplorer.scala
@@ -34,7 +34,7 @@ trait RemoteLayerExplorer extends FoxImplicits {
       elementClass)
 
   protected def guessNameFromPath(path: VaultPath): String =
-    path.fileName
+    path.basename
 
   protected def elementClassFromMags(magsWithAttributes: List[MagWithAttributes]): Fox[ElementClass.Value] = {
     val elementClasses = magsWithAttributes.map(_.elementClass)

--- a/app/models/binary/explore/WebknossosZarrExplorer.scala
+++ b/app/models/binary/explore/WebknossosZarrExplorer.scala
@@ -3,24 +3,24 @@ package models.binary.explore
 import com.scalableminds.util.geometry.Vec3Double
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.dataformats.zarr.{ZarrDataLayer, ZarrLayer, ZarrSegmentationLayer}
+import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.{Category, DataSource}
 
-import java.nio.file.Path
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class WebknossosZarrExplorer extends RemoteLayerExplorer {
 
   override def name: String = "WEBKNOSSOS-based Zarr"
 
-  override def explore(remotePath: Path, credentialId: Option[String]): Fox[List[(ZarrLayer, Vec3Double)]] =
+  override def explore(remotePath: VaultPath, credentialId: Option[String]): Fox[List[(ZarrLayer, Vec3Double)]] =
     for {
-      dataSourcePropertiesPath <- Fox.successful(remotePath.resolve("datasource-properties.json"))
+      dataSourcePropertiesPath <- Fox.successful(remotePath / "datasource-properties.json")
       dataSource <- parseJsonFromPath[DataSource](dataSourcePropertiesPath)
       ngffExplorer = new NgffExplorer
       zarrLayers <- Fox.serialCombined(dataSource.dataLayers) {
         case l: ZarrSegmentationLayer =>
           for {
-            zarrLayersFromNgff <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
+            zarrLayersFromNgff <- ngffExplorer.explore(remotePath / l.name, credentialId)
           } yield
             zarrLayersFromNgff.map(
               zarrLayer =>
@@ -32,7 +32,7 @@ class WebknossosZarrExplorer extends RemoteLayerExplorer {
                  zarrLayer._2))
         case l: ZarrDataLayer =>
           for {
-            zarrLayersFromNgff <- ngffExplorer.explore(remotePath.resolve(l.name), credentialId)
+            zarrLayersFromNgff <- ngffExplorer.explore(remotePath / l.name, credentialId)
           } yield
             zarrLayersFromNgff.map(
               zarrLayer =>

--- a/app/models/binary/explore/ZarrArrayExplorer.scala
+++ b/app/models/binary/explore/ZarrArrayExplorer.scala
@@ -6,19 +6,19 @@ import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.dataformats.zarr.{ZarrDataLayer, ZarrLayer, ZarrSegmentationLayer}
 import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.datareaders.zarr.ZarrHeader
+import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.Category
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import java.nio.file.Path
 
 class ZarrArrayExplorer extends RemoteLayerExplorer {
 
   override def name: String = "Zarr Array"
 
-  override def explore(remotePath: Path, credentialId: Option[String]): Fox[List[(ZarrLayer, Vec3Double)]] =
+  override def explore(remotePath: VaultPath, credentialId: Option[String]): Fox[List[(ZarrLayer, Vec3Double)]] =
     for {
-      zarrayPath <- Fox.successful(remotePath.resolve(ZarrHeader.FILENAME_DOT_ZARRAY))
-      name <- guessNameFromPath(remotePath)
+      zarrayPath <- Fox.successful(remotePath / ZarrHeader.FILENAME_DOT_ZARRAY)
+      name = guessNameFromPath(remotePath)
       zarrHeader <- parseJsonFromPath[ZarrHeader](zarrayPath) ?~> s"failed to read zarr header at $zarrayPath"
       elementClass <- zarrHeader.elementClass ?~> "failed to read element class from zarr header"
       guessedAxisOrder = AxisOrder.asZyxFromRank(zarrHeader.rank)

--- a/conf/messages
+++ b/conf/messages
@@ -104,9 +104,9 @@ dataSet.upload.storageExceeded=Cannot upload dataset because the storage quota o
 dataSet.explore.failed.readFile=Failed to read remote file
 dataSet.explore.magDtypeMismatch=Element class must be the same for all mags of a layer. Got {0}
 
-remoteFileSystem.insert.failed=Failed to store remote file system credential
-remoteFileSystem.setup.failed=Failed to set up remote file system
-remoteFileSystem.getPath.failed=Failed to get remote path
+dataVault.insert.failed=Failed to store remote file system credential
+dataVault.setup.failed=Failed to set up remote file system
+dataVault.getPath.failed=Failed to get remote path
 
 
 dataSource.notFound=Datasource not found on datastore server

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.datavault.{FileSystemVaultPath, VaultPath}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, FileSystemService}
+import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultsService}
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.Empty
 
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext
 
 trait BucketProvider extends FoxImplicits with LazyLogging {
 
-  def fileSystemServiceOpt: Option[FileSystemService]
+  def fileSystemServiceOpt: Option[DataVaultsService]
 
   // To be defined in subclass.
   def loadFromUnderlying(readInstruction: DataReadInstruction)(implicit ec: ExecutionContext): Fox[DataCubeHandle] =
@@ -52,7 +52,7 @@ trait BucketProvider extends FoxImplicits with LazyLogging {
         .resolve(readInstruction.dataSource.id.name)
         .resolve(readInstruction.dataLayer.name)
         .resolve(relativeMagPath))
-    if (magPath.toFile.exists()) {
+    if (magPath.exists) {
       Fox.successful(magPath)
     } else Fox.empty
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/BucketProvider.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.datavault.{FileSystemVaultPath, VaultPath}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultsService}
+import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultService}
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.Empty
 
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext
 
 trait BucketProvider extends FoxImplicits with LazyLogging {
 
-  def fileSystemServiceOpt: Option[DataVaultsService]
+  def dataVaultServiceOpt: Option[DataVaultService]
 
   // To be defined in subclass.
   def loadFromUnderlying(readInstruction: DataReadInstruction)(implicit ec: ExecutionContext): Fox[DataCubeHandle] =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/MagLocator.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/MagLocator.scala
@@ -3,14 +3,14 @@ package com.scalableminds.webknossos.datastore.dataformats
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.models.datasource.ResolutionFormatHelper
-import com.scalableminds.webknossos.datastore.storage.{DataVaultsHolder, LegacyFileSystemCredential}
+import com.scalableminds.webknossos.datastore.storage.{DataVaultsHolder, LegacyDataVaultCredential}
 import play.api.libs.json.{Json, OFormat}
 
 import java.net.URI
 
 case class MagLocator(mag: Vec3Int,
                       path: Option[String],
-                      credentials: Option[LegacyFileSystemCredential],
+                      credentials: Option[LegacyDataVaultCredential],
                       axisOrder: Option[AxisOrder],
                       channelIndex: Option[Int],
                       credentialId: Option[String]) {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5BucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5BucketProvider.scala
@@ -8,7 +8,7 @@ import com.scalableminds.webknossos.datastore.datareaders.n5.N5Array
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.{Empty, Failure, Full}
 import net.liftweb.util.Helpers.tryo
@@ -29,7 +29,7 @@ class N5CubeHandle(n5Array: N5Array) extends DataCubeHandle with LazyLogging wit
 
 }
 
-class N5BucketProvider(layer: N5Layer, val fileSystemServiceOpt: Option[FileSystemService])
+class N5BucketProvider(layer: N5Layer, val fileSystemServiceOpt: Option[DataVaultsService])
     extends BucketProvider
     with LazyLogging
     with RateLimitedErrorLogging {
@@ -43,10 +43,10 @@ class N5BucketProvider(layer: N5Layer, val fileSystemServiceOpt: Option[FileSyst
       case None => Fox.empty
       case Some(n5Mag) =>
         fileSystemServiceOpt match {
-          case Some(fileSystemService: FileSystemService) =>
+          case Some(fileSystemService: DataVaultsService) =>
             for {
               magPath: VaultPath <- if (n5Mag.isRemote) {
-                fileSystemService.remotePathFor(n5Mag)
+                fileSystemService.vaultPathFor(n5Mag)
               } else localPathFrom(readInstruction, n5Mag.pathWithFallback)
               cubeHandle <- tryo(onError = e => logError(e))(N5Array.open(magPath, n5Mag.axisOrder, n5Mag.channelIndex))
                 .map(new N5CubeHandle(_))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5BucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5BucketProvider.scala
@@ -8,7 +8,7 @@ import com.scalableminds.webknossos.datastore.datareaders.n5.N5Array
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.{Empty, Failure, Full}
 import net.liftweb.util.Helpers.tryo
@@ -29,7 +29,7 @@ class N5CubeHandle(n5Array: N5Array) extends DataCubeHandle with LazyLogging wit
 
 }
 
-class N5BucketProvider(layer: N5Layer, val fileSystemServiceOpt: Option[DataVaultsService])
+class N5BucketProvider(layer: N5Layer, val dataVaultServiceOpt: Option[DataVaultService])
     extends BucketProvider
     with LazyLogging
     with RateLimitedErrorLogging {
@@ -42,11 +42,11 @@ class N5BucketProvider(layer: N5Layer, val fileSystemServiceOpt: Option[DataVaul
     n5MagOpt match {
       case None => Fox.empty
       case Some(n5Mag) =>
-        fileSystemServiceOpt match {
-          case Some(fileSystemService: DataVaultsService) =>
+        dataVaultServiceOpt match {
+          case Some(dataVaultService: DataVaultService) =>
             for {
               magPath: VaultPath <- if (n5Mag.isRemote) {
-                fileSystemService.vaultPathFor(n5Mag)
+                dataVaultService.vaultPathFor(n5Mag)
               } else localPathFrom(readInstruction, n5Mag.pathWithFallback)
               cubeHandle <- tryo(onError = e => logError(e))(N5Array.open(magPath, n5Mag.axisOrder, n5Mag.channelIndex))
                 .map(new N5CubeHandle(_))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5DataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5DataLayers.scala
@@ -4,14 +4,14 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource._
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import play.api.libs.json.{Json, OFormat}
 
 trait N5Layer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.n5
 
-  def bucketProvider(fileSystemServiceOpt: Option[FileSystemService]) = new N5BucketProvider(this, fileSystemServiceOpt)
+  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]) = new N5BucketProvider(this, fileSystemServiceOpt)
 
   def resolutions: List[Vec3Int] = mags.map(_.mag)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5DataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5DataLayers.scala
@@ -4,14 +4,14 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource._
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.libs.json.{Json, OFormat}
 
 trait N5Layer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.n5
 
-  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]) = new N5BucketProvider(this, fileSystemServiceOpt)
+  def bucketProvider(dataVaultServiceOpt: Option[DataVaultService]) = new N5BucketProvider(this, dataVaultServiceOpt)
 
   def resolutions: List[Vec3Int] = mags.map(_.mag)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedBucketProvider.scala
@@ -8,7 +8,7 @@ import com.scalableminds.webknossos.datastore.datareaders.precomputed.Precompute
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.{Empty, Failure, Full}
 import net.liftweb.util.Helpers.tryo
@@ -32,7 +32,7 @@ class PrecomputedCubeHandle(precomputedArray: PrecomputedArray)
 
 }
 
-class PrecomputedBucketProvider(layer: PrecomputedLayer, val fileSystemServiceOpt: Option[FileSystemService])
+class PrecomputedBucketProvider(layer: PrecomputedLayer, val fileSystemServiceOpt: Option[DataVaultsService])
     extends BucketProvider
     with LazyLogging
     with RateLimitedErrorLogging {
@@ -46,10 +46,10 @@ class PrecomputedBucketProvider(layer: PrecomputedLayer, val fileSystemServiceOp
       case None => Fox.empty
       case Some(precomputedMag) =>
         fileSystemServiceOpt match {
-          case Some(fileSystemService: FileSystemService) =>
+          case Some(fileSystemService: DataVaultsService) =>
             for {
               magPath: VaultPath <- if (precomputedMag.isRemote) {
-                fileSystemService.remotePathFor(precomputedMag)
+                fileSystemService.vaultPathFor(precomputedMag)
               } else localPathFrom(readInstruction, precomputedMag.pathWithFallback)
               cubeHandle <- tryo(onError = e => logError(e))(
                 PrecomputedArray.open(magPath, precomputedMag.axisOrder, precomputedMag.channelIndex))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedBucketProvider.scala
@@ -8,7 +8,7 @@ import com.scalableminds.webknossos.datastore.datareaders.precomputed.Precompute
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.{Empty, Failure, Full}
 import net.liftweb.util.Helpers.tryo
@@ -32,7 +32,7 @@ class PrecomputedCubeHandle(precomputedArray: PrecomputedArray)
 
 }
 
-class PrecomputedBucketProvider(layer: PrecomputedLayer, val fileSystemServiceOpt: Option[DataVaultsService])
+class PrecomputedBucketProvider(layer: PrecomputedLayer, val dataVaultServiceOpt: Option[DataVaultService])
     extends BucketProvider
     with LazyLogging
     with RateLimitedErrorLogging {
@@ -45,11 +45,11 @@ class PrecomputedBucketProvider(layer: PrecomputedLayer, val fileSystemServiceOp
     precomputedMagOpt match {
       case None => Fox.empty
       case Some(precomputedMag) =>
-        fileSystemServiceOpt match {
-          case Some(fileSystemService: DataVaultsService) =>
+        dataVaultServiceOpt match {
+          case Some(dataVaultService: DataVaultService) =>
             for {
               magPath: VaultPath <- if (precomputedMag.isRemote) {
-                fileSystemService.vaultPathFor(precomputedMag)
+                dataVaultService.vaultPathFor(precomputedMag)
               } else localPathFrom(readInstruction, precomputedMag.pathWithFallback)
               cubeHandle <- tryo(onError = e => logError(e))(
                 PrecomputedArray.open(magPath, precomputedMag.axisOrder, precomputedMag.channelIndex))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedDataLayers.scala
@@ -11,15 +11,15 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   ElementClass,
   SegmentationLayer
 }
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.libs.json.{Json, OFormat}
 
 trait PrecomputedLayer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.neuroglancerPrecomputed
 
-  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]) =
-    new PrecomputedBucketProvider(this, fileSystemServiceOpt)
+  def bucketProvider(dataVaultServiceOpt: Option[DataVaultService]) =
+    new PrecomputedBucketProvider(this, dataVaultServiceOpt)
 
   def resolutions: List[Vec3Int] = mags.map(_.mag)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedDataLayers.scala
@@ -11,14 +11,14 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   ElementClass,
   SegmentationLayer
 }
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import play.api.libs.json.{Json, OFormat}
 
 trait PrecomputedLayer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.neuroglancerPrecomputed
 
-  def bucketProvider(fileSystemServiceOpt: Option[FileSystemService]) =
+  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]) =
     new PrecomputedBucketProvider(this, fileSystemServiceOpt)
 
   def resolutions: List[Vec3Int] = mags.map(_.mag)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.dataformats.{BucketProvider, DataCubeHandle}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import com.scalableminds.webknossos.wrap.WKWFile
 import net.liftweb.common.{Empty, Failure, Full}
 import java.nio.file.Path
@@ -33,7 +33,7 @@ class WKWCubeHandle(wkwFile: WKWFile, wkwFilePath: Path) extends DataCubeHandle 
 
 class WKWBucketProvider(layer: WKWLayer) extends BucketProvider with WKWDataFormatHelper {
 
-  override def fileSystemServiceOpt: Option[FileSystemService] = None
+  override def fileSystemServiceOpt: Option[DataVaultsService] = None
 
   override def loadFromUnderlying(readInstruction: DataReadInstruction)(
       implicit ec: ExecutionContext): Fox[WKWCubeHandle] = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWBucketProvider.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.dataformats.{BucketProvider, DataCubeHandle}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import com.scalableminds.webknossos.wrap.WKWFile
 import net.liftweb.common.{Empty, Failure, Full}
 import java.nio.file.Path
@@ -33,7 +33,7 @@ class WKWCubeHandle(wkwFile: WKWFile, wkwFilePath: Path) extends DataCubeHandle 
 
 class WKWBucketProvider(layer: WKWLayer) extends BucketProvider with WKWDataFormatHelper {
 
-  override def fileSystemServiceOpt: Option[DataVaultsService] = None
+  override def dataVaultServiceOpt: Option[DataVaultService] = None
 
   override def loadFromUnderlying(readInstruction: DataReadInstruction)(
       implicit ec: ExecutionContext): Fox[WKWCubeHandle] = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
@@ -3,8 +3,8 @@ package com.scalableminds.webknossos.datastore.dataformats.wkw
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.webknossos.datastore.dataformats.BucketProvider
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
-import com.scalableminds.webknossos.datastore.models.datasource.{DataFormat, _}
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.models.datasource._
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import play.api.libs.json.{Json, OFormat}
 
 case class WKWResolution(resolution: Vec3Int, cubeLength: Int)
@@ -17,7 +17,7 @@ trait WKWLayer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.wkw
 
-  override def bucketProvider(fileSystemServiceOpt: Option[FileSystemService]): BucketProvider =
+  override def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider =
     new WKWBucketProvider(this)
 
   def wkwResolutions: List[WKWResolution]

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWDataLayers.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.webknossos.datastore.dataformats.BucketProvider
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource._
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.libs.json.{Json, OFormat}
 
 case class WKWResolution(resolution: Vec3Int, cubeLength: Int)
@@ -17,7 +17,7 @@ trait WKWLayer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.wkw
 
-  override def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider =
+  override def bucketProvider(dataVaultServiceOpt: Option[DataVaultService]): BucketProvider =
     new WKWBucketProvider(this)
 
   def wkwResolutions: List[WKWResolution]

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
@@ -8,7 +8,7 @@ import com.scalableminds.webknossos.datastore.datareaders.zarr.ZarrArray
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.{Empty, Failure, Full}
 import net.liftweb.util.Helpers.tryo
@@ -29,7 +29,7 @@ class ZarrCubeHandle(zarrArray: ZarrArray) extends DataCubeHandle with LazyLoggi
 
 }
 
-class ZarrBucketProvider(layer: ZarrLayer, val fileSystemServiceOpt: Option[FileSystemService])
+class ZarrBucketProvider(layer: ZarrLayer, val fileSystemServiceOpt: Option[DataVaultsService])
     extends BucketProvider
     with LazyLogging
     with RateLimitedErrorLogging {
@@ -43,10 +43,10 @@ class ZarrBucketProvider(layer: ZarrLayer, val fileSystemServiceOpt: Option[File
       case None => Fox.empty
       case Some(zarrMag) =>
         fileSystemServiceOpt match {
-          case Some(fileSystemService: FileSystemService) =>
+          case Some(fileSystemService: DataVaultsService) =>
             for {
               magPath: VaultPath <- if (zarrMag.isRemote) {
-                fileSystemService.remotePathFor(zarrMag)
+                fileSystemService.vaultPathFor(zarrMag)
               } else localPathFrom(readInstruction, zarrMag.pathWithFallback)
               cubeHandle <- tryo(onError = e => logError(e))(
                 ZarrArray.open(magPath, zarrMag.axisOrder, zarrMag.channelIndex)).map(new ZarrCubeHandle(_))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrDataLayers.scala
@@ -4,14 +4,14 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource._
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import play.api.libs.json.{Json, OFormat}
 
 trait ZarrLayer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.zarr
 
-  def bucketProvider(fileSystemServiceOpt: Option[FileSystemService]) =
+  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]) =
     new ZarrBucketProvider(this, fileSystemServiceOpt)
 
   def resolutions: List[Vec3Int] = mags.map(_.mag)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrDataLayers.scala
@@ -4,15 +4,15 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource._
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.libs.json.{Json, OFormat}
 
 trait ZarrLayer extends DataLayer {
 
   val dataFormat: DataFormat.Value = DataFormat.zarr
 
-  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]) =
-    new ZarrBucketProvider(this, fileSystemServiceOpt)
+  def bucketProvider(dataVaultServiceOpt: Option[DataVaultService]) =
+    new ZarrBucketProvider(this, dataVaultServiceOpt)
 
   def resolutions: List[Vec3Int] = mags.map(_.mag)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetArray.scala
@@ -140,7 +140,7 @@ class DatasetArray(relativePath: DatasetPath,
 
   override def toString: String =
     s"${getClass.getCanonicalName} {'/${relativePath.storeKey}' axisOrder=$axisOrder shape=${header.datasetShape.mkString(
-      ",")} chunks=${header.chunkSize.mkString(",")} dtype=${header.dataType} fillValue=${header.fillValueNumber}, ${header.compressorImpl}, byteOrder=${header.byteOrder}, vault=${vaultPath.getName}}"
+      ",")} chunks=${header.chunkSize.mkString(",")} dtype=${header.dataType} fillValue=${header.fillValueNumber}, ${header.compressorImpl}, byteOrder=${header.byteOrder}, vault=${vaultPath.summary}}"
 
 }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
@@ -34,7 +34,7 @@ object PrecomputedArray extends LazyLogging {
           throw new Exception("Validating json as precomputed metadata failed: " + JsError.toJson(errors).toString())
       }
 
-    val key = magPath.fileName
+    val key = magPath.basename
 
     val scaleHeader: PrecomputedScaleHeader = PrecomputedScaleHeader(
       rootHeader.getScale(key).getOrElse(throw new IllegalArgumentException(s"Did not find a scale for key $key")),

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
@@ -19,7 +19,7 @@ object PrecomputedArray extends LazyLogging {
   @throws[IOException]
   def open(magPath: VaultPath, axisOrderOpt: Option[AxisOrder], channelIndex: Option[Int]): PrecomputedArray = {
 
-    val basePath = magPath.getParent.asInstanceOf[VaultPath]
+    val basePath = magPath.parent
     val headerPath = s"${PrecomputedHeader.FILENAME_INFO}"
     val headerBytes = (basePath / headerPath).readBytes()
     if (headerBytes.isEmpty)
@@ -34,18 +34,16 @@ object PrecomputedArray extends LazyLogging {
           throw new Exception("Validating json as precomputed metadata failed: " + JsError.toJson(errors).toString())
       }
 
-    val key = magPath.getFileName
+    val key = magPath.fileName
 
     val scaleHeader: PrecomputedScaleHeader = PrecomputedScaleHeader(
-      rootHeader
-        .getScale(key.toString)
-        .getOrElse(throw new IllegalArgumentException(s"Did not find a scale for key $key")),
+      rootHeader.getScale(key).getOrElse(throw new IllegalArgumentException(s"Did not find a scale for key $key")),
       rootHeader)
     if (scaleHeader.bytesPerChunk > DatasetArray.chunkSizeLimitBytes) {
       throw new IllegalArgumentException(
         f"Chunk size of this Precomputed Array exceeds limit of ${DatasetArray.chunkSizeLimitBytes}, got ${scaleHeader.bytesPerChunk}")
     }
-    val datasetPath = new DatasetPath(key.toString)
+    val datasetPath = new DatasetPath(key)
     new PrecomputedArray(datasetPath,
                          basePath,
                          scaleHeader,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemDataVault.scala
@@ -1,9 +1,25 @@
 package com.scalableminds.webknossos.datastore.datavault
 
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Path}
 import scala.collection.immutable.NumericRange
 
 class FileSystemDataVault extends DataVault {
   override def readBytes(path: VaultPath, range: Option[NumericRange[Long]]): Array[Byte] = ???
+
+  def readBytesLocal(path: Path, range: Option[NumericRange[Long]]): Array[Byte] =
+    range match {
+      case None => Files.readAllBytes(path)
+      case Some(r) =>
+        val channel = Files.newByteChannel(path)
+        val buf = ByteBuffer.allocateDirect(r.length)
+        channel.position(r.start)
+        channel.read(buf)
+        buf.position(0)
+        val arr = new Array[Byte](r.length)
+        buf.get(arr)
+        arr
+    }
 }
 object FileSystemDataVault {
   def create: FileSystemDataVault = new FileSystemDataVault

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemVaultPath.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemVaultPath.scala
@@ -13,7 +13,7 @@ class FileSystemVaultPath(basePath: Path, dataVault: FileSystemDataVault)
   override def readBytes(range: Option[NumericRange[Long]] = None): Option[Array[Byte]] =
     tryo(dataVault.readBytesLocal(basePath, range)).toOption.map(ZipIO.tryGunzip)
 
-  override def fileName: String = basePath.getFileName.toString
+  override def basename: String = basePath.getFileName.toString
 
   override def parent: VaultPath = new FileSystemVaultPath(basePath.getParent, dataVault)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
@@ -1,9 +1,9 @@
 package com.scalableminds.webknossos.datastore.datavault
 
 import com.scalableminds.webknossos.datastore.storage.{
-  FileSystemCredential,
+  DataVaultCredential,
   HttpBasicAuthCredential,
-  LegacyFileSystemCredential,
+  LegacyDataVaultCredential,
   RemoteSourceDescriptor
 }
 
@@ -14,7 +14,7 @@ import sttp.model.Uri
 
 import scala.collection.immutable.NumericRange
 
-class HttpsDataVault(credential: Option[FileSystemCredential]) extends DataVault {
+class HttpsDataVault(credential: Option[DataVaultCredential]) extends DataVault {
 
   private val connectionTimeout = 1 minute
   private val readTimeout = 10 minutes
@@ -24,7 +24,7 @@ class HttpsDataVault(credential: Option[FileSystemCredential]) extends DataVault
     credential.flatMap { c =>
       c match {
         case h: HttpBasicAuthCredential    => Some(h)
-        case l: LegacyFileSystemCredential => Some(l.toBasicAuth)
+        case l: LegacyDataVaultCredential => Some(l.toBasicAuth)
         case _                             => None
       }
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
@@ -23,9 +23,9 @@ class HttpsDataVault(credential: Option[DataVaultCredential]) extends DataVault 
   def getBasicAuthCredential: Option[HttpBasicAuthCredential] =
     credential.flatMap { c =>
       c match {
-        case h: HttpBasicAuthCredential    => Some(h)
+        case h: HttpBasicAuthCredential   => Some(h)
         case l: LegacyDataVaultCredential => Some(l.toBasicAuth)
-        case _                             => None
+        case _                            => None
       }
     }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/VaultPath.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/VaultPath.scala
@@ -4,54 +4,22 @@ import com.scalableminds.util.io.ZipIO
 import net.liftweb.util.Helpers.tryo
 
 import java.net.URI
-import java.nio.file.{FileSystem, LinkOption, Path, Paths, WatchEvent, WatchKey, WatchService}
 import scala.collection.immutable.NumericRange
 
-/*
-VaultPath implements Path so that a drop in replacement is possible while continuing to use Paths for local storage.
-This class does not implement all relevant methods and it might be a good idea to remove the inheritance on Path in the
-future.
- */
-
-class VaultPath(uri: URI, dataVault: DataVault) extends Path {
-
-  protected def readBytesGet(range: Option[NumericRange[Long]]): Array[Byte] =
-    dataVault.readBytes(this, range)
+class VaultPath(uri: URI, dataVault: DataVault) {
 
   def readBytes(range: Option[NumericRange[Long]] = None): Option[Array[Byte]] =
-    tryo(readBytesGet(range)).toOption.map(ZipIO.tryGunzip)
+    tryo(dataVault.readBytes(this, range)).toOption.map(ZipIO.tryGunzip)
 
-  override def getFileSystem: FileSystem = ???
+  def fileName: String =
+    uri.toString.split("/").last
 
-  override def isAbsolute: Boolean = ???
-
-  override def getRoot: Path = ???
-
-  override def getFileName: Path =
-    Paths.get(uri.toString.split("/").last)
-
-  override def getParent: Path = {
+  def parent: VaultPath = {
     val newUri =
       if (uri.getPath.endsWith("/")) uri.resolve("..")
       else uri.resolve(".")
     new VaultPath(newUri, dataVault)
   }
-
-  override def getNameCount: Int = ???
-
-  override def getName(index: Int): Path = ???
-
-  override def subpath(beginIndex: Int, endIndex: Int): Path = ???
-
-  override def startsWith(other: Path): Boolean = ???
-
-  override def endsWith(other: Path): Boolean = ???
-
-  override def normalize(): Path = ???
-
-  override def resolve(other: String): Path = this / other
-
-  override def resolve(other: Path): Path = this / other.toString
 
   def /(key: String): VaultPath =
     if (uri.toString.endsWith("/")) {
@@ -60,22 +28,10 @@ class VaultPath(uri: URI, dataVault: DataVault) extends Path {
       new VaultPath(new URI(s"${uri.toString}/").resolve(key), dataVault)
     }
 
-  override def relativize(other: Path): Path = ???
-
-  override def toUri: URI =
+  def toUri: URI =
     uri
-
-  override def toAbsolutePath: Path = ???
-
-  override def compareTo(other: Path): Int = ???
-
-  override def toRealPath(options: LinkOption*): Path = ???
-
-  override def register(watcher: WatchService,
-                        events: Array[WatchEvent.Kind[_]],
-                        modifiers: WatchEvent.Modifier*): WatchKey = ???
 
   override def toString: String = uri.toString
 
-  def getName: String = s"VaultPath: ${this.toString} for ${dataVault.getClass.getSimpleName}"
+  def summary: String = s"VaultPath: ${this.toString} for ${dataVault.getClass.getSimpleName}"
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/VaultPath.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/VaultPath.scala
@@ -11,7 +11,7 @@ class VaultPath(uri: URI, dataVault: DataVault) {
   def readBytes(range: Option[NumericRange[Long]] = None): Option[Array[Byte]] =
     tryo(dataVault.readBytes(this, range)).toOption.map(ZipIO.tryGunzip)
 
-  def fileName: String =
+  def basename: String =
     uri.toString.split("/").last
 
   def parent: VaultPath = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -14,7 +14,7 @@ import com.scalableminds.webknossos.datastore.dataformats.zarr.{ZarrDataLayer, Z
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDataType
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.libs.json._
 
 object DataFormat extends ExtendedEnumeration {
@@ -181,7 +181,7 @@ trait DataLayer extends DataLayerLike {
     */
   def lengthOfUnderlyingCubes(resolution: Vec3Int): Int
 
-  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider
+  def bucketProvider(dataVaultServiceOpt: Option[DataVaultService]): BucketProvider
 
   def containsResolution(resolution: Vec3Int): Boolean = resolutions.contains(resolution)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -14,7 +14,7 @@ import com.scalableminds.webknossos.datastore.dataformats.zarr.{ZarrDataLayer, Z
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDataType
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 import play.api.libs.json._
 
 object DataFormat extends ExtendedEnumeration {
@@ -181,7 +181,7 @@ trait DataLayer extends DataLayerLike {
     */
   def lengthOfUnderlyingCubes(resolution: Vec3Int): Int
 
-  def bucketProvider(fileSystemServiceOpt: Option[FileSystemService]): BucketProvider
+  def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider
 
   def containsResolution(resolution: Vec3Int): Boolean = resolutions.contains(resolution)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class BinaryDataService(val dataBaseDir: Path,
                         maxCacheSize: Int,
                         val agglomerateServiceOpt: Option[AgglomerateService],
-                        fileSystemServiceOpt: Option[FileSystemService],
+                        fileSystemServiceOpt: Option[DataVaultsService],
                         val applicationHealthService: Option[ApplicationHealthService])
     extends FoxImplicits
     with DataSetDeleter

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class BinaryDataService(val dataBaseDir: Path,
                         maxCacheSize: Int,
                         val agglomerateServiceOpt: Option[AgglomerateService],
-                        fileSystemServiceOpt: Option[DataVaultsService],
+                        dataVaultServiceOpt: Option[DataVaultService],
                         val applicationHealthService: Option[ApplicationHealthService])
     extends FoxImplicits
     with DataSetDeleter
@@ -83,7 +83,7 @@ class BinaryDataService(val dataBaseDir: Path,
       val readInstruction =
         DataReadInstruction(dataBaseDir, request.dataSource, request.dataLayer, bucket, request.settings.version)
       val bucketProvider = bucketProviderCache.getOrLoadAndPut(request.dataLayer)(dataLayer =>
-        dataLayer.bucketProvider(fileSystemServiceOpt))
+        dataLayer.bucketProvider(dataVaultServiceOpt))
       bucketProvider.load(readInstruction, shardHandleCache).futureBox.flatMap {
         case Failure(msg, Full(e: InternalError), _) =>
           applicationHealthService.foreach(a => a.pushError(e))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.datastore.services
 
 import java.nio.file.Paths
 import com.scalableminds.webknossos.datastore.DataStoreConfig
-import com.scalableminds.webknossos.datastore.storage.DataVaultsService
+import com.scalableminds.webknossos.datastore.storage.DataVaultService
 
 import javax.inject.Inject
 
@@ -16,13 +16,13 @@ import javax.inject.Inject
 class BinaryDataServiceHolder @Inject()(config: DataStoreConfig,
                                         agglomerateService: AgglomerateService,
                                         applicationHealthService: ApplicationHealthService,
-                                        fileSystemService: DataVaultsService) {
+                                        dataVaultService: DataVaultService) {
 
   val binaryDataService: BinaryDataService = new BinaryDataService(
     Paths.get(config.Datastore.baseFolder),
     config.Datastore.Cache.DataCube.maxEntries,
     Some(agglomerateService),
-    Some(fileSystemService),
+    Some(dataVaultService),
     Some(applicationHealthService)
   )
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataServiceHolder.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.datastore.services
 
 import java.nio.file.Paths
 import com.scalableminds.webknossos.datastore.DataStoreConfig
-import com.scalableminds.webknossos.datastore.storage.FileSystemService
+import com.scalableminds.webknossos.datastore.storage.DataVaultsService
 
 import javax.inject.Inject
 
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class BinaryDataServiceHolder @Inject()(config: DataStoreConfig,
                                         agglomerateService: AgglomerateService,
                                         applicationHealthService: ApplicationHealthService,
-                                        fileSystemService: FileSystemService) {
+                                        fileSystemService: DataVaultsService) {
 
   val binaryDataService: BinaryDataService = new BinaryDataService(
     Paths.get(config.Datastore.baseFolder),

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebKnossosClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebKnossosClient.scala
@@ -12,7 +12,7 @@ import com.scalableminds.webknossos.datastore.models.annotation.AnnotationSource
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.models.datasource.inbox.InboxDataSourceLike
 import com.scalableminds.webknossos.datastore.rpc.RPC
-import com.scalableminds.webknossos.datastore.storage.FileSystemCredential
+import com.scalableminds.webknossos.datastore.storage.DataVaultCredential
 import com.typesafe.scalalogging.LazyLogging
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.{Json, OFormat}
@@ -150,10 +150,10 @@ class DSRemoteWebKnossosClient @Inject()(
           .getWithJsonResponse[AnnotationSource]
     )
 
-  private lazy val credentialCache: AlfuFoxCache[String, FileSystemCredential] =
+  private lazy val credentialCache: AlfuFoxCache[String, DataVaultCredential] =
     AlfuFoxCache(timeToLive = 5 seconds, timeToIdle = 5 seconds)
 
-  def getCredential(credentialId: String): Fox[FileSystemCredential] =
+  def getCredential(credentialId: String): Fox[DataVaultCredential] =
     credentialCache.getOrLoad(
       credentialId,
       _ =>
@@ -161,6 +161,6 @@ class DSRemoteWebKnossosClient @Inject()(
           .addQueryString("credentialId" -> credentialId)
           .addQueryString("key" -> dataStoreKey)
           .silent
-          .getWithJsonResponse[FileSystemCredential]
+          .getWithJsonResponse[DataVaultCredential]
     )
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataVaultCredentials.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataVaultCredentials.scala
@@ -2,14 +2,14 @@ package com.scalableminds.webknossos.datastore.storage
 
 import play.api.libs.json.{JsValue, Json, OFormat}
 
-sealed trait FileSystemCredential
+sealed trait DataVaultCredential
 
-object FileSystemCredential {
-  implicit val jsonFormat: OFormat[FileSystemCredential] = Json.format[FileSystemCredential]
+object DataVaultCredential {
+  implicit val jsonFormat: OFormat[DataVaultCredential] = Json.format[DataVaultCredential]
 }
 
 case class HttpBasicAuthCredential(name: String, username: String, password: String, user: String, organization: String)
-    extends FileSystemCredential
+    extends DataVaultCredential
 
 object HttpBasicAuthCredential {
   implicit val jsonFormat: OFormat[HttpBasicAuthCredential] = Json.format[HttpBasicAuthCredential]
@@ -20,20 +20,20 @@ case class S3AccessKeyCredential(name: String,
                                  secretAccessKey: String,
                                  user: String,
                                  organization: String)
-    extends FileSystemCredential
+    extends DataVaultCredential
 
 object S3AccessKeyCredential {
   implicit val jsonFormat: OFormat[S3AccessKeyCredential] = Json.format[S3AccessKeyCredential]
 }
 
 case class GoogleServiceAccountCredential(name: String, secretJson: JsValue, user: String, organization: String)
-    extends FileSystemCredential
+    extends DataVaultCredential
 
 object GoogleServiceAccountCredential {
   implicit val jsonFormat: OFormat[GoogleServiceAccountCredential] = Json.format[GoogleServiceAccountCredential]
 }
 
-case class LegacyFileSystemCredential(user: String, password: Option[String]) extends FileSystemCredential {
+case class LegacyDataVaultCredential(user: String, password: Option[String]) extends DataVaultCredential {
   def toBasicAuth: HttpBasicAuthCredential =
     HttpBasicAuthCredential(name = "", username = user, password = password.getOrElse(""), user = "", organization = "")
 
@@ -45,6 +45,6 @@ case class LegacyFileSystemCredential(user: String, password: Option[String]) ex
                           organization = "")
 }
 
-object LegacyFileSystemCredential {
-  implicit val jsonFormat: OFormat[LegacyFileSystemCredential] = Json.format[LegacyFileSystemCredential]
+object LegacyDataVaultCredential {
+  implicit val jsonFormat: OFormat[LegacyDataVaultCredential] = Json.format[LegacyDataVaultCredential]
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataVaultService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataVaultService.scala
@@ -9,18 +9,18 @@ import java.net.URI
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-case class RemoteSourceDescriptor(uri: URI, credential: Option[FileSystemCredential])
+case class RemoteSourceDescriptor(uri: URI, credential: Option[DataVaultCredential])
 
-class DataVaultsService @Inject()(dSRemoteWebKnossosClient: DSRemoteWebKnossosClient) {
+class DataVaultService @Inject()(dSRemoteWebKnossosClient: DSRemoteWebKnossosClient) {
 
   def vaultPathFor(magLocator: MagLocator)(implicit ec: ExecutionContext): Fox[VaultPath] =
     for {
       credentialBox <- credentialFor(magLocator: MagLocator).futureBox
       remoteSource = RemoteSourceDescriptor(magLocator.uri, credentialBox.toOption)
-      remotePath <- DataVaultsHolder.getVaultPath(remoteSource) ?~> "remoteFileSystem.setup.failed"
+      remotePath <- DataVaultsHolder.getVaultPath(remoteSource) ?~> "dataVault.setup.failed"
     } yield remotePath
 
-  private def credentialFor(magLocator: MagLocator)(implicit ec: ExecutionContext): Fox[FileSystemCredential] =
+  private def credentialFor(magLocator: MagLocator)(implicit ec: ExecutionContext): Fox[DataVaultCredential] =
     magLocator.credentialId match {
       case Some(credentialId) =>
         dSRemoteWebKnossosClient.getCredential(credentialId)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataVaultsService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/DataVaultsService.scala
@@ -11,9 +11,9 @@ import scala.concurrent.ExecutionContext
 
 case class RemoteSourceDescriptor(uri: URI, credential: Option[FileSystemCredential])
 
-class FileSystemService @Inject()(dSRemoteWebKnossosClient: DSRemoteWebKnossosClient) {
+class DataVaultsService @Inject()(dSRemoteWebKnossosClient: DSRemoteWebKnossosClient) {
 
-  def remotePathFor(magLocator: MagLocator)(implicit ec: ExecutionContext): Fox[VaultPath] =
+  def vaultPathFor(magLocator: MagLocator)(implicit ec: ExecutionContext): Fox[VaultPath] =
     for {
       credentialBox <- credentialFor(magLocator: MagLocator).futureBox
       remoteSource = RemoteSourceDescriptor(magLocator.uri, credentialBox.toOption)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
@@ -15,13 +15,13 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   SegmentationLayer
 }
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, FileSystemService}
+import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultsService}
 
 import scala.concurrent.ExecutionContext
 
 class EditableMappingBucketProvider(layer: EditableMappingLayer) extends BucketProvider with ProtoGeometryImplicits {
 
-  override def fileSystemServiceOpt: Option[FileSystemService] = None
+  override def fileSystemServiceOpt: Option[DataVaultsService] = None
 
   override def load(readInstruction: DataReadInstruction, cache: DataCubeCache)(
       implicit ec: ExecutionContext): Fox[Array[Byte]] = {
@@ -73,7 +73,7 @@ case class EditableMappingLayer(name: String,
 
   override def lengthOfUnderlyingCubes(resolution: Vec3Int): Int = DataLayer.bucketLength
 
-  override def bucketProvider(fileSystemServiceOpt: Option[FileSystemService]): BucketProvider =
+  override def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider =
     new EditableMappingBucketProvider(layer = this)
 
   override def mappings: Option[Set[String]] = None

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
@@ -15,13 +15,13 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   SegmentationLayer
 }
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultsService}
+import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultService}
 
 import scala.concurrent.ExecutionContext
 
 class EditableMappingBucketProvider(layer: EditableMappingLayer) extends BucketProvider with ProtoGeometryImplicits {
 
-  override def fileSystemServiceOpt: Option[DataVaultsService] = None
+  override def dataVaultServiceOpt: Option[DataVaultService] = None
 
   override def load(readInstruction: DataReadInstruction, cache: DataCubeCache)(
       implicit ec: ExecutionContext): Fox[Array[Byte]] = {
@@ -73,7 +73,7 @@ case class EditableMappingLayer(name: String,
 
   override def lengthOfUnderlyingCubes(resolution: Vec3Int): Int = DataLayer.bucketLength
 
-  override def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider =
+  override def bucketProvider(dataVaultServiceOpt: Option[DataVaultService]): BucketProvider =
     new EditableMappingBucketProvider(layer = this)
 
   override def mappings: Option[Set[String]] = None

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
@@ -7,7 +7,7 @@ import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.datastore.models.datasource._
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultsService}
+import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultService}
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryImplicits
 import com.scalableminds.webknossos.tracingstore.tracings.{
@@ -21,7 +21,7 @@ import scala.concurrent.ExecutionContext
 
 trait AbstractVolumeTracingBucketProvider extends BucketProvider with VolumeTracingBucketHelper with FoxImplicits {
 
-  override def fileSystemServiceOpt: Option[DataVaultsService] = None
+  override def dataVaultServiceOpt: Option[DataVaultService] = None
 
   def bucketStreamWithVersion(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte], Long)]
 }
@@ -100,7 +100,7 @@ case class VolumeTracingLayer(
     else
       new VolumeTracingBucketProvider(this)
 
-  override def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider = volumeBucketProvider
+  override def bucketProvider(dataVaultServiceOpt: Option[DataVaultService]): BucketProvider = volumeBucketProvider
 
   def bucketProvider: AbstractVolumeTracingBucketProvider = volumeBucketProvider
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
@@ -5,9 +5,9 @@ import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.dataformats.BucketProvider
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
-import com.scalableminds.webknossos.datastore.models.datasource.{ElementClass, _}
+import com.scalableminds.webknossos.datastore.models.datasource._
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
-import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, FileSystemService}
+import com.scalableminds.webknossos.datastore.storage.{DataCubeCache, DataVaultsService}
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryImplicits
 import com.scalableminds.webknossos.tracingstore.tracings.{
@@ -21,7 +21,7 @@ import scala.concurrent.ExecutionContext
 
 trait AbstractVolumeTracingBucketProvider extends BucketProvider with VolumeTracingBucketHelper with FoxImplicits {
 
-  override def fileSystemServiceOpt: Option[FileSystemService] = None
+  override def fileSystemServiceOpt: Option[DataVaultsService] = None
 
   def bucketStreamWithVersion(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte], Long)]
 }
@@ -100,7 +100,7 @@ case class VolumeTracingLayer(
     else
       new VolumeTracingBucketProvider(this)
 
-  override def bucketProvider(fileSystemServiceOpt: Option[FileSystemService]): BucketProvider = volumeBucketProvider
+  override def bucketProvider(fileSystemServiceOpt: Option[DataVaultsService]): BucketProvider = volumeBucketProvider
 
   def bucketProvider: AbstractVolumeTracingBucketProvider = volumeBucketProvider
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://vaultpathnonio.webknossos.xyz

### Steps to test:
- Try loading both a local and a remote zarr/n5/neuroglancer dataset, should yield data
- Explore a remote dataset as well, should be importable

### Issues:
- fixes #6929 

------
- [x] Needs datastore update after deployment
