### PR TITLE
Fix vx artifacts disk usage list

### DIFF
--- a/frontend/javascripts/admin/voxelytics/artifacts_disk_usage_list.tsx
+++ b/frontend/javascripts/admin/voxelytics/artifacts_disk_usage_list.tsx
@@ -35,6 +35,9 @@ export default function DiskUsageList({
           .filter((artifactTableEntry) => artifactTableEntry != null),
       );
     }
+    if (!artifacts[taskGroup.taskName]) {
+      return [];
+    }
     return Object.entries(artifacts[taskGroup.taskName]).map(([artifactName, artifact]) => ({
       artifactName,
       fileSize: artifact.fileSize,


### PR DESCRIPTION
The current list/table does not handle skipped tasks correctly which causes it to crash.
The fix simply ignores skipped artifacts and thus correctly displays the existing artifacts of the job.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I suggest testing locally
- enable vx in wk and start wk locally
- run `WK_URL=http://localhost:9000 WK_TOKEN=<token> TEST_RUN=True DISABLE_LOG_STREAMING=True python -m voxelytics voxelytics/connect/test/configs/segem_test_from_segment.yaml --only average_predictions` in the vx repo
- Open the created workflow in wk and open the artifacts list. 
- The list should open up properly and display the artifacts. This should not crash with an error.

### Issues:
- no issue exists for this bug
