### PR TITLE
Fix offset when creating node with mouse

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed small styling errors as a follow up to the antd v5 upgrade [#7612](https://github.com/scalableminds/webknossos/pull/7612)
 - Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
 - Fixed small styling error with a welcome notification for new users on webknossos.org. [7623](https://github.com/scalableminds/webknossos/pull/7623)
+- Fixed a slight offset when creating a node with the mouse. [#7639](https://github.com/scalableminds/webknossos/pull/7639)
 
 ### Removed
 

--- a/frontend/javascripts/libs/input.ts
+++ b/frontend/javascripts/libs/input.ts
@@ -676,9 +676,10 @@ export class InputMouse {
       width: 0,
       height: 0,
     };
-    return _.extend({}, boundingRect, {
+    return {
+      ...boundingRect,
       left: boundingRect.left + window.scrollX,
       top: boundingRect.top + window.scrollY,
-    });
+    };
   }
 }

--- a/frontend/javascripts/libs/input.ts
+++ b/frontend/javascripts/libs/input.ts
@@ -676,10 +676,11 @@ export class InputMouse {
       width: 0,
       height: 0,
     };
-    return {
-      ...boundingRect,
+    // Don't use {...boundingRect, }, because boundingRect is a DOMRect
+    // which isn't compatible with the spreading, apparently.
+    return _.extend({}, boundingRect, {
       left: boundingRect.left + window.scrollX,
       top: boundingRect.top + window.scrollY,
-    };
+    });
   }
 }

--- a/frontend/javascripts/oxalis/constants.ts
+++ b/frontend/javascripts/oxalis/constants.ts
@@ -264,10 +264,6 @@ export enum TreeTypeEnum {
 export type TreeType = keyof typeof TreeTypeEnum;
 export const NODE_ID_REF_REGEX = /#([0-9]+)/g;
 export const POSITION_REF_REGEX = /#\(([0-9]+,[0-9]+,[0-9]+)\)/g;
-// The plane in orthogonal mode is a little smaller than the viewport
-// There is an outer yellow CSS border and an inner (red/green/blue) border
-// that is a result of the plane being smaller than the renderer viewport
-export const OUTER_CSS_BORDER = 0;
 const VIEWPORT_WIDTH = 376;
 export const ensureSmallerEdge = false;
 export const Unicode = {

--- a/frontend/javascripts/oxalis/constants.ts
+++ b/frontend/javascripts/oxalis/constants.ts
@@ -267,7 +267,7 @@ export const POSITION_REF_REGEX = /#\(([0-9]+,[0-9]+,[0-9]+)\)/g;
 // The plane in orthogonal mode is a little smaller than the viewport
 // There is an outer yellow CSS border and an inner (red/green/blue) border
 // that is a result of the plane being smaller than the renderer viewport
-export const OUTER_CSS_BORDER = 2;
+export const OUTER_CSS_BORDER = 0;
 const VIEWPORT_WIDTH = 376;
 export const ensureSmallerEdge = false;
 export const Unicode = {

--- a/frontend/javascripts/oxalis/controller/combinations/skeleton_handlers.ts
+++ b/frontend/javascripts/oxalis/controller/combinations/skeleton_handlers.ts
@@ -6,7 +6,7 @@ import type {
   Vector3,
   ShowContextMenuFunction,
 } from "oxalis/constants";
-import { OUTER_CSS_BORDER, OrthoViews } from "oxalis/constants";
+import { OrthoViews } from "oxalis/constants";
 import { V3 } from "libs/mjs";
 import _ from "lodash";
 import { enforce, values } from "libs/utils";
@@ -345,9 +345,7 @@ export function maybeGetNodeIdFromPosition(
   height = Math.round(height);
   const buffer = renderToTexture(plane, pickingScene, camera, true);
   // Beware of the fact that new browsers yield float numbers for the mouse position
-  // Subtract the CSS border as the renderer viewport is smaller than the inputcatcher
-  const borderWidth = OUTER_CSS_BORDER;
-  const [x, y] = [Math.round(position.x) - borderWidth, Math.round(position.y) - borderWidth];
+  const [x, y] = [Math.round(position.x), Math.round(position.y)];
   // compute the index of the pixel under the cursor,
   // while inverting along the y-axis, because WebGL has its origin bottom-left :/
   const index = (x + (height - y) * width) * 4;

--- a/frontend/javascripts/oxalis/geometries/plane.ts
+++ b/frontend/javascripts/oxalis/geometries/plane.ts
@@ -140,12 +140,11 @@ class Plane {
   };
 
   setScale(xFactor: number, yFactor: number): void {
-    if (this.lastScaleFactors[0] !== xFactor || this.lastScaleFactors[1] !== yFactor) {
-      this.lastScaleFactors[0] = xFactor;
-      this.lastScaleFactors[1] = yFactor;
-    } else {
+    if (this.lastScaleFactors[0] === xFactor && this.lastScaleFactors[1] === yFactor) {
       return;
     }
+    this.lastScaleFactors[0] = xFactor;
+    this.lastScaleFactors[1] = yFactor;
 
     const scaleVec = new THREE.Vector3().multiplyVectors(
       new THREE.Vector3(xFactor, yFactor, 1),

--- a/frontend/javascripts/oxalis/model/accessors/view_mode_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/view_mode_accessor.ts
@@ -13,7 +13,6 @@ import type {
 } from "oxalis/constants";
 import constants, {
   ArbitraryViewport,
-  OUTER_CSS_BORDER,
   OrthoViews,
   OrthoViewValuesWithoutTDView,
 } from "oxalis/constants";
@@ -86,11 +85,8 @@ export function getInputCatcherAspectRatio(state: OxalisState, viewport: Viewpor
 // Returns the ratio between VIEWPORT_WIDTH and the actual extent of the viewport for width and height
 export function getViewportScale(state: OxalisState, viewport: Viewport): [number, number] {
   const { width, height } = getInputCatcherRect(state, viewport);
-  // For the orthogonal views the CSS border width was subtracted before, so we'll need to
-  // add it back again to get an accurate scale
-  const borderWidth = viewport === ArbitraryViewport ? 0 : OUTER_CSS_BORDER;
-  const xScale = (width + 2 * borderWidth) / constants.VIEWPORT_WIDTH;
-  const yScale = (height + 2 * borderWidth) / constants.VIEWPORT_WIDTH;
+  const xScale = width / constants.VIEWPORT_WIDTH;
+  const yScale = height / constants.VIEWPORT_WIDTH;
   return [xScale, yScale];
 }
 

--- a/frontend/javascripts/oxalis/view/input_catcher.tsx
+++ b/frontend/javascripts/oxalis/view/input_catcher.tsx
@@ -146,30 +146,32 @@ function InputCatcher({
   );
 
   return (
-    <div
-      className="flexlayout-dont-overflow"
-      onContextMenu={ignoreContextMenu}
-      style={{ cursor: busyBlockingInfo.isBusy ? "wait" : cursorForTool[adaptedTool] }}
-    >
+    <div className={`inputcatcher_border ${viewportID}`}>
       <div
-        id={`inputcatcher_${viewportID}`}
-        ref={(domElement) => {
-          domElementRef.current = domElement;
-        }}
-        data-value={viewportID}
-        className={`inputcatcher ${viewportID}`}
-        style={{
-          position: "relative",
-          // Disable inputs while wk is busy. However, keep the custom cursor and the ignoreContextMenu handler
-          // which is why those are defined at the outer element.
-          pointerEvents: busyBlockingInfo.isBusy ? "none" : "auto",
-        }}
+        className="flexlayout-dont-overflow"
+        onContextMenu={ignoreContextMenu}
+        style={{ cursor: busyBlockingInfo.isBusy ? "wait" : cursorForTool[adaptedTool] }}
       >
-        <ViewportStatusIndicator />
-        {displayScalebars && viewportID !== "arbitraryViewport" ? (
-          <Scalebar viewportID={viewportID} />
-        ) : null}
-        {children}
+        <div
+          id={`inputcatcher_${viewportID}`}
+          ref={(domElement) => {
+            domElementRef.current = domElement;
+          }}
+          data-value={viewportID}
+          className={`inputcatcher ${viewportID}`}
+          style={{
+            position: "relative",
+            // Disable inputs while wk is busy. However, keep the custom cursor and the ignoreContextMenu handler
+            // which is why those are defined at the outer element.
+            pointerEvents: busyBlockingInfo.isBusy ? "none" : "auto",
+          }}
+        >
+          <ViewportStatusIndicator />
+          {displayScalebars && viewportID !== "arbitraryViewport" ? (
+            <Scalebar viewportID={viewportID} />
+          ) : null}
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/frontend/javascripts/oxalis/view/input_catcher.tsx
+++ b/frontend/javascripts/oxalis/view/input_catcher.tsx
@@ -146,7 +146,7 @@ function InputCatcher({
   );
 
   return (
-    <div className={`inputcatcher_border ${viewportID}`}>
+    <div className={`inputcatcher-border ${viewportID}`}>
       <div
         className="flexlayout-dont-overflow"
         onContextMenu={ignoreContextMenu}

--- a/frontend/javascripts/oxalis/view/layouting/layout_canvas_adapter.ts
+++ b/frontend/javascripts/oxalis/view/layouting/layout_canvas_adapter.ts
@@ -1,5 +1,4 @@
 import type { Rect } from "oxalis/constants";
-import { OUTER_CSS_BORDER } from "oxalis/constants";
 import { document } from "libs/window";
 
 export default function makeRectRelativeToCanvas(rect: Rect): Rect {
@@ -10,15 +9,13 @@ export default function makeRectRelativeToCanvas(rect: Rect): Rect {
   }
 
   const { left: containerX, top: containerY } = layoutContainerDOM.getBoundingClientRect();
-  const borderWidth = OUTER_CSS_BORDER;
-
   const minNull = (el: number) => Math.max(el, 0);
 
   // Since we want to paint inside the InputCatcher we have to subtract the border
   return {
-    left: minNull(rect.left - containerX + borderWidth),
-    top: minNull(rect.top - containerY + borderWidth),
-    width: minNull(rect.width - 2 * borderWidth),
-    height: minNull(rect.height - 2 * borderWidth),
+    left: minNull(rect.left - containerX),
+    top: minNull(rect.top - containerY),
+    width: minNull(rect.width),
+    height: minNull(rect.height),
   };
 }

--- a/frontend/javascripts/oxalis/view/rendering_utils.ts
+++ b/frontend/javascripts/oxalis/view/rendering_utils.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { saveAs } from "file-saver";
 import Store from "oxalis/store";
-import { OUTER_CSS_BORDER, OrthoView } from "oxalis/constants";
+import { OrthoView } from "oxalis/constants";
 import constants, {
   ArbitraryViewport,
   OrthoViewColors,
@@ -121,10 +121,7 @@ export async function downloadScreenshot() {
         ? (ctx: CanvasRenderingContext2D) => {
             const scalebarDistanceToRightBorder = constants.SCALEBAR_OFFSET;
             const scalebarDistanceToTopBorder =
-              ctx.canvas.height +
-              OUTER_CSS_BORDER -
-              constants.SCALEBAR_OFFSET -
-              constants.SCALEBAR_HEIGHT;
+              ctx.canvas.height + constants.SCALEBAR_OFFSET - constants.SCALEBAR_HEIGHT;
             const logoHeight = constants.SCALEBAR_HEIGHT;
             const logoWidth = (logoHeight / logo.height) * logo.width;
             ctx.drawImage(

--- a/frontend/javascripts/oxalis/view/scalebar.tsx
+++ b/frontend/javascripts/oxalis/view/scalebar.tsx
@@ -80,7 +80,7 @@ function Scalebar({ zoomValue, dataset, viewportWidthInPixels, viewportHeightInP
             ? 16
             : `calc(${scaleBarWidthFactor * 100}% - ${Math.round(
                 ((2 * OUTER_CSS_BORDER) / constants.VIEWPORT_WIDTH) * 100,
-              )}% + ${2 * padding}px)`,
+              )}%)`,
           height: constants.SCALEBAR_HEIGHT - padding * 2,
           background: "rgba(0, 0, 0, .3)",
           color: "white",

--- a/frontend/javascripts/oxalis/view/scalebar.tsx
+++ b/frontend/javascripts/oxalis/view/scalebar.tsx
@@ -8,7 +8,7 @@ import { formatNumberToLength } from "libs/format_utils";
 import { getViewportExtents, getTDViewZoom } from "oxalis/model/accessors/view_mode_accessor";
 import { getZoomValue } from "oxalis/model/accessors/flycam_accessor";
 import type { OrthoView } from "oxalis/constants";
-import constants, { Unicode, OUTER_CSS_BORDER, OrthoViews } from "oxalis/constants";
+import constants, { Unicode, OrthoViews } from "oxalis/constants";
 const { ThinSpace, MultiplicationSymbol } = Unicode;
 type OwnProps = {
   viewportID: OrthoView;
@@ -76,11 +76,7 @@ function Scalebar({ zoomValue, dataset, viewportWidthInPixels, viewportHeightInP
           position: "absolute",
           bottom: constants.SCALEBAR_OFFSET,
           right: constants.SCALEBAR_OFFSET,
-          width: collapseScalebar
-            ? 16
-            : `calc(${scaleBarWidthFactor * 100}% - ${Math.round(
-                ((2 * OUTER_CSS_BORDER) / constants.VIEWPORT_WIDTH) * 100,
-              )}%)`,
+          width: collapseScalebar ? 16 : `${scaleBarWidthFactor * 100}%`,
           height: constants.SCALEBAR_HEIGHT - padding * 2,
           background: "rgba(0, 0, 0, .3)",
           color: "white",

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -18,18 +18,15 @@
   position: absolute;
   width: 100%;
 }
-.inputcatcher {
+.inputcatcher_border {
   border-style: solid;
   border-width: 2px;
-  z-index: 20;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  float: left;
-  margin: 0;
   opacity: 0.85;
   width: 100%;
   height: 100%;
-
+  &:hover {
+    opacity: 1;
+  }
   &.PLANE_XY {
     border-color: var(--color-xy-viewport);
   }
@@ -42,10 +39,15 @@
   &.TDView {
     border-color: white;
   }
-
-  &:hover {
-    opacity: 1;
-  }
+}
+.inputcatcher {
+  z-index: 20;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  float: left;
+  margin: 0;
+  width: 100%;
+  height: 100%;
 }
 
 #inputcatcher_TDView {
@@ -548,7 +550,6 @@ img.keyboard-mouse-icon:first-child {
   background-size: contain;
   opacity: 0.65;
 }
-
 
 .segment-context-icon {
   margin-inline-end: var(--ant-margin-xs);

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -18,7 +18,7 @@
   position: absolute;
   width: 100%;
 }
-.inputcatcher_border {
+.inputcatcher-border {
   border-style: solid;
   border-width: 2px;
   opacity: 0.85;
@@ -42,8 +42,6 @@
 }
 .inputcatcher {
   z-index: 20;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
   float: left;
   margin: 0;
   width: 100%;


### PR DESCRIPTION
The border around the viewports caused a slight offset when creating a node (probably, other interactions were also impacted). Debugging showed that the mouse move listeners used `getBoundingClientRect` (which contains the border) to make the clicked position relative. However, the remaining code assumes that the border has to be ignored when interacting with the div. For example, `makeRectRelativeToCanvas` subtracts the border after calling `getBoundingClientRect`. I think, it makes sense to ignore the border altogether. However, doing this in `input.ts` would mean to dynamically read the border and subtract it there.
I figured the easiest way was to move the border simply somewhere else so that the targeted viewport divs don't have any border.

@daniel-wer I suggest to test this first thoroughly. If you are fine with this, I'd remove OUTER_CSS_BORDER completely, since it shouldn't have any relevance afterwards (hopefully).

By the way, a smell of the current border was also that you could create nodes on the border. With this PR, this is not possible anymore.

### URL of deployed dev instance (used for testing):
- https://fixnodecreationoffset.webknossos.xyz

### Steps to test:
- test that the mouse position is respected precisely when
  - creating, moving, selecting nodes (remember that node positions are integer; so zoom out a bit to get precise positions)
  - brushing
  - moving with alt + mouse move
  - something else?

### TODOs:
- [x] fix brush preview
- [x] remove OUTER_CSS_BORDER

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1708346079685159

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
