### PR TITLE
fix search input for publication gallery

### DIFF
--- a/frontend/stylesheets/_utils.less
+++ b/frontend/stylesheets/_utils.less
@@ -66,6 +66,18 @@ td.nowrap * {
   float: right !important;
 }
 
+.clearfix::before {
+  // sometimes required by .pull-right
+  display: table;
+  content: '';
+}
+.clearfix::after {
+  // sometimes required by .pull-right
+  display: table;
+  clear: both;
+  content: '';
+}
+
 .circle {
   display: inline-block;
   width: 10px;


### PR DESCRIPTION
Small fix to restore the layouting of the publication gallery and its search input.

Before:
![image](https://github.com/scalableminds/webknossos/assets/1105056/f76080ac-9c6f-4f3e-8312-a83dd2be31f8)

After:
![image](https://github.com/scalableminds/webknossos/assets/1105056/6a5a4620-c930-4324-b9f9-c7d39c80cc56)


### Steps to test:
- None.


### Issues:
- Follow up to https://github.com/scalableminds/webknossos/pull/7522

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
