### PR TITLE
Insert credentialId when exploring remote zarr dataset with datasource-properties

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed loading local datasets for organizations that have spaces in their names. [#7593](https://github.com/scalableminds/webknossos/pull/7593)
 - Fixed a bug where proofreading annotations would stay black until the next server restart due to expired but cached tokens. [#7598](https://github.com/scalableminds/webknossos/pull/7598)
 - Fixed a bug where ad-hoc meshing didn't make use of a segment index, even when it existed. [#7600](https://github.com/scalableminds/webknossos/pull/7600)
+- Fixed a bug where importing remote datasets with existing datasource-properties.jsons would not properly register the remote credentials. [#7601](https://github.com/scalableminds/webknossos/pull/7601)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/WebknossosZarrExplorer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/WebknossosZarrExplorer.scala
@@ -23,32 +23,33 @@ class WebknossosZarrExplorer(implicit val ec: ExecutionContext) extends RemoteLa
       zarrLayers <- Fox.serialCombined(dataSource.dataLayers) {
         case l: Zarr3SegmentationLayer =>
           for {
-            mags <- fixMagsWithRemotePaths(l.mags, remotePath / l.name, Zarr3ArrayHeader.FILENAME_ZARR_JSON)
+            mags <- adaptMags(l.mags, remotePath / l.name, Zarr3ArrayHeader.FILENAME_ZARR_JSON, credentialId)
           } yield l.copy(mags = mags)
         case l: Zarr3DataLayer =>
           for {
-            mags <- fixMagsWithRemotePaths(l.mags, remotePath / l.name, Zarr3ArrayHeader.FILENAME_ZARR_JSON)
+            mags <- adaptMags(l.mags, remotePath / l.name, Zarr3ArrayHeader.FILENAME_ZARR_JSON, credentialId)
           } yield l.copy(mags = mags)
         case l: ZarrSegmentationLayer =>
           for {
-            mags <- fixMagsWithRemotePaths(l.mags, remotePath / l.name, ZarrHeader.FILENAME_DOT_ZARRAY)
+            mags <- adaptMags(l.mags, remotePath / l.name, ZarrHeader.FILENAME_DOT_ZARRAY, credentialId)
           } yield l.copy(mags = mags)
         case l: ZarrDataLayer =>
           for {
-            mags <- fixMagsWithRemotePaths(l.mags, remotePath / l.name, ZarrHeader.FILENAME_DOT_ZARRAY)
+            mags <- adaptMags(l.mags, remotePath / l.name, ZarrHeader.FILENAME_DOT_ZARRAY, credentialId)
           } yield l.copy(mags = mags)
-        case layer => Fox.failure(s"Only remote Zarr or Zarr3 layers are supported, got ${layer.getClass}.")
+        case layer => Fox.failure(s"Only remote Zarr2 or Zarr3 layers are supported, got ${layer.getClass}.")
       }
       zarrLayersWithScale <- Fox.serialCombined(zarrLayers)(l => Fox.successful((l, dataSource.scale)))
     } yield zarrLayersWithScale
 
-  private def fixMagsWithRemotePaths(mags: List[MagLocator],
-                                     remoteLayerPath: VaultPath,
-                                     headerFilename: String): Fox[List[MagLocator]] =
+  private def adaptMags(mags: List[MagLocator],
+                        remoteLayerPath: VaultPath,
+                        headerFilename: String,
+                        credentialId: Option[String]): Fox[List[MagLocator]] =
     Fox.serialCombined(mags)(m =>
       for {
         magPath <- fixRemoteMagPath(m, remoteLayerPath, headerFilename)
-      } yield m.copy(path = magPath))
+      } yield m.copy(path = magPath, credentialId = credentialId))
 
   private def fixRemoteMagPath(mag: MagLocator,
                                remoteLayerPath: VaultPath,


### PR DESCRIPTION
### Steps to test:
- With credentials, explore remote zarr dataset that has a datasource-properties.json 
- credentialId should be inserted in the json, dataset should be viewable

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
