### PR TITLE
Always show proofreading tool + refactoring

### DIFF
--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -237,7 +237,7 @@ instead. Only enable this option if you understand its effect. All layers will n
   "tracing.agglomerate_skeleton.no_agglomerate_file_active":
     "Loading a skeleton for a segment only works with agglomerate file mappings.",
   "tracing.agglomerate_skeleton.no_agglomerate_file_available":
-    "No agglomerate file mapping is available for this segmentation layer. Please reach out to hello@scalableminds.com to get help with generating one.",
+    "No agglomerate file mapping is available for this segmentation layer. Please reach out to hello@webknossos.org to get help with generating one.",
   "tracing.agglomerate_skeleton.no_skeleton_tracing":
     "Loading a skeleton for a segment only works in skeleton or hybrid tracings.",
   "tracing.skeletons_are_hidden_warning":

--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -234,8 +234,10 @@ instead. Only enable this option if you understand its effect. All layers will n
     "Clicked on the background. Please click on a segment to load a skeleton.",
   "tracing.agglomerate_skeleton.no_mapping":
     "Activate an agglomerate file mapping to load a skeleton for a segment.",
-  "tracing.agglomerate_skeleton.no_agglomerate_file":
+  "tracing.agglomerate_skeleton.no_agglomerate_file_active":
     "Loading a skeleton for a segment only works with agglomerate file mappings.",
+  "tracing.agglomerate_skeleton.no_agglomerate_file_available":
+    "No agglomerate file mapping is available for this segmentation layer. Please reach out to hello@scalableminds.com to get help with generating one.",
   "tracing.agglomerate_skeleton.no_skeleton_tracing":
     "Loading a skeleton for a segment only works in skeleton or hybrid tracings.",
   "tracing.skeletons_are_hidden_warning":

--- a/frontend/javascripts/oxalis/controller/combinations/segmentation_handlers.ts
+++ b/frontend/javascripts/oxalis/controller/combinations/segmentation_handlers.ts
@@ -5,6 +5,7 @@ import { calculateGlobalPos } from "oxalis/model/accessors/view_mode_accessor";
 import {
   getMappingInfo,
   getVisibleOrLastSegmentationLayer,
+  getVisibleSegmentationLayer,
 } from "oxalis/model/accessors/dataset_accessor";
 import { loadAgglomerateSkeletonAction } from "oxalis/model/actions/skeletontracing_actions";
 import type { OxalisState } from "oxalis/store";
@@ -28,21 +29,30 @@ const AGGLOMERATE_STATES = {
     value: false,
     reason: messages["tracing.agglomerate_skeleton.no_mapping"],
   },
-  NO_AGGLOMERATE_FILE: {
+  NO_AGGLOMERATE_FILE_ACTIVE: {
     value: false,
-    reason: messages["tracing.agglomerate_skeleton.no_agglomerate_file"],
+    reason: messages["tracing.agglomerate_skeleton.no_agglomerate_file_active"],
+  },
+  NO_AGGLOMERATE_FILE_AVAILABLE: {
+    value: false,
+    reason: messages["tracing.agglomerate_skeleton.no_agglomerate_file_available"],
   },
   YES: {
     value: true,
     reason: "",
   },
 };
+export type AgglomerateState = typeof AGGLOMERATE_STATES[keyof typeof AGGLOMERATE_STATES];
 
 export function hasAgglomerateMapping(state: OxalisState) {
-  const segmentation = Model.getVisibleSegmentationLayer();
+  const segmentation = getVisibleSegmentationLayer(state);
 
   if (!segmentation) {
     return AGGLOMERATE_STATES.NO_SEGMENTATION;
+  }
+
+  if ((segmentation.agglomerates?.length ?? 0) === 0) {
+    return AGGLOMERATE_STATES.NO_AGGLOMERATE_FILE_AVAILABLE;
   }
 
   const { mappingName, mappingType, mappingStatus } = getMappingInfo(
@@ -55,7 +65,7 @@ export function hasAgglomerateMapping(state: OxalisState) {
   }
 
   if (mappingType !== "HDF5") {
-    return AGGLOMERATE_STATES.NO_AGGLOMERATE_FILE;
+    return AGGLOMERATE_STATES.NO_AGGLOMERATE_FILE_ACTIVE;
   }
 
   return AGGLOMERATE_STATES.YES;

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -709,7 +709,7 @@ async function applyLayerState(stateByLayer: UrlStateByLayer) {
         }
 
         if (mappingType !== "HDF5") {
-          Toast.error(messages["tracing.agglomerate_skeleton.no_agglomerate_file"]);
+          Toast.error(messages["tracing.agglomerate_skeleton.no_agglomerate_file_active"]);
           continue;
         }
 

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -208,6 +208,30 @@ function RadioButtonWithTooltip({
   );
 }
 
+function ToolRadioButton({
+  name,
+  description,
+  disabledExplanation,
+  ...props
+}: {
+  name: string;
+  description: string;
+  disabledExplanation?: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+  style: React.CSSProperties;
+  value: string;
+  onClick?: Function;
+}) {
+  return (
+    <RadioButtonWithTooltip
+      title={`${name} – ${description}`}
+      disabledTitle={`${name} – ${disabledExplanation}`}
+      {...props}
+    />
+  );
+}
+
 function OverwriteModeSwitch({
   isControlPressed,
   isShiftPressed,
@@ -779,6 +803,20 @@ function calculateMediumBrushSize(maximumBrushSize: number) {
   return Math.ceil((maximumBrushSize - userSettings.brushSize.minimum) / 10) * 5;
 }
 
+const TOOL_NAMES = {
+  MOVE: "Move",
+  SKELETON: "Skeleton",
+  BRUSH: "Brush",
+  ERASE_BRUSH: "Erase (via Brush)",
+  TRACE: "Trace",
+  ERASE_TRACE: "Erase",
+  FILL_CELL: "Fill Tool",
+  PICK_CELL: "Segment Picker",
+  QUICK_SELECT: "Quick Select Tool",
+  BOUNDING_BOX: "Bounding Box Tool",
+  PROOFREAD: "Proofreading Tool",
+};
+
 export default function ToolbarView() {
   const hasVolume = useSelector((state: OxalisState) => state.tracing.volumes.length > 0);
   const hasSkeleton = useSelector((state: OxalisState) => state.tracing.skeleton != null);
@@ -851,11 +889,10 @@ export default function ToolbarView() {
       ? getSkeletonToolHint(activeTool, isShiftPressed, isControlPressed, isAltPressed)
       : null;
   const previousSkeletonToolHint = usePrevious(skeletonToolHint);
-  const moveToolDescription =
-    "Move – Use left-click to move around and right-click to open a contextmenu.";
+
   const skeletonToolDescription = useLegacyBindings
-    ? "Skeleton – Use left-click to move around and right-click to create new skeleton nodes"
-    : "Skeleton – Use left-click to move around or to create/select/move nodes. Right-click opens a context menu with further options.";
+    ? "Use left-click to move around and right-click to create new skeleton nodes"
+    : "Use left-click to move around or to create/select/move nodes. Right-click opens a context menu with further options.";
   const showEraseTraceTool =
     adaptedActiveTool === AnnotationToolEnum.TRACE ||
     adaptedActiveTool === AnnotationToolEnum.ERASE_TRACE;
@@ -864,9 +901,10 @@ export default function ToolbarView() {
   return (
     <>
       <Radio.Group onChange={handleSetTool} value={adaptedActiveTool}>
-        <RadioButtonWithTooltip
-          title={moveToolDescription}
-          disabledTitle=""
+        <ToolRadioButton
+          name={TOOL_NAMES.MOVE}
+          description="Use left-click to move around and right-click to open a contextmenu."
+          disabledExplanation=""
           disabled={false}
           style={NARROW_BUTTON_STYLE}
           value={AnnotationToolEnum.MOVE}
@@ -877,12 +915,13 @@ export default function ToolbarView() {
             }}
             className="fas fa-arrows-alt"
           />
-        </RadioButtonWithTooltip>
+        </ToolRadioButton>
 
         {hasSkeleton ? (
-          <RadioButtonWithTooltip
-            title={skeletonToolDescription}
-            disabledTitle=""
+          <ToolRadioButton
+            name={TOOL_NAMES.SKELETON}
+            description={skeletonToolDescription}
+            disabledExplanation=""
             disabled={disabledInfosForTools[AnnotationToolEnum.SKELETON].isDisabled}
             style={NARROW_BUTTON_STYLE}
             value={AnnotationToolEnum.SKELETON}
@@ -904,14 +943,17 @@ export default function ToolbarView() {
                 className="fas fa-project-diagram"
               />
             </Tooltip>
-          </RadioButtonWithTooltip>
+          </ToolRadioButton>
         ) : null}
 
         {hasVolume && isVolumeModificationAllowed ? (
           <React.Fragment>
-            <RadioButtonWithTooltip
-              title="Brush – Draw over the voxels you would like to label. Adjust the brush size with Shift + Mousewheel."
-              disabledTitle={disabledInfosForTools[AnnotationToolEnum.BRUSH].explanation}
+            <ToolRadioButton
+              name={TOOL_NAMES.BRUSH}
+              description={
+                "Draw over the voxels you would like to label. Adjust the brush size with Shift + Mousewheel."
+              }
+              disabledExplanation={disabledInfosForTools[AnnotationToolEnum.BRUSH].explanation}
               disabled={disabledInfosForTools[AnnotationToolEnum.BRUSH].isDisabled}
               style={NARROW_BUTTON_STYLE}
               value={AnnotationToolEnum.BRUSH}
@@ -923,11 +965,14 @@ export default function ToolbarView() {
                 }}
               />
               {adaptedActiveTool === AnnotationToolEnum.BRUSH ? multiSliceAnnotationInfoIcon : null}
-            </RadioButtonWithTooltip>
+            </ToolRadioButton>
 
-            <RadioButtonWithTooltip
-              title="Erase (via Brush) – Erase the voxels by brushing over them. Adjust the brush size with Shift + Mousewheel."
-              disabledTitle={disabledInfosForTools[AnnotationToolEnum.ERASE_BRUSH].explanation}
+            <ToolRadioButton
+              name={TOOL_NAMES.ERASE_BRUSH}
+              description="Erase the voxels by brushing over them. Adjust the brush size with Shift + Mousewheel."
+              disabledExplanation={
+                disabledInfosForTools[AnnotationToolEnum.ERASE_BRUSH].explanation
+              }
               disabled={disabledInfosForTools[AnnotationToolEnum.ERASE_BRUSH].isDisabled}
               style={{
                 ...NARROW_BUTTON_STYLE,
@@ -948,11 +993,12 @@ export default function ToolbarView() {
               {adaptedActiveTool === AnnotationToolEnum.ERASE_BRUSH
                 ? multiSliceAnnotationInfoIcon
                 : null}
-            </RadioButtonWithTooltip>
+            </ToolRadioButton>
 
-            <RadioButtonWithTooltip
-              title="Trace – Draw outlines around the voxels you would like to label."
-              disabledTitle={disabledInfosForTools[AnnotationToolEnum.TRACE].explanation}
+            <ToolRadioButton
+              name={TOOL_NAMES.TRACE}
+              description="Draw outlines around the voxels you would like to label."
+              disabledExplanation={disabledInfosForTools[AnnotationToolEnum.TRACE].explanation}
               disabled={disabledInfosForTools[AnnotationToolEnum.TRACE].isDisabled}
               style={NARROW_BUTTON_STYLE}
               value={AnnotationToolEnum.TRACE}
@@ -965,11 +1011,14 @@ export default function ToolbarView() {
                 }}
               />
               {adaptedActiveTool === AnnotationToolEnum.TRACE ? multiSliceAnnotationInfoIcon : null}
-            </RadioButtonWithTooltip>
+            </ToolRadioButton>
 
-            <RadioButtonWithTooltip
-              title="Erase – Draw outlines around the voxel you would like to erase."
-              disabledTitle={disabledInfosForTools[AnnotationToolEnum.ERASE_TRACE].explanation}
+            <ToolRadioButton
+              name={TOOL_NAMES.ERASE_TRACE}
+              description="Draw outlines around the voxel you would like to erase."
+              disabledExplanation={
+                disabledInfosForTools[AnnotationToolEnum.ERASE_TRACE].explanation
+              }
               disabled={disabledInfosForTools[AnnotationToolEnum.ERASE_TRACE].isDisabled}
               style={{
                 ...NARROW_BUTTON_STYLE,
@@ -990,11 +1039,12 @@ export default function ToolbarView() {
               {adaptedActiveTool === AnnotationToolEnum.ERASE_TRACE
                 ? multiSliceAnnotationInfoIcon
                 : null}
-            </RadioButtonWithTooltip>
+            </ToolRadioButton>
 
-            <RadioButtonWithTooltip
-              title="Fill Tool – Flood-fill the clicked region."
-              disabledTitle={disabledInfosForTools[AnnotationToolEnum.FILL_CELL].explanation}
+            <ToolRadioButton
+              name={TOOL_NAMES.FILL_CELL}
+              description="Flood-fill the clicked region."
+              disabledExplanation={disabledInfosForTools[AnnotationToolEnum.FILL_CELL].explanation}
               disabled={disabledInfosForTools[AnnotationToolEnum.FILL_CELL].isDisabled}
               style={NARROW_BUTTON_STYLE}
               value={AnnotationToolEnum.FILL_CELL}
@@ -1009,10 +1059,11 @@ export default function ToolbarView() {
               {adaptedActiveTool === AnnotationToolEnum.FILL_CELL
                 ? multiSliceAnnotationInfoIcon
                 : null}
-            </RadioButtonWithTooltip>
-            <RadioButtonWithTooltip
-              title="Segment Picker – Click on a voxel to make its segment id the active segment id."
-              disabledTitle={disabledInfosForTools[AnnotationToolEnum.PICK_CELL].explanation}
+            </ToolRadioButton>
+            <ToolRadioButton
+              name={TOOL_NAMES.PICK_CELL}
+              description="Click on a voxel to make its segment id the active segment id."
+              disabledExplanation={disabledInfosForTools[AnnotationToolEnum.PICK_CELL].explanation}
               disabled={disabledInfosForTools[AnnotationToolEnum.PICK_CELL].isDisabled}
               style={NARROW_BUTTON_STYLE}
               value={AnnotationToolEnum.PICK_CELL}
@@ -1023,12 +1074,13 @@ export default function ToolbarView() {
                   opacity: disabledInfosForTools[AnnotationToolEnum.PICK_CELL].isDisabled ? 0.5 : 1,
                 }}
               />
-            </RadioButtonWithTooltip>
+            </ToolRadioButton>
           </React.Fragment>
         ) : null}
-        <RadioButtonWithTooltip
-          title="Quick Select Tool - Draw a rectangle around a segment to automatically detect it"
-          disabledTitle={disabledInfosForTools[AnnotationToolEnum.QUICK_SELECT].explanation}
+        <ToolRadioButton
+          name={TOOL_NAMES.QUICK_SELECT}
+          description="Draw a rectangle around a segment to automatically detect it"
+          disabledExplanation={disabledInfosForTools[AnnotationToolEnum.QUICK_SELECT].explanation}
           disabled={disabledInfosForTools[AnnotationToolEnum.QUICK_SELECT].isDisabled}
           style={NARROW_BUTTON_STYLE}
           value={AnnotationToolEnum.QUICK_SELECT}
@@ -1043,10 +1095,11 @@ export default function ToolbarView() {
               opacity: disabledInfosForTools[AnnotationToolEnum.QUICK_SELECT].isDisabled ? 0.5 : 1,
             }}
           />
-        </RadioButtonWithTooltip>
-        <RadioButtonWithTooltip
-          title="Bounding Box Tool - Create, resize and modify bounding boxes."
-          disabledTitle={disabledInfosForTools[AnnotationToolEnum.BOUNDING_BOX].explanation}
+        </ToolRadioButton>
+        <ToolRadioButton
+          name={TOOL_NAMES.BOUNDING_BOX}
+          description="Create, resize and modify bounding boxes."
+          disabledExplanation={disabledInfosForTools[AnnotationToolEnum.BOUNDING_BOX].explanation}
           disabled={disabledInfosForTools[AnnotationToolEnum.BOUNDING_BOX].isDisabled}
           style={NARROW_BUTTON_STYLE}
           value={AnnotationToolEnum.BOUNDING_BOX}
@@ -1059,13 +1112,20 @@ export default function ToolbarView() {
               ...imgStyleForSpaceyIcons,
             }}
           />
-        </RadioButtonWithTooltip>
+        </ToolRadioButton>
 
-        {hasSkeleton && hasVolume && isAgglomerateMappingEnabled.value ? (
-          <RadioButtonWithTooltip
-            title="Proofreading Tool - Modify an agglomerated segmentation. Other segmentation modifications, like brushing, are not allowed if this tool is used."
-            disabledTitle={disabledInfosForTools[AnnotationToolEnum.PROOFREAD].explanation}
-            disabled={disabledInfosForTools[AnnotationToolEnum.PROOFREAD].isDisabled}
+        {hasSkeleton && hasVolume ? (
+          <ToolRadioButton
+            name={TOOL_NAMES.PROOFREAD}
+            description="Modify an agglomerated segmentation. Other segmentation modifications, like brushing, are not allowed if this tool is used."
+            disabledExplanation={
+              isAgglomerateMappingEnabled.reason ||
+              disabledInfosForTools[AnnotationToolEnum.PROOFREAD].explanation
+            }
+            disabled={
+              isAgglomerateMappingEnabled.value ||
+              disabledInfosForTools[AnnotationToolEnum.PROOFREAD].isDisabled
+            }
             style={NARROW_BUTTON_STYLE}
             value={AnnotationToolEnum.PROOFREAD}
           >
@@ -1075,7 +1135,7 @@ export default function ToolbarView() {
                 opacity: disabledInfosForTools[AnnotationToolEnum.PROOFREAD].isDisabled ? 0.5 : 1,
               }}
             />
-          </RadioButtonWithTooltip>
+          </ToolRadioButton>
         ) : null}
       </Radio.Group>
 

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -336,7 +336,7 @@ img.keyboard-mouse-icon:first-child {
 
     &:hover {
       border-color: @hover-border !important;
-      z-index: 1;
+      z-index: 1 !important;
     }
 
     &:not(:first-child):hover::before {
@@ -348,7 +348,7 @@ img.keyboard-mouse-icon:first-child {
     &.ant-radio-button-wrapper-disabled,
     &.ant-select-selector-disabled {
       color: fade(@dark-fg, 50%);
-      border-color: @dark-border;
+      border-color: @dark-border !important;
 
       &:hover::before {
         background-color: @dark-border !important;


### PR DESCRIPTION
The proofreading tool is always shown (for hybrid annotations) so that users can find this tool better. In case of a missing agglomerate file, a tool tip tells the user to contact the WK team.

![image](https://github.com/scalableminds/webknossos/assets/2486553/ec1f6606-a7f7-4e37-80ae-350e8b53b5f7)

Additional changes:
- refactoring/improvement of the agglomerate disabled message
- tool names are always shown in tool tip (even when tool is disabled)
- improve styling of disabled buttons (e.g., on hover)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- try to activate the different tools in the different scenarios (e.g., brush is not available on coarser mags; proofreading requires agglomerate file etc)

### Issues:
- fixes #7098 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)