### PR TITLE
Make pixel diffing in screenshot a bit more tolerant

### DIFF
--- a/frontend/javascripts/test/puppeteer/screenshot_helpers.ts
+++ b/frontend/javascripts/test/puppeteer/screenshot_helpers.ts
@@ -74,7 +74,10 @@ export async function compareScreenshot(
     existingScreenshot.width,
     existingScreenshot.height,
     {
-      threshold: 0.0,
+      // The default of the pixelmatch library is 0.1.
+      // 0.01 was chosen since it was the smallest threshold
+      // that could solve some flakiness.
+      threshold: 0.01,
     },
   );
 


### PR DESCRIPTION
### Steps to test:
- since the test is flaky, i'd say let's merge it and check the nightly in the next days. I ran the threshold on the screenshots manually to make sure that the threshold is okay.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1689746369137609
