### PR TITLE
Add option to only track time when there are significant changes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,7 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added support for storing analytics events in the Postgres. [#7594](https://github.com/scalableminds/webknossos/pull/7594) [#7609](https://github.com/scalableminds/webknossos/pull/7609)
-- Segment statistics are now available for ND datases. [#7411](https://github.com/scalableminds/webknossos/pull/7411)
+- Segment statistics are now available for ND datasets. [#7411](https://github.com/scalableminds/webknossos/pull/7411)
 - Added support for uploading N5 and Neuroglancer Precomputed datasets. [#7578](https://github.com/scalableminds/webknossos/pull/7578)
 - Webknossos can now open ND Zarr datasets with arbitrary axis orders (not limited to `**xyz` anymore). [#7592](https://github.com/scalableminds/webknossos/pull/7592)
 
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - WEBKNOSSOS now uses Java 21. [#7599](https://github.com/scalableminds/webknossos/pull/7599)
 - Email verification is disabled by default. To enable it, set `webKnossos.user.emailVerification.activated` to `true` in your `application.conf`. [#7620](https://github.com/scalableminds/webknossos/pull/7620) [#7621](https://github.com/scalableminds/webknossos/pull/7621)
 - Added more documentation for N5 and Neuroglancer precomputed web upload. [#7622](https://github.com/scalableminds/webknossos/pull/7622)
+- Added the config key `webKnossos.user.timeTrackingOnlyWithSignificantChanges`, which when set to `true` will only track time if the user has made significant changes to the annotation. [#7627](https://github.com/scalableminds/webknossos/pull/7627)
 
 ### Fixed
 - Fixed rare SIGBUS crashes of the datastore module that were caused by memory mapping on unstable file systems. [#7528](https://github.com/scalableminds/webknossos/pull/7528)
@@ -31,8 +32,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where importing remote datasets with existing datasource-properties.jsons would not properly register the remote credentials. [#7601](https://github.com/scalableminds/webknossos/pull/7601)
 - Fixed a bug in ND volume annotation downloads where the additionalAxes metadata had wrong indices. [#7592](https://github.com/scalableminds/webknossos/pull/7592)
 - Fixed a bug in proofreading aka editable mapping annotations where splitting would sometimes give the new id to the selected segment rather than to the split-off one. [#7608](https://github.com/scalableminds/webknossos/pull/7608)
-- Fixed small styling errors as a follow up to the antd v5 upgrade [#7612](https://github.com/scalableminds/webknossos/pull/7612)
--Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
+- Fixed small styling errors as a follow-up to the antd v5 upgrade. [#7612](https://github.com/scalableminds/webknossos/pull/7612)
+- Fixed deprecation warnings caused by Antd \<Collapse\> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
 
 
 ### Removed

--- a/app/controllers/WKRemoteTracingStoreController.scala
+++ b/app/controllers/WKRemoteTracingStoreController.scala
@@ -60,8 +60,7 @@ class WKRemoteTracingStoreController @Inject()(
             annotationLayerDAO.updateStatistics(annotation._id, report.tracingId, statistics)
           }
           userBox <- bearerTokenService.userForTokenOpt(report.userToken).futureBox
-          trackTime = (!wkConf.WebKnossos.User.timeTrackingOnlyWithSignificantChanges ||
-            (wkConf.WebKnossos.User.timeTrackingOnlyWithSignificantChanges && report.significantChangesCount > 0))
+          trackTime = (report.significantChangesCount > 0 || !wkConf.WebKnossos.User.timeTrackingOnlyWithSignificantChanges)
           _ <- Fox.runOptional(userBox)(user =>
             Fox.runIf(trackTime)(timeSpanService.logUserInteraction(report.timestamps, user, annotation)))
           _ <- Fox.runOptional(userBox)(user =>

--- a/app/controllers/WKRemoteTracingStoreController.scala
+++ b/app/controllers/WKRemoteTracingStoreController.scala
@@ -24,6 +24,7 @@ import play.api.i18n.Messages
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.{WebknossosBearerTokenAuthenticatorService, WkSilhouetteEnvironment}
+import utils.WkConf
 
 import scala.concurrent.ExecutionContext
 
@@ -38,7 +39,8 @@ class WKRemoteTracingStoreController @Inject()(
     analyticsService: AnalyticsService,
     datasetDAO: DatasetDAO,
     annotationDAO: AnnotationDAO,
-    annotationLayerDAO: AnnotationLayerDAO)(implicit ec: ExecutionContext, playBodyParsers: PlayBodyParsers)
+    annotationLayerDAO: AnnotationLayerDAO,
+    wkConf: WkConf)(implicit ec: ExecutionContext, playBodyParsers: PlayBodyParsers)
     extends Controller
     with FoxImplicits {
 
@@ -58,7 +60,10 @@ class WKRemoteTracingStoreController @Inject()(
             annotationLayerDAO.updateStatistics(annotation._id, report.tracingId, statistics)
           }
           userBox <- bearerTokenService.userForTokenOpt(report.userToken).futureBox
-          _ <- Fox.runOptional(userBox)(user => timeSpanService.logUserInteraction(report.timestamps, user, annotation))
+          trackTime = (!wkConf.WebKnossos.User.timeTrackingOnlyWithSignificantChanges ||
+            (wkConf.WebKnossos.User.timeTrackingOnlyWithSignificantChanges && report.significantChangesCount > 0))
+          _ <- Fox.runOptional(userBox)(user =>
+            Fox.runIf(trackTime)(timeSpanService.logUserInteraction(report.timestamps, user, annotation)))
           _ <- Fox.runOptional(userBox)(user =>
             Fox.runIf(user._id != annotation._user)(annotationDAO.addContributor(annotation._id, user._id)))
           _ = userBox.map { user =>

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -30,6 +30,8 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
 
     object User {
       val timeTrackingPause: FiniteDuration = get[FiniteDuration]("webKnossos.user.timeTrackingPause")
+      val timeTrackingOnlyWithSignificantChanges: Boolean =
+        get[Boolean]("webKnossos.user.timeTrackingOnlyWithSignificantChanges")
       val inviteExpiry: FiniteDuration = get[FiniteDuration]("webKnossos.user.inviteExpiry")
       val ssoKey: String = get[String]("webKnossos.user.ssoKey")
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -79,6 +79,7 @@ webKnossos {
   tabTitle = "WEBKNOSSOS"
   user {
     timeTrackingPause = 60 seconds
+    timeTrackingOnlyWithSignificantChanges = false
     inviteExpiry = 14 days
     ssoKey = ""
     emailVerification {


### PR DESCRIPTION
Set the new application.conf option `webKnossos.timeTrackingOnlyWithSignificantChanges` to `false` to disable time tracking for changes where only camera movements happened.

Note that the timeTrackingPause is still active, so if there are “significant changes” within that duration again, the timespans will be extended.

### Steps to test:
- Set option to true, no time tracking for moving cam and saving
- Set option to false, time tracking for moving cam and saving

### Issues:
- fixes #7543 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
