### PR TITLE
Fix that changing a segment color could lead to a crash

### DIFF
--- a/frontend/javascripts/oxalis/controller/segment_mesh_controller.ts
+++ b/frontend/javascripts/oxalis/controller/segment_mesh_controller.ts
@@ -22,6 +22,14 @@ export default class SegmentMeshController {
     this.addLights();
   }
 
+  hasIsosurface(id: number, layerName: string): boolean {
+    const segments = this.isosurfacesGroupsPerSegmentationId[layerName];
+    if (!segments) {
+      return false;
+    }
+    return segments[id] != null;
+  }
+
   addIsosurfaceFromVertices(
     vertices: Float32Array,
     segmentationId: number,

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
@@ -904,9 +904,12 @@ function* handleIsosurfaceVisibilityChange(action: UpdateIsosurfaceVisibilityAct
   segmentMeshController.setIsosurfaceVisibility(id, visibility, layerName);
 }
 
-function* handleIsosurfaceColorChange(action: UpdateSegmentAction): Saga<void> {
+function* handleSegmentColorChange(action: UpdateSegmentAction): Saga<void> {
   const { segmentMeshController } = yield* call(getSceneController);
-  if ("color" in action.segment) {
+  if (
+    "color" in action.segment &&
+    segmentMeshController.hasIsosurface(action.segmentId, action.layerName)
+  ) {
     segmentMeshController.setIsosurfaceColor(action.segmentId, action.layerName);
   }
 }
@@ -930,5 +933,5 @@ export default function* isosurfaceSaga(): Saga<void> {
   yield* takeEvery("REFRESH_ISOSURFACE", refreshIsosurface);
   yield* takeEvery("UPDATE_ISOSURFACE_VISIBILITY", handleIsosurfaceVisibilityChange);
   yield* takeEvery(["START_EDITING", "COPY_SEGMENTATION_LAYER"], markEditedCellAsDirty);
-  yield* takeEvery("UPDATE_SEGMENT", handleIsosurfaceColorChange);
+  yield* takeEvery("UPDATE_SEGMENT", handleSegmentColorChange);
 }


### PR DESCRIPTION
(if no mesh was loaded yet for that segment)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open an annotation
- change the color of a segment

### Issues:
- follow-up for #6960 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
