### PR TITLE
Fix handling underscores in GCS bucket name

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that unsaved changes were shown when opening an annotation, although there weren't any. [#6972](https://github.com/scalableminds/webknossos/pull/6972)
 - Fixed misleading email about successful dataset upload, which was in some cases sent even for unusable datasets. [#6977](https://github.com/scalableminds/webknossos/pull/6977)
 - Fixed upload of skeleton annotations with no trees, only bounding boxes, being incorrectly rejected. [#6985](https://github.com/scalableminds/webknossos/pull/6985)
+- Fixed that Google Cloud Storage URLs with bucket names containing underscores could not be parsed. [#6998](https://github.com/scalableminds/webknossos/pull/6998)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
@@ -23,7 +23,7 @@ class GoogleCloudDataVault(uri: URI, credential: Option[GoogleServiceAccountCred
 
   private lazy val storage: Storage = storageOptions.getService
 
-  private lazy val bucket: String = uri.getHost
+  private lazy val bucket: String = uri.getAuthority
 
   override def readBytes(path: VaultPath, range: Option[NumericRange[Long]]): Array[Byte] = {
     val objName = path.toUri.getPath.tail

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
@@ -23,6 +23,9 @@ class GoogleCloudDataVault(uri: URI, credential: Option[GoogleServiceAccountCred
 
   private lazy val storage: Storage = storageOptions.getService
 
+  // gs://bucket-name/object/name  -> getAuthority -> bucket-name
+  // Get bucket name with *getAuthority*. *Authority* is used here because *host* may only contain alphanumeric chars or
+  // dashes, excluding chars that may be part of the bucket name (e.g. underscore).
   private lazy val bucket: String = uri.getAuthority
 
   override def readBytes(path: VaultPath, range: Option[NumericRange[Long]]): Array[Byte] = {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Explore gs://iarpa_microns/minnie/minnie65/seg (now possible)
- Explore gs://neuroglancer-fafb-data/fafb_v14/fafb_v14_orig (still possible)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
