### PR TITLE
Fix that hiding all layers would crash wk

### DIFF
--- a/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
@@ -615,7 +615,7 @@ function _getActiveResolutionInfo(state: OxalisState) {
       ({ sortedMag }) => sortedMag[0],
       ({ sortedMag }) => sortedMag[1],
       ({ sortedMag }) => sortedMag[2],
-    )[0].mag;
+    )[0]?.mag;
   }
 
   return {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a dataset
- hide all layers
- should not crash

### Issues:
- follow-up for #6943 

------
(Please delete unneeded items, merge only when none are left open)
- [x] ~Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)~ Since this is a follow-up for 43a119861620ff8412995f44e904ae2250f36719 which was merged today, I think a changelog entry is not necessary
