### PR TITLE
Small styling fixes for antd v5 upgrade

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where importing remote datasets with existing datasource-properties.jsons would not properly register the remote credentials. [#7601](https://github.com/scalableminds/webknossos/pull/7601)
 - Fixed a bug in ND volume annotation downloads where the additionalAxes metadata had wrong indices. [#7592](https://github.com/scalableminds/webknossos/pull/7592)
 - Fixed a bug in proofreading aka editable mapping annotations where splitting would sometimes give the new id to the selected segment rather than to the split-off one. [#7608](https://github.com/scalableminds/webknossos/pull/7608)
+- Fixed small styling errors as a follow up to the antd v5 upgrade [#7612](https://github.com/scalableminds/webknossos/pull/7612)
+
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
+++ b/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
@@ -197,7 +197,6 @@ export class LogSliderSetting extends React.PureComponent<LogSliderSettingProps>
             onChange={this.onChangeInput}
             disabled={disabled}
             size="small"
-            variant="borderless"
           />
         </Col>
       </Row>

--- a/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
+++ b/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
@@ -92,6 +92,7 @@ export class NumberSliderSetting extends React.PureComponent<NumberSliderSetting
             onChange={this._onChange}
             size="small"
             disabled={disabled}
+            variant="borderless"
           />
         </Col>
       </Row>
@@ -196,6 +197,7 @@ export class LogSliderSetting extends React.PureComponent<LogSliderSettingProps>
             onChange={this.onChangeInput}
             disabled={disabled}
             size="small"
+            variant="borderless"
           />
         </Col>
       </Row>
@@ -293,6 +295,7 @@ export class NumberInputSetting extends React.PureComponent<NumberInputSettingPr
             value={value}
             step={step}
             size="small"
+            variant="borderless"
           />
         </Col>
       </Row>
@@ -337,6 +340,7 @@ export function NumberInputPopoverSetting(props: NumberInputPopoverSettingProps)
         value={value}
         step={step}
         size="small"
+        variant="borderless"
       />
     </div>
   );

--- a/frontend/javascripts/oxalis/view/left-border-tabs/histogram_view.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/histogram_view.tsx
@@ -303,6 +303,7 @@ class Histogram extends React.PureComponent<HistogramProps, HistogramState> {
                   max={maxRange}
                   defaultValue={currentMin}
                   value={currentMin}
+                  variant="borderless"
                   onChange={(value) => {
                     // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
                     value = parseFloat(value);
@@ -337,6 +338,7 @@ class Histogram extends React.PureComponent<HistogramProps, HistogramState> {
                   max={defaultMinMax[1]}
                   defaultValue={currentMax}
                   value={currentMax}
+                  variant="borderless"
                   onChange={(value) => {
                     // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
                     value = parseFloat(value);

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -60,7 +60,7 @@ body {
 .save-error {
   .ant-layout-header,
   .ant-menu {
-    background-color: var(--ant-color-error-bg) !important;
+    background-color: var(--ant-color-error) !important;
   }
 }
 
@@ -166,13 +166,8 @@ body {
 }
 
 
-
-// Buttons with just an icon, e.g. on annotation dashboard 
-.ant-btn-icon-only .anticon {
-  margin-right: 0;
-}
-
 button.narrow {
+  // undo/redo + toolbar buttons
   padding: 0 10px;
   i {
     margin-right: 0 !important;


### PR DESCRIPTION
- make number inputs borderless
  - fixes: 
![image](https://github.com/scalableminds/webknossos/assets/1105056/13d783f6-d586-4b81-8cf1-a7954090adc4)

- Use darker red background color for navbar in case of errors
  - Fixes: 
<img width="1672" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/1afae7b8-a5a8-45f9-8994-5d90bd51ca5e">



### Issues:
- Follow up to #6861 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
