### PR TITLE
Make index location in zarr3 sharding metadata optional

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3ArrayHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3ArrayHeader.scala
@@ -199,7 +199,9 @@ object Zarr3ArrayHeader extends JsonImplicits {
         chunk_shape <- config("chunk_shape").validate[Array[Int]]
         codecs = readCodecs(config("codecs"))
         index_codecs = readCodecs(config("index_codecs"))
-        index_location <- config("index_location").validate[IndexLocationSetting.IndexLocationSetting]
+        index_location = (config \ "index_location")
+          .asOpt[IndexLocationSetting.IndexLocationSetting]
+          .getOrElse(IndexLocationSetting.end)
       } yield ShardingCodecConfiguration(chunk_shape, codecs, index_codecs, index_location)
 
     private def readCodecs(value: JsValue): Seq[CodecConfiguration] = {


### PR DESCRIPTION
### Steps to test:
- Open a zarr3 dataset with sharding that does not specify explicit index_location in its metadata
- should show data (defualt is IndexLocationSetting.end)

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
