### PR TITLE
small documentation updates for N5 and Neuroglancer Precomputed

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Content Security Policy (CSP) settings are now relaxed by default. To keep stricter CSP rules, add them to your specific `application.conf`. [#7589](https://github.com/scalableminds/webknossos/pull/7589)
 - WEBKNOSSOS now uses Java 21. [#7599](https://github.com/scalableminds/webknossos/pull/7599)
 - Email verification is disabled by default. To enable it, set `webKnossos.emailVerification.activated` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620)
+- Added more documentation for N5 and Neuroglancer precomputed web upload. [#7622](https://github.com/scalableminds/webknossos/pull/7622)
 
 
 ### Fixed

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -74,8 +74,6 @@ Any other WEBKNOSSOS feature, e.g., annotations, and access rights, will be stor
 
 Note that data streaming may incur costs and count against any usage limits or minutes as defined by these third-party services. Check with the service provider or dataset owner.
 
-Hint: If you happen to have any Zarr dataset locally that you would like to view in WEBKNOSSOS, consider running an HTTP server locally to serve the dataset. 
-Then WEBKNOSSOS can easily stream the data.
 
 ### Uploading through the Python API
 For those wishing to automate dataset upload or to do it programmatically, check out the WEBKNOSSOS [Python library](https://docs.webknossos.org/webknossos-py). You can create, manage and upload datasets with the Python lib. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,7 +31,7 @@ WEBKNOSSOS does not allow you to run custom machine learning models on your data
 
 ## How can I use my dataset with WEBKNOSSOS?
 
-WEBKNOSSOS supports [WKW (optimized), KNOSSOS cubes](./datasets.md), and image stacks (converted on upload). You can also connect to Neuroglancer Precomputed, N5, and Zarr datasets hosted in the cloud (Google Cloud Storage, AWS S3).
+WEBKNOSSOS supports [WKW (optimized), OME-Zarr (NGFF), Neuroglancer Precomputed, N5, KNOSSOS cubes](./datasets.md), and image stacks (converted on upload). You can also connect to Neuroglancer Precomputed, N5, and Zarr datasets hosted in the cloud (Google Cloud Storage, AWS S3).
 
 Smaller datasets (up to multiple GB) can be uploaded directly through the web interface. For larger datasets, we recommend converting them to the standard WKW format using the [WEBKNOSSOS CLI](https://docs.webknossos.org/cli) CLI tool and uploading it via the [WEBKNOSSOS Python package](https://docs.webknossos.org/webknossos-py/examples/upload_image_data.html).
 

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -447,23 +447,24 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
             flexDirection: "column",
           }}
         >
-          <FolderOutlined
-            style={{
-              fontSize: 50,
-            }}
-          />
-          <br />
-          {isRetrying
-            ? `Upload of dataset ${form.getFieldValue("name")} froze.`
-            : `Uploading Dataset ${form.getFieldValue("name")}.`}
-          <br />
-          {isRetrying ? "Retrying to continue the upload …" : null}
-          <br />
-          <Progress // Round to 1 digit after the comma.
-            percent={Math.round(uploadProgress * 1000) / 10}
-            status="active"
-          />
-          {isFinishing ? <Spin style={{ marginTop: 4 }} tip="Processing uploaded files …" /> : null}
+          <Spin spinning={isFinishing} style={{ marginTop: 4 }} tip="Processing uploaded files …">
+            <FolderOutlined
+              style={{
+                fontSize: 50,
+              }}
+            />
+            <br />
+            {isRetrying
+              ? `Upload of dataset ${form.getFieldValue("name")} froze.`
+              : `Uploading Dataset ${form.getFieldValue("name")}.`}
+            <br />
+            {isRetrying ? "Retrying to continue the upload …" : null}
+            <br />
+            <Progress // Round to 1 digit after the comma.
+              percent={Math.round(uploadProgress * 1000) / 10}
+              status="active"
+            />
+          </Spin>
         </div>
       </Modal>
     );
@@ -917,6 +918,7 @@ function FileUploadArea({
       )}
     />
   );
+
   return (
     <div>
       <div

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -1010,6 +1010,50 @@ function FileUploadArea({
                       />
                     </Popover>
                   </li>
+                  <li>
+                    <Popover
+                      content={
+                        <a
+                          href="https://docs.webknossos.org/webknossos/neuroglancer_precomputed.html"
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Read more in docs
+                        </a>
+                      }
+                      trigger="hover"
+                    >
+                      Neuroglancer Precomputed datasets{" "}
+                      <InfoCircleOutlined
+                        style={{
+                          marginLeft: 4,
+                        }}
+                      />
+                    </Popover>
+                  </li>
+                  <li>
+                    <Popover
+                      content={
+                        <a
+                          href="https://docs.webknossos.org/webknossos/n5.html"
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Read more in docs
+                        </a>
+                      }
+                      trigger="hover"
+                    >
+                      N5 datasets{" "}
+                      <InfoCircleOutlined
+                        style={{
+                          marginLeft: 4,
+                        }}
+                      />
+                    </Popover>
+                  </li>
                   <li>Single-file images (tif, czi, nifti, raw)</li>
 
                   <li>KNOSSOS file hierarchy</li>


### PR DESCRIPTION
As a follow up to PR #7578, I added some more small documentation "hints" for support of N5 and Neuroglancer precomputed datasets when uploading datasets.

Additionally I fixed a `antd` warning. `<Spin tip={"Some text"} />` requires the use of children. See docs https://ant.design/components/spin. Additionally the "spin" text would be stacked vertically, because the `<Spin  />` did not have enough width / no-width defined at all. By wrapping the whole modal this can be fixed - even though it is not the prettiest solution. Anyway, this spinner should only ever be visible for a short time anyway if at all.

**With fix**:
<img width="548" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/f9dfb6d7-5f00-4961-a703-3f6a749d74ef">

**Warning**
<img width="790" alt="Screenshot 2024-02-13 at 14 31 14" src="https://github.com/scalableminds/webknossos/assets/1105056/d1304f1f-796b-4fd6-9497-16171e73ff97">


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Test datasets for uploading can be found in Felix's PR: #7578
- Otheriwse, reading the docs should be find


### Issues:
- follow up to #7578

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
