### PR TITLE
Make tag search precise

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed small styling errors as a follow up to the antd v5 upgrade [#7612](https://github.com/scalableminds/webknossos/pull/7612)
 - Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
 - Fixed small styling error with a welcome notification for new users on webknossos.org. [7623](https://github.com/scalableminds/webknossos/pull/7623)
+- Fixed that filtering by tags could produce false positives. [#7640](https://github.com/scalableminds/webknossos/pull/7640)
 
 ### Removed
 

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -491,11 +491,19 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
     // (e.g., filtering by owner in the column header).
     // Use `this.currentPageData` if you need all currently visible
     // items of the active page.
-    return Utils.filterWithSearchQueryAND(
+    const filteredTracings = Utils.filterWithSearchQueryAND(
       this.getCurrentTracings(),
       ["id", "name", "modified", "tags", "owner"],
-      `${this.state.searchQuery} ${this.state.tags.join(" ")}`,
+      this.state.searchQuery,
     );
+
+    if (this.state.tags.length === 0) {
+      // This check is not strictly necessary, but serves
+      // as an early-out to save some computations.
+      return filteredTracings;
+    }
+
+    return filteredTracings.filter((el) => _.intersection(this.state.tags, el.tags).length > 0);
   }
 
   renderIdAndCopyButton(tracing: APIAnnotationInfo) {


### PR DESCRIPTION
The current tag search produces false positives if the tag name also appears somewhere else in the annotation properties.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- assign a `t` tag to an annotation in the dashboard
- rename another annotation to contain a "t"
- click on the t tag and check that only the one annotation is shown


### Issues:
- fixes #7629

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)