### PR TITLE
Add script to list old mesh-files

### DIFF
--- a/tools/mesh-format/list_old_mesh_files.py
+++ b/tools/mesh-format/list_old_mesh_files.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import h5py
+import argparse
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("binary_data_dir", type=Path, help="WEBKNOSSOS binary data dir")
+    parser.add_argument(
+        "--all",
+        "-a",
+        action="store_true",
+        help="Print all files, not just old versions",
+    )
+    parser.add_argument(
+        "--plain",
+        "-p",
+        action="store_true",
+        help="Print only the file names, not the version",
+    )
+    args = parser.parse_args()
+    binary_data_dir = args.binary_data_dir
+
+    print(f"Scanning {binary_data_dir} for mesh files", file=sys.stderr)
+
+    for orga_dir in [item for item in binary_data_dir.iterdir() if item.is_dir()]:
+        for dataset_dir in [item for item in orga_dir.iterdir() if item.is_dir()]:
+            for layer_dir in [item for item in dataset_dir.iterdir() if item.is_dir()]:
+                meshes_dir = layer_dir.joinpath("meshes")
+                if meshes_dir.exists():
+                    for mesh_file in [
+                        item
+                        for item in meshes_dir.iterdir()
+                        if item.name.endswith(".hdf5")
+                    ]:
+                        with h5py.File(mesh_file, "r") as f:
+                            try:
+                                version = f.attrs["artifact_schema_version"]
+                            except KeyError:
+                                version = 0
+                            if version < 3 or args.all:
+                                if args.plain:
+                                    print(mesh_file)
+                                else:
+                                    print(f"{mesh_file} has version {version}")
+
+    print(f"Done scanning {binary_data_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mesh-format/list_old_mesh_files.py
+++ b/tools/mesh-format/list_old_mesh_files.py
@@ -23,15 +23,21 @@ def main():
     binary_data_dir = args.binary_data_dir
 
     if not args.plain:
-        print(f"Scanning {binary_data_dir} for mesh files")
+        print(f"Scanning {binary_data_dir} for mesh files", file=sys.stderr)
 
     seen = []
 
-    for orga_dir in [item for item in binary_data_dir.iterdir() if item.exists() and item.is_dir()]:
+    for orga_dir in [
+        item for item in binary_data_dir.iterdir() if item.exists() and item.is_dir()
+    ]:
         for dataset_dir in orga_dir.iterdir():
             try:
                 if dataset_dir.exists() and dataset_dir.is_dir():
-                    for layer_dir in [item for item in dataset_dir.iterdir() if item.exists() and item.is_dir()]:
+                    for layer_dir in [
+                        item
+                        for item in dataset_dir.iterdir()
+                        if item.exists() and item.is_dir()
+                    ]:
                         meshes_dir = layer_dir.joinpath("meshes")
                         if meshes_dir.exists():
                             for mesh_file in [
@@ -52,13 +58,21 @@ def main():
                                                 if args.plain:
                                                     print(mesh_file)
                                                 else:
-                                                    print(f"{mesh_file} has version {version}")
+                                                    print(
+                                                        f"{mesh_file} has version {version}"
+                                                    )
             except Exception as e:
                 if not args.plain:
-                    print(f"Exception while scanning dataset dir at {dataset_dir}: {e}")
+                    print(
+                        f"Exception while scanning dataset dir at {dataset_dir}: {e}",
+                        file=sys.stderr,
+                    )
 
     if not args.plain:
-        print(f"Done scanning {binary_data_dir}, listed {len(seen)} meshfiles.")
+        print(
+            f"Done scanning {binary_data_dir}, listed {len(seen)} meshfiles.",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/tools/mesh-format/list_old_mesh_files.py
+++ b/tools/mesh-format/list_old_mesh_files.py
@@ -22,30 +22,43 @@ def main():
     args = parser.parse_args()
     binary_data_dir = args.binary_data_dir
 
-    print(f"Scanning {binary_data_dir} for mesh files", file=sys.stderr)
+    if not args.plain:
+        print(f"Scanning {binary_data_dir} for mesh files")
 
-    for orga_dir in [item for item in binary_data_dir.iterdir() if item.is_dir()]:
-        for dataset_dir in [item for item in orga_dir.iterdir() if item.is_dir()]:
-            for layer_dir in [item for item in dataset_dir.iterdir() if item.is_dir()]:
-                meshes_dir = layer_dir.joinpath("meshes")
-                if meshes_dir.exists():
-                    for mesh_file in [
-                        item
-                        for item in meshes_dir.iterdir()
-                        if item.name.endswith(".hdf5")
-                    ]:
-                        with h5py.File(mesh_file, "r") as f:
-                            try:
-                                version = f.attrs["artifact_schema_version"]
-                            except KeyError:
-                                version = 0
-                            if version < 3 or args.all:
-                                if args.plain:
-                                    print(mesh_file)
-                                else:
-                                    print(f"{mesh_file} has version {version}")
+    seen = []
 
-    print(f"Done scanning {binary_data_dir}", file=sys.stderr)
+    for orga_dir in [item for item in binary_data_dir.iterdir() if item.exists() and item.is_dir()]:
+        for dataset_dir in orga_dir.iterdir():
+            try:
+                if dataset_dir.exists() and dataset_dir.is_dir():
+                    for layer_dir in [item for item in dataset_dir.iterdir() if item.exists() and item.is_dir()]:
+                        meshes_dir = layer_dir.joinpath("meshes")
+                        if meshes_dir.exists():
+                            for mesh_file in [
+                                item
+                                for item in meshes_dir.iterdir()
+                                if item.name.endswith(".hdf5")
+                            ]:
+                                if mesh_file.exists():
+                                    with h5py.File(mesh_file, "r") as f:
+                                        try:
+                                            version = f.attrs["artifact_schema_version"]
+                                        except KeyError:
+                                            version = 0
+                                        if version < 3 or args.all:
+                                            realpath = mesh_file.resolve()
+                                            if realpath not in seen:
+                                                seen.append(realpath)
+                                                if args.plain:
+                                                    print(mesh_file)
+                                                else:
+                                                    print(f"{mesh_file} has version {version}")
+            except Exception as e:
+                if not args.plain:
+                    print(f"Exception while scanning dataset dir at {dataset_dir}: {e}")
+
+    if not args.plain:
+        print(f"Done scanning {binary_data_dir}, listed {len(seen)} meshfiles.")
 
 
 if __name__ == "__main__":

--- a/tools/mesh-format/requirements.txt
+++ b/tools/mesh-format/requirements.txt
@@ -1,0 +1,3 @@
+pathlib
+h5py
+argparse


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

Since we did not talk about the issue much I didn't know exactly what to do. But this script should detect the old mesh files.

### Issues:
- contributes to #7597

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
