### PR TITLE
Allow to convert agglomerate skeletons to normal ones

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added thumbnails to the dashboard dataset list. [#7479](https://github.com/scalableminds/webknossos/pull/7479)
 - Adhoc mesh rendering is now available for ND datasets.[#7394](https://github.com/scalableminds/webknossos/pull/7394)
 - When setting up WEBKNOSSOS from the git repository for development, the organization directory for storing datasets is now automatically created on startup. [#7517](https://github.com/scalableminds/webknossos/pull/7517)
+- Added the option to convert agglomerate skeletons to freely modifiable skeletons in the context menu of the Skeleton tab. [#7537](https://github.com/scalableminds/webknossos/pull/7537)
 
 
 ### Changed
@@ -41,6 +42,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where dataset managers were not allowed to assign teams to new datasets that they are only member of. This already worked while editing the dataset later, but not during upload. [#7518](https://github.com/scalableminds/webknossos/pull/7518)
 - Fixed regression in proofreading tool when automatic mesh loading was disabled and a merge/split operation was performed. [#7534](https://github.com/scalableminds/webknossos/pull/7534)
 - Fixed that last dimension value in ND dataset was not loaded. [#7535](https://github.com/scalableminds/webknossos/pull/7535)
+- Fixed the initialization of the mapping list for agglomerate views if json mappings are present. [#7537](https://github.com/scalableminds/webknossos/pull/7537)
 
 ### Removed
 - Removed several unused frontend libraries. [#7521](https://github.com/scalableminds/webknossos/pull/7521)

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
@@ -1,7 +1,7 @@
 import { Modal } from "antd";
 import React from "react";
 import type { ServerSkeletonTracing } from "types/api_flow_types";
-import type { Vector3 } from "oxalis/constants";
+import type { Vector3, TreeType } from "oxalis/constants";
 import {
   enforceSkeletonTracing,
   getNodeAndTree,
@@ -50,6 +50,7 @@ type SetTreeColorIndexAction = ReturnType<typeof setTreeColorIndexAction>;
 type ShuffleTreeColorAction = ReturnType<typeof shuffleTreeColorAction>;
 type SetTreeColorAction = ReturnType<typeof setTreeColorAction>;
 type ShuffleAllTreeColorsAction = ReturnType<typeof shuffleAllTreeColorsAction>;
+type SetTreeTypeAction = ReturnType<typeof setTreeTypeAction>;
 type CreateCommentAction = ReturnType<typeof createCommentAction>;
 type DeleteCommentAction = ReturnType<typeof deleteCommentAction>;
 type SetTracingAction = ReturnType<typeof setTracingAction>;
@@ -97,6 +98,7 @@ export type SkeletonTracingAction =
   | SetTreeNameAction
   | SelectNextTreeAction
   | SetTreeColorAction
+  | SetTreeTypeAction
   | ShuffleTreeColorAction
   | ShuffleAllTreeColorsAction
   | SetTreeColorIndexAction
@@ -427,6 +429,13 @@ export const setTreeColorAction = (treeId: number, color: Vector3) =>
 export const shuffleAllTreeColorsAction = () =>
   ({
     type: "SHUFFLE_ALL_TREE_COLORS",
+  } as const);
+
+export const setTreeTypeAction = (treeId: number, treeType: TreeType) =>
+  ({
+    type: "SET_TREE_TYPE",
+    treeId,
+    treeType,
   } as const);
 
 export const createCommentAction = (commentText: string, nodeId?: number, treeId?: number) =>

--- a/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
+++ b/frontend/javascripts/oxalis/model/actions/skeletontracing_actions.tsx
@@ -140,6 +140,7 @@ export const SkeletonTracingSaveRelevantActions = [
   "SELECT_NEXT_TREE",
   "SHUFFLE_TREE_COLOR",
   "SHUFFLE_ALL_TREE_COLORS",
+  "SET_TREE_TYPE",
   "CREATE_COMMENT",
   "DELETE_COMMENT",
   "SET_TREE_GROUPS",

--- a/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/skeletontracing_reducer.ts
@@ -389,6 +389,27 @@ function SkeletonTracingReducer(state: OxalisState, action: Action): OxalisState
             .getOrElse(state);
         }
 
+        case "SET_TREE_TYPE": {
+          const { treeType, treeId } = action;
+          return getTree(skeletonTracing, treeId)
+            .map((tree) =>
+              update(state, {
+                tracing: {
+                  skeleton: {
+                    trees: {
+                      [tree.treeId]: {
+                        type: {
+                          $set: treeType,
+                        },
+                      },
+                    },
+                  },
+                },
+              }),
+            )
+            .getOrElse(state);
+        }
+
         case "SHUFFLE_ALL_TREE_COLORS": {
           const newColors = ColorGenerator.getNRandomColors(_.size(skeletonTracing.trees));
           return update(state, {

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -159,7 +159,8 @@ function* checkForAgglomerateSkeletonModification(
 
   getNodeAndTree(skeletonTracing, nodeId, treeId, TreeTypeEnum.AGGLOMERATE).map((_) => {
     Toast.warning(
-      "Agglomerate skeletons can only be modified when using the proofreading tool to add or delete edges.",
+      "Agglomerate skeletons can only be modified when using the proofreading tool to add or delete edges. Consider switching to the proofreading tool or converting the skeleton to a normal tree via right-click in the Skeleton tab.",
+      { timeout: 10000 },
     );
   });
 }

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
@@ -15,6 +15,7 @@ import {
 } from "typed-redux-saga";
 import { select } from "oxalis/model/sagas/effect-generators";
 import type { UpdateAction } from "oxalis/model/sagas/update_actions";
+import { TreeTypeEnum } from "oxalis/constants";
 import {
   createEdge,
   createNode,
@@ -47,6 +48,7 @@ import {
   enforceSkeletonTracing,
   findTreeByName,
   getTreeNameForAgglomerateSkeleton,
+  getTreesWithType,
 } from "oxalis/model/accessors/skeletontracing_accessor";
 import { getPosition, getRotation } from "oxalis/model/accessors/flycam_accessor";
 import {
@@ -349,7 +351,9 @@ export function* loadAgglomerateSkeletonWithId(
   }
 
   const treeName = getTreeNameForAgglomerateSkeleton(agglomerateId, mappingName);
-  const trees = yield* select((state) => enforceSkeletonTracing(state.tracing).trees);
+  const trees = yield* select((state) =>
+    getTreesWithType(enforceSkeletonTracing(state.tracing), TreeTypeEnum.AGGLOMERATE),
+  );
   const maybeTree = findTreeByName(trees, treeName);
 
   if (maybeTree != null) {

--- a/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/skeletontracing_saga.ts
@@ -537,7 +537,8 @@ function updateTreePredicate(prevTree: Tree, tree: Tree): boolean {
     prevTree.name !== tree.name ||
     !_.isEqual(prevTree.comments, tree.comments) ||
     prevTree.timestamp !== tree.timestamp ||
-    prevTree.groupId !== tree.groupId
+    prevTree.groupId !== tree.groupId ||
+    prevTree.type !== tree.type
   );
 }
 

--- a/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
@@ -78,13 +78,13 @@ class MappingSettingsView extends React.Component<Props, State> {
 
   componentDidMount() {
     if (this.props.isMappingEnabled) {
-      this.refreshLayerMappings();
+      this.ensureMappingsAreLoaded();
     }
   }
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.isMappingEnabled !== prevProps.isMappingEnabled) {
-      this.refreshLayerMappings();
+      this.ensureMappingsAreLoaded();
     }
   }
 
@@ -106,17 +106,10 @@ class MappingSettingsView extends React.Component<Props, State> {
     if (document.activeElement) document.activeElement.blur();
   };
 
-  async refreshLayerMappings() {
+  async ensureMappingsAreLoaded() {
     const { segmentationLayer } = this.props;
 
     if (!segmentationLayer) {
-      return;
-    }
-
-    if (
-      this.props.segmentationLayer?.mappings != null &&
-      this.props.segmentationLayer?.agglomerates != null
-    ) {
       return;
     }
 
@@ -125,7 +118,7 @@ class MappingSettingsView extends React.Component<Props, State> {
 
   handleSetMappingEnabled = (shouldMappingBeEnabled: boolean): void => {
     if (shouldMappingBeEnabled) {
-      this.refreshLayerMappings();
+      this.ensureMappingsAreLoaded();
     }
 
     this.setState({

--- a/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/mapping_settings_view.tsx
@@ -113,7 +113,10 @@ class MappingSettingsView extends React.Component<Props, State> {
       return;
     }
 
-    if (this.props.segmentationLayer?.mappings != null) {
+    if (
+      this.props.segmentationLayer?.mappings != null &&
+      this.props.segmentationLayer?.agglomerates != null
+    ) {
       return;
     }
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/tree_hierarchy_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/tree_hierarchy_view.tsx
@@ -612,9 +612,9 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
                 this.handleMeasureSkeletonLength(tree.treeId, tree.name);
                 this.handleTreeDropdownMenuVisibility(tree.treeId, false);
               },
-              title: "Measure Skeleton Length",
+              title: "Measure Tree Length",
               icon: <i className="fas fa-ruler" />,
-              label: "Measure Skeleton Length",
+              label: "Measure Tree Length",
             },
             {
               key: "hideTree",
@@ -645,9 +645,9 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
                     this.props.onSetTreeType(tree.treeId, TreeTypeEnum.DEFAULT);
                     this.handleTreeDropdownMenuVisibility(tree.treeId, false);
                   },
-                  title: "Convert to Normal Skeleton",
+                  title: "Convert to Normal Tree",
                   icon: <span className="fas fa-clipboard-check" />,
-                  label: "Convert to Normal Skeleton",
+                  label: "Convert to Normal Tree",
                 }
               : null,
           ],

--- a/frontend/javascripts/oxalis/view/right-border-tabs/tree_hierarchy_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/tree_hierarchy_view.tsx
@@ -21,7 +21,7 @@ import {
 import _ from "lodash";
 import type { Dispatch } from "redux";
 import type { Action } from "oxalis/model/actions/actions";
-import { TreeTypeEnum, Vector3 } from "oxalis/constants";
+import { TreeTypeEnum, type TreeType, type Vector3 } from "oxalis/constants";
 
 import {
   getGroupByIdWithSubgroups,
@@ -54,6 +54,7 @@ import {
   toggleInactiveTreesAction,
   shuffleAllTreeColorsAction,
   setTreeEdgeVisibilityAction,
+  setTreeTypeAction,
 } from "oxalis/model/actions/skeletontracing_actions";
 import messages from "messages";
 import { formatNumberToLength, formatLengthAsVx } from "libs/format_utils";
@@ -91,6 +92,7 @@ type Props = OwnProps & {
   onToggleHideInactiveTrees: () => void;
   onShuffleAllTreeColors: () => void;
   onSetTreeEdgesVisibility: (treeId: number, edgesAreVisible: boolean) => void;
+  onSetTreeType: (treeId: number, type: TreeTypeEnum) => void;
 };
 type State = {
   prevProps: Props | null | undefined;
@@ -567,6 +569,7 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
       const tree = this.props.trees[parseInt(node.id, 10)];
       const rgbColorString = tree.color.map((c) => Math.round(c * 255)).join(",");
       const isEditingDisabled = !this.props.allowUpdate;
+      const isAgglomerateSkeleton = tree.type === TreeTypeEnum.AGGLOMERATE;
       // Defining background color of current node
       const styleClass = this.getNodeStyleClassForBackground(node.id);
 
@@ -620,9 +623,9 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
                 this.props.onToggleHideInactiveTrees();
                 this.handleTreeDropdownMenuVisibility(tree.treeId, false);
               },
-              title: "Hide/Show all other trees",
+              title: "Hide/Show All Other Trees",
               icon: <i className="fas fa-eye" />,
-              label: "Hide/Show all other trees",
+              label: "Hide/Show All Other Trees",
             },
             {
               key: "hideTreeEdges",
@@ -631,10 +634,22 @@ class TreeHierarchyView extends React.PureComponent<Props, State> {
                 this.props.onSetTreeEdgesVisibility(tree.treeId, !tree.edgesAreVisible);
                 this.handleTreeDropdownMenuVisibility(tree.treeId, false);
               },
-              title: "Hide/Show edges of this tree",
+              title: "Hide/Show Edges of This Tree",
               icon: <span className="hide-tree-edges-icon" />,
-              label: "Hide/Show edges of this tree",
+              label: "Hide/Show Edges of This Tree",
             },
+            isAgglomerateSkeleton
+              ? {
+                  key: "convertToNormalSkeleton",
+                  onClick: () => {
+                    this.props.onSetTreeType(tree.treeId, TreeTypeEnum.DEFAULT);
+                    this.handleTreeDropdownMenuVisibility(tree.treeId, false);
+                  },
+                  title: "Convert to Normal Skeleton",
+                  icon: <span className="fas fa-clipboard-check" />,
+                  label: "Convert to Normal Skeleton",
+                }
+              : null,
           ],
         };
       };
@@ -837,6 +852,10 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
 
   onShuffleAllTreeColors() {
     dispatch(shuffleAllTreeColorsAction());
+  },
+
+  onSetTreeType(treeId: number, type: TreeType) {
+    dispatch(setTreeTypeAction(treeId, type));
   },
 });
 


### PR DESCRIPTION
I also fixed the initialization of the mapping list for agglomerate skeletons iff json mappings are present. This was broken due to a regression before. The `mappings` property of a layer might already be set when initially obtaining the layer information, so it's not sufficient to check for that when checking whether mappings (and agglomerates) were already loaded.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the test-agglomerate-file dataset
- Enable ID Mapping and check that agglomerate_view_70 is listed
- Enable agglomerate_view_70 and load an agglomerate skeleton
- Rightclick on the skeleton in the tree list and select "Convert to Normal Skeleton"
- Check that the proofreading icon disappears, the skeleton can be modified freely and the change persists after a reload
- Check that the conversion option is not offered for normal skeletons

### TODOs:
- [ ] ...

### Issues:
- fixes https://discuss.webknossos.org/t/normal-editing-of-agglomerate-skeletons/1812

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
