### PR TITLE
make antd messages click-through

### DIFF
--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -667,3 +667,7 @@ i.without-icon-margin,
     }
   }
 }
+
+.ant-message, .ant-message * {
+  pointer-events: none;
+}


### PR DESCRIPTION
Makes antd messages click-through. (A user noted that they block selecting tools during annotating, which can be annoying).

Do you think there are cases where the user wants to interact with antd messages (e.g. copy the text)? Nothing comes to my mind.

### URL of deployed dev instance (used for testing):
- https://messagesclickthrough.webknossos.xyz

### Steps to test:
- Brush some in a volume annotation, hit undo, try to switch tool behind the “finished undo” message
- Should be able to click right through the message, selecting tools.

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
