### PR TITLE
Dashboard annotation list: skip deleted annotations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,7 +33,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug in proofreading aka editable mapping annotations where splitting would sometimes give the new id to the selected segment rather than to the split-off one. [#7608](https://github.com/scalableminds/webknossos/pull/7608)
 - Fixed small styling errors as a follow up to the antd v5 upgrade [#7612](https://github.com/scalableminds/webknossos/pull/7612)
 - Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
-- Fixed a bug where the annotation list in the dashboard would attempt to display deleted annotations, and then fail.
+- Fixed a bug where the annotation list in the dashboard would attempt to display deleted annotations, and then fail. [#7628](https://github.com/scalableminds/webknossos/pull/7628)
 
 
 ### Removed

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,7 +32,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug in ND volume annotation downloads where the additionalAxes metadata had wrong indices. [#7592](https://github.com/scalableminds/webknossos/pull/7592)
 - Fixed a bug in proofreading aka editable mapping annotations where splitting would sometimes give the new id to the selected segment rather than to the split-off one. [#7608](https://github.com/scalableminds/webknossos/pull/7608)
 - Fixed small styling errors as a follow up to the antd v5 upgrade [#7612](https://github.com/scalableminds/webknossos/pull/7612)
--Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
+- Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
+- Fixed a bug where the annotation list in the dashboard would attempt to display deleted annotations, and then fail.
 
 
 ### Removed

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -346,7 +346,7 @@ class AnnotationDAO @Inject()(sqlClient: SqlClient, annotationLayerDAO: Annotati
           ARRAY_REMOVE(ARRAY_AGG(al.name), null) AS tracing_names,
           ARRAY_REMOVE(ARRAY_AGG(al.typ :: varchar), null) AS tracing_typs,
           ARRAY_REMOVE(ARRAY_AGG(al.statistics), null) AS annotation_layer_statistics
-      FROM webknossos.annotations as a
+      FROM webknossos.annotations_ as a
                LEFT JOIN webknossos.users_ u
                          ON u._id = a._user
                LEFT JOIN webknossos.annotation_sharedteams ast


### PR DESCRIPTION
The annotation list attempted to include deleted annotations, which fails in the frontend, since some properties may become null.

Was a regression introduced in #7410

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
