### PR TITLE
Fix incorrect logic when deciding whether to use segment stats for adhoc meshing

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed rare SIGBUS crashes of the datastore module that were caused by memory mapping on unstable file systems. [#7528](https://github.com/scalableminds/webknossos/pull/7528)
 - Fixed loading local datasets for organizations that have spaces in their names. [#7593](https://github.com/scalableminds/webknossos/pull/7593)
 - Fixed a bug where proofreading annotations would stay black until the next server restart due to expired but cached tokens. [#7598](https://github.com/scalableminds/webknossos/pull/7598)
+- Fixed a bug where ad-hoc meshing didn't make use of a segment index, even when it existed. [#7600](https://github.com/scalableminds/webknossos/pull/7600)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/sagas/mesh_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/mesh_saga.ts
@@ -352,7 +352,7 @@ function* loadFullAdHocMesh(
     volumeTracing?.hasSegmentIndex &&
     !volumeTracing.mappingIsEditable &&
     visibleSegmentationLayer?.tracingId != null &&
-    additionalCoordinates == null; // TODO remove in https://github.com/scalableminds/webknossos/pull/7411
+    (additionalCoordinates == null || additionalCoordinates.length === 0); // TODO remove in https://github.com/scalableminds/webknossos/pull/7411
   let positionsToRequest = usePositionsFromSegmentStats
     ? yield* getChunkPositionsFromSegmentStats(
         tracingStoreHost,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- use adhoc meshing and ensure that the positions are queried first in the network tab

### Issues:
- follow-up for #7394

------
(Please delete unneeded items, merge only when none are left open)
- [X] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
