### PR TITLE
No longer show failed conversion jobs as Manual

### DIFF
--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -1128,7 +1128,7 @@ export async function getJobs(): Promise<APIJob[]> {
           annotationId: job.commandArgs.annotation_id,
           annotationType: job.commandArgs.annotation_type,
           mergeSegments: job.commandArgs.merge_segments,
-          state: adaptJobState(job.command, job.state, job.manualState),
+          state: adaptJobState(job.state, job.manualState),
           manualState: job.manualState,
           result: job.returnValue,
           resultLink: job.resultLink,
@@ -1155,7 +1155,7 @@ export async function getJob(jobId: string): Promise<APIJob> {
     annotationId: job.commandArgs.annotation_id,
     annotationType: job.commandArgs.annotation_type,
     mergeSegments: job.commandArgs.merge_segments,
-    state: adaptJobState(job.command, job.state, job.manualState),
+    state: adaptJobState(job.state, job.manualState),
     manualState: job.manualState,
     result: job.returnValue,
     resultLink: job.resultLink,
@@ -1164,21 +1164,14 @@ export async function getJob(jobId: string): Promise<APIJob> {
 }
 
 function adaptJobState(
-  command: string,
   celeryState: APIJobCeleryState,
   manualState: APIJobManualState,
 ): APIJobState {
   if (manualState) {
     return manualState;
-  } else if (celeryState === "FAILURE" && isManualPassJobType(command)) {
-    return "MANUAL";
   }
 
   return celeryState || "UNKNOWN";
-}
-
-function isManualPassJobType(command: string) {
-  return ["convert_to_wkw"].includes(command);
 }
 
 export async function cancelJob(jobId: string): Promise<APIJob> {

--- a/frontend/javascripts/admin/job/job_hooks.ts
+++ b/frontend/javascripts/admin/job/job_hooks.ts
@@ -9,13 +9,11 @@ type JobInfo = [jobKey: string, jobId: string];
 export function useStartAndPollJob({
   onSuccess = () => {},
   onFailure = () => {},
-  onManual = () => {},
   initialJobKeyExtractor,
   interval = 2000,
 }: {
   onSuccess?: (job: APIJob) => void;
   onFailure?: (job: APIJob) => void;
-  onManual?: (job: APIJob) => void;
   initialJobKeyExtractor?: (job: APIJob) => string | null;
   interval?: number;
 }): {
@@ -55,9 +53,6 @@ export function useStartAndPollJob({
         }
       } else if (job.state === "FAILURE") {
         onFailure(job);
-        setRunningJobs((previous) => previous.filter(([, j]) => j !== jobId));
-      } else if (job.state === "MANUAL") {
-        onManual(job);
         setRunningJobs((previous) => previous.filter(([, j]) => j !== jobId));
       }
     }

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -13,7 +13,6 @@ import {
   EyeOutlined,
   LoadingOutlined,
   QuestionCircleTwoTone,
-  ToolTwoTone,
   InfoCircleOutlined,
 } from "@ant-design/icons";
 import * as React from "react";
@@ -51,11 +50,6 @@ export const TOOLTIP_MESSAGES_AND_ICONS = {
   CANCELLED: {
     tooltip: "This job was cancelled.",
     icon: <CloseCircleTwoTone twoToneColor="#aaaaaa" />,
-  },
-  MANUAL: {
-    tooltip:
-      "The job will be handled by an admin shortly, since it could not be finished automatically. Please check back here soon.",
-    icon: <ToolTwoTone twoToneColor="#d89614" />,
   },
 };
 const refreshInterval = 5000;

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -610,16 +610,6 @@ class SegmentsView extends React.Component<Props, State> {
           break;
         }
 
-        case "MANUAL": {
-          Toast.info(
-            "The computation of a mesh file for this dataset didn't finish properly. The job will be handled by an admin shortly. Please check back here soon.",
-          );
-          this.setState({
-            activeMeshJobId: null,
-          });
-          break;
-        }
-
         default: {
           break;
         }

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -620,7 +620,7 @@ export type APIFeatureToggles = {
 };
 export type APIJobCeleryState = "SUCCESS" | "PENDING" | "STARTED" | "FAILURE" | null;
 export type APIJobManualState = "SUCCESS" | "FAILURE" | null;
-export type APIJobState = "UNKNOWN" | "SUCCESS" | "PENDING" | "STARTED" | "FAILURE" | "MANUAL";
+export type APIJobState = "UNKNOWN" | "SUCCESS" | "PENDING" | "STARTED" | "FAILURE";
 export enum APIJobType {
   "CONVERT_TO_WKW" = "convert_to_wkw",
   "EXPORT_TIFF" = "export_tiff",
@@ -647,7 +647,7 @@ export type APIJob = {
   readonly mergeSegments: boolean | null | undefined;
   readonly type: APIJobType;
   readonly state: APIJobState;
-  readonly manualState: string;
+  readonly manualState: APIJobManualState;
   readonly result: string | null | undefined;
   readonly resultLink: string | null | undefined;
   readonly createdAt: number;


### PR DESCRIPTION
The conversions fail way less frequently now. We decided to not automatically offer a “manual pass” anymore.

Note that the manualState mechanism still works, so if the manualState is set in the database, it is still used.

### Steps to test:
- Set up jobs and a worker
- Upload data that cannot be converted to wkw
- job should be shown as Failure (not “Manual”) in the job list view

### Issues:
- fixes #7499

Follow-up: https://github.com/scalableminds/webknossos/issues/5236