### PR TITLE
Create Organization Directory When Inserting Initial Data

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added route for triggering the compute segment index worker job. [#7471](https://github.com/scalableminds/webknossos/pull/7471)
 - Added thumbnails to the dashboard dataset list. [#7479](https://github.com/scalableminds/webknossos/pull/7479)
 - Adhoc mesh rendering is now available for ND datasets.[#7394](https://github.com/scalableminds/webknossos/pull/7394)
+- When setting up WEBKNOSSOS from the git repository for development, the organization directory for storing datasets is now automatically created on startup. [#7517](https://github.com/scalableminds/webknossos/pull/7517)
+
 
 ### Changed
 - Improved loading speed of the annotation list. [#7410](https://github.com/scalableminds/webknossos/pull/7410)

--- a/DEV_INSTALL.md
+++ b/DEV_INSTALL.md
@@ -130,10 +130,12 @@ On older Ubuntu distributions: Please make sure to have the correct versions of 
 First, install all frontend dependencies via
 
 ```bash
-yarn install --ignore-engines
+yarn install
 ```
 
 Note: During this installation step, it might happen that the module `gl` cannot be installed correctly. As this module is only used for testing WEBKNOSSOS, you can safely ignore this error.
+
+Note: If you are getting node version incompatibility errors, it is usually safe to call yarn with [`--ignore-engines`](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-ignore-engines).
 
 To start WEBKNOSSOS, use
 

--- a/DEV_INSTALL.md
+++ b/DEV_INSTALL.md
@@ -130,7 +130,7 @@ On older Ubuntu distributions: Please make sure to have the correct versions of 
 First, install all frontend dependencies via
 
 ```bash
-yarn install
+yarn install --ignore-engines
 ```
 
 Note: During this installation step, it might happen that the module `gl` cannot be installed correctly. As this module is only used for testing WEBKNOSSOS, you can safely ignore this error.

--- a/app/Startup.scala
+++ b/app/Startup.scala
@@ -89,10 +89,10 @@ class Startup @Inject()(actorSystem: ActorSystem,
   }
 
   initialDataService.insert.futureBox.map {
-    case Full(_) => logger.info(s"Webknossos startup took ${System.currentTimeMillis() - beforeStartup} ms. ")
+    case Full(_) => logger.info(s"Webknossos startup took ${System.currentTimeMillis() - beforeStartup} ms.")
     case Failure(msg, _, _) =>
       logger.info("No initial data inserted: " + msg)
-      logger.info(s"Webknossos startup took ${System.currentTimeMillis() - beforeStartup} ms. ")
+      logger.info(s"Webknossos startup took ${System.currentTimeMillis() - beforeStartup} ms.")
     case _ => ()
   }
 

--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -66,6 +66,7 @@ class AuthenticationController @Inject()(
     voxelyticsDAO: VoxelyticsDAO,
     wkSilhouetteEnvironment: WkSilhouetteEnvironment,
     openIdConnectClient: OpenIdConnectClient,
+    initialDataService: InitialDataService,
     emailVerificationService: EmailVerificationService,
     sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller
@@ -601,6 +602,7 @@ class AuthenticationController @Inject()(
                     BadRequest(Json.obj("messages" -> Json.toJson(errors.map(t => Json.obj("error" -> t))))))
                 } else {
                   for {
+                    _ <- initialDataService.insertLocalDataStoreIfEnabled()
                     organization <- organizationService.createOrganization(
                       Option(signUpData.organization).filter(_.trim.nonEmpty),
                       signUpData.organizationDisplayName) ?~> "organization.create.failed"

--- a/app/controllers/AuthenticationController.scala
+++ b/app/controllers/AuthenticationController.scala
@@ -619,7 +619,7 @@ class AuthenticationController @Inject()(
                     multiUser <- multiUserDAO.findOne(user._multiUser)
                     dataStoreToken <- bearerTokenAuthenticatorService.createAndInitDataStoreTokenForUser(user)
                     _ <- organizationService
-                      .createOrganizationFolder(organization.name, dataStoreToken) ?~> "organization.folderCreation.failed"
+                      .createOrganizationDirectory(organization.name, dataStoreToken) ?~> "organization.folderCreation.failed"
                   } yield {
                     Mailer ! Send(defaultMails
                       .newOrganizationMail(organization.displayName, email, request.headers.get("Host").getOrElse("")))

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -322,8 +322,6 @@ Samplecountry
       }
     } else Fox.successful(())
 
-  private def createOrganizationDirectory(): Fox[Unit] = {
-    logger.info("calling createOrganizationDirectory...")
-    organizationService.createOrganizationDirectory(defaultOrganization.name, RpcTokenHolder.webknossosToken) ?~> "organization.folderCreation.failed"
-  }
+  private def createOrganizationDirectory(): Fox[Unit] =
+    organizationService.createOrganizationDirectory(defaultOrganization.name, RpcTokenHolder.webknossosToken) ?~> "organization.directoryCreation.failed"
 }

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -4,7 +4,6 @@ import play.silhouette.api.{LoginInfo, Silhouette}
 import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
-import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.scalalogging.LazyLogging
 import models.annotation.{TracingStore, TracingStoreDAO}
 import models.dataset._
@@ -52,7 +51,6 @@ class InitialDataService @Inject()(userService: UserService,
                                    organizationDAO: OrganizationDAO,
                                    storeModules: StoreModules,
                                    organizationService: OrganizationService,
-                                   bearerTokenAuthenticatorService: BearerTokenAuthenticatorService,
                                    conf: WkConf)(implicit ec: ExecutionContext)
     extends FoxImplicits
     with LazyLogging {

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -148,7 +148,7 @@ Samplecountry
       _ <- insertLocalDataStoreIfEnabled()
       _ <- insertLocalTracingStoreIfEnabled()
       _ <- assertInitialDataEnabled
-      _ <- assertNoOrganizationsPresent
+      _ <- organizationService.assertNoOrganizationsPresent
       _ <- insertRootFolder()
       _ <- insertOrganization()
       _ <- createOrganizationDirectory()
@@ -164,12 +164,6 @@ Samplecountry
   private def assertInitialDataEnabled: Fox[Unit] =
     for {
       _ <- bool2Fox(conf.WebKnossos.SampleOrganization.enabled) ?~> "initialData.notEnabled"
-    } yield ()
-
-  def assertNoOrganizationsPresent: Fox[Unit] =
-    for {
-      organizations <- organizationDAO.findAll
-      _ <- bool2Fox(organizations.isEmpty) ?~> "initialData.organizationsNotEmpty"
     } yield ()
 
   private def insertRootFolder(): Fox[Unit] =

--- a/app/models/organization/OrganizationService.scala
+++ b/app/models/organization/OrganizationService.scala
@@ -125,7 +125,7 @@ class OrganizationService @Inject()(organizationDAO: OrganizationDAO,
 
   def createOrganizationDirectory(organizationName: String, dataStoreToken: String): Fox[Unit] = {
     def sendRPCToDataStore(dataStore: DataStore) =
-      rpc(s"${dataStore.url}/data/triggers/newOrganizationFolder")
+      rpc(s"${dataStore.url}/data/triggers/createOrganizationDirectory")
         .addQueryString("token" -> dataStoreToken, "organizationName" -> organizationName)
         .post()
         .futureBox

--- a/app/models/organization/OrganizationService.scala
+++ b/app/models/organization/OrganizationService.scala
@@ -132,7 +132,6 @@ class OrganizationService @Inject()(organizationDAO: OrganizationDAO,
 
     for {
       datastores <- dataStoreDAO.findAll(GlobalAccessContext)
-      _ = logger.info(s"found ${datastores.length} datastores!")
       _ <- Future.sequence(datastores.map(sendRPCToDataStore))
     } yield ()
   }

--- a/app/models/organization/OrganizationService.scala
+++ b/app/models/organization/OrganizationService.scala
@@ -10,7 +10,7 @@ import javax.inject.Inject
 import models.dataset.{DataStore, DataStoreDAO}
 import models.folder.{Folder, FolderDAO, FolderService}
 import models.team.{PricingPlan, Team, TeamDAO}
-import models.user.{Invite, MultiUserDAO, User, UserDAO, UserService}
+import models.user.{Invite, MultiUserDAO, User, UserDAO}
 import play.api.libs.json.{JsObject, Json}
 import utils.{ObjectId, WkConf}
 

--- a/conf/messages
+++ b/conf/messages
@@ -292,7 +292,7 @@ script.name.invalid.characters=Script name is invalid. Please use only letters, 
 serialization.failed=Failed to serialize data.
 
 initialData.notEnabled=Initial Data Insertion is not enabled in the configuration of this wK instance
-initialData.organizationsNotEmpty=There are already organizations present in the database. Please refresh the db schema and try again
+organizationsNotEmpty=There are already organizations present in the database. Please refresh the db schema and try again
 
 job.couldNotRunCubing = Failed to start WKW conversion job.
 job.couldNotRunTiffExport = Failed to start Tiff export job.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -372,9 +372,10 @@ class DataSourceController @Inject()(
     implicit request =>
       accessTokenService
         .validateAccessForSyncBlock(UserAccessRequest.administrateDataSources(organizationName), token) {
-          val newOrganizationFolder = new File(f"${dataSourceService.dataBaseDir}/$organizationName")
-          newOrganizationFolder.mkdirs()
-          if (newOrganizationFolder.isDirectory)
+          val newOrganizationDirectory = new File(f"${dataSourceService.dataBaseDir}/$organizationName")
+          logger.info(s"creating organization dir at ${newOrganizationDirectory}")
+          newOrganizationDirectory.mkdirs()
+          if (newOrganizationDirectory.isDirectory)
             Ok
           else
             BadRequest

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -373,11 +373,11 @@ class DataSourceController @Inject()(
       accessTokenService
         .validateAccessForSyncBlock(UserAccessRequest.administrateDataSources(organizationName), token) {
           val newOrganizationDirectory = new File(f"${dataSourceService.dataBaseDir}/$organizationName")
-          logger.info(s"creating organization dir at ${newOrganizationDirectory}")
           newOrganizationDirectory.mkdirs()
-          if (newOrganizationDirectory.isDirectory)
+          if (newOrganizationDirectory.isDirectory) {
+            logger.info(s"Created organization directory at $newOrganizationDirectory")
             Ok
-          else
+          } else
             BadRequest
         }
   }

--- a/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
+++ b/webknossos-datastore/conf/com.scalableminds.webknossos.datastore.routes
@@ -87,7 +87,7 @@ DELETE        /datasets/:organizationName/:dataSetName/deleteOnDisk             
 
 # Actions
 POST          /triggers/checkInboxBlocking                                                                                                    @com.scalableminds.webknossos.datastore.controllers.DataSourceController.triggerInboxCheckBlocking(token: Option[String])
-POST          /triggers/newOrganizationFolder                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DataSourceController.createOrganizationDirectory(token: Option[String], organizationName: String)
+POST          /triggers/createOrganizationDirectory                                                                                           @com.scalableminds.webknossos.datastore.controllers.DataSourceController.createOrganizationDirectory(token: Option[String], organizationName: String)
 POST          /triggers/reload/:organizationName/:dataSetName                                                                                 @com.scalableminds.webknossos.datastore.controllers.DataSourceController.reload(token: Option[String], organizationName: String, dataSetName: String, layerName: Option[String])
 
 # Exports


### PR DESCRIPTION
- When inserting initialData, webknossos now creates the organization directory (with parents), so usually `binaryData/sample_organization`.
- Moved around some code to avoid circular dependencies.
- Renamed Folder to Directory in one more place, in order to distinguish it from the in-postgres folder concept.

### Steps to test:
- delete/backup your binaryData directory or clone a fresh webknossos
- refresh postgres schema
- start webknossos with `yarn start --ignore-engines`
- `binaryData/sample_organization` should be created, datasets put there should be served

### Issues:
- fixes #7509

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment **IMPORTANT: update all datastores**
