### PR TITLE
Added a delete dataset action to dashboard

### DIFF
--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -1,4 +1,5 @@
 import {
+  DeleteOutlined,
   EllipsisOutlined,
   EyeOutlined,
   LoadingOutlined,
@@ -9,14 +10,17 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import window from "libs/window";
-import { Link, LinkProps, RouteComponentProps, withRouter } from "react-router-dom";
+import { Link, LinkProps } from "react-router-dom";
 import * as React from "react";
 import type { APIDatasetId, APIDataset, APIDatasetCompact } from "types/api_flow_types";
-import { clearCache, getDataset } from "admin/admin_rest_api";
+import { clearCache, deleteDatasetOnDisk, getDataset } from "admin/admin_rest_api";
 import Toast from "libs/toast";
 import messages from "messages";
 import CreateExplorativeModal from "dashboard/advanced_dataset/create_explorative_modal";
-import { MenuProps, Modal } from "antd";
+import { MenuProps, Modal, Typography } from "antd";
+import { confirmAsync } from "dashboard/dataset/helper_components";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 const disabledStyle: React.CSSProperties = {
   pointerEvents: "none",
   color: "var(--ant-disabled)",
@@ -83,10 +87,6 @@ type Props = {
   dataset: APIDatasetCompact;
   reloadDataset: (arg0: APIDatasetId) => Promise<void>;
 };
-type State = {
-  isReloading: boolean;
-  isCreateExplorativeModalVisible: boolean;
-};
 
 function LinkWithDisabled({
   disabled,
@@ -116,114 +116,145 @@ function LinkWithDisabled({
   );
 }
 
-class DatasetActionView extends React.PureComponent<Props, State> {
-  state = {
-    isReloading: false,
-    isCreateExplorativeModalVisible: false,
-  };
+function DatasetActionView(props: Props) {
+  const queryClient = useQueryClient();
+  const { dataset } = props;
 
-  onClearCache = async (compactDataset: APIDatasetCompact) => {
-    this.setState({
-      isReloading: true,
-    });
+  const [isReloading, setIsReloading] = useState(false);
+  const [isCreateExplorativeModalVisible, setIsCreateExplorativeModalVisible] = useState(false);
+
+  const onClearCache = async (compactDataset: APIDatasetCompact) => {
+    setIsReloading(true);
     const dataset = await getDataset(compactDataset);
     await clearCache(dataset);
-    await this.props.reloadDataset(dataset);
+    await props.reloadDataset(dataset);
     Toast.success(
       messages["dataset.clear_cache_success"]({
         datasetName: dataset.name,
       }),
     );
-    this.setState({
-      isReloading: false,
-    });
+    setIsReloading(false);
   };
 
-  render() {
-    const { dataset } = this.props;
-    const { isReloading } = this.state;
-    const { isCreateExplorativeModalVisible } = this.state;
-    const disabledWhenReloadingStyle = getDisabledWhenReloadingStyle(isReloading);
-    const reloadLink = (
-      <a
-        onClick={() => this.onClearCache(dataset)}
-        title="Reload Dataset"
-        style={disabledWhenReloadingStyle}
-        type="link"
+  const onDeleteDataset = async () => {
+    const dataset = await getDataset(props.dataset);
+
+    const deleteDataset = await confirmAsync({
+      title: "Danger Zone",
+      content: (
+        <>
+          <Typography.Title level={4} type="danger">
+            Deleting a dataset on disk cannot be undone. Are you certain to delete dataset{" "}
+            {dataset.name}?
+          </Typography.Title>
+          <Typography.Paragraph>
+            Note, WEBKNOSSOS cannot delete datasets that have annotations associated with them.
+          </Typography.Paragraph>
+        </>
+      ),
+      okText: "Yes, Delete Dataset on Disk now",
+      okType: "danger",
+    });
+
+    if (!deleteDataset) {
+      return;
+    }
+
+    const datasetId: APIDatasetId = {
+      name: dataset.name,
+      owningOrganization: dataset.owningOrganization,
+    };
+    await deleteDatasetOnDisk(dataset.dataStore.url, datasetId);
+
+    Toast.success(
+      messages["dataset.delete_success"]({
+        datasetName: dataset.name,
+      }),
+    );
+
+    // Invalidate the dataset list cache to exclude the deleted dataset
+    queryClient.invalidateQueries({
+      queryKey: ["datasetsByFolder", dataset.folderId],
+    });
+    queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+  };
+
+  const disabledWhenReloadingStyle = getDisabledWhenReloadingStyle(isReloading);
+  const reloadLink = (
+    <a
+      onClick={() => onClearCache(dataset)}
+      title="Reload Dataset"
+      style={disabledWhenReloadingStyle}
+      type="link"
+    >
+      {isReloading ? <LoadingOutlined /> : <ReloadOutlined />}
+      Reload
+    </a>
+  );
+  const importLink = (
+    <div className="dataset-table-actions">
+      <Link
+        to={`/datasets/${dataset.owningOrganization}/${dataset.name}/import`}
+        className="import-dataset"
       >
-        {isReloading ? <LoadingOutlined /> : <ReloadOutlined />}
-        Reload
+        <PlusCircleOutlined />
+        Import
+      </Link>
+      {reloadLink}
+      <a
+        onClick={() =>
+          Modal.error({
+            title: "Cannot load this dataset",
+            content: dataset.status,
+          })
+        }
+      >
+        <WarningOutlined />
+        Show Error
       </a>
-    );
-    const importLink = (
-      <div className="dataset-table-actions">
-        <Link
-          to={`/datasets/${dataset.owningOrganization}/${dataset.name}/import`}
-          className="import-dataset"
-        >
-          <PlusCircleOutlined />
-          Import
-        </Link>
-        {reloadLink}
-        <a
-          onClick={() =>
-            Modal.error({
-              title: "Cannot load this dataset",
-              content: dataset.status,
-            })
-          }
-        >
-          <WarningOutlined />
-          Show Error
-        </a>
-      </div>
-    );
-    return (
-      <div>
-        {dataset.isEditable && !dataset.isActive ? importLink : null}
-        {dataset.isActive ? (
-          <div className="dataset-table-actions nowrap">
-            <NewAnnotationLink
-              dataset={dataset}
-              isReloading={isReloading}
-              isCreateExplorativeModalVisible={isCreateExplorativeModalVisible}
-              onShowCreateExplorativeModal={() =>
-                this.setState({
-                  isCreateExplorativeModalVisible: true,
-                })
-              }
-              onCloseCreateExplorativeModal={() =>
-                this.setState({
-                  isCreateExplorativeModalVisible: false,
-                })
-              }
-            />
-            <LinkWithDisabled
-              to={`/datasets/${dataset.owningOrganization}/${dataset.name}/view`}
-              title="View Dataset"
-              disabled={isReloading}
-            >
-              <EyeOutlined />
-              View
-            </LinkWithDisabled>
-            {dataset.isEditable ? (
-              <React.Fragment>
-                <LinkWithDisabled
-                  to={`/datasets/${dataset.owningOrganization}/${dataset.name}/edit`}
-                  title="Open Dataset Settings"
-                  disabled={isReloading}
-                >
-                  <SettingOutlined />
-                  Settings
-                </LinkWithDisabled>
-                {reloadLink}
-              </React.Fragment>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-    );
-  }
+      <a onClick={() => onDeleteDataset()}>
+        <DeleteOutlined />
+        Delete Dataset
+      </a>
+    </div>
+  );
+  return (
+    <div>
+      {dataset.isEditable && !dataset.isActive ? importLink : null}
+      {dataset.isActive ? (
+        <div className="dataset-table-actions nowrap">
+          <NewAnnotationLink
+            dataset={dataset}
+            isReloading={isReloading}
+            isCreateExplorativeModalVisible={isCreateExplorativeModalVisible}
+            onShowCreateExplorativeModal={() => setIsCreateExplorativeModalVisible(true)}
+            onCloseCreateExplorativeModal={() => setIsCreateExplorativeModalVisible(false)}
+          />
+          <LinkWithDisabled
+            to={`/datasets/${dataset.owningOrganization}/${dataset.name}/view`}
+            title="View Dataset"
+            disabled={isReloading}
+          >
+            <EyeOutlined />
+            View
+          </LinkWithDisabled>
+          {dataset.isEditable ? (
+            <React.Fragment>
+              <LinkWithDisabled
+                to={`/datasets/${dataset.owningOrganization}/${dataset.name}/edit`}
+                title="Open Dataset Settings"
+                disabled={isReloading}
+              >
+                <SettingOutlined />
+                Settings
+              </LinkWithDisabled>
+              {reloadLink}
+            </React.Fragment>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 const onClearCache = async (
   dataset: APIDataset,
@@ -312,4 +343,4 @@ export function getDatasetActionContextMenu({
   };
 }
 
-export default withRouter<RouteComponentProps & Props, any>(DatasetActionView);
+export default DatasetActionView;

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -417,11 +417,11 @@ function getDashboardSubMenu(collapse: boolean): SubMenuType {
     label: getCollapsibleMenuTitle("Dashboard", <HomeOutlined />, collapse),
     children: [
       { key: "/dashboard/datasets", label: <Link to="/dashboard/datasets">Datasets</Link> },
-      { key: "/dashboard/tasks", label: <Link to="/dashboard/tasks">Tasks</Link> },
       {
         key: "/dashboard/annotations",
         label: <Link to="/dashboard/annotations">Annotations</Link>,
       },
+      { key: "/dashboard/tasks", label: <Link to="/dashboard/tasks">Tasks</Link> },
     ],
   };
 }


### PR DESCRIPTION
Every now and again there appear old, unimported datasets on your dashboard, mostly on WK instance with file system access. Thus far there is no easy way to delete them. This PR adds a "Delete" action to this unimported datasets.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
1. Duplicate any DS in your `binaryData` folder and remove `datasource-porps.json` to make it go kaputt
2. Re-scan datasets on your dashboard
3. See and press "Delete" action
4. Profit

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
