### PR TITLE
Fix issues with styling in dark mode on login page

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed layouting of used storage space on the organization page. [#7034](https://github.com/scalableminds/webknossos/pull/7034)
 - Fixed a bug where updating skeleton annotation tree group visibility would break the annotation. [#7037](https://github.com/scalableminds/webknossos/pull/7037)
 - Fixed importing Neuroglancer Precomputed datasets that have a voxel offset in their header. [#7019](https://github.com/scalableminds/webknossos/pull/7019)
+- Fixed an bug where invalid email addresses were not readable in dark mode on the login/signup pages. [#7052](https://github.com/scalableminds/webknossos/pull/7052)
 
 ### Removed
 

--- a/frontend/stylesheets/dark.less
+++ b/frontend/stylesheets/dark.less
@@ -69,3 +69,9 @@ a:hover {
     fill: rgba(50, 50, 50, 0.7);
   }
 }
+
+.login-view {
+  .ant-input-affix-wrapper-status-error {
+    background-color: @black !important;
+  }
+}

--- a/frontend/stylesheets/dark.less
+++ b/frontend/stylesheets/dark.less
@@ -71,6 +71,7 @@ a:hover {
 }
 
 .login-view {
+  // TODO: consider removing with Antd-v5
   .ant-input-affix-wrapper-status-error {
     background-color: @black !important;
   }


### PR DESCRIPTION
Fix issues with styling in dark mode on login page. Antd v4 does not explicitly set a background color for inputs in dark mode (`background: transparent`) but always expects a dark underground.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Switch OS / browser to dark mode 
- Go to login / register page
- Enter email wrong
- You should see white text on black background even if the input component is highlighted because of an error (invalid email)

### Issues:
- fixes #6997

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
