### PR TITLE
Fix loading local datasets for orgas with spaces in their names

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed rare SIGBUS crashes of the datastore module that were caused by memory mapping on unstable file systems. [#7528](https://github.com/scalableminds/webknossos/pull/7528)
+- Fixed loading local datasets for organizations that have spaces in their names. [#7593](https://github.com/scalableminds/webknossos/pull/7593)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RemoteSourceDescriptorService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RemoteSourceDescriptorService.scala
@@ -88,7 +88,7 @@ class RemoteSourceDescriptorService @Inject()(dSRemoteWebKnossosClient: DSRemote
   }
 
   private def localFileUriFromPath(path: Path) =
-    new URI(DataVaultService.schemeFile + "://" + path.toAbsolutePath.toString)
+    path.toAbsolutePath.toUri
 
   private def credentialFor(magLocator: MagLocator)(implicit ec: ExecutionContext): Fox[DataVaultCredential] =
     magLocator.credentialId match {


### PR DESCRIPTION
This bug existed before #7528 but now we noticed it since it now also hits WKW datasets

### Steps to test:
- Change your orga name to `sample organization` with a space (in InitialDataController + in db + in binaryData directory on disk)
- Load a local dataset
- Should show data, backend logging should not show `java.net.URISyntaxException`

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
