### PR TITLE
Improve layer overflow menu

### DIFF
--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -803,17 +803,13 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             {isColorLayer ? null : this.getOptionalDownsampleVolumeIcon(maybeVolumeTracing)}
           </div>
         </div>
-        <div className="flex-container">
-          <div className="flex-item">
-            <Dropdown
-              menu={{ items }}
-              trigger={["click", "contextMenu", "hover"]}
-              placement="bottomRight"
-            >
+        <Dropdown menu={{ items }} trigger={["hover"]} placement="bottomRight">
+          <div className="flex-container" style={{ cursor: "pointer" }}>
+            <div className="flex-item">
               <EllipsisOutlined />
-            </Dropdown>
+            </div>
           </div>
-        </div>
+        </Dropdown>
       </div>
     );
   };


### PR DESCRIPTION
- make click target for overview menu bigger
- only use "hover" as trigger to avoid that another click closes the menu again

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- use the menu

### Issues:
- fixes #7585
