### PR TITLE
Fix offset when loading non-aligned buckets for zarr/n5/precomputed

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed reading Neuroglancer Precomputed datasets with non-integer resolutions. [#7041](https://github.com/scalableminds/webknossos/pull/7041)
 - Fixed an bug where invalid email addresses were not readable in dark mode on the login/signup pages. [#7052](https://github.com/scalableminds/webknossos/pull/7052)
 - Fixed a bug where users could sometimes not access their own time tracking information. [#7055](https://github.com/scalableminds/webknossos/pull/7055)
+- Fixed a bug where thumbnails and raw data requests with non-bucket-aligned positions would show data at slightly wrong positions. [#7058](https://github.com/scalableminds/webknossos/pull/7058)
 
 ### Removed
 

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -442,7 +442,7 @@ class JobService @Inject()(wkConf: WkConf,
   def assertTiffExportBoundingBoxLimits(boundingBox: String, mag: Option[String]): Fox[Unit] =
     for {
       parsedBoundingBox <- BoundingBox.fromLiteral(boundingBox).toFox ?~> "job.export.tiff.invalidBoundingBox"
-      parsedMag <- Vec3Int.fromMagLiteral(mag.getOrElse("1-1-1"), true) ?~> "job.export.tiff.invalidMag"
+      parsedMag <- Vec3Int.fromMagLiteral(mag.getOrElse("1-1-1"), allowScalar = true) ?~> "job.export.tiff.invalidMag"
       boundingBoxInMag = parsedBoundingBox / parsedMag
       _ <- bool2Fox(boundingBoxInMag.volume <= wkConf.Features.exportTiffMaxVolumeMVx * 1024 * 1024) ?~> "job.export.tiff.volumeExceeded"
       _ <- bool2Fox(boundingBoxInMag.dimensions.maxDim <= wkConf.Features.exportTiffMaxEdgeLengthVx) ?~> "job.export.tiff.edgeLengthExceeded"

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -108,7 +108,7 @@ class BinaryDataController @Inject()(
         (dataSource, dataLayer) <- dataSourceRepository.getDataSourceAndDataLayer(organizationName,
                                                                                   dataSetName,
                                                                                   dataLayerName) ~> NOT_FOUND
-        magParsed <- Vec3Int.fromMagLiteral(mag).toFox
+        magParsed <- Vec3Int.fromMagLiteral(mag).toFox ?~> "malformedMag"
         request = DataRequest(
           VoxelPosition(x, y, z, magParsed),
           width,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5BucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/n5/N5BucketProvider.scala
@@ -19,7 +19,7 @@ class N5CubeHandle(n5Array: N5Array) extends DataCubeHandle with LazyLogging wit
 
   def cutOutBucket(bucket: BucketPosition)(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
     val shape = Vec3Int.full(bucket.bucketLength)
-    val offset = Vec3Int(bucket.voxelXInMag, bucket.voxelYInMag, bucket.voxelZInMag)
+    val offset = Vec3Int(bucket.topLeft.voxelXInMag, bucket.topLeft.voxelYInMag, bucket.topLeft.voxelZInMag)
     n5Array.readBytesXYZ(shape, offset).recover {
       case t: Throwable => logError(t); Failure(t.getMessage, Full(t), Empty)
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/precomputed/PrecomputedBucketProvider.scala
@@ -22,7 +22,7 @@ class PrecomputedCubeHandle(precomputedArray: PrecomputedArray)
 
   def cutOutBucket(bucket: BucketPosition)(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
     val shape = Vec3Int.full(bucket.bucketLength)
-    val offset = Vec3Int(bucket.voxelXInMag, bucket.voxelYInMag, bucket.voxelZInMag)
+    val offset = Vec3Int(bucket.topLeft.voxelXInMag, bucket.topLeft.voxelYInMag, bucket.topLeft.voxelZInMag)
     precomputedArray.readBytesXYZ(shape, offset).recover {
       case t: Throwable => logError(t); Failure(t.getMessage, Full(t), Empty)
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
@@ -19,7 +19,7 @@ class ZarrCubeHandle(zarrArray: ZarrArray) extends DataCubeHandle with LazyLoggi
 
   def cutOutBucket(bucket: BucketPosition)(implicit ec: ExecutionContext): Fox[Array[Byte]] = {
     val shape = Vec3Int.full(bucket.bucketLength)
-    val offset = Vec3Int(bucket.voxelXInMag, bucket.voxelYInMag, bucket.voxelZInMag)
+    val offset = Vec3Int(bucket.topLeft.voxelXInMag, bucket.topLeft.voxelYInMag, bucket.topLeft.voxelZInMag)
     zarrArray.readBytesXYZ(shape, offset).recover {
       case t: Throwable => logError(t); Failure(t.getMessage, Full(t), Empty)
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/Positions.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/Positions.scala
@@ -20,7 +20,7 @@ case class VoxelPosition(
   def toBucket: BucketPosition =
     BucketPosition(mag1X, mag1Y, mag1Z, mag)
 
-  def move(dx: Int, dy: Int, dz: Int) =
+  def move(dx: Int, dy: Int, dz: Int): VoxelPosition =
     VoxelPosition(mag1X + dx, mag1Y + dy, mag1Z + dz, mag)
 
   override def toString = s"($mag1X, $mag1Y, $mag1Z) / $mag"

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/Cuboid.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/requests/Cuboid.scala
@@ -22,7 +22,7 @@ case class Cuboid(topLeft: VoxelPosition, width: Int, height: Int, depth: Int) {
     width == bucketLength && height == bucketLength && depth == bucketLength && topLeft == topLeft.toBucket.topLeft
 
   /**
-    * Returns all buckets that are withing the cuboid spanned by top-left and bottom-right
+    * Returns all buckets that are within the cuboid spanned by top-left and bottom-right
     */
   def allBucketsInCuboid: Seq[BucketPosition] = {
     val minBucket = topLeft.toBucket


### PR DESCRIPTION
the BucketPosition case class stores not the topleft position of the bucket, but the position it was requested for. When passing this to the bucket providers, the *topleft* position has to be used.

This worked for normal bucket requests, because there the requested position happens to be equal to topleft. But when loading raw data, the request’s position was propagated all the way down, and then did not match the copy-from-buckets stuff.

### URL of deployed dev instance (used for testing):
- https://zarrbucketoffset.webknossos.xyz

### Steps to test:
- I wrote a little python script to test that the data returned by the raw data request looks right:
```
import requests
import numpy as np
from PIL import Image

ds_name = "e75_zarr_local"
width = 100
height = 100
uri = f"http://localhost:9000/data/datasets/sample_organization/{ds_name}/layers/color/data?token=secretSampleUserToken&x=0&y=0&z=78&width={width}&height={height}&depth=1&mag=1-1-1"
response = requests.get(uri)
array = np.frombuffer(response.content, dtype=np.uint16)
array = array.reshape((width, height))
array = array * 20 # amplify weak image
im = Image.fromarray(array)
im.save(f"{ds_name}.png")
```

### Issues:
- fixes #7054

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
