### PR TITLE
Fix access check in time tracking controller

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where updating skeleton annotation tree group visibility would break the annotation. [#7037](https://github.com/scalableminds/webknossos/pull/7037)
 - Fixed importing Neuroglancer Precomputed datasets that have a voxel offset in their header. [#7019](https://github.com/scalableminds/webknossos/pull/7019)
 - Fixed an bug where invalid email addresses were not readable in dark mode on the login/signup pages. [#7052](https://github.com/scalableminds/webknossos/pull/7052)
+- Fixed a bug where users could sometimes not access their own time tracking information. [#7055](https://github.com/scalableminds/webknossos/pull/7055)
 
 ### Removed
 

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -57,7 +57,7 @@ class TimeController @Inject()(userService: UserService,
         userIdValidated <- ObjectId.fromString(userId)
         user <- userService.findOneCached(userIdValidated) ?~> "user.notFound" ~> NOT_FOUND
         isTeamManagerOrAdmin <- userService.isTeamManagerOrAdminOf(request.identity, user)
-        _ <- bool2Fox(isTeamManagerOrAdmin || user == request.identity) ?~> "user.notAuthorised" ~> FORBIDDEN
+        _ <- bool2Fox(isTeamManagerOrAdmin || user._id == request.identity._id) ?~> "user.notAuthorised" ~> FORBIDDEN
         js <- loggedTimeForUserListByTimestamp(user, startDate, endDate)
       } yield Ok(js)
     }


### PR DESCRIPTION
Not the full user object should be compared for the access check, that created false differences in lastActivity timestamp. (User caching recently changed slightly, but this should not be able to have effects here)

### Steps to test:
- Create non-admin user (or just use sample2@scm.io from the sample organization)
- Log in as that user, go to time tracking page
- No error concerning authorization should show up

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)