### PR TITLE
Fix duplicate teams+experiences in user list api

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed small styling error with a welcome notification for new users on webknossos.org. [#7623](https://github.com/scalableminds/webknossos/pull/7623)
 - Fixed that filtering by tags could produce false positives. [#7640](https://github.com/scalableminds/webknossos/pull/7640)
 - Fixed a slight offset when creating a node with the mouse. [#7639](https://github.com/scalableminds/webknossos/pull/7639)
+- Fixed a bug where the user list view would show duplicate team roles, and user changes (e.g. giving experience) would sometimes fail.
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed small styling error with a welcome notification for new users on webknossos.org. [#7623](https://github.com/scalableminds/webknossos/pull/7623)
 - Fixed that filtering by tags could produce false positives. [#7640](https://github.com/scalableminds/webknossos/pull/7640)
 - Fixed a slight offset when creating a node with the mouse. [#7639](https://github.com/scalableminds/webknossos/pull/7639)
-- Fixed a bug where the user list view would show duplicate team roles, and user changes (e.g. giving experience) would sometimes fail.
+- Fixed a bug where the user list view would show duplicate team roles, and user changes (e.g. giving experience) would sometimes fail. [#7646](https://github.com/scalableminds/webknossos/pull/7646)
 
 ### Removed
 


### PR DESCRIPTION
Our query suffered from Left Join Fanout effect, leading to duplicates. This is resolved by using subqueries with WITH, as described [here](https://stackoverflow.com/questions/46279081/sql-duplicate-rows-with-multiple-left-joins).
Also, an inner join with `user_team_roles` would lead to users being omitted altogether in case they have no team memberships.
Also, the `users_` view should be used for the join, in order to skip deleted users. Unfortunately, using the view means all selected fields need to occur in the GROUP BY clause (that shortcut is not available for views)

### URL of deployed dev instance (used for testing):
- https://fixuserlistduplicates.webknossos.xyz

### Steps to test:
- Assign multiple experiences and team roles to a user
- /api/users should include their teams and experiences only once each.

### Issues:
- fixes #7644
- follow-up: https://github.com/scalableminds/webknossos/issues/7647

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
