### PR TITLE
Always use olvy to show user what's new

### DIFF
--- a/frontend/javascripts/libs/window.ts
+++ b/frontend/javascripts/libs/window.ts
@@ -51,13 +51,20 @@ const dummyLocation = {
   /* noop */
   toString: () => "",
   /* noop */
-};
-// @ts-expect-error ts-migrate(2322) FIXME: Type 'Location | { ancestorOrigins: never[]; hash:... Remove this comment to see the full error message
+} as any as Window["location"];
 export const location: Location = typeof window === "undefined" ? dummyLocation : window.location;
 
 let performanceCounterForMocking = 0;
 
-const _window =
+type Olvy =
+  | {
+      init: (obj: Object) => void;
+      getUnreadReleasesCount: (timestamp: string) => number;
+      show: () => void;
+    }
+  | undefined;
+
+const _window: Window & typeof globalThis & { Olvy?: Olvy } =
   typeof window === "undefined"
     ? ({
         alert: console.log.bind(console),
@@ -72,6 +79,7 @@ const _window =
         },
         pageXOffset: 0,
         pageYOffset: 0,
+        Olvy: undefined,
         addEventListener,
         removeEventListener,
         open: (_url: string) => {},

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -77,10 +77,6 @@ function useOlvy() {
   const [isInitialized, setIsInitialized] = useState(false);
   // Initialize Olvy after mounting
   useEffect(() => {
-    if (!features().isWkorgInstance) {
-      return;
-    }
-
     const OlvyConfig = {
       organisation: "webknossos",
       // This target needs to be defined (otherwise, Olvy crashes when using .show()). However,
@@ -99,9 +95,7 @@ function useOlvy() {
       },
     };
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'Olvy' does not exist on type '(Window & ... Remove this comment to see the full error message
     if (window.Olvy != null) {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'Olvy' does not exist on type '(Window & ... Remove this comment to see the full error message
       window.Olvy.init(OlvyConfig);
       setIsInitialized(true);
     }
@@ -117,12 +111,10 @@ function useOlvyUnreadReleasesCount(activeUser: APIUser) {
   const isInitialized = useOlvy();
   const unreadCount = useFetch(
     async () => {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'Olvy' does not exist on type '(Window & ... Remove this comment to see the full error message
-      if (!isInitialized || !features().isWkorgInstance || !window.Olvy) {
+      if (!isInitialized || !window.Olvy) {
         return null;
       }
 
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'Olvy' does not exist on type '(Window & ... Remove this comment to see the full error message
       return window.Olvy.getUnreadReleasesCount(
         new Date(lastViewedTimestampWithFallback).toISOString(),
       );
@@ -442,9 +434,7 @@ function NotificationIcon({ activeUser }: { activeUser: APIUser }) {
     Store.dispatch(setActiveUserAction(newUserSync));
     sendAnalyticsEvent("open_whats_new_view");
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'Olvy' does not exist on type '(Window & ... Remove this comment to see the full error message
     if (window.Olvy) {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'Olvy' does not exist on type '(Window & ... Remove this comment to see the full error message
       window.Olvy.show();
     }
   };


### PR DESCRIPTION
Also, clean up typing a bit.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open dev instance (wkorg is false there)
- click what's new button -> should open modal

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1690893029875599
