### PR TITLE
Avoid that an unsaved state is shown when loading an annotation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed incorrect initial tab when clicking "Show Annotations" for a user in the user list. Also, the datasets tab was removed from that page as it was the same as the datasets table from the main dashboard. [#6957](https://github.com/scalableminds/webknossos/pull/6957)
+- Fixed that unsaved changes were shown when opening an annotation, although there weren't any. [#6972](https://github.com/scalableminds/webknossos/pull/6972)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/controller/camera_controller.ts
+++ b/frontend/javascripts/oxalis/controller/camera_controller.ts
@@ -26,7 +26,7 @@ import { api } from "oxalis/singletons";
 type Props = {
   cameras: OrthoViewMap<THREE.OrthographicCamera>;
   onCameraPositionChanged: () => void;
-  onTDCameraChanged: () => void;
+  onTDCameraChanged: (userTriggered?: boolean) => void;
   setTargetAndFixPosition: () => void;
 };
 
@@ -151,7 +151,7 @@ class CameraController extends React.PureComponent<Props> {
       tdCamera.left = oldMid - newWidth / 2;
       tdCamera.right = oldMid + newWidth / 2;
       tdCamera.updateProjectionMatrix();
-      this.props.onTDCameraChanged();
+      this.props.onTDCameraChanged(false);
     }
   }
 

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.ts
@@ -173,7 +173,7 @@ export function* sendRequestToServer(saveQueueType: SaveQueueType, tracingId: st
         {
           method: "POST",
           data: compactedSaveQueue,
-          compress: true,
+          compress: process.env.NODE_ENV === "production",
         },
       );
       const endTime = Date.now();

--- a/frontend/javascripts/test/sagas/save_saga.spec.ts
+++ b/frontend/javascripts/test/sagas/save_saga.spec.ts
@@ -122,7 +122,7 @@ test("SaveSaga should send request to server", (t) => {
     call(sendRequestWithToken, `${TRACINGSTORE_URL}/tracings/skeleton/1234567890/update?token=`, {
       method: "POST",
       data: saveQueueWithVersions,
-      compress: true,
+      compress: false,
     }),
   );
 });
@@ -138,7 +138,7 @@ test("SaveSaga should retry update actions", (t) => {
     {
       method: "POST",
       data: saveQueueWithVersions,
-      compress: true,
+      compress: false,
     },
   );
   const saga = sendRequestToServer(TRACING_TYPE, tracingId);
@@ -177,7 +177,7 @@ test("SaveSaga should escalate on permanent client error update actions", (t) =>
     call(sendRequestWithToken, `${TRACINGSTORE_URL}/tracings/skeleton/1234567890/update?token=`, {
       method: "POST",
       data: saveQueueWithVersions,
-      compress: true,
+      compress: false,
     }),
   );
   saga.throw({


### PR DESCRIPTION
The functionality to "hide" some changes to the 3d viewport from time tracking (so from the save queue) was already there, but in this spot the boolean was not set. Since this piece of code is only triggered when changing the size of the viewports or when changing the zoom (which triggers an update action, anyways) or clipping distance, it's not relevant for time tracking.

I've also added that the save queue entries won't be compressed in the dev environment. This eases debugging and one cannot forget to revert the change before committing any longer. Let me know if you think that's an issue.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open or create an annotation. The save button shouldn't show any unsaved changes.
- Move, zoom or rotate in the 3D viewport -> There should be unsaved changes.
- Other changes should still show unsaved changes and be saved across reloads.

### Issues:
- fixes #5882 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
