### PR TITLE
In proofreading min-cut, return directed edges to keep id of selected

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where ad-hoc meshing didn't make use of a segment index, even when it existed. [#7600](https://github.com/scalableminds/webknossos/pull/7600)
 - Fixed a bug where importing remote datasets with existing datasource-properties.jsons would not properly register the remote credentials. [#7601](https://github.com/scalableminds/webknossos/pull/7601)
 - Fixed a bug in ND volume annotation downloads where the additionalAxes metadata had wrong indices. [#7592](https://github.com/scalableminds/webknossos/pull/7592)
+- Fixed a bug in proofreading aka editable mapping annotations where splitting would sometimes give the new id to the selected segment rather than to the split-off one. [#7608](https://github.com/scalableminds/webknossos/pull/7608)
 
 ### Removed
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
@@ -609,10 +609,16 @@ class EditableMappingService @Inject()(
     tryo {
       val minCutImpl = new PushRelabelMFImpl(g)
       minCutImpl.calculateMinCut(segmentId1, segmentId2)
+      val sourcePartition: util.Set[Long] = minCutImpl.getSourcePartition
       val minCutEdges: util.Set[DefaultWeightedEdge] = minCutImpl.getCutEdges
-      minCutEdges.asScala.toList.map(e => (g.getEdgeSource(e), g.getEdgeTarget(e)))
+      minCutEdges.asScala.toList.map(e =>
+        setDirectionForCutting(g.getEdgeSource(e), g.getEdgeTarget(e), sourcePartition))
     }
   }
+
+  // the returned edges must be directed so that when they are passed to the split action, the source segment keeps its agglomerate id
+  private def setDirectionForCutting(node1: Long, node2: Long, sourcePartition: util.Set[Long]): (Long, Long) =
+    if (sourcePartition.contains(node1)) (node1, node2) else (node2, node1)
 
   private def annotateEdgesWithPositions(edges: List[(Long, Long)],
                                          agglomerateGraph: AgglomerateGraph): List[EdgeWithPositions] =


### PR DESCRIPTION
Min-cut returns a set of edges that are then passed to the proofreading split operation. These edges need to be directed so that when splitting the expected side keeps its agglomerate id. This PR uses the min cut’s source partition to determine which way the edges should be directed.

### Steps to test:
- In proofreading annotation, perform a split one way, merge again, perform the split the other way, repeat. Always the selected (first-clicked, cross-bearing) segment should keep its agglomerate id
- For merging this should have already worked, do some testing for that too

### Issues:
- fixes #6470

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)