### PR TITLE
Added new drawings to job notification emails

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Editing the meta data of segments (e.g., the name) is now undoable. [#6944](https://github.com/scalableminds/webknossos/pull/6944)
 - Added more icons and small redesigns for various pages in line with the new branding. [#6938](https://github.com/scalableminds/webknossos/pull/6938)
 - Added support for viewing neuroglancer precomputed segmentations using "compressed segmentation" compression. [#6947](https://github.com/scalableminds/webknossos/pull/6947)
+- Added more graphics and branding to job notification emails. [#6994](https://github.com/scalableminds/webknossos/pull/6994)
 
 ### Changed
 - Moved the view mode selection in the toolbar next to the position field. [#6949](https://github.com/scalableminds/webknossos/pull/6949)

--- a/app/views/mail/jobFailedGeneric.scala.html
+++ b/app/views/mail/jobFailedGeneric.scala.html
@@ -12,10 +12,12 @@ Feel free to contact us via email for assistance or please try again later.
 </p>
 
 <p>With best regards,<br />the WEBKNOSSOS team</p>
+
 <div style="text-align: center;">
-  <img src="https://static.webknossos.org/mails/drawing_failed_job.png"
-    srcset="https://static.webknossos.org/mails/drawing_failed_job.svg"
-    alt="A person celebrating a successful WEBKNOSSOS job" style="width: 460px; height: 258px; margin-top: 10px;" />
+  <img src="https://static.webknossos.org/mails/email-drawing-failed-job.png"
+    srcset="https://static.webknossos.org/mails/email-drawing-failed-job.svg"
+    alt="A person dismayed about an unsuccessful WEBKNOSSOS job" 
+    style="width: 460px; height: 258px; margin-top: 10px; margin-bottom: 20px" />
 </div>
 
 }

--- a/app/views/mail/jobFailedGeneric.scala.html
+++ b/app/views/mail/jobFailedGeneric.scala.html
@@ -12,4 +12,10 @@ Feel free to contact us via email for assistance or please try again later.
 </p>
 
 <p>With best regards,<br />the WEBKNOSSOS team</p>
+<div style="text-align: center;">
+  <img src="https://static.webknossos.org/mails/drawing_failed_job.png"
+    srcset="https://static.webknossos.org/mails/drawing_failed_job.svg"
+    alt="A person celebrating a successful WEBKNOSSOS job" style="width: 460px; height: 258px; margin-top: 10px;" />
+</div>
+
 }

--- a/app/views/mail/jobFailedUploadConvert.scala.html
+++ b/app/views/mail/jobFailedUploadConvert.scala.html
@@ -23,4 +23,11 @@
 
 
 <p>With best regards,<br />the WEBKNOSSOS team</p>
+
+<div style="text-align: center;">
+  <img src="https://static.webknossos.org/mails/email-drawing-failed-job.png"
+    srcset="https://static.webknossos.org/mails/email-drawing-failed-job.svg"
+    alt="A person dismayed about an unsuccessful WEBKNOSSOS dataset upload job"
+    style="width: 460px; height: 258px; margin-top: 10px; margin-bottom: 20px" />
+</div>
 }

--- a/app/views/mail/jobSuccessfulGeneric.scala.html
+++ b/app/views/mail/jobSuccessfulGeneric.scala.html
@@ -26,4 +26,8 @@
 </div>
 
 <p>With best regards,<br />the WEBKNOSSOS team</p>
+
+<div style="text-align: center;">
+  <img src="https://static.webknossos.org/mails/drawing_successful_job.png" srcset="https://static.webknossos.org/mails/drawing_successful_job.svg" alt="A person celebrating a successful WEBKNOSSOS job" style="width: 460px; height: 307px; margin-top: 10px;"/>
+</div>
 }

--- a/app/views/mail/jobSuccessfulGeneric.scala.html
+++ b/app/views/mail/jobSuccessfulGeneric.scala.html
@@ -28,6 +28,9 @@
 <p>With best regards,<br />the WEBKNOSSOS team</p>
 
 <div style="text-align: center;">
-  <img src="https://static.webknossos.org/mails/drawing_successful_job.png" srcset="https://static.webknossos.org/mails/drawing_successful_job.svg" alt="A person celebrating a successful WEBKNOSSOS job" style="width: 460px; height: 307px; margin-top: 10px;"/>
+  <img src="https://static.webknossos.org/mails/email-drawing-successful-job.png" 
+    srcset="https://static.webknossos.org/mails/email-drawing-successful-job.svg" 
+    alt="A person celebrating a successful WEBKNOSSOS job" 
+    style="width: 460px; height: 307px; margin-top: 10px; margin-bottom: 20px;"/>
 </div>
 }

--- a/app/views/mail/jobSuccessfulSegmentation.scala.html
+++ b/app/views/mail/jobSuccessfulSegmentation.scala.html
@@ -31,10 +31,20 @@
 <p>
   Do you like what you see? Expand the segmentation to the whole dataset. <a href="mailto://hello@@webknossos.com">Contact us to get a quote. We can also fine-tune the segmentation models for higher quality results.</a>.
 </p>
+<div style="text-align: center; margin-top: 10px; margin-bottom: 6px;">
+  <img src="https://static.webknossos.org/mails/email-expand-segmentation-preview.600.jpg"
+    alt="A preview of a full, automated segmentation of a WEBKNOSSOS dataset"
+    style="width: 600px; height: 300px;"/>
+</div>
 
 <p>
   Do you want to make corrections to the automated segmentation? Use the easy-to-use, built-in <a href="https://docs.webknossos.org/webknossos/proof_reading.html#proofreading-tool">proof-reading tools in WEBKNOSSOS</a> (requires Power plan).
 </p>
+<div style="text-align: center; margin-bottom: 20px;">
+  <img src="https://static.webknossos.org/mails/email-proofreading-preview.600.jpg" 
+    alt="A preview of the proofreading tools for a segmentation of a WEBKNOSSOS dataset"
+    style="width: 600px; height: 300px;" />
+</div>
 
 <p>With best regards,<br />the WEBKNOSSOS team</p>
 }

--- a/app/views/mail/jobSuccessfulUploadConvert.scala.html
+++ b/app/views/mail/jobSuccessfulUploadConvert.scala.html
@@ -6,7 +6,7 @@
 <p>
   Your dataset @{datasetName} is ready for exploration. 
   WEBKNOSSOS has successfully uploaded and converted the dataset. 
-  Click the button below to open the dataset or find it amongst your other dataset in the WEBKNOSSOS dashboard.
+  Click the button below to open the dataset or find it amongst your other datasets in the WEBKNOSSOS dashboard.
 </p>
 
 <div style="text-align: center;">

--- a/app/views/mail/jobSuccessfulUploadConvert.scala.html
+++ b/app/views/mail/jobSuccessfulUploadConvert.scala.html
@@ -31,6 +31,17 @@
 <p>
   Did you know that we offer services for <a href="https://webknossos.org/services/alignment">dataset alignment & stitching</a> and <a href="https://webknossos.org/services/automated-segmentation">AI image segmentation</a> to kickstart your research?
 </p>
+<div style="text-align: center; margin-top: 10px; margin-bottom: 6px;">
+  <img src="https://static.webknossos.org/mails/email-alignment-preview.600.jpg"
+    alt="A preview of the alignment services for a WEBKNOSSOS dataset" 
+    style="width: 300px; height: 150px;" />
+</div>
+
+<div style="text-align: center; margin-bottom: 20px;">
+  <img src="https://static.webknossos.org/mails/email-segmentation-preview.600.jpg"
+    alt="A preview of a full, automated segmentation of a WEBKNOSSOS dataset" 
+    style="width: 300px; height: 150px;" />
+</div>
 
 <p>With best regards,<br />the WEBKNOSSOS team</p>
 }


### PR DESCRIPTION
PR adds new drawings to job notification emails in accordance with new branding.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Trigger a successful i.e. export as a tiff
- Upload a dataset to trigger a data uploaded email
- Start a segmentation to trigger a segementation finished email
- Stop the WK Worker and run a job to receive a job failed email

### Successful Upload
<img width="687" alt="image" src="https://user-images.githubusercontent.com/1105056/233640500-19e787fd-235e-43c5-b98f-5252d901def9.png">

### Failed Job (Generic)
<img width="693" alt="image" src="https://user-images.githubusercontent.com/1105056/233640543-45b0f521-6229-48a0-80ab-8c118ced8d3c.png">

### Successful Job (Generic)
<img width="699" alt="image" src="https://user-images.githubusercontent.com/1105056/233641889-8e28d218-30a6-41a4-b8f5-4c3c58caee62.png">


### Issues:
- Related to #6739 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
