### PR TITLE
Fix reading sharded zarr3 from local file system

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed that the deletion of a selected segment would crash the segments tab. [#7316](https://github.com/scalableminds/webknossos/pull/7316)
+- Fixed reading sharded Zarr 3 data from the local file system. [#7321](https://github.com/scalableminds/webknossos/pull/7321)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemDataVault.scala
@@ -6,30 +6,41 @@ import net.liftweb.util.Helpers.tryo
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
-import scala.collection.immutable.NumericRange
 import scala.concurrent.ExecutionContext
 
 class FileSystemDataVault extends DataVault {
   override def readBytesAndEncoding(path: VaultPath, range: RangeSpecifier)(
       implicit ec: ExecutionContext): Fox[(Array[Byte], Encoding.Value)] = ???
 
-  def readBytesLocal(path: Path, range: Option[NumericRange[Long]])(implicit ec: ExecutionContext): Fox[Array[Byte]] =
+  def readBytesLocal(path: Path, range: RangeSpecifier)(implicit ec: ExecutionContext): Fox[Array[Byte]] =
     if (Files.exists(path)) {
       range match {
-        case None => tryo(Files.readAllBytes(path)).toFox
-        case Some(r) =>
+        case Complete() => tryo(Files.readAllBytes(path)).toFox
+        case StartEnd(r) =>
           tryo {
             val channel = Files.newByteChannel(path)
             val buf = ByteBuffer.allocateDirect(r.length)
             channel.position(r.start)
             channel.read(buf)
-            buf.position(0)
+            buf.rewind()
             val arr = new Array[Byte](r.length)
+            buf.get(arr)
+            arr
+          }.toFox
+        case SuffixLength(length) =>
+          tryo {
+            val channel = Files.newByteChannel(path)
+            val buf = ByteBuffer.allocateDirect(length)
+            channel.position(channel.size() - length)
+            channel.read(buf)
+            buf.rewind()
+            val arr = new Array[Byte](length)
             buf.get(arr)
             arr
           }.toFox
       }
     } else Fox.empty
+
 }
 
 object FileSystemDataVault {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemVaultPath.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemVaultPath.scala
@@ -11,7 +11,10 @@ class FileSystemVaultPath(basePath: Path, dataVault: FileSystemDataVault)
     extends VaultPath(uri = new URI(""), dataVault = dataVault) {
 
   override def readBytes(range: Option[NumericRange[Long]] = None)(implicit ec: ExecutionContext): Fox[Array[Byte]] =
-    dataVault.readBytesLocal(basePath, range)
+    dataVault.readBytesLocal(basePath, RangeSpecifier.fromRangeOpt(range))
+
+  override def readLastBytes(byteCount: Int)(implicit ec: ExecutionContext): Fox[Array[Byte]] =
+    dataVault.readBytesLocal(basePath, SuffixLength(byteCount))
 
   override def basename: String = basePath.getFileName.toString
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/RangeSpecifier.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/RangeSpecifier.scala
@@ -5,7 +5,7 @@ import scala.collection.immutable.NumericRange
 trait RangeSpecifier
 
 case class StartEnd(range: NumericRange[Long]) extends RangeSpecifier
-case class SuffixLength(length: Long) extends RangeSpecifier
+case class SuffixLength(length: Int) extends RangeSpecifier
 case class Complete() extends RangeSpecifier
 
 object RangeSpecifier {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/VaultPath.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/VaultPath.scala
@@ -21,7 +21,7 @@ class VaultPath(uri: URI, dataVault: DataVault) extends LazyLogging {
       decoded <- decode(bytesAndEncoding) ?~> s"Failed to decode ${bytesAndEncoding._2}-encoded response."
     } yield decoded
 
-  def readLastBytes(byteCount: Long)(implicit ec: ExecutionContext): Fox[Array[Byte]] =
+  def readLastBytes(byteCount: Int)(implicit ec: ExecutionContext): Fox[Array[Byte]] =
     for {
       bytesAndEncoding <- dataVault.readBytesAndEncoding(this, SuffixLength(byteCount)) ?=> "Failed to read from vault path"
       decoded <- decode(bytesAndEncoding) ?~> s"Failed to decode ${bytesAndEncoding._2}-encoded response."


### PR DESCRIPTION
The FileSystemVaultPath did not yet override `readLastBytes`, which is needed when reading zarr3 sharded datasets. Thus, the implementation of the parent class was used, which forwarded to `readBytesAndEncoding`, but that does not exist in the FileSystemDataVault.

Instead, now I implemented this in `FileSystemVaultPath` and adapted `readBytesLocal` to also support SuffixLength byte ranges.

### Steps to test:
- Open a locally stored zarr3 sharded dataset, should see data

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
