### PR TITLE
Fix missing buckets when annotation has set rotation value

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -1004,7 +1004,7 @@ export async function downloadAnnotation(
     .map(([key, val]) => `${key}Version=${val}`)
     .join("&");
 
-  if (showVolumeFallbackDownloadWarning) {
+  if (includeVolumeData && showVolumeFallbackDownloadWarning) {
     Toast.info(messages["annotation.no_fallback_data_included"], {
       timeout: 12000,
     });

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -558,6 +558,7 @@ function determineDefaultState(
     rotation: urlStateRotation,
     activeNode: urlStateActiveNode,
     stateByLayer: urlStateByLayer,
+    mode,
     ...rest
   } = urlState;
   // If there is no editPosition (e.g. when viewing a dataset) and
@@ -590,14 +591,17 @@ function determineDefaultState(
     zoomStep = urlStateZoomStep;
   }
 
-  let { rotation } = datasetConfiguration;
+  let rotation = undefined;
+  if (mode != "orthogonal") {
+    rotation = datasetConfiguration.rotation;
 
-  if (someTracing != null) {
-    rotation = Utils.point3ToVector3(someTracing.editRotation);
-  }
+    if (someTracing != null) {
+      rotation = Utils.point3ToVector3(someTracing.editRotation);
+    }
 
-  if (urlStateRotation != null) {
-    rotation = urlStateRotation;
+    if (urlStateRotation != null) {
+      rotation = urlStateRotation;
+    }
   }
 
   const stateByLayer = urlStateByLayer ?? {};
@@ -628,6 +632,7 @@ function determineDefaultState(
     rotation,
     activeNode,
     stateByLayer,
+    mode,
     ...rest,
   };
 }


### PR DESCRIPTION
#6748 introduced that the flycam matrix is also used for the orthogonal mode. WK adapts the matrix when switching to the orthogonal mode, but old annotations which had
- a rotation set (because users used the arbitrary views) and
- the orthogonal mode as active view mode
would load with an inappropriate matrix, so that the data was missing during rendering.
The fix is to not use the rotation value during initialization when the orthogonal mode is used. A quick workaround (without this fix) is to switch to oblique and back to orthogonal mode.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
Can be done on master and on this branch to see the difference:
- open an annotation
- switch to oblique mode and rotate the view (e.g., 90, 90, 90)
- save
- copy the url and change the fourth item after the # from `1` to `0` (oblique to ortho)
- open the url in a new tab
- on master, this will use the stored rotation which likely leads to missing data. switching to oblique mode, will show 90, 90, 90 as the active rotation.
- on this branch, everything should work as expected. switching to oblique mode will show a default roation.

### Issues:
- see https://scm.slack.com/archives/C5AKLAV0B/p1680633870641839

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
