### PR TITLE
Include http api versions in buildinfo

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Multiple segments can be dragged and dropped in the segments tab. [#7536](https://github.com/scalableminds/webknossos/pull/7536)
 - Added the option to convert agglomerate skeletons to freely modifiable skeletons in the context menu of the Skeleton tab. [#7537](https://github.com/scalableminds/webknossos/pull/7537)
 - The annotation list in the dashboard now also shows segment counts of volume annotations (after they have been edited). [#7548](https://github.com/scalableminds/webknossos/pull/7548)
+- The buildinfo route now reports the supported HTTP API versions. [#7581](https://github.com/scalableminds/webknossos/pull/7581)
 
 ### Changed
 - Improved loading speed of the annotation list. [#7410](https://github.com/scalableminds/webknossos/pull/7410)

--- a/app/RequestHandler.scala
+++ b/app/RequestHandler.scala
@@ -9,7 +9,7 @@ import play.api.mvc.{Handler, InjectedController, RequestHeader}
 import play.api.routing.Router
 import play.core.WebCommands
 import play.filters.csp.CSPConfig
-import utils.WkConf
+import utils.{ApiVersioning, WkConf}
 
 import scala.concurrent.ExecutionContext
 
@@ -35,13 +35,13 @@ class RequestHandler @Inject()(webCommands: WebCommands,
     with InjectedController
     with ExtendedController
     with CspHeaders
+    with ApiVersioning
     with LazyLogging {
 
   override def routeRequest(request: RequestHeader): Option[Handler] =
-    if (apiVersionIsTooNew(request)) {
+    if (isInvalidApiVersion(request)) {
       Some(Action {
-        JsonNotFound(
-          f"This WEBKNOSSOS instance does not yet support this API version. The requested API version is higher than the current API version $CURRENT_API_VERSION.")
+        JsonNotFound(invalidApiVersionMessage(request))
       })
     } else if (request.uri.matches("^(/api/|/data/|/tracings/|/\\.well-known/).*$")) {
       super.routeRequest(request)
@@ -65,15 +65,5 @@ class RequestHandler @Inject()(webCommands: WebCommands,
     val path = requestHeader.path.replaceFirst("^(/assets/)", "")
     assets.at(path = "/public", file = path)
   }
-
-  private def CURRENT_API_VERSION = 6
-
-  private def apiVersionIsTooNew(request: RequestHeader): Boolean =
-    "^/api/v(\\d+).*$".r.findFirstMatchIn(request.uri) match {
-      case Some(m) =>
-        val version = m.group(1)
-        version.toInt > CURRENT_API_VERSION
-      case None => false
-    }
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -12,7 +12,7 @@ import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.WkEnv
 import utils.sql.{SimpleSQLDAO, SqlClient}
-import utils.{StoreModules, WkConf}
+import utils.{ApiVersioning, StoreModules, WkConf}
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
@@ -26,7 +26,8 @@ class Application @Inject()(actorSystem: ActorSystem,
                             defaultMails: DefaultMails,
                             storeModules: StoreModules,
                             sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
-    extends Controller {
+    extends Controller
+    with ApiVersioning {
 
   private lazy val Mailer =
     actorSystem.actorSelection("/user/mailActor")
@@ -41,6 +42,10 @@ class Application @Inject()(actorSystem: ActorSystem,
             "webknossos" -> Json.toJson(webknossos.BuildInfo.toMap.view.mapValues(_.toString).toMap),
             "webknossos-wrap" -> Json.toJson(webknossoswrap.BuildInfo.toMap.view.mapValues(_.toString).toMap),
             "schemaVersion" -> schemaVersion.toOption,
+            "httpApiVersioning" -> Json.obj(
+              "currentApiVersion" -> CURRENT_API_VERSION,
+              "oldestSupportedApiVersion" -> OLDEST_SUPPORTED_API_VERSION
+            ),
             "localDataStoreEnabled" -> storeModules.localDataStoreEnabled,
             "localTracingStoreEnabled" -> storeModules.localTracingStoreEnabled
           ))

--- a/app/utils/ApiVersioning.scala
+++ b/app/utils/ApiVersioning.scala
@@ -1,0 +1,27 @@
+package utils
+
+import play.api.mvc.RequestHeader
+
+trait ApiVersioning {
+
+  protected def CURRENT_API_VERSION: Int = 6
+
+  protected def OLDEST_SUPPORTED_API_VERSION: Int = 1
+
+  protected def isInvalidApiVersion(request: RequestHeader): Boolean = {
+    val requestedVersion = extractRequestedApiVersion(request)
+    requestedVersion > CURRENT_API_VERSION || requestedVersion < OLDEST_SUPPORTED_API_VERSION
+  }
+
+  protected def invalidApiVersionMessage(request: RequestHeader): String = {
+    val requestedVersion = extractRequestedApiVersion(request)
+    f"This WEBKNOSSOS instance does not support the requested HTTP API version. Client requested $requestedVersion but must be at least $OLDEST_SUPPORTED_API_VERSION and at most $CURRENT_API_VERSION."
+  }
+
+  private def extractRequestedApiVersion(request: RequestHeader): Int =
+    "^/api/v(\\d+).*$".r.findFirstMatchIn(request.uri) match {
+      case Some(m) =>
+        m.group(1).toInt
+      case None => CURRENT_API_VERSION
+    }
+}

--- a/conf/webknossos.versioned.routes
+++ b/conf/webknossos.versioned.routes
@@ -1,6 +1,7 @@
 # API versioning is handled here. Higher-Priority routes first
 
 # example: assume, the features route has changed, introducing v2. The older v1 needs to be provided in the legacyApiController
+# Note: keep this in sync with the reported version numbers in the utils.ApiVersioning trait
 
 # version log:
  # changed in v6: isValidName always returns Ok, with a JSON object containing possible errors and key "isValid"


### PR DESCRIPTION
The buildinfo route now reports the supported HTTP API versions. Also the error message if an unsupported api version was requested is now more descriptive.

### URL of deployed dev instance (used for testing):
- https://httpapiversionbuildinfo.webknossos.xyz

### Steps to test:
- go to `api/buildinfo` should show 1 to 6 (Any suggestions on naming the fields?)
- request `api/v13/buildinfo`, should show readable error message.

### Issues:
- contributes to #5840 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
