### PR TITLE
Fix decompression of garbage data after valid gzip data causing decompression to fail

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
@@ -162,7 +162,7 @@ class GzipCompressor(val properties: Map[String, CompressionSetting]) extends Co
   override def decompress(input: Array[Byte]): Array[Byte] = {
     val is = new ByteArrayInputStream(input)
     val os = new ByteArrayOutputStream()
-    val iis = new GzipCompressorInputStream(is, true)
+    val iis = new GzipCompressorInputStream(is, false)
     try passThrough(iis, os)
     finally if (iis != null) iis.close()
     os.toByteArray


### PR DESCRIPTION
I am not sure if this breaks any other datasets (it fixes minnie65 with s3). The true parameter was introduced with #6466, I tested the only n5 dataset known to me and it worked.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Explore minnie65 via s3

### Issues:
- fixes #7093 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
