### PR TITLE
Fix search for single-folder organizations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed rare rendering bug at viewport edge for anisotropic datasets. [#7163](https://github.com/scalableminds/webknossos/pull/7163)
+- Fixed the dataset search which was broken when only the root folder existed. [#7177](https://github.com/scalableminds/webknossos/pull/7177)
 
 ### Removed
 

--- a/frontend/javascripts/dashboard/dataset_folder_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_folder_view.tsx
@@ -189,7 +189,8 @@ function DatasetFolderViewInner(props: Props) {
     hierarchy.flatItems.length === 1 &&
     context.datasets.length === 0 &&
     context.activeFolderId != null &&
-    !context.isLoading
+    !context.isLoading &&
+    context.globalSearchQuery == null
   ) {
     // Show a placeholder if only the root folder exists and no dataset is available yet
     // (aka a new, empty organization)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open dashboard with single folder
- use search
- should not show empty datasets placeholder

### Issues:
- follow-up to #7008

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
