### PR TITLE
Fix default filter in users table

### DIFF
--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -83,7 +83,7 @@ class UserListView extends React.PureComponent<Props, State> {
     isExperienceModalOpen: false,
     isTeamRoleModalOpen: false,
     isInviteModalOpen: false,
-    activationFilter: ["activated", "verified", "unverified"],
+    activationFilter: ["activated"],
     searchQuery: "",
     singleSelectedUser: null,
     domainToEdit: null,


### PR DESCRIPTION
... so that only activated users are shown by default

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- deactivate a user
- open users tab (don't use page refresh but instead open the url in a new tab, since the history state is used to remember the active filter)
- ensure that only enabled users are shown (use the filter UI in the column to verify that too)

### Issues:
- fixes regression caused by #7231 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
