### PR TITLE
Only reload affected areas when proofreading

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - In addition to drag and drop, the selected tree(s) in the Skeleton tab can also be moved into another group by right-clicking the target group and selecting "Move selected tree(s) here". [#7005](https://github.com/scalableminds/webknossos/pull/7005)
 
 ### Changed
+- Improved speed of proofreading by only reloading affected areas after a split or merge. [#7050](https://github.com/scalableminds/webknossos/pull/7050)
 
 ### Fixed
 - Fixed that changing a segment color could lead to a crash. [#7000](https://github.com/scalableminds/webknossos/pull/7000)

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -1182,6 +1182,10 @@ class DataApi {
 
   /**
    * Invalidates all downloaded buckets of the given layer so that they are reloaded.
+   * If an additional predicate is passed, each bucket is checked to see whether
+   * it should be reloaded. Note that buckets that are in a REQUESTED state (i.e.,
+   * currently being queued or downloaded) will always be reloaded by cancelling and rescheduling
+   * the request.
    */
   async reloadBuckets(
     layerName: string,
@@ -1194,7 +1198,7 @@ class DataApi {
             await Model.ensureSavedState();
           }
 
-          dataLayer.cube.collectAllBuckets(predicateFn);
+          dataLayer.cube.collectBucketsIf(predicateFn || (() => true));
           dataLayer.layerRenderingManager.refresh();
         }
       }),

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -2,7 +2,7 @@ import PriorityQueue from "js-priority-queue";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'twee... Remove this comment to see the full error message
 import TWEEN from "tween.js";
 import _ from "lodash";
-import type { Bucket } from "oxalis/model/bucket_data_handling/bucket";
+import type { Bucket, DataBucket } from "oxalis/model/bucket_data_handling/bucket";
 import { getConstructorForElementClass } from "oxalis/model/bucket_data_handling/bucket";
 import { APICompoundType, APICompoundTypeEnum, ElementClass } from "types/api_flow_types";
 import { InputKeyboardNoLoop } from "libs/input";
@@ -1183,7 +1183,10 @@ class DataApi {
   /**
    * Invalidates all downloaded buckets of the given layer so that they are reloaded.
    */
-  async reloadBuckets(layerName: string): Promise<void> {
+  async reloadBuckets(
+    layerName: string,
+    predicateFn?: (bucket: DataBucket) => boolean,
+  ): Promise<void> {
     await Promise.all(
       Utils.values(this.model.dataLayers).map(async (dataLayer: DataLayer) => {
         if (dataLayer.name === layerName) {
@@ -1191,7 +1194,7 @@ class DataApi {
             await Model.ensureSavedState();
           }
 
-          dataLayer.cube.collectAllBuckets();
+          dataLayer.cube.collectAllBuckets(predicateFn);
           dataLayer.layerRenderingManager.refresh();
         }
       }),

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/bucket.ts
@@ -614,9 +614,8 @@ export class DataBucket {
   }
 
   private recomputeValueSet() {
-    // console.time("recomputeValueSet");
+    // @ts-ignore The Set constructor accepts null and BigUint64Arrays just fine.
     this.cachedValueSet = new Set(this.data);
-    // console.timeEnd("recomputeValueSet");
   }
 
   containsValue(value: number | BigInt): boolean {

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
@@ -342,7 +342,6 @@ class DataCube {
       }
     }
 
-
     this.buckets = notCollectedBuckets;
     this.bucketIterator = notCollectedBuckets.length;
   }

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
@@ -330,7 +330,6 @@ class DataCube {
     this.pullQueue.clear();
     this.pullQueue.abortRequests();
 
-    let collectedCount = 0;
     const notCollectedBuckets = [];
     for (const bucket of this.buckets) {
       // If a bucket is requested, collect it independently of the predicateFn,
@@ -338,13 +337,11 @@ class DataCube {
       // requested state, but will never be filled with data).
       if (bucket.state === "REQUESTED" || predicateFn(bucket)) {
         this.collectBucket(bucket);
-        collectedCount++;
       } else {
         notCollectedBuckets.push(bucket);
       }
     }
 
-    console.log(`collected: ${collectedCount} vs skipped ${notCollectedBuckets.length}`);
 
     this.buckets = notCollectedBuckets;
     this.bucketIterator = notCollectedBuckets.length;

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -537,9 +537,8 @@ function* handleProofreadMergeOrMinCut(
   yield* call([Model, Model.ensureSavedState]);
 
   /* Reload the segmentation */
-  // const affectedIds = [targetAgglomerateId];
   yield* call([api.data, api.data.reloadBuckets], layerName, (bucket) =>
-    bucket.containedIds.has(targetAgglomerateId),
+    bucket.containsValue(targetAgglomerateId),
   );
 
   const [newSourceAgglomerateId, newTargetAgglomerateId] = yield* all([

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -310,8 +310,9 @@ function* splitOrMergeOrMinCutAgglomerate(
   yield* call([Model, Model.ensureSavedState]);
 
   /* Reload the segmentation */
-  // todo
-  yield* call([api.data, api.data.reloadBuckets], layerName);
+  yield* call([api.data, api.data.reloadBuckets], layerName, (bucket) =>
+    bucket.containsValue(targetAgglomerateId),
+  );
 
   const [newSourceAgglomerateId, newTargetAgglomerateId] = yield* all([
     call(getDataValue, sourceNodePosition),

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -82,7 +82,6 @@ function proofreadCoarseResolutionIndex(): number {
     : 3;
 }
 function proofreadUsingMeshes(): boolean {
-  return false;
   // @ts-ignore
   return window.__proofreadUsingMeshes != null ? window.__proofreadUsingMeshes : true;
 }

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -82,6 +82,7 @@ function proofreadCoarseResolutionIndex(): number {
     : 3;
 }
 function proofreadUsingMeshes(): boolean {
+  return false;
   // @ts-ignore
   return window.__proofreadUsingMeshes != null ? window.__proofreadUsingMeshes : true;
 }
@@ -309,7 +310,7 @@ function* splitOrMergeOrMinCutAgglomerate(
   yield* call([Model, Model.ensureSavedState]);
 
   /* Reload the segmentation */
-
+  // todo
   yield* call([api.data, api.data.reloadBuckets], layerName);
 
   const [newSourceAgglomerateId, newTargetAgglomerateId] = yield* all([
@@ -536,8 +537,10 @@ function* handleProofreadMergeOrMinCut(
   yield* call([Model, Model.ensureSavedState]);
 
   /* Reload the segmentation */
-
-  yield* call([api.data, api.data.reloadBuckets], layerName);
+  // const affectedIds = [targetAgglomerateId];
+  yield* call([api.data, api.data.reloadBuckets], layerName, (bucket) =>
+    bucket.containedIds.has(targetAgglomerateId),
+  );
 
   const [newSourceAgglomerateId, newTargetAgglomerateId] = yield* all([
     call(getDataValue, sourcePosition),


### PR DESCRIPTION
Rough measurements show that ~80% of bucket reloads can be avoided that way for an average proofread operation.

### URL of deployed dev instance (used for testing):
- https://smartreload.webknossos.xyz

### Steps to test:
- open l4dense_motta_et_al_dev_v2
- select mapping 80
- do proofreading with
  - merge and split (without skeletons)
  - load agglomerate skeletons and split/merge/min-cut these
- only the affected areas should reload

### Issues:
- fixes #7022

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
