### PR TITLE
Fix mag restrictions when task type uses not-existing mags

### DIFF
--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -579,21 +579,6 @@ export function getSegmentationThumbnailURL(dataset: APIDataset): string {
   return "";
 }
 
-// Currently, only used for valid task range
-function _keyResolutionsByMax(dataset: APIDataset, layerName: string): Record<number, Vector3> {
-  const resolutions = getDenseResolutionsForLayerName(dataset, layerName);
-  return _.keyBy(resolutions, (res) => Math.max(...res));
-}
-
-const keyResolutionsByMax = memoizeOne(_keyResolutionsByMax);
-export function getResolutionByMax(
-  dataset: APIDataset,
-  layerName: string,
-  maxDim: number,
-): Vector3 {
-  const keyedResolutionsByMax = keyResolutionsByMax(dataset, layerName);
-  return keyedResolutionsByMax[maxDim];
-}
 export function isLayerVisible(
   dataset: APIDataset,
   layerName: string,

--- a/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
@@ -12,7 +12,6 @@ import {
   getEnabledLayers,
   getLayerByName,
   getMaxZoomStep,
-  getResolutionByMax,
   getResolutionInfo,
   getTransformsForLayer,
   invertAndTranspose,
@@ -373,21 +372,30 @@ export function getMaxZoomValueForResolution(
   layerName: string,
   targetResolution: Vector3,
 ): number {
+  const targetResolutionIdentifier = Math.max(...targetResolution);
   // Extract the max value from the range
-  return getValidZoomRangeForResolution(state, layerName, targetResolution)[1];
+  const maxZoom = getValidZoomRangeForResolution(state, layerName, targetResolutionIdentifier)[1];
+  if (maxZoom == null) {
+    // This should never happen as long as a valid target resolution is passed to this function.
+    throw new Error("Zoom range could not be determined for target resolution.");
+  }
+  return maxZoom;
 }
 
 function getValidZoomRangeForResolution(
   state: OxalisState,
   layerName: string,
-  targetResolution: Vector3,
-): Vector2 {
+  resolutionIdentifier: number,
+): Vector2 | [null, null] {
   const maximumZoomSteps = getMaximumZoomForAllResolutionsFromStore(state, layerName);
   const resolutions = getDenseResolutionsForLayerName(state.dataset, layerName);
+  // The above lists are densely defined for all resolutions starting from resolution 1,1,1.
+  // Therefore, we can use log2 as an index.
+  const targetResolutionIndex = Math.log2(resolutionIdentifier);
 
-  const targetResolutionIndex = _.findIndex(resolutions, (resolution) =>
-    V3.isEqual(resolution, targetResolution),
-  );
+  if (targetResolutionIndex > maximumZoomSteps.length) {
+    return [null, null];
+  }
 
   const max = maximumZoomSteps[targetResolutionIndex];
   const min = targetResolutionIndex > 0 ? maximumZoomSteps[targetResolutionIndex - 1] : 0;
@@ -417,17 +425,14 @@ export function getValidTaskZoomRange(
 
   const firstColorLayerName = firstColorLayerNameMaybe;
 
-  function getMinMax(value: number | undefined, isMin: boolean) {
+  function getMinMax(magIdentifier: number | undefined, isMin: boolean) {
     const idx = isMin ? 0 : 1;
     return (
-      (value == null
+      (magIdentifier == null
         ? defaultRange[idx]
-        : // If the value is defined, but doesn't match any resolution, we default to the defaultRange values
-          getValidZoomRangeForResolution(
-            state,
-            firstColorLayerName,
-            getResolutionByMax(state.dataset, firstColorLayerName, value),
-          )[idx]) || defaultRange[idx]
+        : // If the magIdentifier is defined, but doesn't match any resolution, we default to the defaultRange values
+          getValidZoomRangeForResolution(state, firstColorLayerName, magIdentifier)[idx]) ||
+      defaultRange[idx]
     );
   }
 

--- a/frontend/javascripts/oxalis/model/sagas/task_saga.tsx
+++ b/frontend/javascripts/oxalis/model/sagas/task_saga.tsx
@@ -172,10 +172,17 @@ export function* warnAboutMagRestriction(): Saga<void> {
         Store.dispatch(setZoomStepAction(newZoomValue));
       };
 
+      let constraintString = `between ${min.toFixed(2)} and ${max.toFixed(2)}`;
+      if (min === 0) {
+        constraintString = `lower than ${max.toFixed(2)}`;
+      } else if (max === Infinity) {
+        constraintString = `greater than ${min.toFixed(2)}`;
+      }
+
       const message = (
         <React.Fragment>
           Annotating data is restricted to a certain zoom range. Please adapt the zoom value so that
-          it is between {min.toFixed(2)} and {max.toFixed(2)}. Alternatively, click{" "}
+          it is {constraintString}. Alternatively, click{" "}
           <Button
             type="link"
             onClick={clampZoom}


### PR DESCRIPTION
Instead of trying to look up a resolution by the provided mag spec (e.g., task type defines max=512 and then it is assumed that mag 512 exists), the logarithm of the mag spec is used to index into the known zoom ranges. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a new task type with mag restrictions (e.g., 2 to 512)
- create a task for a dataset that does not have mags until 512
- get the task and ensure it doesn't crash
- zoom in to mag 1 -> a toast should appear to warn you that the mag restriction is violated

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1698139256299479

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
