### PR TITLE
Fix disappearing edit description icon in firefox

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed that folders could appear in the dataset search output in the dashboard. [#7232](https://github.com/scalableminds/webknossos/pull/7232)
+- Fixed that the edit icon for an annotation description could disappear in Firefox. [#7250](https://github.com/scalableminds/webknossos/pull/7250)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
@@ -467,26 +467,28 @@ export class DatasetInfoTabView extends React.PureComponent<Props, State> {
       return (
         <div className="info-tab-block">
           <p className="sidebar-label">Description</p>
-          <Typography.Text style={{ position: "relative" }}>
-            {description}
-            <Tooltip title="Edit">
-              <div
-                role="button"
-                className="ant-typography-edit"
-                style={{
-                  display: "inline-block",
-                  ...buttonStylesForMarkdownRendering,
-                }}
-                onClick={() =>
-                  this.setState({
-                    isMarkdownModalOpen: true,
-                  })
-                }
-              >
-                <EditOutlined />
-              </div>
-            </Tooltip>
-          </Typography.Text>
+          <div style={{ position: "relative" }}>
+            <Typography.Text>
+              {description}
+              <Tooltip title="Edit">
+                <div
+                  role="button"
+                  className="ant-typography-edit"
+                  style={{
+                    display: "inline-block",
+                    ...buttonStylesForMarkdownRendering,
+                  }}
+                  onClick={() =>
+                    this.setState({
+                      isMarkdownModalOpen: true,
+                    })
+                  }
+                >
+                  <EditOutlined />
+                </div>
+              </Tooltip>
+            </Typography.Text>
+          </div>
           <MarkdownModal
             label="Annotation Description"
             source={annotationDescription}


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- edit description in an annotation

### Issues:
- fixes #7248

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
