### PR TITLE
Store correct artifacts for wkorg nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
             yarn test-wkorg-screenshot
 
       - store_artifacts:
-          path: frontend/javascripts/test/screenshots
+          path: frontend/javascripts/test/screenshots-wkorg
 
 workflows:
   version: 2


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/scalableminds/webknossos/11449/workflows/c61d3673-2674-4249-8801-137b126c48de/jobs/22914/artifacts which stored the wrong folder.
