### PR TITLE
More verbose fossildb connection errors

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -236,6 +236,7 @@ annotation.volumeBucketsNotEmpty=Cannot make mapping editable in an annotation w
 annotation.deleteLayer.explorationalsOnly=Could not delete a layer because it is only allowed for explorational annotations.
 annotation.deleteLayer.onlyLayer=Could not delete layer because it is the only layer in this annotation.
 annotation.layer.notFound=Layer could not be found.
+annotation.getNewestVersion.failed=Could not get the newest version information for this annotation layer
 
 mesh.notFound=Mesh could not be found
 mesh.write.failed=Failed to convert mesh info to json

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TracingController.scala
@@ -113,7 +113,7 @@ trait TracingController[T <: GeneratedMessage, Ts <: GeneratedMessage] extends C
     log() {
       accessTokenService.validateAccess(UserAccessRequest.readTracing(tracingId), token) {
         for {
-          newestVersion <- tracingService.currentVersion(tracingId)
+          newestVersion <- tracingService.currentVersion(tracingId) ?~> "annotation.getNewestVersion.failed"
         } yield {
           JsonOk(Json.obj("version" -> newestVersion))
         }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -85,11 +85,11 @@ class FossilDBClient(collection: String,
             new net.liftweb.common.Failure(s"FossilDB is unavailable", Full(e), Empty) ~> 500
           case e: Exception =>
             val messageWithCauses = new StringBuilder
-            messageWithCauses.append(e.getMessage)
+            messageWithCauses.append(e.toString)
             var cause: Throwable = e.getCause
             while (cause != null) {
               messageWithCauses.append(" <- ")
-              messageWithCauses.append(cause.getMessage)
+              messageWithCauses.append(cause.toString)
               cause = cause.getCause
             }
             new net.liftweb.common.Failure(s"Request to FossilDB failed: ${messageWithCauses}", Full(e), Empty)


### PR DESCRIPTION
- uses wrapException also for health check, so the exception does not bubble up but is instead wrapped in a fox
- inside of that wrapException, also include the messages of the exception’s causes

### Steps to test:
- run wk with `yarn start noFossilDB` 
- operations that need the fossildb should show error with not only "io exception" but also "connection refused"
- `http://localhost:9000/tracings/health` should also show a standard fox error message rather than play’s runtime exception handler
