### PR TITLE
Fix deprecation warning for antd `<Card>`s

### DIFF
--- a/frontend/javascripts/admin/onboarding.tsx
+++ b/frontend/javascripts/admin/onboarding.tsx
@@ -161,16 +161,18 @@ export function OptionCard({ icon, header, children, action, height }: OptionCar
     >
       <Card
         bordered={false}
-        bodyStyle={{
-          textAlign: "center",
-          height,
-          width: 350,
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-around",
-          boxShadow: "var(--ant-box-shadow)",
-          borderRadius: 3,
-          border: 0,
+        styles={{
+          body: {
+            textAlign: "center",
+            height,
+            width: 350,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-around",
+            boxShadow: "var(--ant-box-shadow)",
+            borderRadius: 3,
+            border: 0,
+          },
         }}
       >
         <div

--- a/frontend/javascripts/admin/organization/organization_cards.tsx
+++ b/frontend/javascripts/admin/organization/organization_cards.tsx
@@ -36,7 +36,7 @@ export function TeamAndPowerPlanUpgradeCards({
       <Col span={12}>
         <Card
           title={`${PricingPlanEnum.Team} Plan`}
-          bodyStyle={{ minHeight: 220, opacity: 0.8 }}
+          styles={{ body: { minHeight: 220, opacity: 0.8 } }}
           actions={[
             <Button type="primary" onClick={teamUpgradeCallback}>
               <PlusCircleOutlined /> Buy Upgrade
@@ -53,7 +53,7 @@ export function TeamAndPowerPlanUpgradeCards({
       <Col span={12}>
         <Card
           title={`${PricingPlanEnum.Power} Plan`}
-          bodyStyle={{ minHeight: 220, opacity: 0.8 }}
+          styles={{ body: { minHeight: 220, opacity: 0.8 } }}
           actions={[
             <Button type="primary" onClick={powerUpgradeCallback}>
               <PlusCircleOutlined /> Buy Upgrade
@@ -131,9 +131,11 @@ export function PlanUpgradeCard({ organization }: { organization: APIOrganizatio
       style={{
         marginBottom: 20,
       }}
-      bodyStyle={{
-        background: "var(--color-wk-blue)",
-        color: "white",
+      styles={{
+        body: {
+          background: "var(--color-wk-blue)",
+          color: "white",
+        },
       }}
     >
       <p>

--- a/frontend/javascripts/dashboard/publication_card.tsx
+++ b/frontend/javascripts/dashboard/publication_card.tsx
@@ -201,8 +201,10 @@ function PublicationCard({ publication, showDetailedLink }: Props) {
 
   return (
     <Card
-      bodyStyle={{
-        padding: 0,
+      styles={{
+        body: {
+          padding: 0,
+        },
       }}
       className="publication-item-card"
       bordered={false}


### PR DESCRIPTION
Fix deprecation warning for `<Card>` `bodystyle` props.

```
Warning: [antd: Card] `bodyStyle` is deprecated. Please use `styles.body` instead.
console.error @ shader_editor.ts:94
```

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Go publication gallery
- Open dev console
- No deprecation warning
- Run typchecking


### Issues:
- Follow up to #7522

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
