### PR TITLE
Fix reading zarr2 data with channel axis

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed that segment statistics were requested in the wrong resolution and without properly considering the dataset scale. [#7355](https://github.com/scalableminds/webknossos/pull/7355)
 - Fixed that some segment (group) actions were not properly disabled for non-editable segmentation layers. [#7207](https://github.com/scalableminds/webknossos/issues/7207)
+- Fixed a bug where data from zarr2 datasets that have a channel axis was broken. [#7374](https://github.com/scalableminds/webknossos/pull/7374)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/zarr/ZarrBucketProvider.scala
@@ -24,9 +24,9 @@ class ZarrCubeHandle(zarrArray: ZarrArray) extends DataCubeHandle with LazyLoggi
     val offset = Vec3Int(bucket.topLeft.voxelXInMag, bucket.topLeft.voxelYInMag, bucket.topLeft.voxelZInMag)
 
     bucket.additionalCoordinates match {
-      case Some(additionalCoordinates) =>
+      case Some(additionalCoordinates) if additionalCoordinates.nonEmpty =>
         zarrArray.readBytesWithAdditionalCoordinates(shape, offset, additionalCoordinates, dataLayer.additionalAxisMap)
-      case None => zarrArray.readBytesXYZ(shape, offset)
+      case _ => zarrArray.readBytesXYZ(shape, offset)
     }
   }
 


### PR DESCRIPTION
`readBytesWithAdditionalCoordinates` does not do the dimension padding of the requested shape + offset. It should really only be used in the ND dataset case where all axes are present in the request.
Related #7280 

### Steps to test:
- Try to load data from a zarr2 dataset that has a channel axis (but no additional coordinates), should see data

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
