### PR TITLE
Highlight segment in sidebar when using search to cycle through segments

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Searching the segments in the sidebar will highlight newly focussed segments properly now. [#7406](https://github.com/scalableminds/webknossos/pull/7406)
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,7 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
-- Searching the segments in the sidebar will highlight newly focussed segments properly now. [#7406](https://github.com/scalableminds/webknossos/pull/7406)
+- Searching the segments in the sidebar will highlight newly focused segments properly now. [#7406](https://github.com/scalableminds/webknossos/pull/7406)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -440,7 +440,7 @@ class SegmentsView extends React.Component<Props, State> {
         Modal.confirm({
           title: "Do you really want to select this group?",
           content: `You have ${selectedIdsForCaseDistinction.segments.length} selected segments. Do you really want to select this group?
-        This will deselect all selected trees.`,
+        This will deselect all selected segments.`,
           onOk: () => {
             this.setState({ selectedIds: { segments: [], group: selectedIdsForState.group } });
           },

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -666,6 +666,10 @@ class SegmentsView extends React.Component<Props, State> {
   };
 
   onSelectSegment = (segment: Segment) => {
+    this.setState({
+      selectedIds: { segments: [segment.id], group: null },
+    });
+
     if (!segment.somePosition) {
       Toast.info(
         <React.Fragment>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixselectonsearch.webknossos.xyz

### Steps to test:
- create multiple segments
- use segment search to cycle through segments
- segment should be highlighted in the sidebar

### Issues:
- fixes #7405

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)