### PR TITLE
fix styling for sign up view

### DIFF
--- a/frontend/javascripts/admin/auth/registration_view.tsx
+++ b/frontend/javascripts/admin/auth/registration_view.tsx
@@ -98,8 +98,8 @@ function RegistrationViewWkOrg() {
   const history = useHistory();
   return (
     <Row justify="center" align="middle" className="login-view">
-      <Col className="login-content drawing-signup" style={{ width: 1000 }}>
-        <div>
+      <Col>
+        <Card className="login-content drawing-signup" style={{ width: 1000 }}>
           <h3>Sign Up</h3>
           <RegistrationFormWKOrg
             onRegistered={() => {
@@ -113,7 +113,7 @@ function RegistrationViewWkOrg() {
           >
             <Link to="/auth/login">Log in to existing account</Link>
           </p>
-        </div>
+        </Card>
       </Col>
     </Row>
   );


### PR DESCRIPTION
This PR fixes a styling issue with sign up page for wk.org.

### Before
![image](https://github.com/scalableminds/webknossos/assets/1105056/fb6a3a26-f595-44bd-a5e2-66ac85ced8ac)


### After
<img width="1674" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/79c1f1d4-383a-4375-84e5-1ff6ba153e8a">


<img width="1673" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/dd7f5307-8bae-4a2c-a4fb-29e0ca83e78d">



### Steps to test:
- Set application.conf to wkorg
- Navigate to sign up page


### Issues:
- Contributes to #6861 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
