### PR TITLE
Fix bug in fallback rendering when layer has missing mags

### DIFF
--- a/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.ts
+++ b/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.ts
@@ -424,15 +424,20 @@ class PlaneMaterialFactory {
           let representativeMagForVertexAlignment: Vector3 = [Infinity, Infinity, Infinity];
           for (const [layerName, activeMagIndex] of Object.entries(activeMagIndices)) {
             const layer = getLayerByName(Store.getState().dataset, layerName);
-            const activeMag = getResolutionInfo(layer.resolutions).getResolutionByIndex(
-              activeMagIndex,
-            );
+            const resolutionInfo = getResolutionInfo(layer.resolutions);
+            // If the active mag doesn't exist, a fallback mag is likely rendered. Use that
+            // to determine a representative mag.
+            const suitableMagIndex = resolutionInfo.getIndexOrClosestHigherIndex(activeMagIndex);
+            const suitableMag =
+              suitableMagIndex != null
+                ? resolutionInfo.getResolutionByIndex(suitableMagIndex)
+                : null;
 
             const hasTransform = !_.isEqual(getTransformsForLayer(layer), Identity4x4);
-            if (!hasTransform && activeMag) {
+            if (!hasTransform && suitableMag) {
               representativeMagForVertexAlignment = V3.min(
                 representativeMagForVertexAlignment,
-                activeMag,
+                suitableMag,
               );
             }
           }


### PR DESCRIPTION
The computation of the representative mag (used for aligning the vertices with the buckets) effectively ignored layers for which the active mag doesn't exist. However, the fallback mags should be taken into account in that case.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### Issues:
- follow-up to #6085 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
