### PR TITLE
Change user limit alert from error to warning

### DIFF
--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -286,7 +286,7 @@ class UserListView extends React.PureComponent<Props, State> {
         description={`You organization reached the maxmium number of users included in your current plan. Consider upgrading your WEBKNOSSOS plan to accommodate more users or deactivate some user accounts. Email invites are disabled in the meantime. Your organization currently has ${getActiveUserCount(
           this.state.users,
         )} active users of ${this.props.activeOrganization.includedUsers} allowed by your plan.`}
-        type="error"
+        type="warning"
         showIcon
         style={{
           marginTop: 20,


### PR DESCRIPTION
In the user list view, change the user limit alert from an error (red background) to a warning (yellow background). It is less in your face.

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
