### PR TITLE
Reverse compression on sharded neuroglancer datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed problems which could arise when annotating volume data at negative positions (which is not supported and is properly ignored now). [#7124](https://github.com/scalableminds/webknossos/pull/7124)
 - Fixed some requests failing for streaming remote data via HTTP, which was observed when streaming data via Zarr from another WEBKNOSSOS instance. [#7125](https://github.com/scalableminds/webknossos/pull/7125)
 - Fixed that the brush preview was inaccurate in some scenarios. [#7129](https://github.com/scalableminds/webknossos/pull/7129)
+- Fixed order of decompression on neuroglancer precomputed datasets, which caused some segmentation layers to not load correctly. [#7135](https://github.com/scalableminds/webknossos/pull/7135/)
 
 ### Removed
 - Support for [webknososs-connect](https://github.com/scalableminds/webknossos-connect) data store servers has been removed. Use the "Add Remote Dataset" functionality instead. [#7031](https://github.com/scalableminds/webknossos/pull/7031)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedCompressorFactory.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedCompressorFactory.scala
@@ -21,9 +21,9 @@ object PrecomputedCompressorFactory {
         getCompressorForShardingChunks(shardingSpecification.data_encoding)
       case None => nullCompressor
     }
-    val outerCompression = getCompressorForEncoding(header)
+    val chunkCompression = getCompressorForEncoding(header)
 
-    new ChainedCompressor(Seq(shardingCompression, outerCompression))
+    new ChainedCompressor(Seq(chunkCompression, shardingCompression))
 
   }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://__.webknossos.xyz

Seems like I misunderstood the precomputed specification with the order of decompressions, which caused problems with one dataset's sharded segmentation.

### Steps to test:
- Open sharded datasets, specifically manc-v1 was failing and works now, while the others should still work.

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
