### PR TITLE
Avoid left join fanout effect in annotation list query

### DIFF
--- a/.github/common_edge_cases.md
+++ b/.github/common_edge_cases.md
@@ -9,3 +9,7 @@ Will this also work if
  - The user is logged out and views a public dataset or annotation
  - User uses dark mode / light mode
  - There is no local datastore/tracingstore module (Compare [instructions to test this locally](https://github.com/scalableminds/webknossos/wiki/Set-up-a-standalone-datastore-locally))
+
+ Also check that
+  - Complex SQL queries have no fan out effect due to multiple left joins
+  - SQL `IN` statements are never called with empty list

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,7 +37,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed small styling error with a welcome notification for new users on webknossos.org. [#7623](https://github.com/scalableminds/webknossos/pull/7623)
 - Fixed that filtering by tags could produce false positives. [#7640](https://github.com/scalableminds/webknossos/pull/7640)
 - Fixed a slight offset when creating a node with the mouse. [#7639](https://github.com/scalableminds/webknossos/pull/7639)
-- Fixed small styling error with NML drag and drop uploading. [7641](https://github.com/scalableminds/webknossos/pull/7641)
+- Fixed small styling error with NML drag and drop uploading. [#7641](https://github.com/scalableminds/webknossos/pull/7641)
+- Fixed a bug where the annotation list would show teams the annotation is shared with multiple times. [#7659](https://github.com/scalableminds/webknossos/pull/7659)
 
 ### Removed
 

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -323,6 +323,24 @@ class AnnotationDAO @Inject()(sqlClient: SqlClient, annotationLayerDAO: Annotati
       typQuery = q"a.typ = $typ"
 
       query = q"""
+          WITH
+          -- teams_agg is extracted to avoid left-join fanout.
+          -- Note that only one of the joins in it has 1:n, so they can happen together
+          teams_agg AS (
+            SELECT
+            a._id as _annotation,
+            ARRAY_REMOVE(ARRAY_AGG(t._id), null) AS team_ids,
+            ARRAY_REMOVE(ARRAY_AGG(t.name), null) AS team_names,
+            ARRAY_REMOVE(ARRAY_AGG(o._id), null) AS team_organization_ids
+            FROM webknossos.annotations a
+            LEFT JOIN webknossos.annotation_sharedteams ast
+                ON ast._annotation = a._id
+            LEFT JOIN webknossos.teams_ t
+                ON ast._team = t._id
+            LEFT JOIN webknossos.organizations_ o
+                ON t._organization = o._id
+            GROUP BY a._id
+          )
           SELECT
           a._id,
           a.name,
@@ -331,9 +349,9 @@ class AnnotationDAO @Inject()(sqlClient: SqlClient, annotationLayerDAO: Annotati
           u.firstname,
           u.lastname,
           a.othersmayedit,
-          ARRAY_REMOVE(ARRAY_AGG(t._id), null) AS team_ids,
-          ARRAY_REMOVE(ARRAY_AGG(t.name), null) AS team_names,
-          ARRAY_REMOVE(ARRAY_AGG(t._organization), null) AS team_orgs,
+          teams_agg.team_ids,
+          teams_agg.team_names,
+          teams_agg.team_organization_ids,
           a.modified,
           a.tags,
           a.state,
@@ -346,23 +364,23 @@ class AnnotationDAO @Inject()(sqlClient: SqlClient, annotationLayerDAO: Annotati
           ARRAY_REMOVE(ARRAY_AGG(al.name), null) AS tracing_names,
           ARRAY_REMOVE(ARRAY_AGG(al.typ :: varchar), null) AS tracing_typs,
           ARRAY_REMOVE(ARRAY_AGG(al.statistics), null) AS annotation_layer_statistics
-      FROM webknossos.annotations_ as a
-               LEFT JOIN webknossos.users_ u
-                         ON u._id = a._user
-               LEFT JOIN webknossos.annotation_sharedteams ast
-                         ON ast._annotation = a._id
-               LEFT JOIN webknossos.teams_ t
-                         ON ast._team = t._id
-               LEFT JOIN webknossos.datasets_ d
-                         ON d._id = a._dataset
-               LEFT JOIN webknossos.organizations_ as o
-                         ON o._id = d._organization
-               LEFT JOIN webknossos.annotation_layers as al
-                         ON al._annotation = a._id
+      FROM
+        webknossos.annotations_ as a
+        JOIN webknossos.users_ u
+                 ON u._id = a._user
+        JOIN teams_agg
+                 ON teams_agg._annotation = a._id
+        JOIN webknossos.datasets_ d
+                 ON d._id = a._dataset
+        JOIN webknossos.organizations_ as o
+                 ON o._id = d._organization
+        JOIN webknossos.annotation_layers as al
+                 ON al._annotation = a._id
       WHERE $stateQuery AND $accessQuery AND $userQuery AND $typQuery
       GROUP BY
         a._id, a.name, a.description, a._user, a.othersmayedit, a.modified, a.tags, a.state, a.typ, a.visibility, a.tracingtime,
         u.firstname, u.lastname,
+        teams_agg.team_ids, teams_agg.team_names, teams_agg.team_organization_ids,
         d.name,
         o.name
         ORDER BY a._id DESC LIMIT $limit OFFSET ${pageNumber * limit}

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -258,6 +258,7 @@ class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
         """
       r <- run(q"""
           WITH
+          -- agg_experiences and agg_user_team_roles are extracted to avoid left-join fanout.
           agg_experiences AS (
             SELECT
               u._id AS _user,


### PR DESCRIPTION
I went through queries that have LEFT JOIN looking for possible fanout effect.

- User list  was fixed in #7646 (subqueries with WITH)
- Annotation list is fixed here (subquery with WITH)

Most other queries should be fine
- Dataset list is already ok (inline subqueries)
- Folder access queries are ok (duplicates don’t hurt)
- Progress reports are ok (subqueries)
- Task assignment query is ok (duplicates don’t hurt)

I did not check the voxelytics queries, @normanrz maybe you could have a quick look there?

### URL of deployed dev instance (used for testing):
- https://avoidjoinfanout.webknossos.xyz

### Steps to test:
- For some annotations, set multiple shared teams in annotation share modal
- annotation list in dashboard should not contain duplicate teams

### Issues:
- fixes #7647 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
