### PR TITLE
Prevent segmentation id from overflowing

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Small messages during annotating (e.g. “finished undo”, “applying mapping…”) are now click-through so they do not block users from selecting tools. [7239](https://github.com/scalableminds/webknossos/pull/7239)
 
 ### Fixed
+- Fixed that is was possible to have larger active segment ids that supported by the data type of the segmentation layer which caused the segmentation ids to overflow. [#7240](https://github.com/scalableminds/webknossos/pull/7240)
 
 ### Removed
 

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
@@ -532,6 +532,17 @@ function SimpleLayerForm({
                     {
                       warningOnly: true,
                       validator: (_rule, value) =>
+                        value != null && value === 2 ** bitDepth - 1
+                          ? Promise.reject(
+                              new Error(
+                                `The largest segmentation ID has already reached the maximum possible value of 2^${bitDepth}-1. Annotations of this dataset cannot create new segments.`,
+                              ),
+                            )
+                          : Promise.resolve(),
+                    },
+                    {
+                      warningOnly: true,
+                      validator: (_rule, value) =>
                         value == null || value === ""
                           ? Promise.reject(
                               new Error(

--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -173,6 +173,9 @@ instead. Only enable this option if you understand its effect. All layers will n
     </span>
   ),
   "tracing.copy_cell_id": "Hit CTRL + I to copy the currently hovered segment id",
+  "tracing.segment_id_out_of_bounds": _.template(
+    "Cannot create a segment id larger than the segment layers maximum value of <%- maxSegmentId %>.",
+  ),
   "tracing.copy_maybe_mapped_cell_id":
     "Hit CTRL + I to copy the currently hovered segment id. Press CTRL + ALT + I if you want to copy the mapped id.",
   "tracing.no_more_branchpoints": "No more branchpoints",

--- a/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.tsx
+++ b/frontend/javascripts/oxalis/controller/viewmodes/plane_controller.tsx
@@ -152,16 +152,18 @@ class VolumeKeybindings {
   static getKeyboardControls() {
     return {
       c: () => {
-        const volumeLayer = getActiveSegmentationTracing(Store.getState());
+        const volumeTracing = getActiveSegmentationTracing(Store.getState());
 
-        if (volumeLayer == null || volumeLayer.tracingId == null) {
+        if (volumeTracing == null || volumeTracing.tracingId == null) {
           return;
         }
 
-        if (volumeLayer.largestSegmentId != null) {
-          Store.dispatch(createCellAction(volumeLayer.largestSegmentId));
+        if (volumeTracing.largestSegmentId != null) {
+          Store.dispatch(
+            createCellAction(volumeTracing.activeCellId, volumeTracing.largestSegmentId),
+          );
         } else {
-          showToastWarningForLargestSegmentIdMissing(volumeLayer);
+          showToastWarningForLargestSegmentIdMissing(volumeTracing);
         }
       },
       v: () => {

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -341,6 +341,11 @@ export function determineAllowedModes(settings?: Settings): {
     allowedModes,
   };
 }
+
+export function getMaximumSegmentIdForLayer(dataset: APIDataset, layerName: string) {
+  return getDefaultIntensityRangeOfLayer(dataset, layerName)[1];
+}
+
 export function getBitDepth(layerInfo: DataLayer | DataLayerType): number {
   switch (layerInfo.elementClass) {
     case "uint8":

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -343,7 +343,8 @@ export function determineAllowedModes(settings?: Settings): {
 }
 
 export function getMaximumSegmentIdForLayer(dataset: APIDataset, layerName: string) {
-  return getDefaultIntensityRangeOfLayer(dataset, layerName)[1];
+  const valueRange = getDefaultIntensityRangeOfLayer(dataset, layerName);
+  return valueRange[1];
 }
 
 export function getBitDepth(layerInfo: DataLayer | DataLayerType): number {

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -193,7 +193,7 @@ export function getByteCount(dataset: APIDataset, layerName: string): number {
 export function getElementClass(dataset: APIDataset, layerName: string): ElementClass {
   return getLayerByName(dataset, layerName).elementClass;
 }
-export function getDefaultIntensityRangeOfLayer(
+export function getDefaultValueRangeOfLayer(
   dataset: APIDataset,
   layerName: string,
 ): [number, number] {
@@ -343,8 +343,7 @@ export function determineAllowedModes(settings?: Settings): {
 }
 
 export function getMaximumSegmentIdForLayer(dataset: APIDataset, layerName: string) {
-  const valueRange = getDefaultIntensityRangeOfLayer(dataset, layerName);
-  return valueRange[1];
+  return getDefaultValueRangeOfLayer(dataset, layerName)[1];
 }
 
 export function getBitDepth(layerInfo: DataLayer | DataLayerType): number {

--- a/frontend/javascripts/oxalis/model/actions/volumetracing_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/volumetracing_actions.ts
@@ -10,7 +10,7 @@ import { batchActions } from "redux-batched-actions";
 
 export type InitializeVolumeTracingAction = ReturnType<typeof initializeVolumeTracingAction>;
 export type InitializeEditableMappingAction = ReturnType<typeof initializeEditableMappingAction>;
-type CreateCellAction = ReturnType<typeof createCellAction>;
+export type CreateCellAction = ReturnType<typeof createCellAction>;
 type StartEditingAction = ReturnType<typeof startEditingAction>;
 type AddToLayerAction = ReturnType<typeof addToLayerAction>;
 type FloodFillAction = ReturnType<typeof floodFillAction>;
@@ -126,11 +126,16 @@ export const initializeEditableMappingAction = (mapping: ServerEditableMapping) 
  * has dealt with the case where the maximum segment id is not set. In that case,
  * the create cell action should not be exposed via the UI.
  */
-export const createCellAction = (largestSegmentId: number) =>
-  ({
+export const createCellAction = (activeCellId: number, largestSegmentId: number) => {
+  // The largestSegmentId is only updated if a voxel using that id was annotated. Therefore, it can happen
+  // that the activeCellId is larger than the largestSegmentId. Choose the larger of the two ids increased by one.
+  const newSegmentId =
+    largestSegmentId && largestSegmentId > activeCellId ? largestSegmentId + 1 : activeCellId + 1;
+  return {
     type: "CREATE_CELL",
-    largestSegmentId,
-  } as const);
+    newSegmentId,
+  } as const;
+};
 
 export const startEditingAction = (position: Vector3, planeId: OrthoView) =>
   ({

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/abstract_cuckoo_table.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/abstract_cuckoo_table.ts
@@ -5,7 +5,7 @@ import { createUpdatableTexture } from "oxalis/geometries/materials/plane_materi
 
 const TEXTURE_CHANNEL_COUNT = 4;
 const DEFAULT_LOAD_FACTOR = 0.25;
-export const EMPTY_KEY_VALUE = 0;
+export const EMPTY_KEY_VALUE = 2 ** 32 - 1;
 
 export type SeedSubscriberFn = (seeds: number[]) => void;
 

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/abstract_cuckoo_table.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/abstract_cuckoo_table.ts
@@ -5,7 +5,7 @@ import { createUpdatableTexture } from "oxalis/geometries/materials/plane_materi
 
 const TEXTURE_CHANNEL_COUNT = 4;
 const DEFAULT_LOAD_FACTOR = 0.25;
-export const EMPTY_KEY_VALUE = 2 ** 32 - 1;
+export const EMPTY_KEY_VALUE = 0;
 
 export type SeedSubscriberFn = (seeds: number[]) => void;
 

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -244,7 +244,7 @@ function VolumeTracingReducer(
       if (volumeTracing.largestSegmentId != null && volumeTracing.activeCellId === 0) {
         // If a largest segment id is known, but the active cell is 0, we can automatically
         // create a new segment ID for the user.
-        return createCellReducer(newState, volumeTracing, volumeTracing.largestSegmentId);
+        return createCellReducer(newState, volumeTracing, volumeTracing.largestSegmentId + 1);
       }
 
       return newState;
@@ -308,7 +308,7 @@ function VolumeTracingReducer(
     }
 
     case "CREATE_CELL": {
-      return createCellReducer(state, volumeTracing, action.largestSegmentId);
+      return createCellReducer(state, volumeTracing, action.newSegmentId);
     }
 
     case "UPDATE_DIRECTION": {

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.ts
@@ -63,14 +63,9 @@ export function setActiveCellReducer(state: OxalisState, volumeTracing: VolumeTr
 export function createCellReducer(
   state: OxalisState,
   volumeTracing: VolumeTracing,
-  largestSegmentId: number,
+  newSegmentId: number,
 ) {
-  // The largestSegmentId is only updated if a voxel using that id was annotated. Therefore, it can happen
-  // that the activeCellId is larger than the largestSegmentId. Choose the larger of the two ids and increase it by one.
-  const { activeCellId } = volumeTracing;
-
-  const newId = Math.max(activeCellId, largestSegmentId) + 1;
-  return setActiveCellReducer(state, volumeTracing, newId);
+  return setActiveCellReducer(state, volumeTracing, newSegmentId);
 }
 
 const MAXIMUM_LABEL_ACTIONS_COUNT = 50;

--- a/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/toolbar_view.tsx
@@ -151,16 +151,16 @@ const handleSetTool = (event: RadioChangeEvent) => {
 };
 
 const handleCreateCell = () => {
-  const volumeLayer = getActiveSegmentationTracing(Store.getState());
+  const volumeTracing = getActiveSegmentationTracing(Store.getState());
 
-  if (volumeLayer == null || volumeLayer.tracingId == null) {
+  if (volumeTracing == null || volumeTracing.tracingId == null) {
     return;
   }
 
-  if (volumeLayer.largestSegmentId != null) {
-    Store.dispatch(createCellAction(volumeLayer.largestSegmentId));
+  if (volumeTracing.largestSegmentId != null) {
+    Store.dispatch(createCellAction(volumeTracing.activeCellId, volumeTracing.largestSegmentId));
   } else {
-    showToastWarningForLargestSegmentIdMissing(volumeLayer);
+    showToastWarningForLargestSegmentIdMissing(volumeTracing);
   }
 };
 

--- a/frontend/javascripts/oxalis/view/largest_segment_id_modal.tsx
+++ b/frontend/javascripts/oxalis/view/largest_segment_id_modal.tsx
@@ -11,7 +11,10 @@ import Store from "oxalis/throttled_store";
 import { OxalisState, VolumeTracing } from "oxalis/store";
 import { mayUserEditDataset } from "libs/utils";
 import { getBitDepth } from "oxalis/model/accessors/dataset_accessor";
-import { getSegmentationLayerForTracing } from "oxalis/model/accessors/volumetracing_accessor";
+import {
+  getSegmentationLayerForTracing,
+  getVolumeTracingByLayerName,
+} from "oxalis/model/accessors/volumetracing_accessor";
 import { APISegmentationLayer } from "types/api_flow_types";
 
 const TOAST_KEY = "enter-largest-segment-id";
@@ -50,6 +53,11 @@ export default function EnterLargestSegmentIdModal({
   const [largestSegmentId, setLargestSegmentId] = React.useState<number | null>(0);
   const activeUser = useSelector((state: OxalisState) => state.activeUser);
   const dataset = useSelector((state: OxalisState) => state.dataset);
+  const activeCellId =
+    useSelector(
+      (state: OxalisState) =>
+        getVolumeTracingByLayerName(state.tracing, segmentationLayer.name)?.activeCellId,
+    ) || 0;
 
   const dispatch = useDispatch();
   const handleOk = () => {
@@ -58,7 +66,7 @@ export default function EnterLargestSegmentIdModal({
       return;
     }
     dispatch(setLargestSegmentIdAction(largestSegmentId));
-    dispatch(createCellAction(largestSegmentId));
+    dispatch(createCellAction(activeCellId, largestSegmentId));
     Toast.close(TOAST_KEY);
     destroy();
   };

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -50,7 +50,7 @@ import {
   deleteAnnotationLayer,
 } from "admin/admin_rest_api";
 import {
-  getDefaultIntensityRangeOfLayer,
+  getDefaultValueRangeOfLayer,
   getElementClass,
   isColorLayer as getIsColorLayer,
   getLayerByName,
@@ -356,7 +356,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
 
   getHistogram = (layerName: string, layer: DatasetLayerConfiguration) => {
     const { intensityRange, min, max, isInEditMode } = layer;
-    const defaultIntensityRange = getDefaultIntensityRangeOfLayer(this.props.dataset, layerName);
+    const defaultIntensityRange = getDefaultValueRangeOfLayer(this.props.dataset, layerName);
     const histograms = this.props.histogramData?.[layerName];
 
     return (

--- a/frontend/javascripts/types/schemas/dataset_view_configuration_defaults.ts
+++ b/frontend/javascripts/types/schemas/dataset_view_configuration_defaults.ts
@@ -4,7 +4,7 @@ import {
   defaultDatasetViewConfiguration,
 } from "types/schemas/dataset_view_configuration.schema";
 import type { APIDataset, APIMaybeUnimportedDataset, APIDataLayer } from "types/api_flow_types";
-import { getDefaultIntensityRangeOfLayer } from "oxalis/model/accessors/dataset_accessor";
+import { getDefaultValueRangeOfLayer } from "oxalis/model/accessors/dataset_accessor";
 import { validateObjectWithType } from "types/validation";
 
 const eliminateErrors = (
@@ -31,7 +31,7 @@ const eliminateErrors = (
 };
 
 export const getSpecificDefaultsForLayers = (dataset: APIDataset, layer: APIDataLayer) => ({
-  intensityRange: getDefaultIntensityRangeOfLayer(dataset, layer.name),
+  intensityRange: getDefaultValueRangeOfLayer(dataset, layer.name),
   alpha: layer.category === "color" ? 100 : 20,
 });
 


### PR DESCRIPTION
This PR prevents the segmentId to overflow and informs the user that overflowing the maximum possible segment id is not allowed.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Go to the dataset configurations of a dataset with a segmentation layer
- Set the largestSegmentId setting of that segmentation layer to `2 ** <bit_depth> - 1`. This should show a warning that the maximum possible segmentId has been reached and thus annotations cannot create new segments. Save this change.
- Create an annotation of that dataset. The segmentation id should equal `2 ** <bit_depth> - 1`.
- Try to increase the segmentId by creating a new cell using e.g. the shortcut `c`. This should not update the segment id and show a warning toast, that the largest possible segment id must not be exceeded.
- Try to set the segmenId to something larger than `2 ** <bit_depth> - 1` by e.g. setting it manually in the footer bar. This should also show the toast and ignore the update.

### TODOs:
 ~~- [ ] Check whether it is ok to set the the `EMPYT_KEY_VALUE` of the cuckoo table to `0`? Maybe only do this for the segmentation cuckoo table.~~
  - We decided to simply accept this edge case for now where the `segmentId === EMPYT_KEY_VALUE`.

### Issues:
- fixes [#6777](https://github.com/scalableminds/webknossos/issues/6777)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
