### PR TITLE
Support blosc for N5

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,8 +14,9 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Zarr datasets can now be directly uploaded to WEBKNOSSOS. [#7397](https://github.com/scalableminds/webknossos/pull/7397)
 - Added support for reading uint24 rgb layers in datasets with zarr2/zarr3/n5/neuroglancerPrecomputed format, as used for voxelytics predictions. [#7413](https://github.com/scalableminds/webknossos/pull/7413)
 - Adding a remote dataset can now be done by providing a Neuroglancer URI. [#7416](https://github.com/scalableminds/webknossos/pull/7416)
-- Added a filter to the Task List->Stats column to quickly filter for tasks with "Prending", "In-Progress" or "Finished" instances. [#7430](https://github.com/scalableminds/webknossos/pull/7430)
+- Added a filter to the Task List->Stats column to quickly filter for tasks with "Pending", "In-Progress" or "Finished" instances. [#7430](https://github.com/scalableminds/webknossos/pull/7430)
 - Added support for S3-compliant object storage services (e.g. MinIO) as a storage backend for remote datasets. [#7453](https://github.com/scalableminds/webknossos/pull/7453)
+- Added support for blosc compressed N5 datasets. [#7465](https://github.com/scalableminds/webknossos/pull/7465)
 
 ### Changed
 - An appropriate error is returned when requesting an API version that is higher that the current version. [#7424](https://github.com/scalableminds/webknossos/pull/7424)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5CompressorFactory.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5CompressorFactory.scala
@@ -1,6 +1,7 @@
 package com.scalableminds.webknossos.datastore.datareaders.n5
 
 import com.scalableminds.webknossos.datastore.datareaders.{
+  BloscCompressor,
   BoolCompressionSetting,
   CompressionSetting,
   Compressor,
@@ -25,7 +26,8 @@ object N5CompressorFactory {
       case "zlib" => new ZlibCompressor(properties)
       case "gzip" if properties.getOrElse("useZlib", BoolCompressionSetting(false)) == BoolCompressionSetting(true) =>
         new ZlibCompressor(properties)
-      case "gzip" => new GzipCompressor(properties)
-      case _      => throw new IllegalArgumentException("Compressor id:'" + id + "' not supported.")
+      case "gzip"  => new GzipCompressor(properties)
+      case "blosc" => new BloscCompressor(properties)
+      case _       => throw new IllegalArgumentException("Compressor id:'" + id + "' not supported.")
     }
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Explore s3://janelia-cosem-datasets/jrc_mus-pacinian-corpuscle/jrc_mus-pacinian-corpuscle.n5/em/fibsem-uint8/

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
