### PR TITLE
Disable email verification by default

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Datasets stored in WKW format are no longer loaded with memory mapping, reducing memory demands. [#7528](https://github.com/scalableminds/webknossos/pull/7528)
 - Content Security Policy (CSP) settings are now relaxed by default. To keep stricter CSP rules, add them to your specific `application.conf`. [#7589](https://github.com/scalableminds/webknossos/pull/7589)
 - WEBKNOSSOS now uses Java 21. [#7599](https://github.com/scalableminds/webknossos/pull/7599)
+- Email verification is disabled by default. To enable it, set `webKnossos.emailVerification` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620)
 
 
 ### Fixed

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Datasets stored in WKW format are no longer loaded with memory mapping, reducing memory demands. [#7528](https://github.com/scalableminds/webknossos/pull/7528)
 - Content Security Policy (CSP) settings are now relaxed by default. To keep stricter CSP rules, add them to your specific `application.conf`. [#7589](https://github.com/scalableminds/webknossos/pull/7589)
 - WEBKNOSSOS now uses Java 21. [#7599](https://github.com/scalableminds/webknossos/pull/7599)
-- Email verification is disabled by default. To enable it, set `webKnossos.emailVerification` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620)
+- Email verification is disabled by default. To enable it, set `webKnossos.emailVerification.activated` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620)
 
 
 ### Fixed

--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -15,6 +15,7 @@ UPDATE webknossos.annotations_ SET state = 'Finished' WHERE _id IN  (SELECT DIST
 ```
 - WEBKNOSSOS now uses Java 21 (up from Java 11). [#7599](https://github.com/scalableminds/webknossos/pull/7599)
 - NodeJS version 18+ is required for snapshot tests with ShadowDOM elements from Antd v5. [#7522](https://github.com/scalableminds/webknossos/pull/7522)
+- Email verification is disabled by default. To enable it, set `webKnossos.emailVerification` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620)
 
 ### Postgres Evolutions:
 

--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -15,7 +15,7 @@ UPDATE webknossos.annotations_ SET state = 'Finished' WHERE _id IN  (SELECT DIST
 ```
 - WEBKNOSSOS now uses Java 21 (up from Java 11). [#7599](https://github.com/scalableminds/webknossos/pull/7599)
 - NodeJS version 18+ is required for snapshot tests with ShadowDOM elements from Antd v5. [#7522](https://github.com/scalableminds/webknossos/pull/7522)
-- Email verification is disabled by default. To enable it, set `webKnossos.emailVerification` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620)
+- Email verification is disabled by default. To enable it, set `webKnossos.emailVerification.activated` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620)
 
 ### Postgres Evolutions:
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -82,7 +82,7 @@ webKnossos {
     inviteExpiry = 14 days
     ssoKey = ""
     emailVerification {
-      activated = true
+      activated = false
       required = false
       gracePeriod = 7 days # time period in which users do not need to verify their email address
       linkExpiry = 30 days


### PR DESCRIPTION
Disable email verification by default because for instances without an email provider (probably most open-source installations) it won't work anyways and annoy all users.

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable