### PR TITLE
Fix clone command in docs

### DIFF
--- a/DEV_INSTALL.md
+++ b/DEV_INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Docker
 
-This is only recommended for local testing. Docker 19.03.0+ and Docker Compose 2.+ are required.
+This is only recommended for local testing (not for development). Docker 19.03.0+ and Docker Compose 2.+ are required.
 
 ```bash
 git clone -b master --depth=1 git@github.com:scalableminds/webknossos.git
@@ -89,7 +89,7 @@ sudo apt install -y nodejs git postgresql postgresql-client scala sbt openjdk-11
 # Assign a password to PostgreSQL user
 sudo -u postgres psql -c "ALTER USER postgres WITH ENCRYPTED PASSWORD 'postgres';"
 # Clone the git repo to the current directory
-git clone -b master --depth=1 https://github.com/scalableminds/webknossos.git
+git clone git@github.com:scalableminds/webknossos.git
 ```
 
 If you already have a different Java version installed, set the default version to Java 11:


### PR DESCRIPTION
Cloning shouldn't be done with `--depth=1` when one wants to develop against this repository. Now, the clone command in the ubuntu section is identical to the os x section.