### PR TITLE
Add tooltips explaining task "cancel and reset"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added support for transformations with thin plate splines. [#7131](https://github.com/scalableminds/webknossos/pull/7131)
 - WEBKNOSSOS can now read S3 remote dataset credentials from environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`. Those will be used, if available, when accessing remote datasets for which no explicit credentials are supplied. [#7170](https://github.com/scalableminds/webknossos/pull/7170)
 - Added security.txt according to [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116). The content is configurable and it can be disabled. [#7182](https://github.com/scalableminds/webknossos/pull/7182)
+- Added tooltips to explain the task actions "Reset" and "Reset and Cancel". [#7201](https://github.com/scalableminds/webknossos/pull/7201)
 
 ### Changed
 - Redesigned the info tab in the right-hand sidebar to be fit the new branding and design language. [#7110](https://github.com/scalableminds/webknossos/pull/7110)

--- a/frontend/javascripts/admin/task/task_annotation_view.tsx
+++ b/frontend/javascripts/admin/task/task_annotation_view.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, MenuProps, Modal } from "antd";
+import { Dropdown, MenuProps, Modal, Tooltip, message } from "antd";
 import {
   EyeOutlined,
   PlayCircleOutlined,
@@ -154,13 +154,21 @@ class TaskAnnotationView extends React.PureComponent<Props, State> {
           key: `${annotation.id}-reset`,
           onClick: () => this.resetAnnotation(annotation),
           icon: <RollbackOutlined />,
-          label: "Reset",
+          label: (
+            <Tooltip title={messages["task.tooltip_explain_reset"]} placement="left">
+              Reset
+            </Tooltip>
+          ),
         },
         {
           key: `${annotation.id}-delete`,
           onClick: () => this.deleteAnnotation(annotation),
           icon: <DeleteOutlined />,
-          label: "Reset and Cancel",
+          label: (
+            <Tooltip title={messages["task.tooltip_explain_reset_cancel"]} placement="left">
+              Reset and Cancel
+            </Tooltip>
+          ),
         },
         annotation.state === "Finished"
           ? {

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, Tag, Card, Row, Col, List } from "antd";
+import { Button, Modal, Tag, Card, Row, Col, List, Tooltip } from "antd";
 import {
   CheckCircleOutlined,
   DeleteOutlined,
@@ -278,13 +278,17 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
             </AsyncLink>
             <br />
             <LinkButton onClick={() => this.resetTask(annotation)}>
-              <RollbackOutlined />
-              Reset
+              <Tooltip title={messages["task.tooltip_explain_reset"]} placement="left">
+                <RollbackOutlined />
+                Reset
+              </Tooltip>
             </LinkButton>
             <br />
             <LinkButton onClick={() => this.cancelAnnotation(annotation)}>
-              <DeleteOutlined />
-              Reset and Cancel
+              <Tooltip title={messages["task.tooltip_explain_reset_cancel"]} placement="left">
+                <DeleteOutlined />
+                Reset and Cancel
+              </Tooltip>
             </LinkButton>
             <br />
           </div>

--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -288,6 +288,10 @@ instead. Only enable this option if you understand its effect. All layers will n
     "The dataset <%- datasetName %> was successfully deleted on disk. Redirecting to dashboard...",
   ),
   "task.no_tasks_to_download": "There are no tasks available to download.",
+  "task.tooltip_explain_reset":
+    "This resets a task to its initial state and thereby undoes any annotation work of the assigned user account. The task will remain assigned to this user account for further annotation work.",
+  "task.tooltip_explain_reset_cancel":
+    "This resets a task to its initial state and thereby undoes any annotation work of the assigned user account. Further, the task assignment will be removed from the user's account and recycled into the pool of available tasks for other potential users. The currently assigned user account will not be assigned to this task again by the system (unless he is an Admin).",
   "dataset.upload_success": "The dataset was uploaded successfully.",
   "dataset.upload_failed": "The dataset upload failed.",
   "dataset.upload_cancel": "The dataset upload was cancelled.",

--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -291,7 +291,7 @@ instead. Only enable this option if you understand its effect. All layers will n
   "task.tooltip_explain_reset":
     "This resets a task to its initial state and thereby undoes any annotation work of the assigned user account. The task will remain assigned to this user account for further annotation work.",
   "task.tooltip_explain_reset_cancel":
-    "This resets a task to its initial state and thereby undoes any annotation work of the assigned user account. Further, the task assignment will be removed from the user's account and recycled into the pool of available tasks for other potential users. The currently assigned user account will not be assigned to this task again by the system (unless he is an Admin).",
+    "Resets this task instance to its initial state, undoing any annotation work of the assigned user. Furthermore, the task assignment will be removed from the user’s account and recycled into the pool of available tasks for other users. The currently assigned user will not be assigned to this task again (unless they are an Admin).",
   "dataset.upload_success": "The dataset was uploaded successfully.",
   "dataset.upload_failed": "The dataset upload failed.",
   "dataset.upload_cancel": "The dataset upload was cancelled.",

--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -289,7 +289,7 @@ instead. Only enable this option if you understand its effect. All layers will n
   ),
   "task.no_tasks_to_download": "There are no tasks available to download.",
   "task.tooltip_explain_reset":
-    "This resets a task to its initial state and thereby undoes any annotation work of the assigned user account. The task will remain assigned to this user account for further annotation work.",
+    "Resets this task instance to its initial state, undoing any annotation work of the assigned user. The task will remain assigned to this user for further annotation work.",
   "task.tooltip_explain_reset_cancel":
     "Resets this task instance to its initial state, undoing any annotation work of the assigned user. Furthermore, the task assignment will be removed from the user’s account and recycled into the pool of available tasks for other users. The currently assigned user will not be assigned to this task again (unless they are an Admin).",
   "dataset.upload_success": "The dataset was uploaded successfully.",


### PR DESCRIPTION
### Steps to test:
- Create new tasks
- Go to Admin > Tasks, manually a task to yourself
- Hover of the "Reset" and "Reset and Cancel" actions to read the tooltips.

### Issues:
- fixes #7047

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
