### PR TITLE
Fix Volume Annotation Download (data.zip contained only headers)

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed that the deletion of a selected segment would crash the segments tab. [#7316](https://github.com/scalableminds/webknossos/pull/7316)
 - Fixed reading sharded Zarr 3 data from the local file system. [#7321](https://github.com/scalableminds/webknossos/pull/7321)
+- Fixed no-bucket data zipfile when downloading volume annotations. [#7323](https://github.com/scalableminds/webknossos/pull/7323)
 
 ### Removed
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -89,8 +89,8 @@ trait BucketKeys extends WKWMortonHelper with WKWDataFormatHelper with LazyLoggi
   protected def parseBucketKey(key: String,
                                additionalAxes: Option[Seq[AdditionalAxis]]): Option[(String, BucketPosition)] =
     additionalAxes match {
-      case Some(value) => parseBucketKeyWithAdditionalAxes(key, value)
-      case None        => parseBucketKeyXYZ(key)
+      case Some(value) if value.nonEmpty => parseBucketKeyWithAdditionalAxes(key, value)
+      case _                             => parseBucketKeyXYZ(key)
     }
 
   private def parseBucketKeyXYZ(key: String) = {


### PR DESCRIPTION
The perils of Option[Seq[stuff]] – Some(Empty) can happen and must be handled.

Regression introduced in #7136

### Steps to test:
- Create volume annotation, brush some, download
- Look into the data.zip, should create wkw files (not only header.wkw)
- Should yield the same data on re-upload

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)