### PR TITLE
Default Sorting for Job List View: newest on top

### DIFF
--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -359,6 +359,7 @@ class JobListView extends React.PureComponent<Props, State> {
               key="createdAt"
               render={(job) => <FormattedDate timestamp={job.createdAt} />}
               sorter={Utils.compareBy(typeHint, (job) => job.createdAt)}
+              defaultSortOrder="descend"
             />
             <Column
               title="State"


### PR DESCRIPTION
I’ve been confused multiple times by this not being sorted in descending order

### Steps to test:
- run `yarn enable-jobs`
- go to jobs page, should be sorted in descending order by default. 
- sorting should be configurable still

