### PR TITLE
enable security.txt route also for no-ds setup

### DIFF
--- a/conf/noDS.noTS.routes
+++ b/conf/noDS.noTS.routes
@@ -1,3 +1,4 @@
--> /api/      webknossos.versioned.Routes
+-> /api/                         webknossos.versioned.Routes
 
-GET  /swagger.json  controllers.ApiHelpController.getResources
+GET   /swagger.json              controllers.ApiHelpController.getResources
+GET   /.well-known/security.txt  controllers.Application.getSecurityTxt

--- a/conf/noDS.routes
+++ b/conf/noDS.routes
@@ -1,4 +1,5 @@
--> /api/      webknossos.versioned.Routes
--> /tracings/ com.scalableminds.webknossos.tracingstore.Routes
+-> /api/                         webknossos.versioned.Routes
+-> /tracings/                    com.scalableminds.webknossos.tracingstore.Routes
 
-GET  /swagger.json  controllers.ApiHelpController.getResources
+GET   /swagger.json              controllers.ApiHelpController.getResources
+GET   /.well-known/security.txt  controllers.Application.getSecurityTxt

--- a/conf/noTS.routes
+++ b/conf/noTS.routes
@@ -1,4 +1,5 @@
--> /api/      webknossos.versioned.Routes
--> /data/     com.scalableminds.webknossos.datastore.Routes
+-> /api/                         webknossos.versioned.Routes
+-> /data/                        com.scalableminds.webknossos.datastore.Routes
 
-GET  /swagger.json  controllers.ApiHelpController.getResources
+GET   /swagger.json              controllers.ApiHelpController.getResources
+GET   /.well-known/security.txt  controllers.Application.getSecurityTxt


### PR DESCRIPTION
follow-up for #7182

in some instances, the routes file is changed to one of these (to disable the datastore and/or tracingstore routes if those modules are disabled)