### PR TITLE
Warn when browser doesn't support certain features

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,6 +13,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Added
 - In order to facilitate changing the brush size in the brush tool, buttons with preset brush sizes were added. These presets are user configurable by assigning the current brush size to any of the preset buttons. Additionally the preset brush sizes can be set with keyboard shortcuts. [#7101](https://github.com/scalableminds/webknossos/pull/7101)
 - Added new graphics and restyled empty dashboards. [#7008](https://github.com/scalableminds/webknossos/pull/7008)
+- Added warning when using WEBKNOSSOS in an outdated browser. [#7165](https://github.com/scalableminds/webknossos/pull/7165)
 
 ### Changed
 - Redesigned the info tab in the right-hand sidebar to be fit the new branding and design language. [#7110](https://github.com/scalableminds/webknossos/pull/7110)

--- a/frontend/javascripts/libs/browser_feature_check.tsx
+++ b/frontend/javascripts/libs/browser_feature_check.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import Toast from "./toast";
+
+export default function checkBrowserFeatures() {
+  try {
+    // Test some features that WK uses and that are known
+    // to not exist on older browsers.
+    new AbortController();
+    Object.fromEntries([]);
+    new BigUint64Array(1);
+  } catch (exception) {
+    console.error(
+      "This browser lacks support for some modern features. Exception caught during test of features:",
+      exception,
+    );
+    Toast.warning(
+      <div>
+        Your browser seems to be outdated.{" "}
+        <a href="https://browser-update.org/update.html" target="_blank" rel="noreferrer">
+          Update your browser
+        </a>{" "}
+        to avoid errors. See console for details.
+      </div>,
+    );
+  }
+}

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -25,6 +25,7 @@ import { setStore, setModel } from "oxalis/singletons";
 import Model from "oxalis/model";
 import { setupApi } from "oxalis/api/internal_api";
 import { setActiveOrganizationAction } from "oxalis/model/actions/organization_actions";
+import checkBrowserFeatures from "libs/browser_feature_check";
 
 setModel(Model);
 setStore(UnthrottledStore);
@@ -88,6 +89,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     throwAssertions: false,
   });
   document.addEventListener("click", googleAnalyticsLogClicks);
+  checkBrowserFeatures();
   await Promise.all([loadFeatureToggles(), loadActiveUser(), loadHasOrganizations()]);
   await Promise.all([loadOrganization()]);
   const containerElement = document.getElementById("main-container");


### PR DESCRIPTION
I decided to do a simple smoke test instead of adding a new dependency which does fancy browser-lists comparisons. That way, the added code is very little and we can only test against features from which we know that WK needs them.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I tested that no error appears in modern browsers
- I changed AbortController to have a typo --> toast appears

### Issues:
- fixes #5726

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)