### PR TITLE
If open graph tag generation fails, fall back to default

### DIFF
--- a/app/controllers/ShortLinkController.scala
+++ b/app/controllers/ShortLinkController.scala
@@ -30,7 +30,7 @@ class ShortLinkController @Inject()(shortLinkDAO: ShortLinkDAO, sil: Silhouette[
 
   def getByKey(key: String): Action[AnyContent] = Action.async { implicit request =>
     for {
-      shortLink <- shortLinkDAO.findOneByKey(key)
+      shortLink <- shortLinkDAO.findOneByKey(key) ?~> "shortLink.notFound"
     } yield Ok(Json.toJson(shortLink))
   }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -348,3 +348,5 @@ segmentAnything.notEnabled=AI based quick select is not enabled for this WEBKNOS
 segmentAnything.noUri=No Uri for SAM server configured.
 segmentAnything.getData.failed=Failed to get image data to send to SAM server.
 segmentAnything.getEmbedding.failed=Failed to get image embedding from SAM server.
+
+shortLink.notFound=No shortlink with this key could be found


### PR DESCRIPTION
Adds another layer of futureBox catching, in case `resolveShortLinkIfNeeded` already fails.

### Steps to test:
- Open page with invalid short link (correct format, but key doesn’t exist)
- Page should still be displayed, should show readable error toast

### Issues:
- fixes #7503
