### PR TITLE
Delete dataset: also clear tables for additional axes, coordinate transforms

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed several deprecation warning for using antd's Tabs.TabPane components. [#7469](https://github.com/scalableminds/webknossos/pull/7469)
 - Fixed problems when requests for loading data failed (could impact volume data consistency and rendering). [#7477](https://github.com/scalableminds/webknossos/pull/7477)
 - The settings page for non-wkw datasets no longer shows a wall of non-applying errors. [#7475](https://github.com/scalableminds/webknossos/pull/7475)
+- Fixed a bug where dataset deletion for ND datasets and datasets with coordinate transforms would not free the name even if no referencing annotations exist. [#7495](https://github.com/scalableminds/webknossos/pull/7495)
 
 ### Removed
 

--- a/app/models/dataset/Dataset.scala
+++ b/app/models/dataset/Dataset.scala
@@ -562,20 +562,30 @@ class DatasetDAO @Inject()(sqlClient: SqlClient, datasetLayerDAO: DatasetLayerDA
 
   def deleteDataset(datasetId: ObjectId, onlyMarkAsDeleted: Boolean = false): Fox[Unit] = {
     val deleteResolutionsQuery =
-      q"delete from webknossos.dataSet_resolutions where _dataset = $datasetId".asUpdate
+      q"DELETE FROM webknossos.dataSet_resolutions WHERE _dataset = $datasetId".asUpdate
+    val deleteCoordinateTransformsQuery =
+      q"DELETE FROM webknossos.dataSet_layer_coordinateTransformations WHERE _dataset = $datasetId".asUpdate
     val deleteLayersQuery =
-      q"delete from webknossos.dataSet_layers where _dataset = $datasetId".asUpdate
-    val deleteAllowedTeamsQuery = q"delete from webknossos.dataSet_allowedTeams where _dataset = $datasetId".asUpdate
+      q"DELETE FROM webknossos.dataSet_layers WHERE _dataset = $datasetId".asUpdate
+    val deleteAllowedTeamsQuery = q"DELETE FROM webknossos.dataSet_allowedTeams WHERE _dataset = $datasetId".asUpdate
+    val deleteAdditionalAxesQuery =
+      q"DELETE FROM webknossos.dataSet_layer_additionalAxes WHERE _dataset = $datasetId".asUpdate
     val deleteDatasetQuery =
       if (onlyMarkAsDeleted)
-        q"update webknossos.datasets set status = $deletedByUserStatus, isUsable = false where _id = $datasetId".asUpdate
+        q"UPDATE webknossos.datasets SET status = $deletedByUserStatus, isUsable = false WHERE _id = $datasetId".asUpdate
       else
-        q"delete from webknossos.datasets where _id = $datasetId".asUpdate
+        q"DELETE FROM webknossos.datasets WHERE _id = $datasetId".asUpdate
 
     for {
       _ <- run(
         DBIO
-          .sequence(List(deleteResolutionsQuery, deleteLayersQuery, deleteAllowedTeamsQuery, deleteDatasetQuery))
+          .sequence(
+            List(deleteResolutionsQuery,
+                 deleteAdditionalAxesQuery,
+                 deleteLayersQuery,
+                 deleteAllowedTeamsQuery,
+                 deleteCoordinateTransformsQuery,
+                 deleteDatasetQuery))
           .transactionally)
     } yield ()
   }


### PR DESCRIPTION
Got some foreign key violations because these were not cleaned up properly on dataset deletion.

### Steps to test:
- use "delete on disk" in the settings page for a dataset with additional axes (4D Dataset)
- no sql errors should appear in backend logging

### Issues:
- fixes #7488

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
