### PR TITLE
Fix too tight assertions in annotation saving

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that the deletion of a selected segment would crash the segments tab. [#7316](https://github.com/scalableminds/webknossos/pull/7316)
 - Fixed reading sharded Zarr 3 data from the local file system. [#7321](https://github.com/scalableminds/webknossos/pull/7321)
 - Fixed no-bucket data zipfile when downloading volume annotations. [#7323](https://github.com/scalableminds/webknossos/pull/7323)
+- Fixed too tight assertions when saving annotations, leading to failed save requests. [#7326](https://github.com/scalableminds/webknossos/pull/7326)
 
 ### Removed
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -184,7 +184,9 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
                                 userToken: Option[String]): Fox[Long] =
     for {
       previousActionGroupsToCommit <- tracingService.getAllUncommittedFor(tracingId, updateGroup.transactionId)
-      _ <- bool2Fox(previousActionGroupsToCommit.exists(_.transactionGroupIndex == 0)) ?~> s"Trying to commit a transaction without a group that has transactionGroupIndex 0."
+      _ <- bool2Fox(
+        previousActionGroupsToCommit
+          .exists(_.transactionGroupIndex == 0) || updateGroup.transactionGroupCount == 1) ?~> s"Trying to commit a transaction without a group that has transactionGroupIndex 0."
       commitResult <- commitUpdates(tracingId, previousActionGroupsToCommit :+ updateGroup, userToken)
       _ <- tracingService.removeAllUncommittedFor(tracingId, updateGroup.transactionId)
     } yield commitResult


### PR DESCRIPTION
Fixing regression introduced in #7290 

### Steps to test:
- Save skeleton with just a few clicks, should work
- Save skeleton with imported large nml, should work
- Save skeleton with a few clicks PLUS an import of a large nml, should work (this was the error case before)

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
