### PR TITLE
Added a hotfix to prevent the animation modal from crashing

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/create_animation_modal.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/create_animation_modal.tsx
@@ -74,6 +74,16 @@ function selectMagForTextureCreation(
   return [bestMag, bestDifference];
 }
 
+export function CreateAnimationModalWrapper(props: Props) {
+  const dataset = useSelector((state: OxalisState) => state.dataset);
+
+  // early stop if no color layer exists
+  const colorLayers = getColorLayers(dataset);
+  if (colorLayers.length === 0) return null;
+
+  return <CreateAnimationModal {...props} />;
+}
+
 function CreateAnimationModal(props: Props) {
   const { isOpen, onClose } = props;
   const dataset = useSelector((state: OxalisState) => state.dataset);
@@ -81,6 +91,7 @@ function CreateAnimationModal(props: Props) {
   const activeOrganization = useSelector((state: OxalisState) => state.activeOrganization);
 
   const colorLayers = getColorLayers(dataset);
+
   const colorLayer = colorLayers[0];
   const [selectedColorLayerName, setSelectedColorLayerName] = useState<string>(colorLayer.name);
   const selectedColorLayer = getLayerByName(dataset, selectedColorLayerName);

--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
@@ -74,7 +74,7 @@ import UrlManager from "oxalis/controller/url_manager";
 import { withAuthentication } from "admin/auth/authentication_modal";
 import { PrivateLinksModal } from "./private_links_view";
 import { ItemType, SubMenuType } from "antd/lib/menu/hooks/useItems";
-import CreateAnimationModal from "./create_animation_modal";
+import { CreateAnimationModalWrapper as CreateAnimationModal } from "./create_animation_modal";
 
 const AsyncButtonWithAuthentication = withAuthentication<AsyncButtonProps, typeof AsyncButton>(
   AsyncButton,

--- a/frontend/javascripts/oxalis/view/action-bar/view_dataset_actions_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/view_dataset_actions_view.tsx
@@ -19,7 +19,7 @@ import {
 import Store, { OxalisState } from "oxalis/store";
 import { MenuItemType, SubMenuType } from "antd/lib/menu/hooks/useItems";
 import DownloadModalView from "./download_modal_view";
-import CreateAnimationModal from "./create_animation_modal";
+import { CreateAnimationModalWrapper as CreateAnimationModal } from "./create_animation_modal";
 
 type Props = {
   layoutMenu: SubMenuType;


### PR DESCRIPTION
Added a hotfix to prevent the animation modal from crashing color layer is present

### Steps to test:
- Open a dataset without a color layer
- WK should not crash
- 🎉 

### Issues:
- https://scm.slack.com/archives/C5AKLAV0B/p1698221922713279

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
