### PR TITLE
Store voxelytics log not by organization id but organization name

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added the config key `webKnossos.user.timeTrackingOnlyWithSignificantChanges`, which when set to `true` will only track time if the user has made significant changes to the annotation. [#7627](https://github.com/scalableminds/webknossos/pull/7627)
 - Only display UI elements to launch background jobs if the (worker) backend actually supports them. [#7591](https://github.com/scalableminds/webknossos/pull/7591)
 - If the current dataset folder in the dashboard cannot be found (e.g., because somebody else deleted it), the page navigates to the root folder automatically. [#7669](https://github.com/scalableminds/webknossos/pull/7669)
+- Voxelytics logs are now stored by organization name, rather than id, in Loki. This is inpreparation of the unificaction of these two concepts. [#7687](https://github.com/scalableminds/webknossos/pull/7687)
 
 ### Fixed
 - Fixed rare SIGBUS crashes of the datastore module that were caused by memory mapping on unstable file systems. [#7528](https://github.com/scalableminds/webknossos/pull/7528)

--- a/app/controllers/VoxelyticsController.scala
+++ b/app/controllers/VoxelyticsController.scala
@@ -250,7 +250,7 @@ class VoxelyticsController @Inject()(
         _ <- bool2Fox(wkConf.Features.voxelyticsEnabled) ?~> "voxelytics.disabled"
         organization <- organizationDAO.findOne(request.identity._organization)
         logEntries = request.body
-        _ <- lokiClient.bulkInsertBatched(logEntries, organization._id)
+        _ <- lokiClient.bulkInsertBatched(logEntries, organization.name)
       } yield Ok
     }
 
@@ -271,6 +271,7 @@ class VoxelyticsController @Inject()(
           logEntries <- lokiClient.queryLogsBatched(
             runName,
             organization._id,
+            organization.name,
             taskName,
             minLevel.flatMap(VoxelyticsLogLevel.fromString).getOrElse(VoxelyticsLogLevel.INFO),
             Instant(startTimestamp),

--- a/app/models/voxelytics/LokiClient.scala
+++ b/app/models/voxelytics/LokiClient.scala
@@ -157,7 +157,7 @@ class LokiClient @Inject()(wkConf: WkConf, rpc: RPC, val system: ActorSystem)(im
         Some(s"""level=~"(${levels.mkString("|")})"""")
       ).flatten.mkString(" | ")
       val logQL =
-        s"""{vx_run_name="$runName",wk_org="${organizationId.id}",wk_url="${wkConf.Http.uri}"} | json vx_task_name,level | $logQLFilter"""
+        s"""{vx_run_name="$runName",wk_org=~"${organizationId.id}|$organizationName",wk_url="${wkConf.Http.uri}"} | json vx_task_name,level | $logQLFilter"""
 
       val queryString =
         List("query" -> logQL,

--- a/test/backend/Zarr3TestSuite.scala
+++ b/test/backend/Zarr3TestSuite.scala
@@ -8,6 +8,7 @@ import com.scalableminds.webknossos.datastore.datareaders.zarr3.{
 import com.scalableminds.webknossos.datastore.datareaders.zarr3.Zarr3ArrayHeader.Zarr3ArrayHeaderFormat
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
+import spire.math.Number
 
 class Zarr3TestSuite extends PlaySpec {
 
@@ -32,9 +33,9 @@ class Zarr3TestSuite extends PlaySpec {
       "read correct basic header data" in {
         val header = Zarr3ArrayHeaderFormat.reads(zarr3json).get
         assert(header.shape.sameElements(Seq(64, 64, 64)))
-        assert(header.data_type.left.get == "uint8")
+        assert(header.data_type.left.getOrElse("notUint8") == "uint8")
         assert(header.zarr_format == 3)
-        assert(header.fill_value.right.get.intValue() == 0)
+        assert(header.fill_value.getOrElse(Number(1)).intValue() == 0)
         assert(header.dimension_names.get.sameElements(Seq("x", "y", "z")))
       }
 


### PR DESCRIPTION
- store voxelytics log not by organization id (soon to be dropped) but organization name (soon to be renamed to id)
- query by both (will be removed after one log retention period is over after deploying this)
- also slipped in here: fix deprecation warnings in zarr3testsuite

### Steps to test:
- ?
------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
