### PR TITLE
Fix that proofreading got stuck with expired token

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed rare SIGBUS crashes of the datastore module that were caused by memory mapping on unstable file systems. [#7528](https://github.com/scalableminds/webknossos/pull/7528)
 - Fixed loading local datasets for organizations that have spaces in their names. [#7593](https://github.com/scalableminds/webknossos/pull/7593)
+- Fixed a bug where proofreading annotations would stay black until the next server restart due to expired but cached tokens. [#7598](https://github.com/scalableminds/webknossos/pull/7598)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -217,6 +217,8 @@ trait DataLayer extends DataLayerLike {
                      dataSourceId: DataSourceId,
                      sharedChunkContentsCache: Option[AlfuCache[String, MultiArray]]): BucketProvider
 
+  def bucketProviderCacheKey: String = this.name
+
   def containsResolution(resolution: Vec3Int): Boolean = resolutions.contains(resolution)
 
   def doesContainBucket(bucket: BucketPosition): Boolean =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -91,7 +91,7 @@ class BinaryDataService(val dataBaseDir: Path,
       // dataSource is null and unused for volume tracings. Insert dummy DataSourceId (also unused in that case)
       val dataSourceId = if (request.dataSource != null) request.dataSource.id else DataSourceId("", "")
       val bucketProvider =
-        bucketProviderCache.getOrLoadAndPut((dataSourceId, request.dataLayer.name))(_ =>
+        bucketProviderCache.getOrLoadAndPut((dataSourceId, request.dataLayer.bucketProviderCacheKey))(_ =>
           request.dataLayer.bucketProvider(remoteSourceDescriptorServiceOpt, dataSourceId, sharedChunkContentsCache))
       bucketProvider.load(readInstruction, shardHandleCache).futureBox.flatMap {
         case Failure(msg, Full(e: InternalError), _) =>

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
@@ -90,6 +90,8 @@ case class EditableMappingLayer(name: String,
                               sharedChunkContentsCache: Option[AlfuCache[String, MultiArray]]): BucketProvider =
     new EditableMappingBucketProvider(layer = this)
 
+  override def bucketProviderCacheKey: String = s"$name-token=$token"
+
   override def mappings: Option[Set[String]] = None
 
   override def defaultViewConfiguration: Option[LayerViewConfiguration] = None


### PR DESCRIPTION
The bucketProvider was cached using only the layer name. For EditableMappingLayers, the token is stored in the layer. That meant that even when a new request uses a new token, the old token is still used by the cached bucketProvider. When that token expires, the BucketProvider fails permanently with the old token.

This PR includes the token in the bucketProviderCacheKey similar to the mechanism in https://github.com/scalableminds/webknossos/pull/7437/files#diff-0a1de65bd00003637bef68955997c0de7a92d0402bda79f32fda5dde4e5a5816



### Steps to test:
- I tested this by setting `silhouettetokenAuthenticator.dataStoreExpiry = 10 seconds` in application.conf. With this, the frontend will request a new token and use that after the old one is expired. It is then also passed to the bucketProvider. The bug occurred quickly with that config but the old code.

### Issues:
- fixes #7546

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
