### PR TITLE
Fix download of public annotation, include access ctx in user cache key

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed that changing a segment color could lead to a crash. [#7000](https://github.com/scalableminds/webknossos/pull/7000)
 - Fixed rendering issues on some affected systems that led to "black holes". [#7018](https://github.com/scalableminds/webknossos/pull/7018)
+- Fixed a bug that made downloads of public annotations fail occasionally. [#7025](https://github.com/scalableminds/webknossos/pull/7025)
 
 ### Removed
 

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -411,7 +411,7 @@ Expects:
           skeletonAnnotationLayer =>
             tracingStoreClient.getSkeletonTracing(skeletonAnnotationLayer, skeletonVersion)
         } ?~> "annotation.download.fetchSkeletonLayer.failed"
-        user <- userService.findOneCached(annotation._user) ?~> "annotation.download.findUser.failed"
+        user <- userService.findOneCached(annotation._user)(GlobalAccessContext) ?~> "annotation.download.findUser.failed"
         taskOpt <- Fox.runOptional(annotation._task)(taskDAO.findOne)
         nmlStream = nmlWriter.toNmlStream(
           fetchedSkeletonLayers ::: fetchedVolumeLayers,

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -47,7 +47,7 @@ class UserService @Inject()(conf: WkConf,
   private lazy val Mailer =
     actorSystem.actorSelection("/user/mailActor")
 
-  private val userCache: AlfuFoxCache[ObjectId, User] =
+  private val userCache: AlfuFoxCache[(ObjectId, DBAccessContext), User] =
     AlfuFoxCache(timeToLive = conf.WebKnossos.Cache.User.timeout, timeToIdle = conf.WebKnossos.Cache.User.timeout)
 
   def userFromMultiUserEmail(email: String)(implicit ctx: DBAccessContext): Fox[User] =
@@ -56,7 +56,7 @@ class UserService @Inject()(conf: WkConf,
       user <- disambiguateUserFromMultiUser(multiUser)
     } yield user
 
-  def disambiguateUserFromMultiUser(multiUser: MultiUser)(implicit ctx: DBAccessContext): Fox[User] =
+  private def disambiguateUserFromMultiUser(multiUser: MultiUser)(implicit ctx: DBAccessContext): Fox[User] =
     multiUser._lastLoggedInIdentity match {
       case Some(userId) =>
         for {
@@ -82,7 +82,12 @@ class UserService @Inject()(conf: WkConf,
     } yield ()
 
   def findOneCached(userId: ObjectId)(implicit ctx: DBAccessContext): Fox[User] =
-    userCache.getOrLoad(userId, id => userDAO.findOne(id))
+    userCache.getOrLoad(
+      (userId, ctx),
+      userIdAndAccessContext => {
+        userDAO.findOne(userIdAndAccessContext._1)(userIdAndAccessContext._2)
+      }
+    )
 
   def insert(organizationId: ObjectId,
              email: String,
@@ -198,11 +203,14 @@ class UserService @Inject()(conf: WkConf,
                                 lastTaskTypeId)
       _ <- userDAO.updateTeamMembershipsForUser(user._id, teamMemberships)
       _ <- userExperiencesDAO.updateExperiencesForUser(user, experiences)
-      _ = userCache.remove(user._id)
+      _ = removeUserFromCache(user._id)
       _ <- if (oldEmail == email) Fox.successful(()) else tokenDAO.updateEmail(oldEmail, email)
       updated <- userDAO.findOne(user._id)
     } yield updated
   }
+
+  private def removeUserFromCache(userId: ObjectId): Unit =
+    userCache.remove(idAndAccessContext => idAndAccessContext._1 == userId)
 
   def changePasswordInfo(loginInfo: LoginInfo, passwordInfo: PasswordInfo): Fox[PasswordInfo] =
     for {
@@ -216,7 +224,7 @@ class UserService @Inject()(conf: WkConf,
 
   def updateUserConfiguration(user: User, configuration: JsObject)(implicit ctx: DBAccessContext): Fox[Unit] =
     userDAO.updateUserConfiguration(user._id, configuration).map { result =>
-      userCache.remove(user._id)
+      removeUserFromCache(user._id)
       result
     }
 
@@ -249,12 +257,12 @@ class UserService @Inject()(conf: WkConf,
 
   def updateLastTaskTypeId(user: User, lastTaskTypeId: Option[String])(implicit ctx: DBAccessContext): Fox[Unit] =
     userDAO.updateLastTaskTypeId(user._id, lastTaskTypeId).map { result =>
-      userCache.remove(user._id)
+      removeUserFromCache(user._id)
       result
     }
 
   def retrieve(loginInfo: LoginInfo): Future[Option[User]] =
-    userDAO.findOne(ObjectId(loginInfo.providerKey))(GlobalAccessContext).futureBox.map(_.toOption)
+    findOneCached(ObjectId(loginInfo.providerKey))(GlobalAccessContext).futureBox.map(_.toOption)
 
   def createLoginInfo(userId: ObjectId): LoginInfo =
     LoginInfo(CredentialsProvider.ID, userId.id)

--- a/util/src/main/scala/com/scalableminds/util/cache/AlfuCache.scala
+++ b/util/src/main/scala/com/scalableminds/util/cache/AlfuCache.scala
@@ -39,6 +39,12 @@ class AlfuFoxCache[K, V](underlyingAkkaCache: Cache[K, Box[V]]) extends FoxImpli
 
   def remove(key: K): Unit = underlyingAkkaCache.remove(key)
 
+  def remove(fn: K => Boolean): Int = {
+    val keysToRemove = underlyingAkkaCache.keys.filter(fn(_))
+    keysToRemove.foreach(remove)
+    keysToRemove.size
+  }
+
   def clear(): Unit = underlyingAkkaCache.clear()
 }
 


### PR DESCRIPTION
Fetching the user object to write the NML failed for logged-out users, since it was missing the GlobalAccessContext modifier. However, the user cache was independent of the access context, making this work sometimes nonetheless (except if the cache was expired). Instead, the user cache should take the access context as cache key, avoiding leaking user info in unexpected contexts.

### Steps to test:
- Set annotation and its dataset to public
- Download route should work even when logged out and no other requests have been sent in the past 3 minutes (use wget directly on `/api/annotations/:id/download`

### Issues:
- fixes #7016

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
