### PR TITLE
Treat ND bounds as inclusive in bucket handling

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,6 +39,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a race condition when opening a short link, that would sometimes lead to an error toast. [#7507](https://github.com/scalableminds/webknossos/pull/7507)
 - Fixed that the Segment Statistics feature was not available in the context menu of segment groups and in the context menu of the data viewports. [#7510](https://github.com/scalableminds/webknossos/pull/7510)
 - Fixed a bug where dataset managers were not allowed to assign teams to new datasets that they are only member of. This already worked while editing the dataset later, but not during upload. [#7518](https://github.com/scalableminds/webknossos/pull/7518)
+- Fixed that last dimension value in ND dataset was not loaded. [#7535](https://github.com/scalableminds/webknossos/pull/7535)
 
 ### Removed
 - Removed several unused frontend libraries. [#7521](https://github.com/scalableminds/webknossos/pull/7521)

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
@@ -232,7 +232,7 @@ class DataCube {
       for (const coord of coords || []) {
         if (coord.name in this.additionalAxes) {
           const { bounds } = this.additionalAxes[coord.name];
-          if (coord.value < bounds[0] || coord.value >= bounds[1]) {
+          if (coord.value < bounds[0] || coord.value > bounds[1]) {
             return null;
           }
         }


### PR DESCRIPTION
In the long run, we want to change this to a half-open interval, but for now it should be inclusive.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- load the last t-section in a 4D dataset

### Issues:
- related to #7515

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)