### PR TITLE
Changed the spacing/width of VX reports runs selection

### DIFF
--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -604,7 +604,7 @@ export default function TaskListView({
           <Search
             placeholder="Filter workflows"
             onSearch={handleOnSearch}
-            style={{ width: 350 }}
+            style={{ minWidth: 150 }}
             allowClear
           />
           <div style={{ flex: 1 }} />
@@ -620,7 +620,7 @@ export default function TaskListView({
                   : addUrlParam(history.location, "runId", value),
               )
             }
-            style={{ maxWidth: 300 }}
+            style={{ maxWidth: "70%" }}
           >
             <Select.Option value="">Consolidated</Select.Option>
             {report.runs.map((run) => (


### PR DESCRIPTION
Slightly changed the spacing and width of the VX report task bar to make the `runs` dropdown somewhat wider for better legibility.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
