### PR TITLE
Fix theme initialization

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that trees with ids around 1023 were invisible on some systems. [#7443](https://github.com/scalableminds/webknossos/pull/7443)
 - Fixed styling issues with the maintenance banner so that it no longer overlaps other menus, tabs, and buttons. [#7421](https://github.com/scalableminds/webknossos/pull/7421)
 - Exploring HTTP uris of unknown hosts no longer causes an exception error message to be displayed. [#7422](https://github.com/scalableminds/webknossos/pull/7422)
+- Fixed the initialization of the dark theme if it was active during page load. [#7446](https://github.com/scalableminds/webknossos/pull/7446)
 
 ### Removed
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -35,6 +35,7 @@ Option[String], openGraphImage: Option[String] )
       media="screen"
       href="/assets/bundle/vendors~main.css?nocache=@(webknossos.BuildInfo.commitHash)"
     />
+    <script src="/assets/bundle/theme.js?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script
       data-airbrake-project-id="@(conf.Airbrake.projectID)"
       data-airbrake-project-key="@(conf.Airbrake.projectKey)"

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -31,43 +31,10 @@ import checkBrowserFeatures from "libs/browser_feature_check";
 // Suppress warning emitted by Olvy because it tries to eagerly initialize
 window.OlvyConfig = null;
 
-function loadInitialTheme() {
-  let metaElement = document.querySelector("meta[name='commit-hash']");
-  const commitHash = metaElement ? metaElement.getAttribute("content") : null;
-  metaElement = document.querySelector("meta[name='selected-theme']");
-  let initialTheme = metaElement ? metaElement.getAttribute("content") : null;
-  if (initialTheme === "auto") {
-    initialTheme =
-      window.matchMedia("(prefers-color-scheme: dark)").media !== "not all" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-        ? "dark"
-        : "light";
-  }
-  document.documentElement.style.display = "none";
-  document.head.insertAdjacentHTML(
-    "beforeend",
-    "<link " +
-      'id="primary-stylesheet" ' +
-      'rel="stylesheet" ' +
-      'type="text/css" ' +
-      'media="screen" ' +
-      'href="/assets/bundle/' +
-      initialTheme +
-      ".css?nocache=" +
-      commitHash +
-      '" ' +
-      "/>",
-  );
-  document.getElementById("primary-stylesheet")?.addEventListener("load", () => {
-    document.documentElement.style.display = "";
-  });
-}
-
 setModel(Model);
 setStore(UnthrottledStore);
 setupApi();
 startSagas(rootSaga);
-loadInitialTheme();
 
 const reactQueryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/javascripts/theme.tsx
+++ b/frontend/javascripts/theme.tsx
@@ -1,0 +1,29 @@
+let metaElement = document.querySelector("meta[name='commit-hash']");
+const commitHash = metaElement ? metaElement.getAttribute("content") : null;
+metaElement = document.querySelector("meta[name='selected-theme']");
+let initialTheme = metaElement ? metaElement.getAttribute("content") : null;
+if (initialTheme === "auto") {
+  initialTheme =
+    window.matchMedia("(prefers-color-scheme: dark)").media !== "not all" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+}
+document.documentElement.style.display = "none";
+document.head.insertAdjacentHTML(
+  "beforeend",
+  "<link " +
+    'id="primary-stylesheet" ' +
+    'rel="stylesheet" ' +
+    'type="text/css" ' +
+    'media="screen" ' +
+    'href="/assets/bundle/' +
+    initialTheme +
+    ".css?nocache=" +
+    commitHash +
+    '" ' +
+    "/>",
+);
+document.getElementById("primary-stylesheet")?.addEventListener("load", () => {
+  document.documentElement.style.display = "";
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = function (env = {}) {
     experiments: { asyncWebAssembly: true },
     entry: {
       main: "main.tsx",
+      theme: "theme.tsx",
       light: "style_light.ts",
       dark: "style_dark.ts",
     },


### PR DESCRIPTION
 by loading theme before main.js. Regression was introduced in https://github.com/scalableminds/webknossos/pull/7367.
 
 The default state initialization assumes that the active theme is already set in the HTML (see [this code](https://github.com/scalableminds/webknossos/blob/master/frontend/javascripts/oxalis/default_state.ts#L244)). Initializing the theme in the HTML too late, leads to rendering issues, because the state is never set correctly (only once the theme is switched again). I'm not sure why the initialization is that hacky, maybe to avoid flickering if the theme is set too late, otherwise :thinking: 

### URL of deployed dev instance (used for testing):
- https://fixtheme.webknossos.xyz

### Steps to test:
- View a dataset in dark mode. Reload the page. The 3d viewport and the other viewport headers should be dark, not white.

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
