### PR TITLE
Dont show placeholders in dashboard during loading

### DIFF
--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -177,8 +177,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
     });
   }
 
-  // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'pageNumber' implicitly has an 'any' typ... Remove this comment to see the full error message
-  fetchNextPage = async (pageNumber) => {
+  fetchNextPage = async (pageNumber: number) => {
     // this refers not to the pagination of antd but to the pagination of querying data from SQL
     const isFinished = this.state.showFinishedTasks;
     const previousTasks = this.getCurrentModeState().tasks;

--- a/frontend/javascripts/dashboard/dataset_folder_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_folder_view.tsx
@@ -179,7 +179,8 @@ function DatasetFolderViewInner(props: Props) {
     hierarchy != null &&
     hierarchy.flatItems.length === 1 &&
     context.datasets.length === 0 &&
-    context.activeFolderId != null
+    context.activeFolderId != null &&
+    !context.isLoading
   ) {
     // Show a placeholder if only the root folder exists and no dataset is available yet
     // (aka a new, empty organization)

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -440,7 +440,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
   };
 
   getEmptyListPlaceholder = () => {
-    return (
+    return this.state.isLoading ? null : (
       <Row gutter={32} justify="center" style={{ padding: 50 }}>
         <Col span="6">
           <Card bordered={false} cover={<i className="drawing drawing-empty-list-annotations" />}>


### PR DESCRIPTION
I noticed that the placeholders are briefly visible during loading.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- clear localstorage, reload and ensure that placeholders are not visible during loading

### Issues:
- follow-up to #7008