### PR TITLE
Fix deprecation warnings for antd <Collapse> components

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where importing remote datasets with existing datasource-properties.jsons would not properly register the remote credentials. [#7601](https://github.com/scalableminds/webknossos/pull/7601)
 - Fixed a bug in ND volume annotation downloads where the additionalAxes metadata had wrong indices. [#7592](https://github.com/scalableminds/webknossos/pull/7592)
 - Fixed a bug in proofreading aka editable mapping annotations where splitting would sometimes give the new id to the selected segment rather than to the split-off one. [#7608](https://github.com/scalableminds/webknossos/pull/7608)
+-Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
 
 ### Removed
 

--- a/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
@@ -38,7 +38,6 @@ import { Unicode } from "oxalis/constants";
 import { readFileAsText } from "libs/read_file";
 import * as Utils from "libs/utils";
 
-const { Panel } = Collapse;
 const FormItem = Form.Item;
 const RadioGroup = Radio.Group;
 
@@ -551,13 +550,20 @@ function AddZarrLayer({
       {exploreLog ? (
         <Row gutter={8}>
           <Col span={24}>
-            <Collapse defaultActiveKey="1">
-              <Panel header="Error Log" key="1">
-                <Hint style={{ width: "90%" }}>
-                  <pre style={{ whiteSpace: "pre-wrap" }}>{exploreLog}</pre>
-                </Hint>
-              </Panel>
-            </Collapse>
+            <Collapse
+              defaultActiveKey="1"
+              items={[
+                {
+                  key: "1",
+                  label: "Error Log",
+                  children: (
+                    <Hint style={{ width: "90%" }}>
+                      <pre style={{ whiteSpace: "pre-wrap" }}>{exploreLog}</pre>
+                    </Hint>
+                  ),
+                },
+              ]}
+            />
           </Col>
         </Row>
       ) : null}

--- a/frontend/javascripts/admin/tasktype/recommended_configuration_view.tsx
+++ b/frontend/javascripts/admin/tasktype/recommended_configuration_view.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Col, Collapse, Form, Input, Row, Table, Button } from "antd";
+import { Checkbox, Col, Collapse, Form, Input, Row, Table, Button, CollapseProps } from "antd";
 import { FormInstance } from "antd/lib/form";
 import * as React from "react";
 import _ from "lodash";
@@ -9,7 +9,6 @@ import { validateUserSettingsJSON } from "types/validation";
 import { TDViewDisplayModeEnum } from "oxalis/constants";
 import features from "features";
 const FormItem = Form.Item;
-const { Panel } = Collapse;
 
 function getRecommendedConfigByCategory() {
   return {
@@ -138,79 +137,84 @@ export default function RecommendedConfigurationView({
     };
   });
 
+  const recommendedSettingsView = (
+    <Row gutter={32}>
+      <Col span={12}>
+        <div>
+          The recommended configuration will be displayed to users when starting to work on a task
+          with this task type. The user is able to accept or decline this recommendation.
+          <br />
+          <br />
+          <FormItem
+            name="recommendedConfiguration"
+            hasFeedback
+            rules={[
+              {
+                validator: (rule, value) =>
+                  enabled ? validateUserSettingsJSON(rule, value) : Promise.resolve(),
+              },
+            ]}
+          >
+            <Input.TextArea
+              spellCheck={false}
+              autoSize={{
+                minRows: 20,
+              }}
+              style={jsonEditStyle}
+            />
+          </FormItem>
+        </div>
+        <Button className="button-margin" onClick={() => removeSettings(form, "orthogonal")}>
+          Remove Orthogonal-only Settings
+        </Button>
+        <Button className="button-margin" onClick={() => removeSettings(form, "flight")}>
+          Remove Flight/Oblique-only Settings
+        </Button>
+        <Button className="button-margin" onClick={() => removeSettings(form, "volume")}>
+          Remove Volume-only Settings
+        </Button>
+      </Col>
+      <Col span={12}>
+        Valid settings and their default values: <br />
+        <br />
+        <Table
+          columns={columns}
+          dataSource={configurationEntries}
+          size="small"
+          pagination={false}
+          className="large-table"
+          scroll={{
+            x: "max-content",
+          }}
+        />
+      </Col>
+    </Row>
+  );
+
+  const collapseItems: CollapseProps["items"] = [
+    {
+      key: "config",
+      label: (
+        <React.Fragment>
+          <Checkbox
+            checked={enabled}
+            style={{
+              marginRight: 10,
+            }}
+          />{" "}
+          Add Recommended User Settings
+        </React.Fragment>
+      ),
+      showArrow: false,
+      children: recommendedSettingsView,
+    },
+  ];
+
   return (
     <Collapse
       onChange={(openedPanels) => onChangeEnabled(openedPanels.length === 1)}
-      // @ts-expect-error ts-migrate(2322) FIXME: Type 'string | null' is not assignable to type 'st... Remove this comment to see the full error message
-      activeKey={enabled ? "config" : null}
-    >
-      <Panel
-        key="config"
-        header={
-          <React.Fragment>
-            <Checkbox
-              checked={enabled}
-              style={{
-                marginRight: 10,
-              }}
-            />{" "}
-            Add Recommended User Settings
-          </React.Fragment>
-        }
-        showArrow={false}
-      >
-        <Row gutter={32}>
-          <Col span={12}>
-            <div>
-              The recommended configuration will be displayed to users when starting to work on a
-              task with this task type. The user is able to accept or decline this recommendation.
-              <br />
-              <br />
-              <FormItem
-                name="recommendedConfiguration"
-                hasFeedback
-                rules={[
-                  {
-                    validator: (rule, value) =>
-                      enabled ? validateUserSettingsJSON(rule, value) : Promise.resolve(),
-                  },
-                ]}
-              >
-                <Input.TextArea
-                  spellCheck={false}
-                  autoSize={{
-                    minRows: 20,
-                  }}
-                  style={jsonEditStyle}
-                />
-              </FormItem>
-            </div>
-            <Button className="button-margin" onClick={() => removeSettings(form, "orthogonal")}>
-              Remove Orthogonal-only Settings
-            </Button>
-            <Button className="button-margin" onClick={() => removeSettings(form, "flight")}>
-              Remove Flight/Oblique-only Settings
-            </Button>
-            <Button className="button-margin" onClick={() => removeSettings(form, "volume")}>
-              Remove Volume-only Settings
-            </Button>
-          </Col>
-          <Col span={12}>
-            Valid settings and their default values: <br />
-            <br />
-            <Table
-              columns={columns}
-              dataSource={configurationEntries}
-              size="small"
-              pagination={false}
-              className="large-table"
-              scroll={{
-                x: "max-content",
-              }}
-            />
-          </Col>
-        </Row>
-      </Panel>
-    </Collapse>
+      activeKey={enabled ? "config" : undefined}
+      items={collapseItems}
+    />
   );
 }

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -483,7 +483,7 @@ export default function TaskListView({
         ),
         children: (
           <React.Fragment>
-            openMetatask !== taskGroup.key && (
+            {openMetatask !== taskGroup.key && (
             <div style={{ marginBottom: 8 }}>
               <a
                 href=""
@@ -497,7 +497,8 @@ export default function TaskListView({
               </a>
               <Link to={addUrlParam(location, "metatask", taskGroup.key)}>Open in extra View</Link>
             </div>
-            ){/* <Collapse items={collapseItems} /> */}
+            )}
+            <Collapse items={collapseItems} />
           </React.Fragment>
         ),
       };

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -484,19 +484,21 @@ export default function TaskListView({
         children: (
           <React.Fragment>
             {openMetatask !== taskGroup.key && (
-            <div style={{ marginBottom: 8 }}>
-              <a
-                href=""
-                style={{ marginRight: 16 }}
-                onClick={(ev) => {
-                  ev.preventDefault();
-                  onToggleExpandedMetaTaskKey(taskGroup.key);
-                }}
-              >
-                {expandedMetaTaskKeys[taskGroup.key] ? "Collapse in DAG" : "Expand in DAG"}
-              </a>
-              <Link to={addUrlParam(location, "metatask", taskGroup.key)}>Open in extra View</Link>
-            </div>
+              <div style={{ marginBottom: 8 }}>
+                <a
+                  href=""
+                  style={{ marginRight: 16 }}
+                  onClick={(ev) => {
+                    ev.preventDefault();
+                    onToggleExpandedMetaTaskKey(taskGroup.key);
+                  }}
+                >
+                  {expandedMetaTaskKeys[taskGroup.key] ? "Collapse in DAG" : "Expand in DAG"}
+                </a>
+                <Link to={addUrlParam(location, "metatask", taskGroup.key)}>
+                  Open in extra View
+                </Link>
+              </div>
             )}
             <Collapse items={collapseItems} />
           </React.Fragment>

--- a/frontend/javascripts/dashboard/dataset/color_layer_ordering_component.tsx
+++ b/frontend/javascripts/dashboard/dataset/color_layer_ordering_component.tsx
@@ -1,12 +1,11 @@
 import { MenuOutlined, InfoCircleOutlined } from "@ant-design/icons";
-import { List, Collapse, Tooltip } from "antd";
+import { List, Collapse, Tooltip, CollapseProps } from "antd";
 import React from "react";
 import { SortEnd } from "react-sortable-hoc";
 import { SortableContainer, SortableElement, SortableHandle } from "react-sortable-hoc";
 import { settings, settingsTooltips } from "messages";
 
 // Example taken and modified from https://4x.ant.design/components/table/#components-table-demo-drag-sorting-handler.
-const { Panel } = Collapse;
 
 const DragHandle = SortableHandle(() => <MenuOutlined style={{ cursor: "grab", color: "#999" }} />);
 
@@ -52,9 +51,11 @@ export default function ColorLayerOrderingTable({
     </span>
   );
 
-  return (
-    <Collapse defaultActiveKey={[]} collapsible={isSettingEnabled ? "header" : "disabled"}>
-      <Panel header={panelTitle} key="1">
+  const collapseItems: CollapseProps["items"] = [
+    {
+      label: panelTitle,
+      key: "1",
+      children: (
         <SortableLayerSettingsContainer
           onSortEnd={onSortEnd}
           onSortStart={() =>
@@ -68,7 +69,15 @@ export default function ColorLayerOrderingTable({
             <SortableItem key={name} index={index} name={name} />
           ))}
         </SortableLayerSettingsContainer>
-      </Panel>
-    </Collapse>
+      ),
+    },
+  ];
+
+  return (
+    <Collapse
+      defaultActiveKey={[]}
+      collapsible={isSettingEnabled ? "header" : "disabled"}
+      items={collapseItems}
+    />
   );
 }

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -98,7 +98,7 @@ function DatasetSettingsSharingTab({ form, datasetId, dataset, activeUser }: Pro
         collapsible="header"
         items={[
           {
-            label: { panelTitle: panelLabel },
+            label: panelLabel,
             key: "1",
             children: <DatasetAccessListView dataset={dataset} />,
           },

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -84,7 +84,7 @@ function DatasetSettingsSharingTab({ form, datasetId, dataset, activeUser }: Pro
     if (!activeUser || !dataset) return undefined;
     if (!isUserAdminOrTeamManager(activeUser)) return undefined;
 
-    const header = (
+    const panelLabel = (
       <span>
         All users with access permission to work with this dataset{" "}
         <Tooltip title="Based on the specified team permissions and individiual user roles. Any changes will only appear after pressing the Save button.">
@@ -94,11 +94,16 @@ function DatasetSettingsSharingTab({ form, datasetId, dataset, activeUser }: Pro
     );
 
     return (
-      <Collapse collapsible="header">
-        <Collapse.Panel header={header} key="1">
-          <DatasetAccessListView dataset={dataset} />
-        </Collapse.Panel>
-      </Collapse>
+      <Collapse
+        collapsible="header"
+        items={[
+          {
+            label: { panelTitle: panelLabel },
+            key: "1",
+            children: <DatasetAccessListView dataset={dataset} />,
+          },
+        ]}
+      />
     );
   }
 

--- a/frontend/javascripts/libs/toast.tsx
+++ b/frontend/javascripts/libs/toast.tsx
@@ -1,7 +1,6 @@
 import { notification, Collapse } from "antd";
 import { CloseCircleOutlined } from "@ant-design/icons";
 import React from "react";
-const { Panel } = Collapse;
 
 export type ToastStyle = "info" | "warning" | "success" | "error";
 export type Message = {
@@ -59,19 +58,19 @@ const Toast = {
             background: "transparent",
             marginLeft: -16,
           }}
-        >
-          <Panel
-            key="toast-panel"
-            header="Show more information"
-            style={{
-              background: "transparent",
-              border: 0,
-              fontSize: 10,
-            }}
-          >
-            {details}
-          </Panel>
-        </Collapse>
+          items={[
+            {
+              key: "toast-panel",
+              label: "Show more information",
+              style: {
+                background: "transparent",
+                border: 0,
+                fontSize: 10,
+              },
+              children: details,
+            },
+          ]}
+        />
       </div>
     );
   },

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -16,6 +16,7 @@ import type {
 import window, { document, location } from "libs/window";
 
 export type Comparator<T> = (arg0: T, arg1: T) => -1 | 0 | 1;
+export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
 type UrlParams = Record<string, string>;
 // Fix JS modulo bug
@@ -1180,3 +1181,10 @@ export function getFileExtension(fileName: string): string {
 }
 
 export class SoftError extends Error {}
+
+export function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
+  // Strongly typed helper to filter any non empty values from an array
+  // e.g. [1, 2, undefined].filter(notEmpty) => type should be number[]
+  // Source https://github.com/microsoft/TypeScript/issues/45097#issuecomment-882526325
+  return value !== null && value !== undefined;
+}

--- a/frontend/javascripts/oxalis/view/left-border-tabs/controls_and_rendering_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/controls_and_rendering_settings_tab.tsx
@@ -1,4 +1,4 @@
-import { Collapse, Tooltip } from "antd";
+import { Collapse, CollapseProps, Tooltip } from "antd";
 import type { Dispatch } from "redux";
 import { connect } from "react-redux";
 import React, { PureComponent } from "react";
@@ -28,8 +28,6 @@ import Toast from "libs/toast";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { PricingPlanEnum } from "admin/organization/pricing_plan_utils";
 import { PricingEnforcedSwitchSetting } from "components/pricing_enforcers";
-
-const { Panel } = Collapse;
 
 type ControlsAndRenderingSettingsTabProps = {
   activeUser: APIUser | null | undefined;
@@ -76,120 +74,128 @@ class ControlsAndRenderingSettingsTab extends PureComponent<ControlsAndRendering
     );
   }
 
-  getViewportOptions = () => {
+  getViewportOptions = (): CollapseProps["items"] => {
     if (
       this.props.viewMode === Constants.MODE_ARBITRARY ||
       this.props.viewMode === Constants.MODE_ARBITRARY_PLANE
     ) {
-      return (
-        <Panel header="Flight Options" key="2">
-          <LogSliderSetting
-            label={<Tooltip title={settingsTooltips.zoom}>{settingsLabels.zoom}</Tooltip>}
-            roundTo={3}
-            min={this.props.validZoomRange[0]}
-            max={this.props.validZoomRange[1]}
-            value={this.props.zoomStep}
-            onChange={this.props.onChangeZoomStep}
-          />
-          <NumberSliderSetting
-            label={
-              <Tooltip title={settingsTooltips.mouseRotateValue}>
-                {settingsLabels.mouseRotateValue}
-              </Tooltip>
-            }
-            min={userSettings.mouseRotateValue.minimum}
-            max={userSettings.mouseRotateValue.maximum}
-            step={0.001}
-            value={this.props.userConfiguration.mouseRotateValue}
-            onChange={this.onChangeUser.mouseRotateValue}
-          />
-          <NumberSliderSetting
-            label={
-              <Tooltip title={settingsTooltips.rotateValue}>{settingsLabels.rotateValue}</Tooltip>
-            }
-            min={userSettings.rotateValue.minimum}
-            max={userSettings.rotateValue.maximum}
-            step={0.001}
-            value={this.props.userConfiguration.rotateValue}
-            onChange={this.onChangeUser.rotateValue}
-          />
-          <NumberSliderSetting
-            label={
-              <Tooltip title={settingsTooltips.crosshairSize}>
-                {settingsLabels.crosshairSize}
-              </Tooltip>
-            }
-            min={userSettings.crosshairSize.minimum}
-            max={userSettings.crosshairSize.maximum}
-            step={0.01}
-            value={this.props.userConfiguration.crosshairSize}
-            onChange={this.onChangeUser.crosshairSize}
-          />
-          <NumberSliderSetting
-            label={
-              <Tooltip title={settingsTooltips.sphericalCapRadius}>
-                {settingsLabels.sphericalCapRadius}
-              </Tooltip>
-            }
-            min={userSettings.sphericalCapRadius.minimum}
-            max={userSettings.sphericalCapRadius.maximum}
-            step={1}
-            value={this.props.userConfiguration.sphericalCapRadius}
-            onChange={this.onChangeUser.sphericalCapRadius}
-          />
-          <SwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.displayCrosshair}>
-                {settingsLabels.displayCrosshair}
-              </Tooltip>
-            }
-            value={this.props.userConfiguration.displayCrosshair}
-            onChange={this.onChangeUser.displayCrosshair}
-          />
-        </Panel>
-      );
+      return {
+        label: "Flight Options",
+        key: "2",
+        children: (
+          <React.Fragment>
+            <LogSliderSetting
+              label={<Tooltip title={settingsTooltips.zoom}>{settingsLabels.zoom}</Tooltip>}
+              roundTo={3}
+              min={this.props.validZoomRange[0]}
+              max={this.props.validZoomRange[1]}
+              value={this.props.zoomStep}
+              onChange={this.props.onChangeZoomStep}
+            />
+            <NumberSliderSetting
+              label={
+                <Tooltip title={settingsTooltips.mouseRotateValue}>
+                  {settingsLabels.mouseRotateValue}
+                </Tooltip>
+              }
+              min={userSettings.mouseRotateValue.minimum}
+              max={userSettings.mouseRotateValue.maximum}
+              step={0.001}
+              value={this.props.userConfiguration.mouseRotateValue}
+              onChange={this.onChangeUser.mouseRotateValue}
+            />
+            <NumberSliderSetting
+              label={
+                <Tooltip title={settingsTooltips.rotateValue}>{settingsLabels.rotateValue}</Tooltip>
+              }
+              min={userSettings.rotateValue.minimum}
+              max={userSettings.rotateValue.maximum}
+              step={0.001}
+              value={this.props.userConfiguration.rotateValue}
+              onChange={this.onChangeUser.rotateValue}
+            />
+            <NumberSliderSetting
+              label={
+                <Tooltip title={settingsTooltips.crosshairSize}>
+                  {settingsLabels.crosshairSize}
+                </Tooltip>
+              }
+              min={userSettings.crosshairSize.minimum}
+              max={userSettings.crosshairSize.maximum}
+              step={0.01}
+              value={this.props.userConfiguration.crosshairSize}
+              onChange={this.onChangeUser.crosshairSize}
+            />
+            <NumberSliderSetting
+              label={
+                <Tooltip title={settingsTooltips.sphericalCapRadius}>
+                  {settingsLabels.sphericalCapRadius}
+                </Tooltip>
+              }
+              min={userSettings.sphericalCapRadius.minimum}
+              max={userSettings.sphericalCapRadius.maximum}
+              step={1}
+              value={this.props.userConfiguration.sphericalCapRadius}
+              onChange={this.onChangeUser.sphericalCapRadius}
+            />
+            <SwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.displayCrosshair}>
+                  {settingsLabels.displayCrosshair}
+                </Tooltip>
+              }
+              value={this.props.userConfiguration.displayCrosshair}
+              onChange={this.onChangeUser.displayCrosshair}
+            />
+          </React.Fragment>
+        ),
+      };
     } else {
-      return (
-        <Panel header="Viewport Options" key="2">
-          <LogSliderSetting
-            label={<Tooltip title={settingsTooltips.zoom}>{settingsLabels.zoom}</Tooltip>}
-            roundTo={3}
-            min={this.props.validZoomRange[0]}
-            max={this.props.validZoomRange[1]}
-            value={this.props.zoomStep}
-            onChange={this.props.onChangeZoomStep}
-          />
-          <SwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.displayCrosshair}>
-                {settingsLabels.displayCrosshair}
-              </Tooltip>
-            }
-            value={this.props.userConfiguration.displayCrosshair}
-            onChange={this.onChangeUser.displayCrosshair}
-          />
-          <SwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.displayScalebars}>
-                {settingsLabels.displayScalebars}
-              </Tooltip>
-            }
-            value={this.props.userConfiguration.displayScalebars}
-            onChange={this.onChangeUser.displayScalebars}
-          />
-          <PricingEnforcedSwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.renderWatermark}>
-                {settingsLabels.renderWatermark}
-              </Tooltip>
-            }
-            value={this.props.userConfiguration.renderWatermark}
-            onChange={this.onChangeUser.renderWatermark}
-            requiredPricingPlan={PricingPlanEnum.Team}
-            defaultValue={true}
-          />
-        </Panel>
-      );
+      return {
+        label: "Viewport Options",
+        key: "2",
+        children: (
+          <React.Fragment>
+            <LogSliderSetting
+              label={<Tooltip title={settingsTooltips.zoom}>{settingsLabels.zoom}</Tooltip>}
+              roundTo={3}
+              min={this.props.validZoomRange[0]}
+              max={this.props.validZoomRange[1]}
+              value={this.props.zoomStep}
+              onChange={this.props.onChangeZoomStep}
+            />
+            <SwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.displayCrosshair}>
+                  {settingsLabels.displayCrosshair}
+                </Tooltip>
+              }
+              value={this.props.userConfiguration.displayCrosshair}
+              onChange={this.onChangeUser.displayCrosshair}
+            />
+            <SwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.displayScalebars}>
+                  {settingsLabels.displayScalebars}
+                </Tooltip>
+              }
+              value={this.props.userConfiguration.displayScalebars}
+              onChange={this.onChangeUser.displayScalebars}
+            />
+            <PricingEnforcedSwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.renderWatermark}>
+                  {settingsLabels.renderWatermark}
+                </Tooltip>
+              }
+              value={this.props.userConfiguration.renderWatermark}
+              onChange={this.onChangeUser.renderWatermark}
+              requiredPricingPlan={PricingPlanEnum.Team}
+              defaultValue={true}
+            />
+          </React.Fragment>
+        ),
+      };
     }
   };
 
@@ -240,6 +246,168 @@ class ControlsAndRenderingSettingsTab extends PureComponent<ControlsAndRendering
         onChange={this.onChangeUser.moveValue}
       />
     );
+
+    const collapseItems: CollapseProps["items"] = [
+      {
+        label: "Controls",
+        key: "1",
+        children: (
+          <React.Fragment>
+            <NumberSliderSetting
+              label={
+                <Tooltip title={settingsTooltips.keyboardDelay}>
+                  {settingsLabels.keyboardDelay}
+                </Tooltip>
+              }
+              min={userSettings.keyboardDelay.minimum}
+              max={userSettings.keyboardDelay.maximum}
+              value={this.props.userConfiguration.keyboardDelay}
+              onChange={this.onChangeUser.keyboardDelay}
+            />
+            {moveValueSetting}
+            <SwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.dynamicSpaceDirection}>
+                  {settingsLabels.dynamicSpaceDirection}
+                </Tooltip>
+              }
+              value={this.props.userConfiguration.dynamicSpaceDirection}
+              onChange={this.onChangeUser.dynamicSpaceDirection}
+            />
+            <SwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.useLegacyBindings}>
+                  {settingsLabels.useLegacyBindings}
+                </Tooltip>
+              }
+              value={this.props.userConfiguration.useLegacyBindings}
+              onChange={this.onChangeUser.useLegacyBindings}
+            />
+          </React.Fragment>
+        ),
+      },
+      this.getViewportOptions(),
+      {
+        label: "Data Rendering",
+        key: "3",
+        children: (
+          <React.Fragment>
+            {" "}
+            <DropdownSetting
+              label={
+                <Tooltip title={settingsTooltips.gpuMemoryFactor}>
+                  {settingsLabels.gpuMemoryFactor}
+                </Tooltip>
+              }
+              value={(
+                this.props.userConfiguration.gpuMemoryFactor || Constants.DEFAULT_GPU_MEMORY_FACTOR
+              ).toString()}
+              onChange={this.onChangeGpuFactor}
+              disabled={this.props.activeUser == null}
+              disabledReason={
+                this.props.activeUser == null ? "Log in to change this setting." : null
+              }
+              options={getGpuFactorsWithLabels().map(([factor, label]) => ({
+                label,
+                value: factor.toString(),
+              }))}
+            />
+            <DropdownSetting
+              label={
+                <Tooltip title={settingsTooltips.loadingStrategy}>
+                  {settingsLabels.loadingStrategy}
+                </Tooltip>
+              }
+              value={this.props.datasetConfiguration.loadingStrategy}
+              onChange={this.onChangeDataset.loadingStrategy}
+              options={[
+                {
+                  value: "BEST_QUALITY_FIRST",
+                  label: "Best quality first",
+                },
+                {
+                  value: "PROGRESSIVE_QUALITY",
+                  label: "Progressive quality",
+                },
+              ]}
+            />
+            <DropdownSetting
+              label={
+                <Tooltip title={settingsTooltips.blendMode}>{settingsLabels.blendMode}</Tooltip>
+              }
+              value={this.props.datasetConfiguration.blendMode}
+              onChange={this.onChangeDataset.blendMode}
+              options={[
+                {
+                  value: BLEND_MODES.Additive,
+                  label: "Additive",
+                },
+                {
+                  value: BLEND_MODES.Cover,
+                  label: "Cover",
+                },
+              ]}
+            />
+            <SwitchSetting
+              label={<Tooltip title={settingsTooltips.fourBit}>{settingsLabels.fourBit}</Tooltip>}
+              value={this.props.datasetConfiguration.fourBit}
+              onChange={this.onChangeDataset.fourBit}
+            />
+            {Constants.MODES_ARBITRARY.includes(this.props.viewMode) ? null : (
+              <div>
+                <SwitchSetting
+                  label={
+                    <Tooltip title={settingsTooltips.interpolation}>
+                      {settingsLabels.interpolation}
+                    </Tooltip>
+                  }
+                  value={this.props.datasetConfiguration.interpolation}
+                  onChange={this.onChangeDataset.interpolation}
+                >
+                  {this.props.datasetConfiguration.interpolation && (
+                    <Tooltip title="Consider disabling interpolation if you notice degraded rendering performance.">
+                      {PERFORMANCE_WARNING_ICON}
+                    </Tooltip>
+                  )}
+                </SwitchSetting>
+              </div>
+            )}
+            <SwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.antialiasRendering}>
+                  {settingsLabels.antialiasRendering}
+                </Tooltip>
+              }
+              value={this.props.userConfiguration.antialiasRendering}
+              disabled={this.props.activeUser == null}
+              disabledReason={
+                this.props.activeUser == null ? "Log in to change this setting." : null
+              }
+              onChange={(arg) => {
+                askUserToReload();
+                this.onChangeUser.antialiasRendering(arg);
+              }}
+            >
+              {this.props.userConfiguration.antialiasRendering && (
+                <Tooltip title="Consider disabling antialiasing if you notice degraded rendering performance.">
+                  {PERFORMANCE_WARNING_ICON}
+                </Tooltip>
+              )}
+            </SwitchSetting>
+            <SwitchSetting
+              label={
+                <Tooltip title={settingsTooltips.renderMissingDataBlack}>
+                  {settingsLabels.renderMissingDataBlack}{" "}
+                </Tooltip>
+              }
+              value={this.props.datasetConfiguration.renderMissingDataBlack}
+              onChange={this.onChangeRenderMissingDataBlack}
+            />
+          </React.Fragment>
+        ),
+      },
+    ];
+
     return (
       <Collapse
         bordered={false}
@@ -248,147 +416,8 @@ class ControlsAndRenderingSettingsTab extends PureComponent<ControlsAndRendering
         style={{
           padding: 0,
         }}
-      >
-        <Panel header="Controls" key="1">
-          <NumberSliderSetting
-            label={
-              <Tooltip title={settingsTooltips.keyboardDelay}>
-                {settingsLabels.keyboardDelay}
-              </Tooltip>
-            }
-            min={userSettings.keyboardDelay.minimum}
-            max={userSettings.keyboardDelay.maximum}
-            value={this.props.userConfiguration.keyboardDelay}
-            onChange={this.onChangeUser.keyboardDelay}
-          />
-          {moveValueSetting}
-          <SwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.dynamicSpaceDirection}>
-                {settingsLabels.dynamicSpaceDirection}
-              </Tooltip>
-            }
-            value={this.props.userConfiguration.dynamicSpaceDirection}
-            onChange={this.onChangeUser.dynamicSpaceDirection}
-          />
-          <SwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.useLegacyBindings}>
-                {settingsLabels.useLegacyBindings}
-              </Tooltip>
-            }
-            value={this.props.userConfiguration.useLegacyBindings}
-            onChange={this.onChangeUser.useLegacyBindings}
-          />
-        </Panel>
-        {this.getViewportOptions()}
-        <Panel header="Data Rendering" key="3">
-          <DropdownSetting
-            label={
-              <Tooltip title={settingsTooltips.gpuMemoryFactor}>
-                {settingsLabels.gpuMemoryFactor}
-              </Tooltip>
-            }
-            value={(
-              this.props.userConfiguration.gpuMemoryFactor || Constants.DEFAULT_GPU_MEMORY_FACTOR
-            ).toString()}
-            onChange={this.onChangeGpuFactor}
-            disabled={this.props.activeUser == null}
-            disabledReason={this.props.activeUser == null ? "Log in to change this setting." : null}
-            options={getGpuFactorsWithLabels().map(([factor, label]) => ({
-              label,
-              value: factor.toString(),
-            }))}
-          />
-          <DropdownSetting
-            label={
-              <Tooltip title={settingsTooltips.loadingStrategy}>
-                {settingsLabels.loadingStrategy}
-              </Tooltip>
-            }
-            value={this.props.datasetConfiguration.loadingStrategy}
-            onChange={this.onChangeDataset.loadingStrategy}
-            options={[
-              {
-                value: "BEST_QUALITY_FIRST",
-                label: "Best quality first",
-              },
-              {
-                value: "PROGRESSIVE_QUALITY",
-                label: "Progressive quality",
-              },
-            ]}
-          />
-          <DropdownSetting
-            label={<Tooltip title={settingsTooltips.blendMode}>{settingsLabels.blendMode}</Tooltip>}
-            value={this.props.datasetConfiguration.blendMode}
-            onChange={this.onChangeDataset.blendMode}
-            options={[
-              {
-                value: BLEND_MODES.Additive,
-                label: "Additive",
-              },
-              {
-                value: BLEND_MODES.Cover,
-                label: "Cover",
-              },
-            ]}
-          />
-          <SwitchSetting
-            label={<Tooltip title={settingsTooltips.fourBit}>{settingsLabels.fourBit}</Tooltip>}
-            value={this.props.datasetConfiguration.fourBit}
-            onChange={this.onChangeDataset.fourBit}
-          />
-          {Constants.MODES_ARBITRARY.includes(this.props.viewMode) ? null : (
-            <div>
-              <SwitchSetting
-                label={
-                  <Tooltip title={settingsTooltips.interpolation}>
-                    {settingsLabels.interpolation}
-                  </Tooltip>
-                }
-                value={this.props.datasetConfiguration.interpolation}
-                onChange={this.onChangeDataset.interpolation}
-              >
-                {this.props.datasetConfiguration.interpolation && (
-                  <Tooltip title="Consider disabling interpolation if you notice degraded rendering performance.">
-                    {PERFORMANCE_WARNING_ICON}
-                  </Tooltip>
-                )}
-              </SwitchSetting>
-            </div>
-          )}
-          <SwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.antialiasRendering}>
-                {settingsLabels.antialiasRendering}
-              </Tooltip>
-            }
-            value={this.props.userConfiguration.antialiasRendering}
-            disabled={this.props.activeUser == null}
-            disabledReason={this.props.activeUser == null ? "Log in to change this setting." : null}
-            onChange={(arg) => {
-              askUserToReload();
-              this.onChangeUser.antialiasRendering(arg);
-            }}
-          >
-            {this.props.userConfiguration.antialiasRendering && (
-              <Tooltip title="Consider disabling antialiasing if you notice degraded rendering performance.">
-                {PERFORMANCE_WARNING_ICON}
-              </Tooltip>
-            )}
-          </SwitchSetting>
-          <SwitchSetting
-            label={
-              <Tooltip title={settingsTooltips.renderMissingDataBlack}>
-                {settingsLabels.renderMissingDataBlack}{" "}
-              </Tooltip>
-            }
-            value={this.props.datasetConfiguration.renderMissingDataBlack}
-            onChange={this.onChangeRenderMissingDataBlack}
-          />
-        </Panel>
-      </Collapse>
+        items={collapseItems}
+      />
     );
   }
 }

--- a/frontend/javascripts/oxalis/view/left-border-tabs/controls_and_rendering_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/controls_and_rendering_settings_tab.tsx
@@ -28,6 +28,7 @@ import Toast from "libs/toast";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { PricingPlanEnum } from "admin/organization/pricing_plan_utils";
 import { PricingEnforcedSwitchSetting } from "components/pricing_enforcers";
+import { ArrayElement } from "libs/utils";
 
 type ControlsAndRenderingSettingsTabProps = {
   activeUser: APIUser | null | undefined;
@@ -74,7 +75,7 @@ class ControlsAndRenderingSettingsTab extends PureComponent<ControlsAndRendering
     );
   }
 
-  getViewportOptions = (): CollapseProps["items"] => {
+  getViewportOptions = (): ArrayElement<CollapseProps["items"]> => {
     if (
       this.props.viewMode === Constants.MODE_ARBITRARY ||
       this.props.viewMode === Constants.MODE_ARBITRARY_PLANE


### PR DESCRIPTION
Fix deprecation warnings for antd `<Collapse>` components. API changed to `items` props instead of React children/`<Panel>`.

See https://ant.design/components/collapse#collapsepanel

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Navaigate to any view using a `<Collapse />`
- Open web dev console
- There should not be any deprecation warnings

### TODOs:
- [x] Fix typescript errors

### Issues:
- Follow up to #7522

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
