### PR TITLE
Fix rendering when switching visibility between multiple volume layers

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that folders could appear in the dataset search output in the dashboard. [#7232](https://github.com/scalableminds/webknossos/pull/7232)
 - Fixed that the edit icon for an annotation description could disappear in Firefox. [#7250](https://github.com/scalableminds/webknossos/pull/7250)
 - Fixed that assigning an invalid script name (e.g. with special characters) would trigger an error in the database. Now leads to a more descriptive error. [#7525](https://github.com/scalableminds/webknossos/pull/7525)
+- Fixed rendering error when multiple segmentation layers exist and the user switched between these. [#7291](https://github.com/scalableminds/webknossos/pull/7291)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.ts
+++ b/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.ts
@@ -922,7 +922,7 @@ class PlaneMaterialFactory {
     // The third parameter returns the number of globally available layers (this is not always equal
     // to the sum of the lengths of the first two arrays, as not all layers might be rendered.)
     const state = Store.getState();
-    const sanitizedOrderedColorLayerNames =
+    const allSanitizedOrderedColorLayerNames =
       state.datasetConfiguration.colorLayerOrder.map(sanitizeName);
     const colorLayerNames = getSanitizedColorLayerNames();
     const segmentationLayerNames = Model.getSegmentationLayers().map((layer) =>
@@ -938,7 +938,7 @@ class PlaneMaterialFactory {
       return [
         colorLayerNames,
         segmentationLayerNames,
-        sanitizedOrderedColorLayerNames,
+        allSanitizedOrderedColorLayerNames,
         globalLayerCount,
       ];
     }
@@ -971,11 +971,12 @@ class PlaneMaterialFactory {
       names,
       ({ isSegmentationLayer }) => !isSegmentationLayer,
     ).map((layers) => layers.map(({ name }) => sanitizeName(name)));
+    const colorNameSet = new Set(sanitizedColorLayerNames);
 
     return [
       sanitizedColorLayerNames,
       sanitizedSegmentationLayerNames,
-      sanitizedOrderedColorLayerNames,
+      allSanitizedOrderedColorLayerNames.filter((name) => colorNameSet.has(name)),
       globalLayerCount,
     ];
   }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create an annotation for a dataset that has a volume layer
- add another volume layer
- switch visibility between these two volume layers
- ensure that the rendering works

### Issues:
- follow-up to #7100
- also see https://scm.slack.com/archives/C5AKLAV0B/p1692284081691689

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
