### PR TITLE
Fix organization storage layouting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed rendering issues on some affected systems that led to "black holes". [#7018](https://github.com/scalableminds/webknossos/pull/7018)
 - Fixed a bug that made downloads of public annotations fail occasionally. [#7025](https://github.com/scalableminds/webknossos/pull/7025)
 - Added a workaround for a WebGL crash which could appear when a dataset contained many segmentation layers. [#6995](https://github.com/scalableminds/webknossos/pull/6995)
+- Fixed layouting of used storage space on the organization page. [#7034](https://github.com/scalableminds/webknossos/pull/7034)
 
 ### Removed
 

--- a/frontend/javascripts/admin/organization/organization_cards.tsx
+++ b/frontend/javascripts/admin/organization/organization_cards.tsx
@@ -200,7 +200,7 @@ export function PlanDashboardCard({
 
   const storageLabel = (
     <span style={{ display: "inline-block", wordBreak: "break-word", width: 100 }}>
-      {usedStorageLabel}/
+      {usedStorageLabel} /
       <wbr />
       {includedStorageLabel}
     </span>

--- a/frontend/javascripts/admin/organization/organization_cards.tsx
+++ b/frontend/javascripts/admin/organization/organization_cards.tsx
@@ -198,7 +198,13 @@ export function PlanDashboardCard({
       ? `${(organization.usedStorageBytes / 10 ** 9).toFixed(1)}`
       : `${(organization.usedStorageBytes / 10 ** 12).toFixed(1)}`;
 
-  const storageLabel = `${usedStorageLabel}/${includedStorageLabel}`;
+  const storageLabel = (
+    <span style={{ display: "inline-block", wordBreak: "break-word", width: 100 }}>
+      {usedStorageLabel}/
+      <wbr />
+      {includedStorageLabel}
+    </span>
+  );
 
   const redStrokeColor = "#ff4d4f";
   const greenStrokeColor = "#52c41a";


### PR DESCRIPTION
PR fixes line breaks for the storage display on the organization page. Rendering will typically default to a two line style.

#### Before
<img width="273" alt="image" src="https://user-images.githubusercontent.com/1105056/235093572-12263b76-87da-4bc0-8ad3-871050b054ef.png">

#### After
![image](https://user-images.githubusercontent.com/1105056/235093333-4bc9db8c-4960-4704-a74d-8fc63584c5e1.png)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Go to /admin/organization
- Storage space should use two lines / not overflow into the circle

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
