### PR TITLE
Small fixes for icon margins and video links

### DIFF
--- a/frontend/javascripts/admin/onboarding.tsx
+++ b/frontend/javascripts/admin/onboarding.tsx
@@ -592,7 +592,7 @@ class OnboardingView extends React.PureComponent<Props, State> {
       <Row gutter={50}>
         <FeatureCard header="Data Annotation" icon={<PlayCircleOutlined />}>
           <a href="/dashboard">Explore and annotate your data.</a> For a brief overview,{" "}
-          <a href="https://www.youtube.com/watch?v=jsz0tc3tuKI&t=30s">watch this video</a>.
+          <a href="https://www.youtube.com/watch?v=iw2C7XB6wP4">watch this video</a>.
         </FeatureCard>
         <FeatureCard header="More Datasets" icon={<CloudUploadOutlined />}>
           <a href="/datasets/upload">Upload more of your datasets.</a>{" "}
@@ -624,12 +624,14 @@ class OnboardingView extends React.PureComponent<Props, State> {
         <FeatureCard header="Project Management" icon={<PaperClipOutlined />}>
           Create <a href="/tasks">tasks</a> and <a href="/projects">projects</a> to efficiently
           accomplish your research goals.{" "}
-          <a href="https://www.youtube.com/watch?v=4DD7408avUY">Watch this demo</a> to learn more.
+          <a href="https://www.youtube.com/watch?v=G6AumzpIzR0">Watch this short video</a> to learn
+          more.
         </FeatureCard>
         <FeatureCard header="Scripting" icon={<CodeOutlined />}>
-          Use the <a href="/assets/docs/frontend-api/index.html">WEBKNOSSOS API</a> to create{" "}
-          <a href="/scripts">scriptable workflows</a>.{" "}
-          <a href="https://www.youtube.com/watch?v=u5j8Sf5YwuM">Watch this demo</a> to learn more.
+          Use the <a href="https://docs.webknossos.org/webknossos-py">WEBKNOSSOS Python library</a>{" "}
+          to create automated workflows.
+          <a href="https://www.youtube.com/watch?v=JABaGvqg2-g">Watch this short video</a> to learn
+          more.
         </FeatureCard>
         <FeatureCard header="Contact Us" icon={<CustomerServiceOutlined />}>
           <a href="mailto:hello@webknossos.org">Get in touch</a> or{" "}

--- a/frontend/javascripts/admin/welcome_ui.tsx
+++ b/frontend/javascripts/admin/welcome_ui.tsx
@@ -99,7 +99,7 @@ export const WhatsNextHeader = ({ activeUser, onDismiss }: WhatsNextHeaderProps)
               title="Learn How To Create Annotations"
               description="Watch a short video to see how data can be annotated with WEBKNOSSOS."
               icon={<i className="icon-annotate" />}
-              href="https://www.youtube.com/watch?v=jsz0tc3tuKI&t=30s"
+              href="https://www.youtube.com/watch?v=iw2C7XB6wP4"
             />
             {isUserAdminOrTeamManager(activeUser) ? (
               <WhatsNextAction

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -184,7 +184,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
             })
           }
         >
-          <WarningOutlined className="icon-margin-right"/>
+          <WarningOutlined className="icon-margin-right" />
           Show Error
         </a>
       </div>

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -184,7 +184,7 @@ class DatasetActionView extends React.PureComponent<Props, State> {
             })
           }
         >
-          <WarningOutlined />
+          <WarningOutlined className="icon-margin-right"/>
           Show Error
         </a>
       </div>

--- a/frontend/javascripts/dashboard/folders/folder_tree.tsx
+++ b/frontend/javascripts/dashboard/folders/folder_tree.tsx
@@ -225,7 +225,7 @@ export function generateSettingsForFolder(
         key: "create",
         disabled: !isEditable,
         onClick: createFolder,
-        icon: <PlusOutlined className="icon-margin-right"/>,
+        icon: <PlusOutlined className="icon-margin-right" />,
         label: (
           <PricingEnforcedSpan requiredPricingPlan={PricingPlanEnum.Team}>
             {newFolderText}
@@ -236,7 +236,7 @@ export function generateSettingsForFolder(
         key: "edit",
         disabled: !isEditable,
         onClick: editFolder,
-        icon: <EditOutlined className="icon-margin-right"/>,
+        icon: <EditOutlined className="icon-margin-right" />,
         label: (
           <PricingEnforcedSpan requiredPricingPlan={PricingPlanEnum.Team}>
             Edit Folder
@@ -247,7 +247,7 @@ export function generateSettingsForFolder(
         key: "delete",
         onClick: deleteFolder,
         disabled: !isEditable,
-        icon: <DeleteOutlined className="icon-margin-right"/>,
+        icon: <DeleteOutlined className="icon-margin-right" />,
         label: <span>Delete Folder</span>,
       },
     ],

--- a/frontend/javascripts/dashboard/folders/folder_tree.tsx
+++ b/frontend/javascripts/dashboard/folders/folder_tree.tsx
@@ -225,7 +225,7 @@ export function generateSettingsForFolder(
         key: "create",
         disabled: !isEditable,
         onClick: createFolder,
-        icon: <PlusOutlined />,
+        icon: <PlusOutlined className="icon-margin-right"/>,
         label: (
           <PricingEnforcedSpan requiredPricingPlan={PricingPlanEnum.Team}>
             {newFolderText}
@@ -236,7 +236,7 @@ export function generateSettingsForFolder(
         key: "edit",
         disabled: !isEditable,
         onClick: editFolder,
-        icon: <EditOutlined />,
+        icon: <EditOutlined className="icon-margin-right"/>,
         label: (
           <PricingEnforcedSpan requiredPricingPlan={PricingPlanEnum.Team}>
             Edit Folder
@@ -247,7 +247,7 @@ export function generateSettingsForFolder(
         key: "delete",
         onClick: deleteFolder,
         disabled: !isEditable,
-        icon: <DeleteOutlined />,
+        icon: <DeleteOutlined className="icon-margin-right"/>,
         label: <span>Delete Folder</span>,
       },
     ],

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -434,11 +434,11 @@ function getDashboardSubMenu(collapse: boolean): SubMenuType {
     ),
     children: [
       { key: "/dashboard/datasets", label: <Link to="/dashboard/datasets">Datasets</Link> },
-      { key: "/dashboard/tasks", label: <Link to="/dashboard/tasks">Tasks</Link> },
       {
         key: "/dashboard/annotations",
         label: <Link to="/dashboard/annotations">Annotations</Link>,
       },
+      { key: "/dashboard/tasks", label: <Link to="/dashboard/tasks">Tasks</Link> },
     ],
   };
 }


### PR DESCRIPTION
PR includes 3 small fixes and improvements:

- add icon margins to folders in the dataset list/dashboard
- updated some outdated video links and URLs to docs
- Some time ago, we decided to swap Tasks and Annotations in the dashboard tabs. I did the same swap in the navbar dropdown menus to restore the same order

<img width="1208" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/c0665d6b-85b0-4c23-837e-8596722b00fc">


### Issues:
- Collaborates to #6861 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
