### PR TITLE
Fix NML uploader styling

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed small styling errors as a follow up to the antd v5 upgrade [#7612](https://github.com/scalableminds/webknossos/pull/7612)
 - Fixed deprecation warnings caused by Antd <Collapse> components. [#7610](https://github.com/scalableminds/webknossos/pull/7610)
 - Fixed small styling error with a welcome notification for new users on webknossos.org. [7623](https://github.com/scalableminds/webknossos/pull/7623)
+- Fixed small styling error with NML drag and drop uploading. [7641](https://github.com/scalableminds/webknossos/pull/7641)
+
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/nml_upload_zone_container.tsx
+++ b/frontend/javascripts/oxalis/view/nml_upload_zone_container.tsx
@@ -59,7 +59,7 @@ function NmlDropArea({
         <InboxOutlined
           style={{
             fontSize: 180,
-            color: "var(color-primary)",
+            color: "var(--ant-color-primary)",
           }}
         />
       </div>

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -315,7 +315,6 @@ button.narrow {
   bottom: 0;
   left: 0;
   padding: 2.5em 0;
-  background: var(--ant-color-bg-mask);
   text-align: center;
   z-index: 1000;
 }
@@ -324,8 +323,8 @@ button.narrow {
   top: 100px;
   width: 400px;
   height: 250px;
-  background: var(--ant-modal-content-bg);
-  border-radius: 4px;
+  background: var(--ant-color-bg-container);
+  border-radius: var(--ant-border-radius);
   margin: 0 auto;
 }
 .dataset-upload-dropzone {

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -315,6 +315,7 @@ button.narrow {
   bottom: 0;
   left: 0;
   padding: 2.5em 0;
+  background: var(--ant-color-bg-mask);
   text-align: center;
   z-index: 1000;
 }


### PR DESCRIPTION
This PR fixes some stylings for NML uploader / drag and drop area as a follow up to antd v5.

Before / Fixes this:
![image](https://github.com/scalableminds/webknossos/assets/1105056/5e7c87dc-f847-499c-99be-275405b098ca)


### URL of deployed dev instance (used for testing):
- https://fixnmlupload.webknossos.xyz

### Steps to test:
- Go to annotation interface
- Drag and drop a NML file over viewport
- DnD area should have a nice background color
- Test in light and dark mode / theme


### Issues:
- follow up to #6861 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
