### PR TITLE
Fix antd deprecation warnings for Tabs.TabPane

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_add_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_view.tsx
@@ -1,6 +1,6 @@
 import type { RouteComponentProps } from "react-router-dom";
 import { withRouter } from "react-router-dom";
-import { Tabs, Modal, Button, Layout } from "antd";
+import { Tabs, Modal, Button, Layout, TabsProps } from "antd";
 import { DatabaseOutlined, UploadOutlined } from "@ant-design/icons";
 import React, { useState } from "react";
 import { connect } from "react-redux";
@@ -13,7 +13,6 @@ import features from "features";
 import { getDatastores } from "admin/admin_rest_api";
 import { useFetch } from "libs/react_helpers";
 
-const { TabPane } = Tabs;
 const { Content, Sider } = Layout;
 
 enum DatasetAddViewTabs {
@@ -107,34 +106,34 @@ function DatasetAddView({ history }: RouteComponentProps) {
     ? (defaultActiveTabFromHash as DatasetAddViewTabs)
     : DatasetAddViewTabs.UPLOAD;
 
+  const tabs: TabsProps["items"] = [
+    {
+      label: (
+        <span>
+          <UploadOutlined />
+          Upload Dataset
+        </span>
+      ),
+      key: DatasetAddViewTabs.UPLOAD,
+      children: <DatasetUploadView datastores={datastores} onUploaded={handleDatasetAdded} />,
+    },
+    {
+      label: (
+        <span>
+          <DatabaseOutlined />
+          Add Remote Dataset
+        </span>
+      ),
+      key: DatasetAddViewTabs.REMOTE,
+      children: <DatasetAddRemoteView datastores={datastores} onAdded={handleDatasetAdded} />,
+    },
+  ];
+
   return (
     <React.Fragment>
       <Layout>
         <Content>
-          <Tabs defaultActiveKey={defaultActiveKey} className="container">
-            <TabPane
-              tab={
-                <span>
-                  <UploadOutlined />
-                  Upload Dataset
-                </span>
-              }
-              key={DatasetAddViewTabs.UPLOAD}
-            >
-              <DatasetUploadView datastores={datastores} onUploaded={handleDatasetAdded} />
-            </TabPane>
-            <TabPane
-              tab={
-                <span>
-                  <DatabaseOutlined />
-                  Add Remote Dataset
-                </span>
-              }
-              key={DatasetAddViewTabs.REMOTE}
-            >
-              <DatasetAddRemoteView datastores={datastores} onAdded={handleDatasetAdded} />
-            </TabPane>
-          </Tabs>
+          <Tabs defaultActiveKey={defaultActiveKey} className="container" items={tabs} />
         </Content>
         <VoxelyticsBanner />
       </Layout>

--- a/frontend/javascripts/admin/task/task_create_view.tsx
+++ b/frontend/javascripts/admin/task/task_create_view.tsx
@@ -1,35 +1,34 @@
 import { BarsOutlined, ScheduleOutlined } from "@ant-design/icons";
-import { Tabs } from "antd";
+import { Tabs, TabsProps } from "antd";
 import React from "react";
 import TaskCreateBulkView from "admin/task/task_create_bulk_view";
 import TaskCreateFormView from "admin/task/task_create_form_view";
-const { TabPane } = Tabs;
 
-const TaskCreateView = () => (
-  <Tabs defaultActiveKey="1" className="container">
-    <TabPane
-      tab={
+const TaskCreateView = () => {
+  const tabs: TabsProps["items"] = [
+    {
+      label: (
         <span>
           <ScheduleOutlined />
           Create Task
         </span>
-      }
-      key="1"
-    >
-      <TaskCreateFormView taskId={null} />
-    </TabPane>
-    <TabPane
-      tab={
+      ),
+      key: "1",
+      children: <TaskCreateFormView taskId={null} />,
+    },
+    {
+      label: (
         <span>
           <BarsOutlined />
           Bulk Creation
         </span>
-      }
-      key="2"
-    >
-      <TaskCreateBulkView />
-    </TabPane>
-  </Tabs>
-);
+      ),
+      key: "2",
+      children: <TaskCreateBulkView />,
+    },
+  ];
+
+  return <Tabs defaultActiveKey="1" className="container" items={tabs} />;
+};
 
 export default TaskCreateView;

--- a/frontend/javascripts/admin/voxelytics/task_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_view.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { JSONTree } from "react-json-tree";
-import { Progress, Tabs, Tooltip } from "antd";
+import { Progress, Tabs, TabsProps, Tooltip } from "antd";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import Markdown from "react-remarkable";
 import {
@@ -15,9 +15,6 @@ import LogTab from "./log_tab";
 import StatisticsTab from "./statistics_tab";
 import { runStateToStatus, useTheme } from "./utils";
 import { formatNumber } from "libs/format_utils";
-
-const { TabPane } = Tabs;
-
 function labelRenderer(_keyPath: Array<string | number>) {
   const keyPath = _keyPath.slice().reverse();
   const divWithId = <div id={`label-${keyPath.join(".")}`}>{keyPath.slice(-1)[0]}</div>;
@@ -49,6 +46,98 @@ function TaskView({
 
   const ingoingEdges = dag.edges.filter((edge) => edge.target === taskName);
   const [theme, invertTheme] = useTheme();
+
+  const configTab = (
+    <>
+      <p>
+        Class: <span style={{ fontFamily: "monospace" }}>{task.task}</span>
+      </p>
+      <JSONTree
+        data={task.config}
+        hideRoot
+        shouldExpandNode={shouldExpandNode}
+        labelRenderer={labelRenderer}
+        theme={theme}
+        invertTheme={invertTheme}
+      />
+    </>
+  );
+
+  const logTab =
+    runId != null ? (
+      <LogTab
+        workflowHash={workflowHash}
+        runId={runId}
+        taskName={taskInfo.taskName}
+        isRunning={taskInfo.state === VoxelyticsRunState.RUNNING}
+        beginTime={taskInfo.beginTime}
+        endTime={taskInfo.endTime}
+      />
+    ) : (
+      <p>Please select a specific run.</p>
+    );
+
+  const tabs: TabsProps["items"] = [{ label: "Config", key: "1", children: configTab }];
+  if (task.description != null)
+    tabs.unshift({
+      label: "Description",
+      key: "0",
+      children: (
+        <Markdown
+          source={task.description}
+          options={{
+            html: false,
+            breaks: true,
+            linkify: true,
+          }}
+        />
+      ),
+    });
+
+  if (Object.keys(artifacts).length > 0)
+    tabs.push({
+      label: "Output Artifacts",
+      key: "2",
+      children: (
+        <ArtifactsViewer
+          workflowHash={workflowHash}
+          runId={runId}
+          taskName={taskName}
+          artifacts={artifacts}
+        />
+      ),
+    });
+
+  if (Object.keys(task.inputs).length > 0)
+    tabs.push({
+      label: "Input Artifacts",
+      key: "3",
+      children: <ul>{renderInputs(task.inputs, ingoingEdges, onSelectTask)}</ul>,
+    });
+
+  if (
+    [
+      VoxelyticsRunState.COMPLETE,
+      VoxelyticsRunState.RUNNING,
+      VoxelyticsRunState.STALE,
+      VoxelyticsRunState.FAILED,
+      VoxelyticsRunState.CANCELLED,
+    ].includes(taskInfo.state)
+  ) {
+    tabs.push({ label: "Logs", key: "4", children: logTab });
+    tabs.push({
+      label: "Statistics",
+      key: "5",
+      children: (
+        <StatisticsTab
+          workflowHash={workflowHash}
+          runId={runId}
+          taskName={taskInfo.taskName}
+          isRunning={taskInfo.state === VoxelyticsRunState.RUNNING}
+        />
+      ),
+    });
+  }
 
   return (
     <div>
@@ -119,86 +208,7 @@ function TaskView({
           </span>
         </div>
       )}
-      <Tabs defaultActiveKey="1">
-        {task.description != null ? (
-          <TabPane tab="Description" key="0">
-            <Markdown
-              source={task.description}
-              options={{
-                html: false,
-                breaks: true,
-                linkify: true,
-              }}
-            />
-          </TabPane>
-        ) : null}
-        <TabPane tab="Config" key="1">
-          <p>
-            Class: <span style={{ fontFamily: "monospace" }}>{task.task}</span>
-          </p>
-          <JSONTree
-            data={task.config}
-            hideRoot
-            shouldExpandNode={shouldExpandNode}
-            labelRenderer={labelRenderer}
-            theme={theme}
-            invertTheme={invertTheme}
-          />
-        </TabPane>
-        {Object.keys(artifacts).length > 0 ? (
-          <TabPane tab="Output Artifacts" key="2">
-            <ArtifactsViewer
-              workflowHash={workflowHash}
-              runId={runId}
-              taskName={taskName}
-              artifacts={artifacts}
-            />
-          </TabPane>
-        ) : null}
-        {Object.keys(task.inputs).length > 0 ? (
-          <TabPane tab="Input Artifacts" key="3">
-            <ul>{renderInputs(task.inputs, ingoingEdges, onSelectTask)}</ul>
-          </TabPane>
-        ) : null}
-        {[
-          VoxelyticsRunState.COMPLETE,
-          VoxelyticsRunState.RUNNING,
-          VoxelyticsRunState.STALE,
-          VoxelyticsRunState.FAILED,
-          VoxelyticsRunState.CANCELLED,
-        ].includes(taskInfo.state) && (
-          <TabPane tab="Logs" key="4">
-            {runId != null ? (
-              <LogTab
-                workflowHash={workflowHash}
-                runId={runId}
-                taskName={taskInfo.taskName}
-                isRunning={taskInfo.state === VoxelyticsRunState.RUNNING}
-                beginTime={taskInfo.beginTime}
-                endTime={taskInfo.endTime}
-              />
-            ) : (
-              <p>Please select a specific run.</p>
-            )}
-          </TabPane>
-        )}
-        {[
-          VoxelyticsRunState.COMPLETE,
-          VoxelyticsRunState.RUNNING,
-          VoxelyticsRunState.STALE,
-          VoxelyticsRunState.FAILED,
-          VoxelyticsRunState.CANCELLED,
-        ].includes(taskInfo.state) && (
-          <TabPane tab="Statistics" key="5">
-            <StatisticsTab
-              workflowHash={workflowHash}
-              runId={runId}
-              taskName={taskInfo.taskName}
-              isRunning={taskInfo.state === VoxelyticsRunState.RUNNING}
-            />
-          </TabPane>
-        )}
-      </Tabs>
+      <Tabs defaultActiveKey="1" items={tabs} />
     </div>
   );
 }

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -57,7 +57,6 @@ import DatasetSettingsDeleteTab from "./dataset_settings_delete_tab";
 import DatasetSettingsDataTab, { syncDataSourceFields } from "./dataset_settings_data_tab";
 import { defaultContext } from "@tanstack/react-query";
 
-const { TabPane } = Tabs;
 const FormItem = Form.Item;
 const notImportedYetStatus = "Not imported yet.";
 type OwnProps = {
@@ -823,6 +822,94 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
       </Tooltip>
     );
 
+    const tabs = [
+      {
+        label: <span> Data {formErrors.data ? errorIcon : ""}</span>,
+        key: "data",
+        forceRender: true,
+        children: (
+          <Hideable hidden={this.state.activeTabKey !== "data"}>
+            {
+              // We use the Hideable component here to avoid that the user can "tab"
+              // to hidden form elements.
+            }
+            {form && (
+              <DatasetSettingsDataTab
+                key="SimpleAdvancedDataForm"
+                datasetId={this.props.datasetId}
+                allowRenamingDataset={false}
+                form={form}
+                activeDataSourceEditMode={this.state.activeDataSourceEditMode}
+                onChange={(activeEditMode) => {
+                  const currentForm = this.formRef.current;
+
+                  if (!currentForm) {
+                    return;
+                  }
+
+                  syncDataSourceFields(currentForm, activeEditMode);
+                  currentForm.validateFields();
+                  this.setState({
+                    activeDataSourceEditMode: activeEditMode,
+                  });
+                }}
+                additionalAlert={this.getDatasourceDiffAlert()}
+              />
+            )}
+          </Hideable>
+        ),
+      },
+
+      {
+        label: <span>Sharing & Permissions {formErrors.general ? errorIcon : null}</span>,
+        key: "sharing",
+        forceRender: true,
+        children: (
+          <Hideable hidden={this.state.activeTabKey !== "sharing"}>
+            <DatasetSettingsSharingTab
+              form={form}
+              datasetId={this.props.datasetId}
+              dataset={this.state.dataset}
+            />
+          </Hideable>
+        ),
+      },
+
+      {
+        label: <span>Metadata</span>,
+        key: "general",
+        forceRender: true,
+        children: (
+          <Hideable hidden={this.state.activeTabKey !== "general"}>
+            <DatasetSettingsMetadataTab />
+          </Hideable>
+        ),
+      },
+
+      {
+        label: <span> View Configuration {formErrors.defaultConfig ? errorIcon : ""}</span>,
+        key: "defaultConfig",
+        forceRender: true,
+        children: (
+          <Hideable hidden={this.state.activeTabKey !== "defaultConfig"}>
+            <DatasetSettingsViewConfigTab />
+          </Hideable>
+        ),
+      },
+    ];
+
+    if (isUserAdmin && features().allowDeleteDatasets)
+      tabs.push({
+        label: <span> Delete Dataset </span>,
+        key: "deleteDataset",
+        forceRender: true,
+        children: (
+          <Hideable hidden={this.state.activeTabKey !== "deleteDataset"}>
+            <DatasetSettingsDeleteTab datasetId={this.props.datasetId} />
+          </Hideable>
+        ),
+      });
+
     return (
       <Form
         ref={this.formRef}
@@ -852,81 +939,8 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
                     activeTabKey,
                   })
                 }
-              >
-                <TabPane
-                  tab={<span> Data {formErrors.data ? errorIcon : ""}</span>}
-                  key="data"
-                  forceRender
-                >
-                  {
-                    // We use the Hideable component here to avoid that the user can "tab"
-                    // to hidden form elements.
-                  }
-                  <Hideable hidden={this.state.activeTabKey !== "data"}>
-                    {form && (
-                      <DatasetSettingsDataTab
-                        key="SimpleAdvancedDataForm"
-                        datasetId={this.props.datasetId}
-                        allowRenamingDataset={false}
-                        form={form}
-                        activeDataSourceEditMode={this.state.activeDataSourceEditMode}
-                        onChange={(activeEditMode) => {
-                          const currentForm = this.formRef.current;
-
-                          if (!currentForm) {
-                            return;
-                          }
-
-                          syncDataSourceFields(currentForm, activeEditMode);
-                          currentForm.validateFields();
-                          this.setState({
-                            activeDataSourceEditMode: activeEditMode,
-                          });
-                        }}
-                        additionalAlert={this.getDatasourceDiffAlert()}
-                      />
-                    )}
-                  </Hideable>
-                </TabPane>
-
-                <TabPane
-                  tab={<span>Sharing & Permissions {formErrors.general ? errorIcon : null}</span>}
-                  key="sharing"
-                  forceRender
-                >
-                  <Hideable hidden={this.state.activeTabKey !== "sharing"}>
-                    <DatasetSettingsSharingTab
-                      form={form}
-                      datasetId={this.props.datasetId}
-                      dataset={this.state.dataset}
-                    />
-                  </Hideable>
-                </TabPane>
-
-                <TabPane tab={<span>Metadata</span>} key="general" forceRender>
-                  <Hideable hidden={this.state.activeTabKey !== "general"}>
-                    <DatasetSettingsMetadataTab />
-                  </Hideable>
-                </TabPane>
-
-                <TabPane
-                  tab={<span> View Configuration {formErrors.defaultConfig ? errorIcon : ""}</span>}
-                  key="defaultConfig"
-                  forceRender
-                >
-                  <Hideable hidden={this.state.activeTabKey !== "defaultConfig"}>
-                    <DatasetSettingsViewConfigTab />
-                  </Hideable>
-                </TabPane>
-
-                {isUserAdmin && features().allowDeleteDatasets ? (
-                  <TabPane tab={<span> Delete Dataset </span>} key="deleteDataset" forceRender>
-                    <Hideable hidden={this.state.activeTabKey !== "deleteDataset"}>
-                      <DatasetSettingsDeleteTab datasetId={this.props.datasetId} />
-                    </Hideable>
-                  </TabPane>
-                ) : null}
-              </Tabs>
+                items={tabs}
+              />
             </Card>
             <FormItem
               style={{

--- a/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/download_modal_view.tsx
@@ -10,6 +10,7 @@ import {
   Radio,
   Alert,
   Tooltip,
+  TabsProps,
 } from "antd";
 import { CopyOutlined } from "@ant-design/icons";
 import React, { useState } from "react";
@@ -53,7 +54,6 @@ import {
 import { formatCountToDataAmountUnit, formatScale } from "libs/format_utils";
 import { BoundingBoxType, Vector3 } from "oxalis/constants";
 import { useStartAndPollJob } from "admin/job/job_hooks";
-const { TabPane } = Tabs;
 const { Paragraph, Text } = Typography;
 
 type TabKeys = "download" | "export" | "python";
@@ -505,6 +505,249 @@ function _DownloadModalView({
 
   // Will be false if no volumes exist.
 
+  const downloadTab = (
+    <>
+      <Row>
+        {maybeShowWarning()}
+        <Text
+          style={{
+            margin: "0 6px 12px",
+          }}
+        >
+          {!hasVolumes ? "This is a Skeleton-only annotation. " : ""}
+          {!hasSkeleton ? "This is a Volume-only annotation. " : ""}
+          {messages["annotation.download"]}
+        </Text>
+      </Row>
+      <Divider
+        style={{
+          margin: "18px 0",
+        }}
+      >
+        Options
+      </Divider>
+      <Row>
+        <Col
+          span={9}
+          style={{
+            lineHeight: "20px",
+            padding: "5px 12px",
+          }}
+        >
+          Select the data you would like to download.
+          <Hint style={{ marginTop: 12 }}>
+            An NML file will always be included with any download.
+          </Hint>
+        </Col>
+        <Col span={15}>
+          <Radio.Group
+            defaultValue={initialFileFormatToDownload}
+            value={fileFormatToDownload}
+            onChange={(e) => setFileFormatToDownload(e.target.value)}
+            style={{ marginLeft: 16 }}
+          >
+            {hasVolumes ? (
+              <>
+                <Tooltip
+                  title={
+                    isVolumeNDimensional ? "WKW is not supported for n-dimensional volumes." : null
+                  }
+                >
+                  <Radio value="wkw" disabled={isVolumeNDimensional} style={radioButtonStyle}>
+                    Include volume annotations as WKW
+                    <Hint style={{}}>Download a zip folder containing WKW files.</Hint>
+                  </Radio>
+                </Tooltip>
+                <Radio value="zarr3" style={radioButtonStyle}>
+                  Include volume annotations as Zarr
+                  <Hint style={{}}>Download a zip folder containing Zarr files.</Hint>
+                </Radio>
+              </>
+            ) : null}
+            <Radio value="nml" style={radioButtonStyle}>
+              {hasSkeleton ? "Skeleton annotations" : "Meta data"} {hasVolumes ? "only " : ""}
+              as NML
+            </Radio>
+          </Radio.Group>
+        </Col>
+      </Row>
+      <Divider
+        style={{
+          margin: "18px 0",
+        }}
+      />
+      {moreInfoHint}
+    </>
+  );
+
+  const tiffExportTab = (
+    <>
+      <Row>
+        {maybeShowWarning()}
+        <Text
+          style={{
+            margin: "0 6px 12px",
+          }}
+        >
+          {messages["download.export_as_tiff"]({ typeName })}
+        </Text>
+      </Row>
+      {activeTabKey === "export" && !features().jobsEnabled ? (
+        workerInfo
+      ) : (
+        <div>
+          <Divider
+            style={{
+              margin: "18px 0",
+            }}
+          >
+            Export format
+          </Divider>
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <Radio.Group value={exportFormat} onChange={(ev) => setExportFormat(ev.target.value)}>
+              <Radio.Button value={ExportFormat.OME_TIFF}>OME-TIFF</Radio.Button>
+              <Radio.Button value={ExportFormat.TIFF_STACK}>TIFF stack (as .zip)</Radio.Button>
+            </Radio.Group>
+          </div>
+
+          <Divider
+            style={{
+              margin: "18px 0",
+            }}
+          >
+            Layer
+          </Divider>
+          <LayerSelection
+            layers={layers}
+            value={selectedLayerName}
+            onChange={setSelectedLayerName}
+            tracing={tracing}
+            style={{ width: "100%" }}
+          />
+
+          <Divider
+            style={{
+              margin: "18px 0",
+            }}
+          >
+            Bounding Box
+          </Divider>
+          <BoundingBoxSelection
+            value={selectedBoundingBoxId}
+            userBoundingBoxes={userBoundingBoxes}
+            setSelectedBoundingBoxId={(boxId: number | null) => {
+              if (boxId != null) {
+                setSelectedBoundingBoxId(boxId);
+              }
+            }}
+            style={{ width: "100%" }}
+          />
+          {boundingBoxCompatibilityAlerts}
+
+          <Divider
+            style={{
+              margin: "18px 0",
+            }}
+          >
+            Mag
+          </Divider>
+          <Row>
+            <Col span={19}>
+              <MagSlider
+                resolutionInfo={selectedLayerResolutionInfo}
+                value={mag}
+                onChange={setMag}
+              />
+            </Col>
+            <Col
+              span={5}
+              style={{ display: "flex", justifyContent: "flex-end", alignItems: "center" }}
+            >
+              {mag.join("-")}
+            </Col>
+          </Row>
+          <Text
+            style={{
+              margin: "0 6px 12px",
+              display: "block",
+            }}
+          >
+            Estimated file size:{" "}
+            {estimateFileSize(selectedLayer, mag, selectedBoundingBox.boundingBox, exportFormat)}
+            <br />
+            Resolution: {formatSelectedScale(dataset, mag)}
+          </Text>
+
+          <Divider />
+          <p>
+            Go to the{" "}
+            <a href="/jobs" target="_blank" rel="noreferrer">
+              Jobs Overview Page
+            </a>{" "}
+            to see running exports and to download the results.
+          </p>
+        </div>
+      )}
+      <Divider
+        style={{
+          margin: "18px 0",
+        }}
+      />
+      {moreInfoHint}
+      <Checkbox
+        style={{ position: "absolute", bottom: -62 }}
+        checked={keepWindowOpen}
+        onChange={handleKeepWindowOpenChecked}
+        disabled={activeTabKey === "export" && !features().jobsEnabled}
+      >
+        Keep window open
+      </Checkbox>
+    </>
+  );
+
+  const pythonClientTab = (
+    <>
+      <Row>
+        <Text
+          style={{
+            margin: "0 6px 12px",
+          }}
+        >
+          The following code snippets are suggestions to get you started quickly with the{" "}
+          <a href="https://docs.webknossos.org/webknossos-py/" target="_blank" rel="noreferrer">
+            WEBKNOSSOS Python API
+          </a>
+          . To download and use this {typeName} in your Python project, simply copy and paste the
+          code snippets to your script.
+        </Text>
+      </Row>
+      <Divider
+        style={{
+          margin: "18px 0",
+        }}
+      >
+        Code Snippets
+      </Divider>
+      {maybeShowWarning()}
+      <Paragraph>
+        <CopyableCodeSnippet code="pip install webknossos" />
+        <CopyableCodeSnippet code={wkInitSnippet} onCopy={alertTokenIsPrivate} />
+      </Paragraph>
+      <Divider
+        style={{
+          margin: "18px 0",
+        }}
+      />
+      {moreInfoHint}
+    </>
+  );
+
+  const tabs: TabsProps["items"] = [
+    { label: "TIFF Export", key: "export", children: tiffExportTab },
+    { label: "Python Client", key: "python", children: pythonClientTab },
+  ];
+  if (isAnnotation) tabs.unshift({ label: "Download", key: "download", children: downloadTab });
+
   return (
     <Modal
       title={`Download this ${typeName}`}
@@ -526,249 +769,7 @@ function _DownloadModalView({
       onCancel={onClose}
       style={{ overflow: "visible" }}
     >
-      <Tabs activeKey={activeTabKey} onChange={handleTabChange} type="card">
-        {isAnnotation ? (
-          <TabPane tab="Download" key="download">
-            <Row>
-              {maybeShowWarning()}
-              <Text
-                style={{
-                  margin: "0 6px 12px",
-                }}
-              >
-                {!hasVolumes ? "This is a Skeleton-only annotation. " : ""}
-                {!hasSkeleton ? "This is a Volume-only annotation. " : ""}
-                {messages["annotation.download"]}
-              </Text>
-            </Row>
-            <Divider
-              style={{
-                margin: "18px 0",
-              }}
-            >
-              Options
-            </Divider>
-            <Row>
-              <Col
-                span={9}
-                style={{
-                  lineHeight: "20px",
-                  padding: "5px 12px",
-                }}
-              >
-                Select the data you would like to download.
-                <Hint style={{ marginTop: 12 }}>
-                  An NML file will always be included with any download.
-                </Hint>
-              </Col>
-              <Col span={15}>
-                <Radio.Group
-                  defaultValue={initialFileFormatToDownload}
-                  value={fileFormatToDownload}
-                  onChange={(e) => setFileFormatToDownload(e.target.value)}
-                  style={{ marginLeft: 16 }}
-                >
-                  {hasVolumes ? (
-                    <>
-                      <Tooltip
-                        title={
-                          isVolumeNDimensional
-                            ? "WKW is not supported for n-dimensional volumes."
-                            : null
-                        }
-                      >
-                        <Radio value="wkw" disabled={isVolumeNDimensional} style={radioButtonStyle}>
-                          Include volume annotations as WKW
-                          <Hint style={{}}>Download a zip folder containing WKW files.</Hint>
-                        </Radio>
-                      </Tooltip>
-                      <Radio value="zarr3" style={radioButtonStyle}>
-                        Include volume annotations as Zarr
-                        <Hint style={{}}>Download a zip folder containing Zarr files.</Hint>
-                      </Radio>
-                    </>
-                  ) : null}
-                  <Radio value="nml" style={radioButtonStyle}>
-                    {hasSkeleton ? "Skeleton annotations" : "Meta data"} {hasVolumes ? "only " : ""}
-                    as NML
-                  </Radio>
-                </Radio.Group>
-              </Col>
-            </Row>
-            <Divider
-              style={{
-                margin: "18px 0",
-              }}
-            />
-            {moreInfoHint}
-          </TabPane>
-        ) : null}
-        <TabPane tab="TIFF Export" key="export">
-          <Row>
-            {maybeShowWarning()}
-            <Text
-              style={{
-                margin: "0 6px 12px",
-              }}
-            >
-              {messages["download.export_as_tiff"]({ typeName })}
-            </Text>
-          </Row>
-          {activeTabKey === "export" && !features().jobsEnabled ? (
-            workerInfo
-          ) : (
-            <div>
-              <Divider
-                style={{
-                  margin: "18px 0",
-                }}
-              >
-                Export format
-              </Divider>
-              <div style={{ display: "flex", justifyContent: "center" }}>
-                <Radio.Group
-                  value={exportFormat}
-                  onChange={(ev) => setExportFormat(ev.target.value)}
-                >
-                  <Radio.Button value={ExportFormat.OME_TIFF}>OME-TIFF</Radio.Button>
-                  <Radio.Button value={ExportFormat.TIFF_STACK}>TIFF stack (as .zip)</Radio.Button>
-                </Radio.Group>
-              </div>
-
-              <Divider
-                style={{
-                  margin: "18px 0",
-                }}
-              >
-                Layer
-              </Divider>
-              <LayerSelection
-                layers={layers}
-                value={selectedLayerName}
-                onChange={setSelectedLayerName}
-                tracing={tracing}
-                style={{ width: "100%" }}
-              />
-
-              <Divider
-                style={{
-                  margin: "18px 0",
-                }}
-              >
-                Bounding Box
-              </Divider>
-              <BoundingBoxSelection
-                value={selectedBoundingBoxId}
-                userBoundingBoxes={userBoundingBoxes}
-                setSelectedBoundingBoxId={(boxId: number | null) => {
-                  if (boxId != null) {
-                    setSelectedBoundingBoxId(boxId);
-                  }
-                }}
-                style={{ width: "100%" }}
-              />
-              {boundingBoxCompatibilityAlerts}
-
-              <Divider
-                style={{
-                  margin: "18px 0",
-                }}
-              >
-                Mag
-              </Divider>
-              <Row>
-                <Col span={19}>
-                  <MagSlider
-                    resolutionInfo={selectedLayerResolutionInfo}
-                    value={mag}
-                    onChange={setMag}
-                  />
-                </Col>
-                <Col
-                  span={5}
-                  style={{ display: "flex", justifyContent: "flex-end", alignItems: "center" }}
-                >
-                  {mag.join("-")}
-                </Col>
-              </Row>
-              <Text
-                style={{
-                  margin: "0 6px 12px",
-                  display: "block",
-                }}
-              >
-                Estimated file size:{" "}
-                {estimateFileSize(
-                  selectedLayer,
-                  mag,
-                  selectedBoundingBox.boundingBox,
-                  exportFormat,
-                )}
-                <br />
-                Resolution: {formatSelectedScale(dataset, mag)}
-              </Text>
-
-              <Divider />
-              <p>
-                Go to the{" "}
-                <a href="/jobs" target="_blank" rel="noreferrer">
-                  Jobs Overview Page
-                </a>{" "}
-                to see running exports and to download the results.
-              </p>
-            </div>
-          )}
-          <Divider
-            style={{
-              margin: "18px 0",
-            }}
-          />
-          {moreInfoHint}
-          <Checkbox
-            style={{ position: "absolute", bottom: -62 }}
-            checked={keepWindowOpen}
-            onChange={handleKeepWindowOpenChecked}
-            disabled={activeTabKey === "export" && !features().jobsEnabled}
-          >
-            Keep window open
-          </Checkbox>
-        </TabPane>
-
-        <TabPane tab="Python Client" key="python">
-          <Row>
-            <Text
-              style={{
-                margin: "0 6px 12px",
-              }}
-            >
-              The following code snippets are suggestions to get you started quickly with the{" "}
-              <a href="https://docs.webknossos.org/webknossos-py/" target="_blank" rel="noreferrer">
-                WEBKNOSSOS Python API
-              </a>
-              . To download and use this {typeName} in your Python project, simply copy and paste
-              the code snippets to your script.
-            </Text>
-          </Row>
-          <Divider
-            style={{
-              margin: "18px 0",
-            }}
-          >
-            Code Snippets
-          </Divider>
-          {maybeShowWarning()}
-          <Paragraph>
-            <CopyableCodeSnippet code="pip install webknossos" />
-            <CopyableCodeSnippet code={wkInitSnippet} onCopy={alertTokenIsPrivate} />
-          </Paragraph>
-          <Divider
-            style={{
-              margin: "18px 0",
-            }}
-          />
-          {moreInfoHint}
-        </TabPane>
-      </Tabs>
+      <Tabs activeKey={activeTabKey} onChange={handleTabChange} type="card" items={tabs} />
     </Modal>
   );
 }


### PR DESCRIPTION
Antd deprecated the use of `<Tabs.TabPane>` components in favor of providing the tabs as an array into the tab props, e.g. `<Tabs items={ ... }>`. See https://4x.ant.design/components/tabs/#Usage-upgrade-after-4.23.0

In this PR I removed all remaining occurrences of `<TabPane>` and replaced them with the new array/object based syntax.  

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Typechecker does most of the formal varification
- Open the corresponding views and check that tabs are still there / work

### Issues:
- fixes #7150
- related to https://github.com/scalableminds/webknossos/issues/6861

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
