### PR TITLE
Move maintenance banner to top of the screen

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Searching the segments in the sidebar will highlight newly focused segments properly now. [#7406](https://github.com/scalableminds/webknossos/pull/7406)
 - Fixed a bug when opening a task for which a mag restriction exists. The bug only occurred when the referenced mag didn't exist in the dataset. [#7403](https://github.com/scalableminds/webknossos/pull/7403)
+- Fixed styling issues with the maintenance banner so that it no longer overlaps other menus, tabs, and buttons. [#7421](https://github.com/scalableminds/webknossos/pull/7421)
 
 ### Removed
 

--- a/frontend/javascripts/maintenance_banner.tsx
+++ b/frontend/javascripts/maintenance_banner.tsx
@@ -6,6 +6,7 @@ import { Alert } from "antd";
 import FormattedDate from "components/formatted_date";
 import { useInterval } from "libs/react_helpers";
 import constants from "oxalis/constants";
+import { setNavbarHeightAction } from "oxalis/model/actions/ui_actions";
 import { setActiveUserAction } from "oxalis/model/actions/user_actions";
 import { Store } from "oxalis/singletons";
 import { OxalisState } from "oxalis/store";
@@ -20,7 +21,7 @@ const BANNER_STYLE: React.CSSProperties = {
   position: "absolute",
   top: 0,
   left: 0,
-  height: 38,
+  height: constants.MAINTENANCE_BANNER_HEIGHT,
 };
 
 function UpcomingMaintenanceBanner({ maintenanceInfo }: {maintenanceInfo:MaintenanceInfo}) {
@@ -70,18 +71,22 @@ export function MaintenanceBanner() {
     MaintenanceInfo[]
   >([]);
 
-  function setNavbarHeight() {
-    const newNavbarHeight = 48 + 38;
-    constants.NAVBAR_HEIGHT = newNavbarHeight; // TODO
+  function setNavbarHeight(newNavbarHeight: number) {
+    Store.dispatch(setNavbarHeightAction(newNavbarHeight))
     document.documentElement.style.setProperty("--navbar-height", `${newNavbarHeight}px`);
   }
 
   async function pollMaintenances() {
-    const scheduledMaintenances = await listCurrentAndUpcomingMaintenances();
-    setCurrentAndUpcomingMaintenances(scheduledMaintenances);
+    const newScheduledMaintenances = await listCurrentAndUpcomingMaintenances();
+    setCurrentAndUpcomingMaintenances(newScheduledMaintenances);
+    
+    if ((currentAndUpcomingMaintenances.length !== newScheduledMaintenances.length) && newScheduledMaintenances.length === 0) {
+      // Reset Navbar Height if maintenance is over
+      setNavbarHeight(constants.DEFAULT_NAVBAR_HEIGHT);
+    }
 
-    if (scheduledMaintenances.length > 0) {
-      setNavbarHeight();
+    if (newScheduledMaintenances.length > 0) {
+      setNavbarHeight(constants.DEFAULT_NAVBAR_HEIGHT + constants.MAINTENANCE_BANNER_HEIGHT);
     }
   }
 

--- a/frontend/javascripts/maintenance_banner.tsx
+++ b/frontend/javascripts/maintenance_banner.tsx
@@ -119,7 +119,7 @@ export function MaintenanceBanner() {
       setNavbarHeight(constants.DEFAULT_NAVBAR_HEIGHT + constants.MAINTENANCE_BANNER_HEIGHT);
     }
 
-    if (currentMaintenance === undefined && closestUpcomingMaintenance === undefined) {
+    if (currentMaintenance == null && closestUpcomingMaintenance == null) {
       // Reset Navbar height if maintenance is over
       setNavbarHeight(constants.DEFAULT_NAVBAR_HEIGHT);
     }

--- a/frontend/javascripts/maintenance_banner.tsx
+++ b/frontend/javascripts/maintenance_banner.tsx
@@ -129,7 +129,7 @@ export function MaintenanceBanner() {
     // Do an initial fetch of the maintenance status so that users are notified
     // quickly in case of ongoing maintenances.
     setTimeout(pollMaintenances, INITIAL_DELAY);
-  }, [])
+  }, []);
 
   // Also poll regularly.
   useInterval(pollMaintenances, INTERVAL_TO_FETCH_MAINTENANCES_MS);

--- a/frontend/javascripts/maintenance_banner.tsx
+++ b/frontend/javascripts/maintenance_banner.tsx
@@ -125,9 +125,11 @@ export function MaintenanceBanner() {
     }
   }, [currentMaintenance, closestUpcomingMaintenance]);
 
-  // Do an initial fetch of the maintenance status so that users are notified
-  // quickly in case of ongoing maintenances.
-  setTimeout(pollMaintenances, INITIAL_DELAY);
+  useEffect(() => {
+    // Do an initial fetch of the maintenance status so that users are notified
+    // quickly in case of ongoing maintenances.
+    setTimeout(pollMaintenances, INITIAL_DELAY);
+  }, [])
 
   // Also poll regularly.
   useInterval(pollMaintenances, INTERVAL_TO_FETCH_MAINTENANCES_MS);

--- a/frontend/javascripts/maintenance_banner.tsx
+++ b/frontend/javascripts/maintenance_banner.tsx
@@ -16,7 +16,7 @@ import { useSelector } from "react-redux";
 import { MaintenanceInfo } from "types/api_flow_types";
 
 const INITIAL_DELAY = 5000;
-const INTERVAL_TO_FETCH_MAINTENANCES_MS = 600000; // 10min
+const INTERVAL_TO_FETCH_MAINTENANCES_MS = 60000; // 1min
 
 const BANNER_STYLE: React.CSSProperties = {
   position: "absolute",

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -69,7 +69,7 @@ type StateProps = {
   othersMayEdit: boolean;
   allowUpdate: boolean;
   blockedByUser: APIUserCompact | null | undefined;
-  navbarHeight: number
+  navbarHeight: number;
 };
 type Props = OwnProps & StateProps;
 // The user should click somewhere else to close that menu like it's done in most OS menus, anyway. 10 seconds.
@@ -426,7 +426,13 @@ function getDashboardSubMenu(collapse: boolean): SubMenuType {
   };
 }
 
-function NotificationIcon({ activeUser,navbarHeight }: { activeUser: APIUser, navbarHeight: number }) {
+function NotificationIcon({
+  activeUser,
+  navbarHeight,
+}: {
+  activeUser: APIUser;
+  navbarHeight: number;
+}) {
   const maybeUnreadReleaseCount = useOlvyUnreadReleasesCount(activeUser);
 
   const handleShowWhatsNewView = () => {
@@ -447,7 +453,8 @@ function NotificationIcon({ activeUser,navbarHeight }: { activeUser: APIUser, na
         position: "relative",
         display: "flex",
         marginRight: 12,
-        paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
+        paddingTop:
+          navbarHeight > constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT : 0,
       }}
     >
       <Tooltip title="See what's new in WEBKNOSSOS" placement="bottomLeft">
@@ -481,8 +488,12 @@ export const switchTo = async (org: APIOrganization) => {
 function LoggedInAvatar({
   activeUser,
   handleLogout,
-  navbarHeight
-}: { activeUser: APIUser; handleLogout: (event: React.SyntheticEvent) => void, navbarHeight: number } & SubMenuProps) {
+  navbarHeight,
+}: {
+  activeUser: APIUser;
+  handleLogout: (event: React.SyntheticEvent) => void;
+  navbarHeight: number;
+} & SubMenuProps) {
   const { firstName, lastName, organization: organizationName, selectedTheme } = activeUser;
   const usersOrganizations = useFetch(getUsersOrganizations, [], []);
   const activeOrganization = usersOrganizations.find((org) => org.name === organizationName);
@@ -541,7 +552,8 @@ function LoggedInAvatar({
     <Menu
       mode="horizontal"
       style={{
-        paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
+        paddingTop:
+          navbarHeight > constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT : 0,
         lineHeight: `${constants.DEFAULT_NAVBAR_HEIGHT}px`,
       }}
       theme="dark"
@@ -708,7 +720,7 @@ function Navbar({
   othersMayEdit,
   blockedByUser,
   allowUpdate,
-  navbarHeight
+  navbarHeight,
 }: Props) {
   const history = useHistory();
 
@@ -780,7 +792,13 @@ function Navbar({
         />,
       );
     }
-    trailingNavItems.push(<NotificationIcon key="notification-icon" activeUser={loggedInUser} navbarHeight={navbarHeight}/>);
+    trailingNavItems.push(
+      <NotificationIcon
+        key="notification-icon"
+        activeUser={loggedInUser}
+        navbarHeight={navbarHeight}
+      />,
+    );
     trailingNavItems.push(
       <LoggedInAvatar
         key="logged-in-avatar"
@@ -822,7 +840,10 @@ function Navbar({
         selectedKeys={selectedKeys}
         onOpenChange={(openKeys) => setIsHelpMenuOpen(openKeys.includes(HELP_MENU_KEY))}
         style={{
-          paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
+          paddingTop:
+            navbarHeight > constants.DEFAULT_NAVBAR_HEIGHT
+              ? constants.MAINTENANCE_BANNER_HEIGHT
+              : 0,
           lineHeight: `${constants.DEFAULT_NAVBAR_HEIGHT}px`,
         }}
         theme="dark"
@@ -845,7 +866,10 @@ function Navbar({
         style={{
           flex: 1,
           display: "flex",
-          paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
+          paddingTop:
+            navbarHeight > constants.DEFAULT_NAVBAR_HEIGHT
+              ? constants.MAINTENANCE_BANNER_HEIGHT
+              : 0,
         }}
       />
 

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -52,6 +52,8 @@ import messages from "messages";
 import { PricingEnforcedSpan } from "components/pricing_enforcers";
 import { ItemType, MenuItemType, SubMenuType } from "antd/lib/menu/hooks/useItems";
 import { MenuClickEventHandler } from "rc-menu/lib/interface";
+import constants from "oxalis/constants";
+import { MaintenanceBanner } from "maintenance_banner";
 
 const { Header } = Layout;
 
@@ -536,7 +538,7 @@ function LoggedInAvatar({
     <Menu
       mode="horizontal"
       style={{
-        lineHeight: "48px",
+        lineHeight: constants.NAVBAR_HEIGHT,
       }}
       theme="dark"
       subMenuCloseDelay={subMenuCloseDelay}
@@ -808,12 +810,13 @@ function Navbar({
         "collapsed-nav-header": collapseAllNavItems,
       })}
     >
+      <MaintenanceBanner />
       <Menu
         mode="horizontal"
         selectedKeys={selectedKeys}
         onOpenChange={(openKeys) => setIsHelpMenuOpen(openKeys.includes(HELP_MENU_KEY))}
         style={{
-          lineHeight: "48px",
+          lineHeight: constants.NAVBAR_HEIGHT,
         }}
         theme="dark"
         subMenuCloseDelay={subMenuCloseDelay}

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -69,6 +69,7 @@ type StateProps = {
   othersMayEdit: boolean;
   allowUpdate: boolean;
   blockedByUser: APIUserCompact | null | undefined;
+  navbarHeight: number
 };
 type Props = OwnProps & StateProps;
 // The user should click somewhere else to close that menu like it's done in most OS menus, anyway. 10 seconds.
@@ -425,7 +426,7 @@ function getDashboardSubMenu(collapse: boolean): SubMenuType {
   };
 }
 
-function NotificationIcon({ activeUser }: { activeUser: APIUser }) {
+function NotificationIcon({ activeUser,navbarHeight }: { activeUser: APIUser, navbarHeight: number }) {
   const maybeUnreadReleaseCount = useOlvyUnreadReleasesCount(activeUser);
 
   const handleShowWhatsNewView = () => {
@@ -446,6 +447,7 @@ function NotificationIcon({ activeUser }: { activeUser: APIUser }) {
         position: "relative",
         display: "flex",
         marginRight: 12,
+        paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
       }}
     >
       <Tooltip title="See what's new in WEBKNOSSOS" placement="bottomLeft">
@@ -479,7 +481,8 @@ export const switchTo = async (org: APIOrganization) => {
 function LoggedInAvatar({
   activeUser,
   handleLogout,
-}: { activeUser: APIUser; handleLogout: (event: React.SyntheticEvent) => void } & SubMenuProps) {
+  navbarHeight
+}: { activeUser: APIUser; handleLogout: (event: React.SyntheticEvent) => void, navbarHeight: number } & SubMenuProps) {
   const { firstName, lastName, organization: organizationName, selectedTheme } = activeUser;
   const usersOrganizations = useFetch(getUsersOrganizations, [], []);
   const activeOrganization = usersOrganizations.find((org) => org.name === organizationName);
@@ -538,7 +541,8 @@ function LoggedInAvatar({
     <Menu
       mode="horizontal"
       style={{
-        lineHeight: constants.NAVBAR_HEIGHT,
+        paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
+        lineHeight: `${constants.DEFAULT_NAVBAR_HEIGHT}px`,
       }}
       theme="dark"
       subMenuCloseDelay={subMenuCloseDelay}
@@ -704,6 +708,7 @@ function Navbar({
   othersMayEdit,
   blockedByUser,
   allowUpdate,
+  navbarHeight
 }: Props) {
   const history = useHistory();
 
@@ -775,12 +780,13 @@ function Navbar({
         />,
       );
     }
-    trailingNavItems.push(<NotificationIcon key="notification-icon" activeUser={loggedInUser} />);
+    trailingNavItems.push(<NotificationIcon key="notification-icon" activeUser={loggedInUser} navbarHeight={navbarHeight}/>);
     trailingNavItems.push(
       <LoggedInAvatar
         key="logged-in-avatar"
         activeUser={loggedInUser}
         handleLogout={handleLogout}
+        navbarHeight={navbarHeight}
       />,
     );
   }
@@ -816,7 +822,8 @@ function Navbar({
         selectedKeys={selectedKeys}
         onOpenChange={(openKeys) => setIsHelpMenuOpen(openKeys.includes(HELP_MENU_KEY))}
         style={{
-          lineHeight: constants.NAVBAR_HEIGHT,
+          paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
+          lineHeight: `${constants.DEFAULT_NAVBAR_HEIGHT}px`,
         }}
         theme="dark"
         subMenuCloseDelay={subMenuCloseDelay}
@@ -838,6 +845,7 @@ function Navbar({
         style={{
           flex: 1,
           display: "flex",
+          paddingTop:  navbarHeight> constants.DEFAULT_NAVBAR_HEIGHT ? constants.MAINTENANCE_BANNER_HEIGHT: 0,
         }}
       />
 
@@ -861,6 +869,7 @@ const mapStateToProps = (state: OxalisState): StateProps => ({
   othersMayEdit: state.tracing.othersMayEdit,
   blockedByUser: state.tracing.blockedByUser,
   allowUpdate: state.tracing.restrictions.allowUpdate,
+  navbarHeight: state.uiInformation.navbarHeight,
 });
 
 const connector = connect(mapStateToProps);

--- a/frontend/javascripts/oxalis/constants.ts
+++ b/frontend/javascripts/oxalis/constants.ts
@@ -310,7 +310,8 @@ const Constants = {
   BUCKET_WIDTH: 32,
   BUCKET_SIZE: 32 ** 3,
   VIEWPORT_WIDTH,
-  NAVBAR_HEIGHT: 48,
+  DEFAULT_NAVBAR_HEIGHT: 48,
+  MAINTENANCE_BANNER_HEIGHT: 38,
   // For reference, the area of a large brush size (let's say, 300px) corresponds to
   // pi * 300 ^ 2 == 282690.
   // We multiply this with 5, since the labeling is not done

--- a/frontend/javascripts/oxalis/default_state.ts
+++ b/frontend/javascripts/oxalis/default_state.ts
@@ -10,6 +10,7 @@ import Constants, {
   InterpolationModeEnum,
 } from "oxalis/constants";
 import { APIAllowedMode, APIAnnotationType, APIAnnotationVisibility } from "types/api_flow_types";
+import constants from "oxalis/constants";
 const defaultViewportRect = {
   top: 0,
   left: 0,
@@ -250,6 +251,7 @@ const defaultState: OxalisState = {
       lastMeasuredPosition: null,
       isMeasuring: false,
     },
+    navbarHeight: constants.DEFAULT_NAVBAR_HEIGHT
   },
   localSegmentationData: {},
 };

--- a/frontend/javascripts/oxalis/default_state.ts
+++ b/frontend/javascripts/oxalis/default_state.ts
@@ -251,7 +251,7 @@ const defaultState: OxalisState = {
       lastMeasuredPosition: null,
       isMeasuring: false,
     },
-    navbarHeight: constants.DEFAULT_NAVBAR_HEIGHT
+    navbarHeight: constants.DEFAULT_NAVBAR_HEIGHT,
   },
   localSegmentationData: {},
 };

--- a/frontend/javascripts/oxalis/model/accessors/view_mode_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/view_mode_accessor.ts
@@ -154,6 +154,7 @@ function _calculateMaybePlaneScreenPos(
   // This is achieved by reversing the calculations in _calculateMaybeGlobalPos.
   let point: Point2;
   planeId = planeId || state.viewModeData.plane.activeViewport;
+  const navbarHeight = state.uiInformation.navbarHeight;
   const curGlobalPos = getPosition(state.flycam);
   const planeRatio = getBaseVoxelFactors(state.dataset.dataSource.scale);
   const { width, height, top, left } = getInputCatcherRect(state, planeId);
@@ -187,7 +188,7 @@ function _calculateMaybePlaneScreenPos(
       return null;
   }
   point.x += width / 2 + left;
-  point.y += height / 2 + top + constants.NAVBAR_HEIGHT;
+  point.y += height / 2 + top + navbarHeight;
   point.x = Math.round(point.x);
   point.y = Math.round(point.y);
 

--- a/frontend/javascripts/oxalis/model/actions/ui_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/ui_actions.ts
@@ -178,6 +178,3 @@ export const setNavbarHeightAction = (navbarHeight: number) =>
     type: "SET_NAVBAR_HEIGHT",
     navbarHeight,
   } as const);
-
-
-  

--- a/frontend/javascripts/oxalis/model/actions/ui_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/ui_actions.ts
@@ -24,6 +24,7 @@ type ShowQuickSelectSettingsAction = ReturnType<typeof showQuickSelectSettingsAc
 type HideMeasurementTooltipAction = ReturnType<typeof hideMeasurementTooltipAction>;
 type SetLastMeasuredPositionAction = ReturnType<typeof setLastMeasuredPositionAction>;
 type SetIsMeasuringAction = ReturnType<typeof setIsMeasuringAction>;
+type SetNavbarHeightAction = ReturnType<typeof setNavbarHeightAction>;
 
 type SetRenderAnimationModalVisibilityAction = ReturnType<
   typeof setRenderAnimationModalVisibilityAction
@@ -52,7 +53,8 @@ export type UiAction =
   | ShowQuickSelectSettingsAction
   | HideMeasurementTooltipAction
   | SetLastMeasuredPositionAction
-  | SetIsMeasuringAction;
+  | SetIsMeasuringAction
+  | SetNavbarHeightAction;
 
 export const setDropzoneModalVisibilityAction = (visible: boolean) =>
   ({
@@ -171,3 +173,11 @@ export const setIsMeasuringAction = (isMeasuring: boolean) =>
     type: "SET_IS_MEASURING",
     isMeasuring,
   } as const);
+export const setNavbarHeightAction = (navbarHeight: number) =>
+  ({
+    type: "SET_NAVBAR_HEIGHT",
+    navbarHeight,
+  } as const);
+
+
+  

--- a/frontend/javascripts/oxalis/model/reducers/ui_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/ui_reducer.ts
@@ -148,6 +148,11 @@ function UiReducer(state: OxalisState, action: Action): OxalisState {
         isMeasuring: action.isMeasuring,
       });
     }
+    case "SET_NAVBAR_HEIGHT": {
+      return updateKey(state, "uiInformation", {
+        navbarHeight: action.navbarHeight,
+      });
+    }
 
     default:
       return state;

--- a/frontend/javascripts/oxalis/store.ts
+++ b/frontend/javascripts/oxalis/store.ts
@@ -528,6 +528,7 @@ type UiInformation = {
     | "active"; // the quick select saga is currently running (calculating as well as preview mode)
   readonly areQuickSelectSettingsOpen: boolean;
   readonly measurementToolInfo: { lastMeasuredPosition: Vector3 | null; isMeasuring: boolean };
+  readonly navbarHeight: number;
 };
 type BaseMeshInformation = {
   readonly segmentId: number;

--- a/frontend/javascripts/oxalis/view/arbitrary_view.ts
+++ b/frontend/javascripts/oxalis/view/arbitrary_view.ts
@@ -16,6 +16,7 @@ import app from "app";
 import getSceneController from "oxalis/controller/scene_controller_provider";
 import window from "libs/window";
 import { clearCanvas, setupRenderArea, renderToTexture } from "oxalis/view/rendering_utils";
+import { listenToStoreProperty } from "oxalis/model/helpers/listener_helpers";
 
 type GeometryLike = {
   addToScene: (obj: THREE.Object3D) => void;
@@ -106,6 +107,13 @@ class ArbitraryView {
       this.animationRequestId = window.requestAnimationFrame(this.animate);
       // Dont forget to handle window resizing!
       window.addEventListener("resize", this.resizeThrottled);
+      this.unsubscribeFunctions.push(
+        listenToStoreProperty(
+          (storeState) => storeState.uiInformation.navbarHeight,
+          () => this.resizeThrottled(),
+          true,
+        ),
+      );
     }
   }
 

--- a/frontend/javascripts/oxalis/view/layouting/default_layout_configs.ts
+++ b/frontend/javascripts/oxalis/view/layouting/default_layout_configs.ts
@@ -6,7 +6,6 @@
  */
 import _ from "lodash";
 import { getIsInIframe } from "libs/utils";
-import constants from "oxalis/constants";
 import type { BorderTabType, ControlMode, ViewMode } from "oxalis/constants";
 import Constants, {
   ArbitraryViews,
@@ -26,6 +25,7 @@ import type {
   Border,
   ModelConfig,
 } from "./flex_layout_types";
+import { Store } from "oxalis/singletons";
 // Increment this number to invalidate old layoutConfigs in localStorage
 export const currentLayoutVersion = 15;
 const layoutHeaderHeight = 20;
@@ -40,6 +40,7 @@ export const DEFAULT_LAYOUT_NAME = "Custom Layout";
 // when it is set to 0, we use a value near value to make it almost not visible.
 const borderBarSize = 1;
 export const getGroundTruthLayoutRect = () => {
+  const storeState = Store.getState();
   const mainContainer = document.querySelector(".ant-layout .ant-layout-has-sider");
   let width;
   let height;
@@ -48,7 +49,7 @@ export const getGroundTruthLayoutRect = () => {
     if (window.innerWidth) {
       width = window.innerWidth;
       height = window.innerHeight;
-      height -= constants.NAVBAR_HEIGHT;
+      height -= storeState.uiInformation.navbarHeight;
     } else {
       // use fallback values
       height = dummyExtent;

--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.tsx
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.tsx
@@ -25,7 +25,7 @@ type OwnProps = {
 type StateProps = {
   showDropzoneModal: boolean;
   hideDropzoneModal: () => void;
-  navbarHeight: number
+  navbarHeight: number;
 };
 type Props = StateProps & OwnProps;
 

--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.tsx
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.tsx
@@ -9,7 +9,7 @@ import type { OxalisState } from "oxalis/store";
 import { setDropzoneModalVisibilityAction } from "oxalis/model/actions/ui_actions";
 import FormattedDate from "components/formatted_date";
 import { trackAction } from "oxalis/model/helpers/analytics";
-import constants from "oxalis/constants";
+
 type State = {
   files: Array<File>;
   dropzoneActive: boolean;
@@ -25,6 +25,7 @@ type OwnProps = {
 type StateProps = {
   showDropzoneModal: boolean;
   hideDropzoneModal: () => void;
+  navbarHeight: number
 };
 type Props = StateProps & OwnProps;
 
@@ -271,7 +272,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
             {...getRootProps()}
             style={{
               position: "relative",
-              height: `calc(100vh - ${constants.NAVBAR_HEIGHT}px)`,
+              height: `calc(100vh - ${this.props.navbarHeight}px)`,
             }}
             className="flex-column"
           >
@@ -309,6 +310,7 @@ class NmlUploadZoneContainer extends React.PureComponent<Props, State> {
 
 const mapStateToProps = (state: OxalisState) => ({
   showDropzoneModal: state.uiInformation.showDropzoneModal,
+  navbarHeight: state.uiInformation.navbarHeight,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => ({

--- a/frontend/javascripts/oxalis/view/plane_view.ts
+++ b/frontend/javascripts/oxalis/view/plane_view.ts
@@ -15,6 +15,7 @@ import { clearCanvas, setupRenderArea } from "oxalis/view/rendering_utils";
 import VisibilityAwareRaycaster, {
   type RaycastIntersection,
 } from "libs/visibility_aware_raycaster";
+import { listenToStoreProperty } from "oxalis/model/helpers/listener_helpers";
 
 const createDirLight = (
   position: Vector3,
@@ -248,6 +249,11 @@ class PlaneView {
     this.resize();
     this.animate();
     window.addEventListener("resize", this.resizeThrottled);
+    listenToStoreProperty(
+      (storeState) => storeState.uiInformation.navbarHeight,
+      () => this.resizeThrottled(),
+      true,
+    )
   }
 }
 

--- a/frontend/javascripts/oxalis/view/plane_view.ts
+++ b/frontend/javascripts/oxalis/view/plane_view.ts
@@ -249,11 +249,11 @@ class PlaneView {
     this.resize();
     this.animate();
     window.addEventListener("resize", this.resizeThrottled);
-    listenToStoreProperty(
+    this.unsubscribeFunctions.push(listenToStoreProperty(
       (storeState) => storeState.uiInformation.navbarHeight,
       () => this.resizeThrottled(),
       true,
-    );
+    ));
   }
 }
 

--- a/frontend/javascripts/oxalis/view/plane_view.ts
+++ b/frontend/javascripts/oxalis/view/plane_view.ts
@@ -249,11 +249,13 @@ class PlaneView {
     this.resize();
     this.animate();
     window.addEventListener("resize", this.resizeThrottled);
-    this.unsubscribeFunctions.push(listenToStoreProperty(
-      (storeState) => storeState.uiInformation.navbarHeight,
-      () => this.resizeThrottled(),
-      true,
-    ));
+    this.unsubscribeFunctions.push(
+      listenToStoreProperty(
+        (storeState) => storeState.uiInformation.navbarHeight,
+        () => this.resizeThrottled(),
+        true,
+      ),
+    );
   }
 }
 

--- a/frontend/javascripts/oxalis/view/plane_view.ts
+++ b/frontend/javascripts/oxalis/view/plane_view.ts
@@ -253,7 +253,7 @@ class PlaneView {
       (storeState) => storeState.uiInformation.navbarHeight,
       () => this.resizeThrottled(),
       true,
-    )
+    );
   }
 }
 

--- a/frontend/javascripts/router.tsx
+++ b/frontend/javascripts/router.tsx
@@ -67,7 +67,6 @@ import {
 import ErrorBoundary from "components/error_boundary";
 import { Store } from "oxalis/singletons";
 import VerifyEmailView from "admin/auth/verify_email_view";
-import { MaintenanceBanner } from "maintenance_banner";
 
 const { Content } = Layout;
 
@@ -223,7 +222,6 @@ class ReactRouter extends React.Component<Props> {
           <CheckTermsOfServices />
           <Navbar isAuthenticated={isAuthenticated} />
           <HelpButton />
-          <MaintenanceBanner />
           <Content>
             <Switch>
               <RouteWithErrorBoundary

--- a/frontend/stylesheets/_utils.less
+++ b/frontend/stylesheets/_utils.less
@@ -132,13 +132,13 @@ td.nowrap * {
 
 .background-organelles {
   height: 100%;
-  min-height: calc(100vh - @navbar-height);
+  min-height: calc(100vh - var(--navbar-height));
   background: @background-blue-organelles;
 }
 
 .full-viewport-height {
   height: 100%;
-  min-height: calc(100vh - @navbar-height);
+  min-height: calc(100vh - var(--navbar-height));
 }
 
 .grabbing {

--- a/frontend/stylesheets/_variables.less
+++ b/frontend/stylesheets/_variables.less
@@ -1,14 +1,17 @@
-@blue-base: #5660ff;
+
 @primary-color: #5660ff;
 @pastel-blue: #aabaff;
 @frosted-mint: #ddfdfa;
 @blue-zircon: #59f8e8;
 @black: rgba(0, 0, 0, 0.85);
 @left-menu-width: 360px;
-@navbar-height: 48px;
 @xyRed: #eb4b98;
 @yzBlue: #5660ff;
 @xzGreen: #59f8e8;
 @footer-height: 20px;
 @background-blue-neurons: url(/assets/images/background_neurons_drawn.svg) 0 / cover no-repeat, @primary-color;
 @background-blue-organelles: url(/assets/images/background_mixed_cells_drawn.svg) 0 / cover no-repeat, @primary-color;
+
+:root {
+    --navbar-height: 48px;
+}

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -51,7 +51,7 @@ body {
   font-size: 16px;
   -webkit-font-smoothing: antialised;
   height: 100vh;
-  padding-top: @navbar-height;
+  padding-top: var(--navbar-height);
 }
 
 #main-container > section > .ant-layout-header {
@@ -139,7 +139,7 @@ body {
 }
 
 .onboarding {
-  min-height: calc(100vh - @navbar-height);
+  min-height: calc(100vh - var(--navbar-height));
   display: flex;
   flex-direction: column;
   padding-bottom: 50px;
@@ -626,7 +626,7 @@ i.without-icon-margin,
 .login-view {
   & {
     height: 100%;
-    min-height: calc(100vh - @navbar-height);
+    min-height: calc(100vh - var(--navbar-height));
     background: @background-blue-neurons;
   }
 

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -92,7 +92,7 @@
 }
 
 .tracing-layout {
-  height: calc(100vh - @navbar-height);
+  height: calc(100vh - var(--navbar-height));
   display: flex;
 
   &.ant-layout,
@@ -205,7 +205,7 @@
   position: fixed;
   right: 0;
   z-index: 1000;
-  top: @navbar-height;
+  top: var(--navbar-height);
   bottom: 0;
 
   .version-section {
@@ -319,7 +319,7 @@ img.keyboard-mouse-icon:first-child {
   overflow-x: auto;
   overflow-y: hidden;
   position: fixed;
-  height: @navbar-height;
+  height: var(--navbar-height);
   display: flex;
   align-items: center;
   white-space: nowrap;
@@ -599,7 +599,7 @@ img.keyboard-mouse-icon:first-child {
   /* The navbar and footer have a higher z-value than the context menu and
      should not be covered by the context menu overlay. At the same time
      the overlay serves as the container for the css-sticky context menu. */
-  height: calc(100% - @navbar-height - @footer-height);
+  height: calc(100% - var(--navbar-height) - @footer-height);
   position: absolute;
   /* The context menu needs a higher z-value than flexlayout__tab_button_content.
      Otherwise the tab title covers the context menu. */


### PR DESCRIPTION
This PR moves the maintenance banner to the very top of the screen as part of the navbar so it does not interfere with other menus / buttons / tabs etc.

The CSS remains mostly untouched. The trick was to use real CSS variables for the navbar height instead of just a LESS variable. These CSS variables can be modified in (JS) code and then the rest of the styles just adapt.
Additionally the current navbar height is also saved in the stored and can be referenced in different downstream methods that used a constant instead.

I also refactored the maintenance banner component a little bit to more clearly separate the data/state from the rendering of the component. 

<img width="1324" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/fd12d5d4-8626-42a2-a0cd-53c149957017">

<img width="1322" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/3b6495a6-e901-43ff-9397-2e1ae8b1e281">

<img width="1318" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/c0f5b9e9-900e-4963-9fb2-696c05919c86">


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create new scheduled maintenances
  - e.g. Edit "maintenances" table
```
INSERT INTO "webknossos"."maintenances"("_id", "_user", "starttime", "endtime", "message", "created", "isdeleted") VALUES('653baadfef0100310a01ec94', '6538f9e0ef0100ef0101ec6d', '2023-11-02 13:03:15.125+01', '2023-11-02 13:50:00.452+01', 'Test Maintenance Banner Foobar Test Maintenance Banner Foobar Test Maintenance Banner Foobar Test Maintenance Banner Foobar Test Maintenance Banner Foobar Test Maintenance Banner Foobar Test Maintenance Banner Foobar ', '2023-10-27 14:19:43.343+02', FALSE) RETURNING "_id", "_user", "starttime", "endtime", "message", "created", "isdeleted";
```
- Try with a currently active maintenance and a maintenance scheduled in the future

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1698066526401089

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
