### PR TITLE
adds support for more omero info keys

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - If storage scan is enabled, the measured used storage is now displayed in the dashboard’s dataset detail view. [#7677](https://github.com/scalableminds/webknossos/pull/7677)
 - Prepared support to download full stl meshes via the HTTP api. [#7587](https://github.com/scalableminds/webknossos/pull/7587)
 - Added an action to delete erronous, unimported datasets directly from the dashboard. [#7448](https://github.com/scalableminds/webknossos/pull/7448)
+- Added support for `window`, `active`, `inverted` keys from the `omero` info in the NGFF metadata. [7685](https://github.com/scalableminds/webknossos/pull/7685)
 
 ### Changed
 - Datasets stored in WKW format are no longer loaded with memory mapping, reducing memory demands. [#7528](https://github.com/scalableminds/webknossos/pull/7528)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/NgffMetadata.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/NgffMetadata.scala
@@ -113,7 +113,16 @@ object NgffOmeroMetadata {
   implicit val jsonFormat: OFormat[NgffOmeroMetadata] = Json.format[NgffOmeroMetadata]
 }
 
-case class NgffChannelAttributes(color: Option[String], label: Option[String])
+case class NgffChannelWindow(min: Double, max: Double, start: Double, end: Double)
+object NgffChannelWindow {
+  implicit val jsonFormat: OFormat[NgffChannelWindow] = Json.format[NgffChannelWindow]
+}
+
+case class NgffChannelAttributes(color: Option[String],
+                                 label: Option[String],
+                                 window: Option[NgffChannelWindow],
+                                 inverted: Option[Boolean],
+                                 active: Option[Boolean])
 object NgffChannelAttributes {
   implicit val jsonFormat: OFormat[NgffChannelAttributes] = Json.format[NgffChannelAttributes]
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NgffExplorer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NgffExplorer.scala
@@ -9,13 +9,8 @@ import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.datareaders.zarr._
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
-import com.scalableminds.webknossos.datastore.models.datasource.{
-  AdditionalAxis,
-  Category,
-  ElementClass,
-  LayerViewConfiguration
-}
-import play.api.libs.json.{JsArray, JsNumber}
+import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, Category, ElementClass, LayerViewConfiguration}
+import play.api.libs.json.{JsArray, JsBoolean, JsNumber, Json}
 
 import scala.concurrent.ExecutionContext
 
@@ -79,14 +74,33 @@ class NgffExplorer(implicit val ec: ExecutionContext) extends RemoteLayerExplore
 
           (viewConfig: LayerViewConfiguration, channelName: String) = channelAttributes match {
             case Some(attributes) => {
-              val color = attributes(channelIndex).color
+              val thisChannelAttributes = attributes(channelIndex)
               val attributeName: String =
-                attributes(channelIndex).name
+                thisChannelAttributes.name
                   .map(TextUtils.normalizeStrong(_).getOrElse(name).replaceAll(" ", ""))
                   .getOrElse(name)
-              (color match {
-                case Some(c) => Seq(("color" -> JsArray(c.toArrayOfInts.map(i => JsNumber(BigDecimal(i)))))).toMap
-                case None    => LayerViewConfiguration.empty
+
+              val layerViewConfiguration = (thisChannelAttributes.color match {
+                case Some(c) => Seq("color" -> JsArray(c.toArrayOfInts.map(i => JsNumber(BigDecimal(i)))))
+                case None    => Seq()
+              }) ++ (thisChannelAttributes.window match {
+                case Some(w) =>
+                  Seq("intensityRange" -> Json.arr(JsNumber(w.start), JsNumber(w.end)),
+                      "min" -> JsNumber(w.min),
+                      "max" -> JsNumber(w.max))
+                case None => Seq()
+              }) ++ (thisChannelAttributes.inverted match {
+                case Some(i) => Seq("isInverted" -> JsBoolean(i))
+                case None    => Seq()
+              }) ++ (thisChannelAttributes.active match {
+                case Some(a) => Seq("isDisabled" -> JsBoolean(!a))
+                case None    => Seq()
+              })
+
+              (if (layerViewConfiguration.isEmpty) {
+                LayerViewConfiguration.empty
+              } else {
+                layerViewConfiguration.toMap
               }, attributeName)
             }
             case None => (LayerViewConfiguration.empty, name)
@@ -136,7 +150,11 @@ class NgffExplorer(implicit val ec: ExecutionContext) extends RemoteLayerExplore
     } yield axes
   }
 
-  private case class ChannelAttributes(color: Option[Color], name: Option[String])
+  private case class ChannelAttributes(color: Option[Color],
+                                       name: Option[String],
+                                       window: Option[NgffChannelWindow],
+                                       inverted: Option[Boolean],
+                                       active: Option[Boolean])
 
   private def getChannelAttributes(
       ngffHeader: NgffMetadata
@@ -145,8 +163,13 @@ class NgffExplorer(implicit val ec: ExecutionContext) extends RemoteLayerExplore
       case Some(value) =>
         Some(
           value.channels.map(omeroChannelAttributes =>
-            ChannelAttributes(omeroChannelAttributes.color.map(Color.fromHTML(_).getOrElse(Color(1, 1, 1, 0))),
-                              omeroChannelAttributes.label)))
+            ChannelAttributes(
+              omeroChannelAttributes.color.map(Color.fromHTML(_).getOrElse(Color(1, 1, 1, 0))),
+              omeroChannelAttributes.label,
+              omeroChannelAttributes.window,
+              omeroChannelAttributes.inverted,
+              omeroChannelAttributes.active
+          )))
       case None => None
     }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NgffExplorer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NgffExplorer.scala
@@ -9,7 +9,12 @@ import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.datareaders.zarr._
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
-import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, Category, ElementClass, LayerViewConfiguration}
+import com.scalableminds.webknossos.datastore.models.datasource.{
+  AdditionalAxis,
+  Category,
+  ElementClass,
+  LayerViewConfiguration
+}
 import play.api.libs.json.{JsArray, JsBoolean, JsNumber, Json}
 
 import scala.concurrent.ExecutionContext


### PR DESCRIPTION
Adds histogram range, isDisabled and isInverted from the `omero` info in the NGFF metadata.

### Steps to test:
- Import https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr
- Check histogram range, isDisabled and isInverted

### Issues:
- fixes #6570 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
