### PR TITLE
Fix rare crash in event handler

### DIFF
--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -765,10 +765,12 @@ export function addEventListenerWithDelegation(
   handlerFunc: (...args: Array<any>) => any,
   options: Record<string, any> = {},
 ) {
-  const wrapperFunc = function (event: Event) {
-    // @ts-ignore
-    for (let { target } = event; target && target !== this; target = target.parentNode) {
-      // @ts-ignore
+  const wrapperFunc = function (this: HTMLElement | Document, event: Event) {
+    for (
+      let { target } = event;
+      target && target !== this && target instanceof Element;
+      target = target.parentNode
+    ) {
       if (target.matches(delegateSelector)) {
         handlerFunc.call(target, event);
         break;


### PR DESCRIPTION
`addEventListenerWithDelegation` created an event handler that would crash on non-Element [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)s. Mostly, event targets are `Element`s and support `matches()`, but other event targets, such as `document` and `window`, don't. when an event handler is called for these, an error occured. TS rightfully complained about these, too.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I don't know how the actual bug can be reproduced reliably, but I hope we can trust TS on this one
- also I tested that the basic interaction with the viewports still works

### Issues:
- fixes https://scm.airbrake.io/projects/95438/groups/3702393900481964371?filters=%7B%22order%22%3A%22last_notice%22%2C%22resolved%22%3A%22false%22%2C%22search%22%3A%22t.matches%22%7D&tab=aggregations

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
