### PR TITLE
Improve performance for large (oversegmentation) meshes

### DIFF
--- a/frontend/javascripts/oxalis/controller/td_controller.tsx
+++ b/frontend/javascripts/oxalis/controller/td_controller.tsx
@@ -197,10 +197,15 @@ class TDController extends React.PureComponent<Props> {
         // Fix the rotation target of the TrackballControls
         this.setTargetAndFixPosition();
       },
-      // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'delta' implicitly has an 'any' type.
-      pinch: (delta) => this.zoomTDView(delta, true),
-      mouseMove: (_delta: Point2, position: Point2) => {
-        if (this.props.planeView == null) {
+      pinch: (delta: number) => this.zoomTDView(delta, true),
+      mouseMove: (
+        _delta: Point2,
+        position: Point2,
+        _id: string | null | undefined,
+        event: MouseEvent,
+      ) => {
+        // Avoid isosurface hit test when rotating or moving the 3d view for performance reasons
+        if (this.props.planeView == null || event.buttons != 0) {
           return;
         }
 

--- a/frontend/javascripts/oxalis/controller/td_controller.tsx
+++ b/frontend/javascripts/oxalis/controller/td_controller.tsx
@@ -205,7 +205,7 @@ class TDController extends React.PureComponent<Props> {
         event: MouseEvent,
       ) => {
         // Avoid isosurface hit test when rotating or moving the 3d view for performance reasons
-        if (this.props.planeView == null || event.buttons != 0) {
+        if (this.props.planeView == null || event.buttons !== 0) {
           return;
         }
 

--- a/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/isosurface_saga.ts
@@ -73,7 +73,6 @@ import processTaskWithPool from "libs/task_pool";
 import { getBaseSegmentationName } from "oxalis/view/right-border-tabs/segments_tab/segments_view_helper";
 import { RemoveSegmentAction, UpdateSegmentAction } from "../actions/volumetracing_actions";
 import { ResolutionInfo } from "../helpers/resolution_info";
-import { mergeGeometries } from "libs/BufferGeometryUtils";
 
 export const NO_LOD_MESH_INDEX = -1;
 const MAX_RETRY_COUNT = 5;


### PR DESCRIPTION
Avoid triggering the raycasting when rotating or moving the 3d viewport to avoid lags.
Merge buffer geometries per chunk when loading oversegmentation meshes to avoid lag due to too many threejs scene objects.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
