### PR TITLE
Unify Fox.transformFuture and future2Fox

### DIFF
--- a/tools/nml/nmlgenerator.py
+++ b/tools/nml/nmlgenerator.py
@@ -1,73 +1,73 @@
 #! /usr/bin/env python
 
-import sys
 import argparse
 
-class NMLGenerator(object):
+class NMLGenerator():
+
+    def __init__(self, nodes_per_tree=1, trees=1, include_comments=False):
+
+        self.nodes_per_tree = nodes_per_tree
+        self.trees = trees
+        self.include_comments = include_comments
 
 
-  def __init__(self, nodes_per_tree=1, trees=1, include_comments=False):
+    def print_nml(self):
 
-    self.nodes_per_tree = nodes_per_tree
-    self.trees = trees
-    self.include_comments = include_comments
-
-
-  def print_nml(self):
-
-    print '<things>'
-    self.print_parameters()
-    self.print_trees()
-    self.print_comments()
-    print '</things>'
+        print('<things>')
+        self.print_parameters()
+        self.print_trees()
+        self.print_comments()
+        print('</things>')
 
 
-  def print_parameters(self):
+    def print_parameters(self):
 
-    print '  <parameters>'
-    print '    <experiment name="2012-09-28_ex145_07x2"/>'
-    print '    <scale x="16.5" y="16.5" z="25.0"/>'
-    print '    <offset x="0" y="0" z="0"/>'
-    print '    <time ms="1395338383400"/>'
-    print '    <activeNode id="1"/>'
-    print '    <editPosition x="107" y="77" z="0"/>'
-    print '  </parameters>'
-
-
-  def print_trees(self):
-
-    node_id_count = 1
-    for tree_id in range(1, self.trees + 1):
-      print '  <thing id="%d" color.r="1.0" color.g="0.0" color.b="0.0" color.a="1.0" name="Tree00%d">' % (tree_id, tree_id)
-      print '    <nodes>'
-      for node_id in range(node_id_count, node_id_count + self.nodes_per_tree):
-        print '      <node '
-        print '        id="%d" radius="165.0" x="%d" y="%d" z="%d"' % (node_id, node_id, node_id, tree_id)
-        print '        inVp="0" inMag="0" bitDepth="8" interpolation="false" time="1395338380800">'
-        print '      </node>'
-      print '    </nodes>'
-      print '    <edges>'
-      for node_id in range(node_id_count + 1, node_id_count + self.nodes_per_tree):
-        print '      <edge source="%d" target="%d"/>' % (node_id - 1, node_id)
-      print '    </edges>'
-      print '  </thing>'
-      node_id_count += self.nodes_per_tree
+        print('    <parameters>')
+        print('        <experiment name="l4_sample" organization="sample_organization"/>')
+        print('        <scale x="11.239999771118164" y="11.239999771118164" z="28"/>')
+        print('        <offset x="0" y="0" z="0"/>')
+        print('        <time ms="1395338383400"/>')
+        print('        <activeNode id="1"/>')
+        print('        <editPosition x="107" y="77" z="0"/>')
+        print('    </parameters>')
 
 
-  def print_comments(self):
+    def print_trees(self):
 
-    print '  <comments>'
-    if self.include_comments:
-      for node_id in range(1, self.trees * self.nodes_per_tree + 1):
-        print '    <comment node="%d" content="Node %d"/>' % (node_id, node_id)
-    print '  </comments>'
+        node_id_count = 1
+        for tree_id in range(1, self.trees + 1):
+            print(f'    <thing id="{tree_id}" color.r="1.0" color.g="0.0" color.b="0.0" color.a="1.0" name="Tree{tree_id}">')
+            print('        <nodes>')
+            for node_id in range(node_id_count, node_id_count + self.nodes_per_tree):
+                print('            <node ')
+                print(f'                id="{node_id}" radius="165.0" x="{node_id}" y="{node_id}" z="{tree_id}"')
+                print(f'                id="{node_id}" radius="165.0" x="{node_id}" y="{node_id}" z="{tree_id}"')
+                print('                inVp="0" inMag="0" bitDepth="8" interpolation="false" time="1395338380800">')
+                print('            </node>')
+            print('        </nodes>')
+            print('        <edges>')
+            for node_id in range(node_id_count + 1, node_id_count + self.nodes_per_tree):
+                print(f'            <edge source="{node_id - 1}" target="{node_id}"/>')
+            print('        </edges>')
+            print('    </thing>')
+            node_id_count += self.nodes_per_tree
 
 
-parser = argparse.ArgumentParser(description='Print an NML file.')
-parser.add_argument('nodes_per_tree', type=int, help='Number of nodes per tree')
-parser.add_argument('trees', type=int, help='Number of trees', default=1, nargs='?')
-parser.add_argument('--comments', dest='include_comments', action='store_const',
-                  const=True, default=False, help='Include comments')
-args = parser.parse_args()
+    def print_comments(self):
 
-NMLGenerator(args.nodes_per_tree, args.trees, args.include_comments).print_nml()
+        print('    <comments>')
+        if self.include_comments:
+            for node_id in range(1, self.trees * self.nodes_per_tree + 1):
+                print(f'        <comment node="{node_id}" content="Node {node_id}"/>')
+        print('    </comments>')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Print(an NML file.')
+    parser.add_argument('nodes_per_tree', type=int, help='Number of nodes per tree')
+    parser.add_argument('trees', type=int, help='Number of trees', default=1, nargs='?')
+    parser.add_argument('--comments', dest='include_comments', action='store_const',
+                                        const=True, default=False, help='Include comments')
+    args = parser.parse_args()
+
+    NMLGenerator(args.nodes_per_tree, args.trees, args.include_comments).print_nml()

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/HttpsDataVault.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.datastore.datavault
 
 import com.scalableminds.util.cache.AlfuCache
 import com.scalableminds.util.tools.Fox
-import com.scalableminds.util.tools.Fox.box2Fox
+import com.scalableminds.util.tools.Fox.{box2Fox, future2Fox}
 import com.scalableminds.webknossos.datastore.storage.{
   DataVaultCredential,
   HttpBasicAuthCredential,
@@ -50,7 +50,7 @@ class HttpsDataVault(credential: Option[DataVaultCredential], ws: WSClient) exte
     headerInfoCache.getOrLoad(
       uri, { uri =>
         for {
-          response <- Fox.transformFuture(ws.url(uri.toString).withRequestTimeout(readTimeout).head())
+          response <- ws.url(uri.toString).withRequestTimeout(readTimeout).head().toFox
           acceptsPartialRequests = response.headerValues("Accept-Ranges").contains("bytes")
           dataSize = response.header("Content-Length").map(_.toLong).getOrElse(0L)
         } yield (acceptsPartialRequests, dataSize)
@@ -60,20 +60,19 @@ class HttpsDataVault(credential: Option[DataVaultCredential], ws: WSClient) exte
   private def getWithRange(uri: URI, range: NumericRange[Long])(implicit ec: ExecutionContext): Fox[WSResponse] =
     for {
       _ <- ensureRangeRequestsSupported(uri)
-      response <- Fox.transformFuture(
-        buildRequest(uri).withHttpHeaders("Range" -> s"bytes=${range.start}-${range.end - 1}").get())
+      response <- buildRequest(uri).withHttpHeaders("Range" -> s"bytes=${range.start}-${range.end - 1}").get().toFox
       _ = updateRangeRequestsSupportedForResponse(response)
     } yield response
 
   private def getWithSuffixRange(uri: URI, length: Long)(implicit ec: ExecutionContext): Fox[WSResponse] =
     for {
       _ <- ensureRangeRequestsSupported(uri)
-      response <- Fox.transformFuture(buildRequest(uri).withHttpHeaders("Range" -> s"bytes=-$length").get())
+      response <- buildRequest(uri).withHttpHeaders("Range" -> s"bytes=-$length").get().toFox
       _ = updateRangeRequestsSupportedForResponse(response)
     } yield response
 
   private def getComplete(uri: URI)(implicit ec: ExecutionContext): Fox[WSResponse] =
-    Fox.transformFuture(buildRequest(uri).get())
+    buildRequest(uri).get().toFox
 
   private def ensureRangeRequestsSupported(uri: URI)(implicit ec: ExecutionContext): Fox[Unit] =
     for {


### PR DESCRIPTION
I’d say if the Future holds an exception as value, converting it to Fox should always result in a Fox.failure. If any cases crop up where it turns out this is unwanted, we can handle those then.

Also slipped in here: updated nmlgenerator.py for python3 (apparently my test for https://scm.slack.com/archives/C02H5T8Q08P/p1700075688666279?thread_ts=1699861762.947499&cid=C02H5T8Q08P was its first usage in some time)

### Steps to test:
- CI should be enough
- Try exploring remote dataset with URI with nonexisting host, should still not throw exception

### Issues:
- fixes #7425

------
- [x] Needs datastore update after deployment
