### PR TITLE
Fix incorrect logo icon path

### DIFF
--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -71,7 +71,7 @@ body {
 
 .ant-layout-header {
   .logo {
-    background: url(/assets/images/icon-only.svg) 15px center no-repeat;
+    background: url(/assets/images/logo-icon-only.svg) 15px center no-repeat;
     padding-left: 46px;
     height: 48px;
     float: left;


### PR DESCRIPTION
#5587 renamed the logo icon file, but didn't rename this one occurrence which is why the wk logo is missing currently on wkorg.
