### PR TITLE
Add client_secret to oidc requests

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added a new button to the layer settings in view only dataset mode to save the current view configuration as the dataset's default. [#7205](https://github.com/scalableminds/webknossos/pull/7205)
 - Added option to select multiple segments in the segment list in order to perform batch actions. [#7242](https://github.com/scalableminds/webknossos/pull/7242)
 - If a dataset layer is transformed (using an affine matrix or a thin plate spline), it can be dynamically shown without that transform via the layers sidebar. All other layers will be transformed accordingly. [#7246](https://github.com/scalableminds/webknossos/pull/7246)
+- OpenID Connect authorization can now use a client secret for added security. [#7263](https://github.com/scalableminds/webknossos/pull/7263)
 
 ### Changed
 - Small messages during annotating (e.g. “finished undo”, “applying mapping…”) are now click-through so they do not block users from selecting tools. [7239](https://github.com/scalableminds/webknossos/pull/7239)

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -103,6 +103,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
     object OpenIdConnect {
       val providerUrl: String = get[String]("singleSignOn.openIdConnect.providerUrl")
       val clientId: String = get[String]("singleSignOn.openIdConnect.clientId")
+      val clientSecret: String = get[String]("singleSignOn.openIdConnect.clientSecret")
       val publicKey: String = get[String]("singleSignOn.openIdConnect.publicKey")
       val publicKeyAlgorithm: String = get[String]("singleSignOn.openIdConnect.publicKeyAlgorithm")
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -118,6 +118,7 @@ singleSignOn {
   openIdConnect {
       providerUrl = "http://localhost:8080/auth/realms/master/"
       clientId = "myclient"
+      clientSecret = "myClientSecret"
       # Public Key to validate claim, for keycloak see Realm settings > keys
       publicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAscUZB3Y5fiOfIdLC/31N1GufZ26bmB21V8D9Crg2bAHPD3g8qofRMg5Uo1+WuKuT5CJrCu+x0hIbA50GYb6E1V78MkYOaCbCT+xE+ec+Jv6zUJAaNJugx71oXI+X5e9kW/O8JSwIicSUYDz7LKvCklwn9/QmgetqGsBrAEOG+4WlwPnrZiKRaQl9V0vBOcwzD946Cbrgg3iLnryJ0pGVKHvWePsXR7Pt8hdA0FeA9V9hVd6gVHR2pHqg46kyPItNMwWTXENqJ4lbhgaoZ9sZpoMXIy1kjh3GXSXGOG+GeOOtOinr1K24I8HG9wsnEefjVSPDB6EvflPrhLKXMfI/JQIDAQAB"
       publicKeyAlgorithm = "RSA"

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
@@ -36,6 +36,14 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient)(implicit ec: 
     this
   }
 
+  def withBasicAuthOpt(usernameOpt: Option[String], passwordOpt: Option[String]): RPCRequest = {
+    (usernameOpt, passwordOpt) match {
+      case (Some(username), Some(password)) => request = request.withAuth(username, password, WSAuthScheme.BASIC)
+      case _                                => ()
+    }
+    this
+  }
+
   def withLongTimeout: RPCRequest = {
     request = request.withRequestTimeout(2 hours)
     this


### PR DESCRIPTION

### Steps to test:
- Set up keycloak via docker-compose as described in https://github.com/scalableminds/webknossos/pull/6534#issuecomment-1285177420 (Note that the admin user in keycloak needs first name, last name, email, which was missing by default when I tried this)
- Adapt the client config in the keycloak UI to use Client authentication. A new tab “credentials” appears. Copy the client secret and add it in the application.conf
- Also double-check the other values, especially publicKey, take that from Realm Settings → Keys in the keycloak UI
- Also set features.openIdConnectEnabled = true in application.conf
- Sign up/log in in webknossos using the OIDC button
- Should work if client secret is correct, not work otherwise
- Should also work if client secret is disabled in keycloak (set to emptystring in application.conf)

### Issues:
- fixes #7260

---
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
