### PR TITLE
fixes Uri encoding in OpenGraphService

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed problems when requests for loading data failed (could impact volume data consistency and rendering). [#7477](https://github.com/scalableminds/webknossos/pull/7477)
 - The settings page for non-wkw datasets no longer shows a wall of non-applying errors. [#7475](https://github.com/scalableminds/webknossos/pull/7475)
 - Fixed a bug where dataset deletion for ND datasets and datasets with coordinate transforms would not free the name even if no referencing annotations exist. [#7495](https://github.com/scalableminds/webknossos/pull/7495)
+- Fixed a bug where the URL in the sharing link was wrongly decoded before encoding into a URI. [#7502](https://github.com/scalableminds/webknossos/pull/7502)
 
 ### Removed
 

--- a/app/opengraph/OpenGraphService.scala
+++ b/app/opengraph/OpenGraphService.scala
@@ -10,11 +10,11 @@ import models.annotation.AnnotationDAO
 import models.dataset.{Dataset, DatasetDAO, DatasetLayerDAO}
 import models.organization.{Organization, OrganizationDAO}
 import models.shortlinks.ShortLinkDAO
+import net.liftweb.common.Box.tryo
 import net.liftweb.common.Full
 import security.URLSharing
 import utils.{ObjectId, WkConf}
 
-import java.net.URLDecoder
 import scala.concurrent.ExecutionContext
 
 case class OpenGraphTags(
@@ -72,7 +72,7 @@ class OpenGraphService @Inject()(datasetDAO: DatasetDAO,
       case shortLinkRouteRegex(key) =>
         for {
           shortLink <- shortLinkDAO.findOneByKey(key)
-          asUri: Uri = Uri(URLDecoder.decode(shortLink.longLink, "UTF-8"))
+          asUri <- tryo(Uri(shortLink.longLink))
         } yield (asUri.path.toString, asUri.query().get("token").orElse(asUri.query().get("sharingToken")))
       case _ => Fox.successful(uriPath, sharingToken)
     }


### PR DESCRIPTION
Don't decode the URL before constructing the URI in OpenGraphService.

### Steps to test:
- Create a sharing link
- Add a `%20` in the database in the longLink (e.g. in the orga part)
- The sharing link should still be resolved ok (but point to a non-existing dataset)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
