### PR TITLE
Change default dataset search mode to be recursive

### DIFF
--- a/frontend/javascripts/dashboard/dataset/dataset_collection_context.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_collection_context.tsx
@@ -305,7 +305,7 @@ function useManagedUrlParams(
       setActiveFolderId(folderId);
     }
     const recursive = params.get("recursive");
-    setSearchRecursively(!!recursive);
+    if (recursive != null) setSearchRecursively(recursive === "true");
 
     const folderSpecifier = _.last(location.pathname.split("/"));
 
@@ -350,9 +350,9 @@ function useManagedUrlParams(
         params.set("folderId", activeFolderId);
         // The recursive property is only relevant when a folderId is specified.
         if (searchRecursively) {
-          params.set("recursive", "true");
-        } else {
           params.delete("recursive");
+        } else {
+          params.set("recursive", "false");
         }
       } else {
         params.delete("folderId");


### PR DESCRIPTION
As discussed internally.
The `recursive` prop already was true by default (see [code](https://github.com/scalableminds/webknossos/blob/master/frontend/javascripts/dashboard/dataset/dataset_collection_context.tsx#L101)), but parsing the url parameters on component mount effectively changed that to be false.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Move some datasets into a folder
- Search for them from the root folder. The default search mode should be recursive and they should be found if there is a match
- Reload the page while any of the three search modes is active -> It should still be active after a reload.

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
