### PR TITLE
Fix that the Segment Statistics were not available in context menus

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where loaded meshes were not encoded in the sharing link. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
 - Fixed a bug where meshes (or chunks of them) were always colored white, if they were loaded while the corresponding segmentation layer was disabled. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
 - Fixed a race condition when opening a short link, that would sometimes lead to an error toast. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
+- Fixed that the Segment Statistics modal was not available in the context menu of segment groups. [#7510](https://github.com/scalableminds/webknossos/pull/7510)
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,7 +35,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where loaded meshes were not encoded in the sharing link. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
 - Fixed a bug where meshes (or chunks of them) were always colored white, if they were loaded while the corresponding segmentation layer was disabled. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
 - Fixed a race condition when opening a short link, that would sometimes lead to an error toast. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
-- Fixed that the Segment Statistics modal was not available in the context menu of segment groups. [#7510](https://github.com/scalableminds/webknossos/pull/7510)
+- Fixed that the Segment Statistics feature was not available in the context menu of segment groups and in the context menu of the data viewports. [#7510](https://github.com/scalableminds/webknossos/pull/7510)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -596,6 +596,10 @@ export function isLayerVisible(
   return !layerConfig.isDisabled && layerConfig.alpha > 0 && !isHiddenBecauseOfArbitraryMode;
 }
 
+export function hasFallbackLayer(layer: APIDataLayer) {
+  return "fallbackLayer" in layer && layer.fallbackLayer != null;
+}
+
 function _getLayerNameToIsDisabled(datasetConfiguration: DatasetConfiguration) {
   const nameToIsDisabled: { [name: string]: boolean } = {};
   for (const layerName of Object.keys(datasetConfiguration.layers)) {

--- a/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/flycam_accessor.ts
@@ -273,6 +273,12 @@ function _getPosition(flycam: Flycam): Vector3 {
   return [matrix[12], matrix[13], matrix[14]];
 }
 
+export function hasAdditionalCoordinates(
+  additionalCoordinates: AdditionalCoordinate[] | null | undefined,
+): boolean {
+  return (additionalCoordinates?.length || 0) > 0;
+}
+
 export function getAdditionalCoordinatesAsString(
   additionalCoordinates: AdditionalCoordinate[] | null | undefined,
 ): string {

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -1154,7 +1154,8 @@ function ContextMenuInner(propsWithInputRef: Props) {
   } = props;
 
   const segmentIdAtPosition = globalPosition != null ? getSegmentIdForPosition(globalPosition) : 0;
-  const hasNoFallbackLayer = visibleSegmentationLayer != null && !hasFallbackLayer(layer);
+  const hasNoFallbackLayer =
+    visibleSegmentationLayer != null && !hasFallbackLayer(visibleSegmentationLayer);
   const [segmentVolume, boundingBoxInfo] = useFetch(
     async () => {
       if (

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -70,6 +70,7 @@ import {
   getVisibleSegmentationLayer,
   getMappingInfo,
   getResolutionInfo,
+  hasFallbackLayer,
 } from "oxalis/model/accessors/dataset_accessor";
 import {
   loadAgglomerateSkeletonAtPosition,
@@ -1153,10 +1154,7 @@ function ContextMenuInner(propsWithInputRef: Props) {
   } = props;
 
   const segmentIdAtPosition = globalPosition != null ? getSegmentIdForPosition(globalPosition) : 0;
-  const hasNoFallbackLayer =
-    visibleSegmentationLayer != null &&
-    "fallbackLayer" in visibleSegmentationLayer &&
-    visibleSegmentationLayer.fallbackLayer == null;
+  const hasNoFallbackLayer = visibleSegmentationLayer != null && !hasFallbackLayer(layer);
   const [segmentVolume, boundingBoxInfo] = useFetch(
     async () => {
       if (

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -109,6 +109,7 @@ import { type AdditionalCoordinate } from "types/api_flow_types";
 import { voxelToNm3 } from "oxalis/model/scaleinfo";
 import { getBoundingBoxInMag1 } from "oxalis/model/sagas/volume/helpers";
 import { ensureLayerMappingsAreLoadedAction } from "oxalis/model/actions/dataset_actions";
+import { hasAdditionalCoordinates } from "oxalis/model/accessors/flycam_accessor";
 
 type ContextMenuContextValue = React.MutableRefObject<HTMLElement | null> | null;
 export const ContextMenuContext = createContext<ContextMenuContextValue>(null);
@@ -1163,7 +1164,7 @@ function ContextMenuInner(propsWithInputRef: Props) {
         volumeTracing == null ||
         !hasNoFallbackLayer ||
         !volumeTracing.hasSegmentIndex ||
-        props.additionalCoordinates != null // TODO change once statistics are available for nd-datasets
+        hasAdditionalCoordinates(props.additionalCoordinates) // TODO change once statistics are available for nd-datasets
       ) {
         return [];
       } else {
@@ -1305,7 +1306,7 @@ function ContextMenuInner(propsWithInputRef: Props) {
     hasNoFallbackLayer &&
     volumeTracing?.hasSegmentIndex &&
     isHoveredSegmentOrMesh &&
-    props.additionalCoordinates == null; // TODO change once statistics are available for nd-datasets
+    !hasAdditionalCoordinates(props.additionalCoordinates); // TODO change once statistics are available for nd-datasets
 
   if (areSegmentStatisticsAvailable) {
     infoRows.push(

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -45,6 +45,7 @@ import {
   getMappingInfo,
   getResolutionInfoOfVisibleSegmentationLayer,
   getVisibleSegmentationLayer,
+  hasFallbackLayer,
 } from "oxalis/model/accessors/dataset_accessor";
 import {
   getAdditionalCoordinatesAsString,
@@ -1517,9 +1518,7 @@ class SegmentsView extends React.Component<Props, State> {
     const segments = this.getSegmentsOfGroupRecursively(groupId);
     const visibleSegmentationLayer = this.props.visibleSegmentationLayer;
     const hasNoFallbackLayer =
-      visibleSegmentationLayer != null &&
-      "fallbackLayer" in visibleSegmentationLayer &&
-      visibleSegmentationLayer.fallbackLayer == null;
+      visibleSegmentationLayer != null && !hasFallbackLayer(visibleSegmentationLayer);
     if (
       hasNoFallbackLayer &&
       this.props.hasVolumeTracing &&

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -49,6 +49,7 @@ import {
 import {
   getAdditionalCoordinatesAsString,
   getPosition,
+  hasAdditionalCoordinates,
 } from "oxalis/model/accessors/flycam_accessor";
 import {
   getActiveSegmentationTracing,
@@ -1081,13 +1082,12 @@ class SegmentsView extends React.Component<Props, State> {
 
   getShowSegmentStatistics = (id: number): ItemType => {
     const visibleSegmentationLayer = this.props.visibleSegmentationLayer;
-    // TODO change once statistics are available for nd-datasets
-    const hasAdditionalCoordinates = (this.props.flycam.additionalCoordinates?.length || 0) > 0;
     if (
       visibleSegmentationLayer == null ||
       visibleSegmentationLayer.fallbackLayer != null ||
       !this.props.activeVolumeTracing?.hasSegmentIndex ||
-      hasAdditionalCoordinates
+      // TODO change once statistics are available for nd-datasets
+      hasAdditionalCoordinates(this.props.flycam.additionalCoordinates)
     ) {
       // In this case there is a fallback layer or an ND annotation.
       return null;

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1081,14 +1081,15 @@ class SegmentsView extends React.Component<Props, State> {
 
   getShowSegmentStatistics = (id: number): ItemType => {
     const visibleSegmentationLayer = this.props.visibleSegmentationLayer;
+    // TODO change once statistics are available for nd-datasets
+    const hasAdditionalCoordinates = (this.props.flycam.additionalCoordinates?.length || 0) > 0;
     if (
       visibleSegmentationLayer == null ||
-      !("fallbackLayer" in visibleSegmentationLayer) ||
       visibleSegmentationLayer.fallbackLayer != null ||
       !this.props.activeVolumeTracing?.hasSegmentIndex ||
-      this.props.flycam.additionalCoordinates != null // TODO change once statistics are available for nd-datasets
+      hasAdditionalCoordinates
     ) {
-      //in this case there is a fallback layer
+      // In this case there is a fallback layer or an ND annotation.
       return null;
     }
     return {


### PR DESCRIPTION
... of segment groups

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- use the context menu of a segment group in an annotation and check that the statistics are available for:
  - a new annotation without fallback (should have an index) for a 3d (or 2d) dataset
- it should not be shown for nd annotations or annotations with fallback layer

### Issues:
- follow-up to #7394

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
