### PR TITLE
Fix antd v5 styling issues

### DIFF
--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -917,7 +917,7 @@ function BreadcrumbsTag({ parts: allParts }: { parts: string[] | null }) {
   return (
     <Tooltip title={`This dataset is located in ${formatPath(allParts)}.`}>
       <Tag style={{ marginTop: "5px" }}>
-        <FolderOpenOutlined />
+        <FolderOpenOutlined className="icon-margin-right" />
         {formatPath(parts)}
       </Tag>
     </Tooltip>


### PR DESCRIPTION
- Fixed an icon margin offset in the dashboard folder search results
  - Before 
    - ![image](https://github.com/scalableminds/webknossos/assets/1105056/ae938de7-b916-4293-9beb-12d68c98a260)
  - After 
    - <img width="726" alt="Screenshot 2024-02-26 at 16 54 51" src="https://github.com/scalableminds/webknossos/assets/1105056/02a00ca0-10c1-448c-a139-26098fe53229">


### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
