### PR TITLE
Fix viewing of public datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed misleading email about successful dataset upload, which was in some cases sent even for unusable datasets. [#6977](https://github.com/scalableminds/webknossos/pull/6977)
 - Fixed upload of skeleton annotations with no trees, only bounding boxes, being incorrectly rejected. [#6985](https://github.com/scalableminds/webknossos/pull/6985)
 - Fixed that Google Cloud Storage URLs with bucket names containing underscores could not be parsed. [#6998](https://github.com/scalableminds/webknossos/pull/6998)
+- Fixed regression that caused public datasets to crash when not being logged in. [#7010](https://github.com/scalableminds/webknossos/pull/7010)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -98,7 +98,6 @@ import {
   setActiveConnectomeAgglomerateIdsAction,
   updateCurrentConnectomeFileAction,
 } from "oxalis/model/actions/connectome_actions";
-import { enforceActiveOrganization } from "./model/accessors/organization_accessors";
 import {
   PricingPlanEnum,
   isFeatureAllowedByPricingPlan,
@@ -777,7 +776,7 @@ async function applyLayerState(stateByLayer: UrlStateByLayer) {
 function enforcePricingRestrictionsOnUserConfiguration(
   userConfiguration: UserConfiguration,
 ): UserConfiguration {
-  const activeOrganization = enforceActiveOrganization(Store.getState().activeOrganization);
+  const activeOrganization = Store.getState().activeOrganization;
   if (!isFeatureAllowedByPricingPlan(activeOrganization, PricingPlanEnum.Team)) {
     return {
       ...userConfiguration,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- make a dataset public
- open DS while being logged out

### Issues:
- fixes #7009

------
(Please delete unneeded items, merge only when none are left open)
- [X] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
