### PR TITLE
Change sttp backend to HttpURLConnectionBackend

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where some volume annotations could not be downloaded. [#7115](https://github.com/scalableminds/webknossos/pull/7115)
 - Fixed reading of some remote datasets where invalid data would follow valid gzip data, causing the decompression to fail. [#7119](https://github.com/scalableminds/webknossos/pull/7119)
+- Fixed some requests failing for streaming remote data via HTTP, which was observed when streaming data via Zarr from another WEBKNOSSOS instance. [#7125](https://github.com/scalableminds/webknossos/pull/7125)
 
 ### Removed
 - Support for [webknososs-connect](https://github.com/scalableminds/webknossos-connect) data store servers has been removed. Use the "Add Remote Dataset" functionality instead. [#7031](https://github.com/scalableminds/webknossos/pull/7031)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
@@ -18,7 +18,7 @@ class HttpsDataVault(credential: Option[DataVaultCredential]) extends DataVault 
 
   private val connectionTimeout = 1 minute
   private val readTimeout = 10 minutes
-  private lazy val backend = HttpClientSyncBackend(options = SttpBackendOptions.connectionTimeout(connectionTimeout))
+  private lazy val backend = HttpURLConnectionBackend(options = SttpBackendOptions.connectionTimeout(connectionTimeout))
 
   private def getBasicAuthCredential: Option[HttpBasicAuthCredential] =
     credential.flatMap { c =>


### PR DESCRIPTION
I don't know why, but this fixes 7073 for me. When testing that issue, I noticed that responses would sometimes be empty, even though I could manually request them and they would be full. This looked like an sttp issue, I tried changing the backend, and the empty responses disappeared. 

### URL of deployed dev instance (used for testing):
- https://changehttpbackend.webknossos.xyz/

### Steps to test:
- See #7073

### Issues:
- fixes #7073

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
