### PR TITLE
Add stats filter to task list view

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/23.11.0...HEAD)
 
 ### Added
+Added a filter to the Task List->Stats column to quickly filter for tasks with "Prending", "In-Progress" or "Finished" instances. [#7430](https://github.com/scalableminds/webknossos/pull/7430)
 
 ### Changed
 

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -18,7 +18,7 @@ import React from "react";
 import _ from "lodash";
 import features from "features";
 import { AsyncLink } from "components/async_clickables";
-import type { APITask, APITaskType, APIUser } from "types/api_flow_types";
+import type { APITask, APITaskType, APIUser, TaskStatus } from "types/api_flow_types";
 import { deleteTask, getTasks, downloadAnnotation, assignTaskToUser } from "admin/admin_rest_api";
 import { formatTuple, formatSeconds } from "libs/format_utils";
 import { handleGenericError } from "libs/error_handling";
@@ -397,6 +397,49 @@ class TaskListView extends React.PureComponent<Props, State> {
               sorter={Utils.localeCompareBy(typeHint, (task) => task.dataSet)}
             />
             <Column
+              title="Stats"
+              dataIndex="status"
+              key="status"
+              render={(status, task: APITask) => (
+                <div className="nowrap">
+                  <span title="Pending Instances">
+                    <PlayCircleOutlined />
+                    {status.pending}
+                  </span>
+                  <br />
+                  <span title="Active Instances">
+                    <ForkOutlined />
+                    {status.active}
+                  </span>
+                  <br />
+                  <span title="Finished Instances">
+                    <CheckCircleOutlined />
+                    {status.finished}
+                  </span>
+                  <br />
+                  <span title="Annotation Time">
+                    <ClockCircleOutlined />
+                    {formatSeconds((task.tracingTime || 0) / 1000)}
+                  </span>
+                </div>
+              )}
+              filters={[
+                {
+                  text: "Has Pending Instances",
+                  value: "pending",
+                },
+                {
+                  text: "Has In Progress Instances",
+                  value: "active",
+                },
+                {
+                  text: "Has Finished Instances",
+                  value: "finished",
+                },
+              ]}
+              onFilter={(key, task: APITask) => task.status[key as unknown as keyof TaskStatus] > 0}
+            />
+            <Column
               title="Edit Position / Bounding Box"
               dataIndex="editPosition"
               key="editPosition"
@@ -429,34 +472,6 @@ class TaskListView extends React.PureComponent<Props, State> {
               width={200}
               sorter={Utils.compareBy(typeHint, (task) => task.created)}
               render={(created) => <FormattedDate timestamp={created} />}
-            />
-            <Column
-              title="Stats"
-              dataIndex="status"
-              key="status"
-              render={(status, task: APITask) => (
-                <div className="nowrap">
-                  <span title="Pending Instances">
-                    <PlayCircleOutlined />
-                    {status.pending}
-                  </span>
-                  <br />
-                  <span title="Active Instances">
-                    <ForkOutlined />
-                    {status.active}
-                  </span>
-                  <br />
-                  <span title="Finished Instances">
-                    <CheckCircleOutlined />
-                    {status.finished}
-                  </span>
-                  <br />
-                  <span title="Annotation Time">
-                    <ClockCircleOutlined />
-                    {formatSeconds((task.tracingTime || 0) / 1000)}
-                  </span>
-                </div>
-              )}
             />
             <Column
               title="Action"

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -429,7 +429,7 @@ class TaskListView extends React.PureComponent<Props, State> {
                   value: "pending",
                 },
                 {
-                  text: "Has In Progress Instances",
+                  text: "Has Active Instances",
                   value: "active",
                 },
                 {


### PR DESCRIPTION
PR does two things:
- Prioritized the stats column in the table by moving it towards the beginning of the table instead of the last position which is often cut off
- Added a filter to the stats column to quickly filter for tasks with "Prending", "In-Progress" or "Finished" instances

<img width="1122" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/ecd9e782-f31b-42d2-96bf-3b5a3a8aa02f">


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create new tasks
- Go to Task List View
- Filter away

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
