### PR TITLE
Quick fixes for overflow menu

### DIFF
--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -416,7 +416,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             key: "mergeWithFallbackLayerButton",
           }
         : null,
-      !this.props.dataset.isEditable
+      this.props.dataset.isEditable
         ? { label: this.getReloadDataButton(layerName), key: "reloadDataButton" }
         : null,
       {
@@ -602,11 +602,13 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
         </div>
         <div className="flex-container">
           <div className="flex-item">
-            <Tooltip title="More actions">
-              <Dropdown menu={{ items }} trigger={["click", "contextMenu"]} placement="bottomRight">
-                <EllipsisOutlined />
-              </Dropdown>
-            </Tooltip>
+            <Dropdown
+              menu={{ items }}
+              trigger={["click", "contextMenu", "hover"]}
+              placement="bottomRight"
+            >
+              <EllipsisOutlined />
+            </Dropdown>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- there was a small error (wrong negotiation) when the reload button is rendered. it should be shown in the layer actions overflow menuif the dataset is editable.
- the overflow menu can now be opened just by hovering. thus I also deleted the tooltip.
