### PR TITLE
Fix crash in proofreading when no meshes existed before

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,6 +39,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a race condition when opening a short link, that would sometimes lead to an error toast. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
 - Fixed that the Segment Statistics feature was not available in the context menu of segment groups and in the context menu of the data viewports. [#7510](https://github.com/scalableminds/webknossos/pull/7510)
 - Fixed a bug where dataset managers were not allowed to assign teams to new datasets that they are only member of. This already worked while editing the dataset later, but not during upload. [#7518](https://github.com/scalableminds/webknossos/pull/7518)
+- Fixed regression in proofreading tool when automatic mesh loading was disabled and a merge/split operation was performed. [#7534](https://github.com/scalableminds/webknossos/pull/7534)
 
 ### Removed
 - Removed several unused frontend libraries. [#7521](https://github.com/scalableminds/webknossos/pull/7521)

--- a/frontend/javascripts/oxalis/model/reducers/annotation_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/annotation_reducer.ts
@@ -258,10 +258,8 @@ function AnnotationReducer(state: OxalisState, action: Action): OxalisState {
         additionalCoordinates,
         layerName,
       );
-      if (maybeMeshes == null) {
-        throw Error("No mesh data found in state.localSegmentationData.");
-      }
-      if (maybeMeshes[segmentId] == null) {
+      if (maybeMeshes == null || maybeMeshes[segmentId] == null) {
+        // No meshes exist for the segment id. No need to do anything.
         return state;
       }
       const { [segmentId]: _, ...remainingMeshes } = maybeMeshes as Record<number, MeshInformation>;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://fixcrashinproofreading.webknossos.xyz

### Steps to test:
- open an annotation with an agglomerate mapping
- select a mapping
- select proofreading tool
- disable automatic mesh loading in toolbar
- merge two segments

### Issues:
- follow-up to #7394

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
