### PR TITLE
Update proofreading docs to reflect current state

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,11 +27,13 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Optimized processing of parallel requests (new thread pool configuration, asynchronous FossilDB client), improving performance and reducing idle waiting. [#7139](https://github.com/scalableminds/webknossos/pull/7139)
 - Renamed "open" tasks to "pending" and slightly redesigned the available task assignment view for clarity. [#7187](https://github.com/scalableminds/webknossos/pull/7187)
 - Being the uploader of a dataset no longer grants edit permissions on that dataset. [#7200](https://github.com/scalableminds/webknossos/pull/7200)
+- Enabled the "Shift + middle-click" shortcut to load agglomerate skeletons for all tools, not just the Skeleton tool. [#7212](https://github.com/scalableminds/webknossos/pull/7212)
 
 ### Fixed
 - Fixed rare rendering bug at viewport edge for anisotropic datasets. [#7163](https://github.com/scalableminds/webknossos/pull/7163)
 - Fixed the dataset search which was broken when only the root folder existed. [#7177](https://github.com/scalableminds/webknossos/pull/7177)
 - Correctly use configured fill-value for missing chunks of remote datasets hosted on gcs or s3. [#7198](https://github.com/scalableminds/webknossos/pull/7198)
+- Adapted the proofreading docs to reflect the current state of the proofreading tool. [#7212](https://github.com/scalableminds/webknossos/pull/7212)
 
 ### Removed
 - Removed the "Globalize Floodfill" feature that could extend partial floodfills across an entire dataset. Please use the fill tool multiple times instead or make use of the proofreading tool when correcting large structures. [#7173](https://github.com/scalableminds/webknossos/pull/7173)

--- a/docs/proof_reading.md
+++ b/docs/proof_reading.md
@@ -4,7 +4,7 @@ WEBKNOSSOS offers several ways for proofreading large-scale, volumetric segmenta
 
 There are three proofreading workflows supported by WEBKNOSSOS:
 
-1. The Proofreading tool to correct large segmentation based on an underlying super-voxel graph
+1. The Proofreading tool to correct large segmentations based on an underlying super-voxel graph
 2. The Merger-Mode tool
 3. Skeleton annotations together with custom scripting
 
@@ -12,29 +12,29 @@ There are three proofreading workflows supported by WEBKNOSSOS:
 
 The proofreading tool enables users to fix merge and split errors in a segmentation generated from an automated workflow (outside of WEBKNOSSOS), e.g. from a machine learning system such as [Voxelytics](https://voxelytics.com). Split and merge operations are directly executed on the underlying [super-voxel graph structure](./terminology.md#agglomerates) of a segmentation.
 
-To use the proofreading tool you need to enable an [ID mapping for your segmentation](./volume_annotation.md#mappings--on-demand-agglomeration) to load the super-voxel graph. Once, WEBKNOSSOS detects this the proofreading tool becomes available on the toolbar (clipboard icon):
+To use the proofreading tool you need to enable an [ID mapping for your segmentation](./volume_annotation.md#mappings--on-demand-agglomeration) to load the super-voxel graph. Once, WEBKNOSSOS detects this the proofreading tool can be activated on the toolbar (clipboard icon):
 
 1. Select an ID mapping for a segmentation layer from the left-hand side panel
 2. From the toolbar, switch to the proofreading tool (clipboard icon)
-3. Left-click on any segment to load and display its super-voxel graph
+3. [Optional] Shift + middle-click on any segment to load and display its super-voxel graph
 4. Proceed to fix split and merge errors:
 
 To fix a split error:
 
-1. Left-click to select any node of the source segment's graph
+1. Left-click on any part of the source segment. It will be marked with a white crosshair
 2. Right-click on the target segment to bring up the context menu. Select `Merge With Active Segment`
-3. WEBKNOSSOS will merge both segments and reload the updated super-voxel graph and 3D meshes
+3. WEBKNOSSOS will merge both segments and reload the updated segmentation and 3D meshes
 
 To fix a merge error:
 
-1. Left-click to select any node of the source segment's graph
-2. Right-click on the target segment to bring up the context menu. Select `Split from active segment (Min-Cut)`
-3. WEBKNOSSOS will perform a min-cut operation to delete all super-voxel graph edges between the source and target segments, effectively splitting the two into individual segments.
-4. WEBKNOSSOS will merge both segments and reload the updated super-voxel graph and 3D meshes
+1. Left-click on any part of the source segment. It will be marked with a white crosshair
+2. Right-click on the part of the source segment that you would like to split off to bring up the context menu. Select `Split from active segment (Min-Cut)`
+3. WEBKNOSSOS will perform a min-cut operation to delete all super-voxel graph edges between the source and target segments, effectively splitting the two into individual segments
+4. WEBKNOSSOS will split both segments and reload the updated segmentation and 3D meshes
 
 Note, the proofreading operations rely directly on the information and quality of an initial over-segmentation. If cells/segments are already erroneously connected in this state, then WEBKNOSSOS cannot split them apart (this might change in the future, though).
 
-If case you want to reload, hide or remove a 3D mesh during proofreading, you can use the context menu in the 3D viewport by hovering the mesh.
+If case you want to reload, hide or remove a 3D mesh during proofreading, you can use the context menu in the 3D viewport by hovering the mesh. You can enable and disable the automatic mesh loading by toggling the respective button in the toolbar, right of the proofreading tool button.
 
 In addition to the handy shortcuts available from the right-click context menu, users can also directly modify the super-voxel graph like any other skeleton to manually add/remove nodes and edges for fine-grained control.
 

--- a/frontend/javascripts/oxalis/controller/combinations/tool_controls.ts
+++ b/frontend/javascripts/oxalis/controller/combinations/tool_controls.ts
@@ -134,6 +134,11 @@ export class MoveTool {
 
         handleClickSegment(pos);
       },
+      middleClick: (pos: Point2, _plane: OrthoView, event: MouseEvent) => {
+        if (event.shiftKey) {
+          handleAgglomerateSkeletonAtClick(pos);
+        }
+      },
       pinch: (delta: number) => MoveHandlers.zoom(delta, true),
       mouseMove: MoveHandlers.moveWhenAltIsPressed,
       out: () => {
@@ -297,11 +302,6 @@ export class SkeletonTool {
           event,
           showNodeContextMenuAt,
         );
-      },
-      middleClick: (pos: Point2, _plane: OrthoView, event: MouseEvent) => {
-        if (event.shiftKey) {
-          handleAgglomerateSkeletonAtClick(pos);
-        }
       },
     };
   }


### PR DESCRIPTION
Also, I enabled Shift + middle-click to load agglomerate skeletons in all tools, not just the skeleton tool as that is how it is documented and shown in the context menu.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Follow the instructions in the docs to check that they reflect the current state of the proofreading tool
- Open an annotation on a dataset with an agglomerate mapping.
- Activate an agglomerate mapping.
- Use Shift + middle-click in any tool to load agglomerate skeletons

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [documentation](../blob/master/docs) if applicable
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
