### PR TITLE
Fix auto save interval

### DIFF
--- a/CHANGELOG.released.md
+++ b/CHANGELOG.released.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 For upgrade instructions, please check the [migration guide](MIGRATIONS.released.md).
 
+## [23.10.1](https://github.com/scalableminds/webknossos/releases/tag/23.10.1) - 2023-09-22
+[Commits](https://github.com/scalableminds/webknossos/compare/23.10.0...23.10.1)
+
+### Fixed
+- Fixed that auto-saving only took place every 5 minutes instead of every 30 seconds. [#7352](https://github.com/scalableminds/webknossos/pull/7352)
+
 ## [23.10.0](https://github.com/scalableminds/webknossos/releases/tag/23.10.0) - 2023-09-21
 [Commits](https://github.com/scalableminds/webknossos/compare/23.09.0...23.10.0)
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -8,14 +8,13 @@ and this project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MIC
 For upgrade instructions, please check the [migration guide](MIGRATIONS.released.md).
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos/compare/23.10.0...HEAD)
+[Commits](https://github.com/scalableminds/webknossos/compare/23.10.1...HEAD)
 
 ### Added
 
 ### Changed
 
 ### Fixed
-- Fixed that auto-saving only took place every 5 minutes instead of every 30 seconds. [#7352](https://github.com/scalableminds/webknossos/pull/7352)
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed that auto-saving only took place every 5 minutes instead of every 30 seconds. [#7352](https://github.com/scalableminds/webknossos/pull/7352)
 
 ### Removed
 

--- a/MIGRATIONS.released.md
+++ b/MIGRATIONS.released.md
@@ -6,6 +6,9 @@ See `MIGRATIONS.unreleased.md` for the changes which are not yet part of an offi
 This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 
+## [23.10.1](https://github.com/scalableminds/webknossos/releases/tag/23.10.1) - 2023-09-22
+[Commits](https://github.com/scalableminds/webknossos/compare/23.10.0...23.10.1)
+
 ## [23.10.0](https://github.com/scalableminds/webknossos/releases/tag/23.10.0) - 2023-09-21
 [Commits](https://github.com/scalableminds/webknossos/compare/23.09.0...23.10.0)
 

--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -6,6 +6,6 @@ This project adheres to [Calendar Versioning](http://calver.org/) `0Y.0M.MICRO`.
 User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos/compare/23.10.0...HEAD)
+[Commits](https://github.com/scalableminds/webknossos/compare/23.10.1...HEAD)
 
 ### Postgres Evolutions:

--- a/frontend/javascripts/oxalis/model/sagas/save_saga_constants.ts
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga_constants.ts
@@ -1,6 +1,6 @@
 // The save saga uses a retry mechanism which is based
 // on exponential back-off.
-export const PUSH_THROTTLE_TIME = 300000; // 30s
+export const PUSH_THROTTLE_TIME = 30000; // 30s
 
 export const SAVE_RETRY_WAITING_TIME = 2000;
 export const MAX_SAVE_RETRY_WAITING_TIME = 300000; // 5m


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/scalableminds/webknossos/commit/e719bc38c31ada5320c30ba79562786a9c9b3c1b which changed the auto-save interval from 30s to 300s.