### PR TITLE
Add missing evolution to migration guide

### DIFF
--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -9,3 +9,4 @@ User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 - Support for [webknososs-connect](https://github.com/scalableminds/webknossos-connect) data store servers has been removed. Please remove the database entries for such datastores and the corresponding datasets and annotations. If you need to keep the datasets, consider adding them to a regular datastore using the same name. If the webknossos datastore does not support the dataset format, it may make sense to manually move the datasets to an existing datastore in the database, to avoid breaking foreign key relations. They will then be shown as “no longer available on the datastore”. [#7032](https://github.com/scalableminds/webknossos/pull/7032)
 
 ### Postgres Evolutions:
+- [102-no-more-wkconnect.sql](conf/evolutions/102-no-more-wkconnect.sql)


### PR DESCRIPTION
Follow-up to https://github.com/scalableminds/webknossos/pull/7032.

- [X] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
