### PR TITLE
[Docs] Update embedded YouTube URLs

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -19,7 +19,7 @@ Read more about the organization of datasets [here](./datasets.md#dataset-organi
 ![Dashboard for Team Managers or Admins with access to dataset settings and additional administration actions.](./images/dashboard_datasets.jpeg)
 ![Dashboard for Regular Users](./images/dashboard_regular_user.jpeg)
 
-![type:video](https://www.youtube.com/watch?v=naPL1jfCdOc)
+![youtube-video](https://www.youtube.com/embed/naPL1jfCdOc)
 
 ## Tasks
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,7 +6,7 @@ Since it is a web-based tool, [collaboration](./sharing.md), [crowdsourcing](./t
 
 Feel free to [contact us](mailto:hello@webknossos.org) or [create a Pull Request](https://github.com/scalableminds/webknossos/pulls) if you have any suggestions for improving the documentation.
 
-![type:video](https://www.youtube.com/watch?v=jsz0tc3tuKI)
+![youtube-video](https://www.youtube.com/embed/jsz0tc3tuKI)
 
 ## Create a webknossos.org Account
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Powerful [user](./users.md) and [task](./tasks.md) management features automatic
 There are a lot of productivity improvements to make the human part as efficient as possible.
 WEBKNOSSOS is also a platform for [showcasing datasets](https://webknossos.org) alongside a paper publication.
 
-![type:video](https://www.youtube.com/watch?v=jsz0tc3tuKI)
+![youtube-video](https://www.youtube.com/embed/jsz0tc3tuKI)
 
 ## Getting Started
 

--- a/docs/proof_reading.md
+++ b/docs/proof_reading.md
@@ -52,7 +52,7 @@ To use the `Merger Mode`:
 
 Note, the `Merger Mode` is a rather light-way tool. WEBKNOSSOS will not directly apply your changes to the underlying segmentation. Rather the `Merger Mode` corrections are applied in real-time based on the currently available skeleton annotations. Disabling the `Merger Mode` will reveal the previous state of the segmentation. Enabling the merge mode will re-apply your corrections.
 
-![type:video](https://www.youtube.com/watch?v=Sq4AuWanK14)
+![youtube-video](https://www.youtube.com/embed/Sq4AuWanK14)
 
 After finishing the proofreading, a [long-running job](./jobs.md) can be started to apply the merging of segments into a new dataset with the same layers. The job can be started by clicking the "Materialize" button next to the merger mode button in the toolbar.
 

--- a/docs/publications.md
+++ b/docs/publications.md
@@ -4,8 +4,7 @@ The following publications used WEBKNOSSOS for exploring large 3D electron-micro
 ## 2022
 * Sahil Loomba, Jakob Straehle, Vijayan Gangadharan, Natalie Heike, Abdelrahman Khalifa, Alessandro Motta, Niansheng Ju, Meike Sievers, Jens Gempt, Hanno S. Meyer & Moritz Helmstaedter.  
   Connectomic comparison of mouse and human cortex.  
-  [Science (2022). DOI: 10.1126/science.abo0924](https://www.science.org/doi/abs/10.1126/science.abo0924). 
-  
+  [Science (2022). DOI: 10.1126/science.abo0924](https://www.science.org/doi/abs/10.1126/science.abo0924).  
   [**View data**](https://webknossos.org/publication/62b979370e130578529d66ca) in WEBKNOSSOS.
 
 * Carles Bosch, Tobias Ackels, Alexandra Pacureanu, Yuxin Zhang, Christopher J. Peddie, Manuel Berning, Norman Rzepka, Marie-Christine Zdora, Isabell Whiteley, Malte Storm, Anne Bonnin, Christoph Rau, Troy Margrie, Lucy Collinson & Andreas T. Schaefer.  
@@ -14,8 +13,7 @@ The following publications used WEBKNOSSOS for exploring large 3D electron-micro
 
 * Vijayan Gangadharan, Hongwei Zheng, Francisco J. Taberner, Jonathan Landry, Timo A. Nees, Jelena Pistolic, Nitin Agarwal, Deepitha Männich, Vladimir Benes, Moritz Helmstaedter, Björn Ommer, Stefan G. Lechner, Thomas Kuner & Rohini Kuner.  
   Neuropathic pain caused by miswiring and abnormal end organ targeting.  
-  [Nature (2022). DOI: 10.1038/s41586-022-04777-z.](https://doi.org/10.1038/s41586-022-04777-z)
-  
+  [Nature (2022). DOI: 10.1038/s41586-022-04777-z.](https://doi.org/10.1038/s41586-022-04777-z)  
   [**View data**](https://webknossos.org/publication/6290b8703153034732b62f54) in WEBKNOSSOS.
 
 * Jialei Zhou, Haibin Sheng, Haoyu Wang, Yan Lu, Fangfang Wang, Hao Wu, Yunfeng Hua.  
@@ -30,14 +28,12 @@ The following publications used WEBKNOSSOS for exploring large 3D electron-micro
 ## 2021
 * Anjali Gour, Kevin M. Boergens, Natalie Heike, Yunfeng Hua, Philip Laserstein,Kun Song & Moritz Helmstaedter.  
   Postnatal connectomic development of inhibition in mouse barrel cortex.  
-  [Science (2021) DOI: 10.1126/science.abb4534.](http://dx.doi.org/10.1126/science.abb4534)
-  
+  [Science (2021) DOI: 10.1126/science.abb4534.](http://dx.doi.org/10.1126/science.abb4534)  
   [**View data**](https://webknossos.org/publication/601801b6d77f39e121656acf) in WEBKNOSSOS.
 
 * Yunfeng Hua, Xu Ding, Haoyu Wang, Fangfang Wang, Yan Lu, Jakob Neef, Yunge Gao, Tobias Moser & Hao Wu.  
   Electron Microscopic Reconstruction of Neural Circuitry in the Cochlea.  
-  [Cell Reports 34 (2021) DOI: 10.1101/2020.01.04.894816.](http://dx.doi.org/10.1101/2020.01.04.894816)
-  
+  [Cell Reports 34 (2021) DOI: 10.1101/2020.01.04.894816.](http://dx.doi.org/10.1101/2020.01.04.894816)  
   [**View data**](https://webknossos.org/publication/5ff301c3d05b8265cfa51cc8) in WEBKNOSSOS.
 
 * Haoyu Wang, Shengxiong Wang, Yan Lu, Ying Chen, Wenqing Huang, Miaoxin Qiu, Hao Wu & Yunfeng Hua.  
@@ -65,14 +61,12 @@ The following publications used WEBKNOSSOS for exploring large 3D electron-micro
 ## 2019
 * Alessandro Motta, Manuel Berning, Kevin M. Boergens, Benedikt Staffler, Marcel Beining, Sahil Loomba, Philipp Hennig, Heiko Wissler, Moritz Helmstaedter.
   Dense connectomic reconstruction in layer 4 of the somatosensory cortex.
-  [Science (2019) DOI: 10.1126/science.aay3134.](https://science.sciencemag.org/content/early/2019/10/23/science.aay3134)
-  
+  [Science (2019) DOI: 10.1126/science.aay3134.](https://science.sciencemag.org/content/early/2019/10/23/science.aay3134)  
   [**View data**](https://webknossos.org/publication/5db1ddabdf0a57ec5ce52e0f) in WEBKNOSSOS.
 
 * Ali Karimi, Jan Odenthal, Florian Drawitsch, Kevin M. Boergens, Moritz Helmstaedter.  
   Cell-type specific innervation of cortical pyramidal cells at their apical tufts.   
-  [bioRxiv (2019) DOI:10.1101/571695.](https://www.biorxiv.org/content/10.1101/571695v1.abstract) 
-  
+  [bioRxiv (2019) DOI:10.1101/571695.](https://www.biorxiv.org/content/10.1101/571695v1.abstract)  
   [**View data**](https://webknossos.org/publication/5eec8149cfa12a93b0431df8) in WEBKNOSSOS.
 
 * Benedikt Sebastian Staffler.  
@@ -86,15 +80,13 @@ The following publications used WEBKNOSSOS for exploring large 3D electron-micro
 ## 2018
 * Kevin M. Boergens, Christoph Kapfer, Moritz Helmstaedter, Winfried Denk, Alexander Borst.   
   Full reconstruction of large lobula plate tangential cells in Drosophila from a 3D EM dataset.  
-  [PLOS ONE (2018) DOI:10.1371/journal.pone.0207828.](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0207828)
-  
+  [PLOS ONE (2018) DOI:10.1371/journal.pone.0207828.](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0207828)  
   [**View data**](https://webknossos.org/publication/5ca3afb48f887cf6f2b3b601) in WEBKNOSSOS.
 
 * Florian Drawitsch, Ali Karimi, Kevin M Boergens, Moritz Helmstaedter.  
   FluoEM, virtual labeling of axons in threedimensional electron microscopy data for
   long-range connectomics.  
-  [eLife (2018) DOI:10.7554/eLife.38976.001.](https://elifesciences.org/articles/38976)
-  
+  [eLife (2018) DOI:10.7554/eLife.38976.001.](https://elifesciences.org/articles/38976)  
   [**View data**](https://webknossos.org/publication/5c5ab61e96ec36b84da1fd13) in WEBKNOSSOS.
 
 * Alessandro Motta, Manuel Berning, Kevin M. Boergens, Benedikt Staffler, Marcel Beining, Sahil Loomba, Christian Schramm, Philipp Hennig,   Heiko Wissler, Moritz Helmstaedter.  
@@ -115,8 +107,7 @@ The following publications used WEBKNOSSOS for exploring large 3D electron-micro
 
 * Eliot Dow, Adrian Jacobo, Sajjad Hossain, Kimberly Siletti & A. J. Hudspeth.  
   Connectomics of the zebrafish's lateral-line neuromast reveals wiring and miswiring in a simple microcircuit.  
-  [eLife (2018) DOI: 10.7554/eLife.33988.001.](https://doi.org/10.7554/eLife.33988.001)
-  
+  [eLife (2018) DOI: 10.7554/eLife.33988.001.](https://doi.org/10.7554/eLife.33988.001)  
   [**View data**](https://webknossos.org/publication/5c5ab2a896ec36b84da1fd0e) in WEBKNOSSOS.
 
 ## 2017
@@ -126,8 +117,7 @@ The following publications used WEBKNOSSOS for exploring large 3D electron-micro
 
 * Helene Schmidt, Anjali Gour, Jakob Straehle, Kevin M. Boergens, Michael Brecht & Moritz Helmstaedter.  
   Axonal synapse sorting in medial entorhinal cortex.  
-  [Nature (2017) DOI:10.1038/nature24005.](https://www.nature.com/articles/nature24005)
-  
+  [Nature (2017) DOI:10.1038/nature24005.](https://www.nature.com/articles/nature24005)  
   [**View data**](https://webknossos.org/publication/5c5ab59796ec36b84da1fd12) in WEBKNOSSOS.
 
 * Benedikt Staffler, Manuel Berning, Kevin M Boergens, Anjali Gour, Patrick van der Smagt & Moritz Helmstaedter.  

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -21,7 +21,7 @@ In many ways, sharing by web link works similarly to products like Google Drive 
 
 WEBKNOSSOS sharing is tightly integrated with user permissions and access rights. See the sections [on dataset management](./datasets.md#general) and [user administration](./users.md) for more info.
 
-![type:video](https://www.youtube.com/watch?v=hcm8Jx22DG8)
+![youtube-video](https://www.youtube.com/embed/hcm8Jx22DG8)
 
 ## Dataset Sharing
 

--- a/docs/skeleton_annotation.md
+++ b/docs/skeleton_annotation.md
@@ -12,7 +12,7 @@ This article outlines commonly used features and operations for viewing, editing
 
 ![An example of a complex WEBKNOSSOS skeleton annotation](images/tracing_ui_skeletontracing.jpeg)
 
-![type:video](https://www.youtube.com/watch?v=jsz0tc3tuKI&t=115s)
+![youtube-video](https://www.youtube.com/embed/jsz0tc3tuKI?start=115)
 
 ### Annotation Modes
 
@@ -93,7 +93,7 @@ Any node can be marked as a branch point using the keyboard shortcut "B" or thro
 Branch points are highlighted using a slightly different color.
 All branch points are stored as a first-in, first-out (FIFO) stack. Press "J" to jump to the latest branch point in FIFO-order to continue working from there and remove it from the stack.
 
-## Controls & Keyboard Shortcuts for Skeleton Annotations
+### Controls & Keyboard Shortcuts for Skeleton Annotations
 
 While most operations for working with skeleton annotations are either available through the UI or the context-sensitive right-click menu, some users prefer to use keyboard shortcuts to work very efficiently.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,7 +14,7 @@ The task systems is designed for automated task distribution to a (large) group 
 
 It is possible to download all annotations that belong to either a _Project_ or a _Task Type_ for further processing.
 
-![type:video](https://www.youtube.com/watch?v=YC4vaia6MkY)
+![youtube-video](https://www.youtube.com/embed/YC4vaia6MkY)
 
 ## How To Create Tasks
 
@@ -65,7 +65,7 @@ Finally, you can collect and review the completed data of all annotations within
 
 ![Download all Tasks of a Project](./images/tasks_download.jpeg)
 
-![type:video](https://www.youtube.com/watch?v=2A3en7Kxl3M)
+![youtube-video](https://www.youtube.com/embed/2A3en7Kxl3M)
 
 ## Task Assignment Criteria
 

--- a/docs/tracing_ui.md
+++ b/docs/tracing_ui.md
@@ -84,7 +84,7 @@ In addition to the general layer properties mentioned above, `color` and `segmen
 - `Pattern Opacity`: Adjust the visibility of the texture/pattern on each segment. To make segments easier to distinguish and more unique, a pattern is applied to each in addition to its base color. 0% hides the pattern. 100% makes the pattern very prominent. Great for increasing the visual contrast between segments.
 - `ID Mapping`: WEBKNOSSOS supports applying pre-computed agglomerations/groupings of segmentation IDs for a given segmentation layer. This is a very powerful feature to explore and compare different segmentation strategies for a given segmentation layer. Mappings need to be pre-computed and stored together with a dataset for WEBKNOSSOS to download and apply. [Read more about this here](./volume_annotation.md#mappings--on-demand-agglomeration).
 
-![type:video](https://www.youtube.com/watch?v=JZLKB9GfMgQ)
+![youtube-video](https://www.youtube.com/embed/JZLKB9GfMgQ)
 
 #### Skeleton Annotation Layer
 

--- a/docs/volume_annotation.md
+++ b/docs/volume_annotation.md
@@ -3,7 +3,7 @@
 In addition to [skeleton annotations](./skeleton_annotation.md), WEBKNOSSOS also supports volume/segmentation annotations.
 With this type of annotation, you can label groups of voxels with efficient drawing tools.
 
-![type:video](https://www.youtube.com/watch?v=jsz0tc3tuKI&t=372s)
+![youtube-video](https://www.youtube.com/embed/jsz0tc3tuKI?start=372)
 
 ### Tools
 
@@ -84,7 +84,7 @@ Now, you can click the "Interpolate" button (or use the shortcut V) to interpola
 
 Note that it is recommended to proofread the interpolated slices afterward since the interpolation is a heuristic.
 
-![type:video](https://www.youtube.com/watch?v=QqU72vHRR2I)
+![youtube-video](https://www.youtube.com/embed/QqU72vHRR2I)
 
 ### Volume Extrusion
 
@@ -98,7 +98,7 @@ With WEBKNOSSOS it is possible to apply a precomputed agglomeration file to re-m
 
 This feature works well with automated machine learning segmentation workflows. We typically produce several agglomeration results based on different prediction and size thresholds leading to several possible segmentations based on one initial over-segmentation. We load these ID maps into WEBKNOSSOS to quickly review these results in an interactive session.
 
-![type:video](https://www.youtube.com/watch?v=ZmUqyIoA9Gw)
+![youtube-video](https://www.youtube.com/embed/ZmUqyIoA9Gw)
 
 Mapping files are automatically identified by WEBKNOSSOS when being placed in a `mappings` folder within the [segmentation folder](./data_formats.md#wkw-folder-structure). All available mappings can be activated from a dropdown under each `Segmentation` layer. Due to their file size, mappings are fetched on demand before being applied. Users can easily switch between several mappings and WEBKNOSSOS will update accordingly.
 


### PR DESCRIPTION
- PR updates all YouTube video URLs to use the embedding format of YT to work out-of-the-box with the `mkdocs-video` plugin for the documentation
  - "Partner PR" for https://github.com/scalableminds/webknossos-libs/pull/906 
- Update the `View in WEBKNOSSOS` links of all publications such that is rendered with the correct indentation of it's parent publication

### Steps to test:
- Generate the docs fro the WK-libs repo
- Check YT videos

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
