### PR TITLE
Fix transaction management bug

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed reading sharded Zarr 3 data from the local file system. [#7321](https://github.com/scalableminds/webknossos/pull/7321)
 - Fixed no-bucket data zipfile when downloading volume annotations. [#7323](https://github.com/scalableminds/webknossos/pull/7323)
 - Fixed too tight assertions when saving annotations, leading to failed save requests. [#7326](https://github.com/scalableminds/webknossos/pull/7326)
+- Fixed a bug when saving large amounts of skeleton annotation data at once. [#7329](https://github.com/scalableminds/webknossos/pull/7329)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/sagas/save_saga_constants.ts
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga_constants.ts
@@ -14,11 +14,11 @@ export const SETTINGS_MAX_RETRY_COUNT = 20; // 20 * 15s == 5m
 export const MAXIMUM_ACTION_COUNT_PER_BATCH = {
   skeleton: 5000,
   volume: 1000, // Since volume saving is slower, use a lower value here.
-  mapping: 5000,
+  mapping: Infinity, // The back-end does not accept transactions for mappings.
 } as const;
 
 export const MAXIMUM_ACTION_COUNT_PER_SAVE = {
   skeleton: 15000,
   volume: 3000,
-  mapping: 15000,
+  mapping: Infinity, // The back-end does not accept transactions for mappings.
 } as const;

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.tracingstore.controllers
 
 import com.scalableminds.util.time.Instant
-import com.scalableminds.util.tools.{Fox, JsonHelper}
+import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.JsonHelper.{boxFormat, optionFormat}
 import com.scalableminds.webknossos.datastore.controllers.Controller
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
@@ -19,7 +19,7 @@ import com.scalableminds.webknossos.tracingstore.{
 }
 import net.liftweb.common.{Empty, Failure, Full}
 import play.api.i18n.Messages
-import play.api.libs.json.{Format, JsArray, Json}
+import play.api.libs.json.{Format, Json}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
@@ -152,8 +152,6 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
                                               userToken: Option[String]): Fox[Long] =
     for {
       previousCommittedVersion: Long <- previousVersionFox
-      _ = logger.info(
-        s"Received a group for v${updateGroup.version}, tid ${updateGroup.transactionId} tidx ${updateGroup.transactionGroupIndex} tcnt ${updateGroup.transactionGroupCount}")
       result <- if (previousCommittedVersion + 1 == updateGroup.version) {
         if (updateGroup.transactionGroupCount == updateGroup.transactionGroupIndex + 1) {
           // Received the last group of this transaction

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -226,8 +226,7 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
     remoteWebKnossosClient.reportTracingUpdates(report).flatMap { _ =>
       updateGroups.foldLeft(currentCommittedVersion) { (previousVersion, updateGroup) =>
         previousVersion.flatMap { prevVersion: Long =>
-          val versionIncrement = if (updateGroup.transactionGroupIndex == 0) 1 else 0 // version increment happens at the start of each transaction
-          if (prevVersion + versionIncrement == updateGroup.version) {
+          if (prevVersion + 1 == updateGroup.version) {
             tracingService
               .handleUpdateGroup(tracingId, updateGroup, prevVersion, userToken)
               .flatMap(


### PR DESCRIPTION
Saved multiple update groups at the same version in the committed update store, which led to updates being overwritten.
This PR changes the logic so that the update groups are saved into one before stored to the committed store under that version number.

### Steps to test:
- Create large skeletons / volumes, save, reload, should all look right

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
