### PR TITLE
Move swagger route

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -2,5 +2,5 @@
 -> /data/                        com.scalableminds.webknossos.datastore.Routes
 -> /tracings/                    com.scalableminds.webknossos.tracingstore.Routes
 
-GET   /.well-known/swagger.json              controllers.ApiHelpController.getResources
+GET   /.well-known/swagger.json  controllers.ApiHelpController.getResources
 GET   /.well-known/security.txt  controllers.Application.getSecurityTxt


### PR DESCRIPTION
https://webknossos.org/swagger.json doesn't seem to work anymore (404). Moving it should resolve that issue. I also updated the wklibs in https://github.com/scalableminds/webknossos-libs/pull/938