### PR TITLE
Assert correct dtype for segment index file

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,7 +34,8 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added the config key `webKnossos.user.timeTrackingOnlyWithSignificantChanges`, which when set to `true` will only track time if the user has made significant changes to the annotation. [#7627](https://github.com/scalableminds/webknossos/pull/7627)
 - Only display UI elements to launch background jobs if the (worker) backend actually supports them. [#7591](https://github.com/scalableminds/webknossos/pull/7591)
 - If the current dataset folder in the dashboard cannot be found (e.g., because somebody else deleted it), the page navigates to the root folder automatically. [#7669](https://github.com/scalableminds/webknossos/pull/7669)
-- Voxelytics logs are now stored by organization name, rather than id, in Loki. This is inpreparation of the unificaction of these two concepts. [#7687](https://github.com/scalableminds/webknossos/pull/7687)
+- Voxelytics logs are now stored by organization name, rather than id, in Loki. This is in preparation of the unification of these two concepts. [#7687](https://github.com/scalableminds/webknossos/pull/7687)
+- Using a segment index file with a different data type than uint16 will now result in an error. [#7698](https://github.com/scalableminds/webknossos/pull/7698)
 
 ### Fixed
 - Fixed rare SIGBUS crashes of the datastore module that were caused by memory mapping on unstable file systems. [#7528](https://github.com/scalableminds/webknossos/pull/7528)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
@@ -107,7 +107,7 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
         topLeftStart = buckets(bucketLocalOffset)(1)
         topLeftEnd = buckets(bucketLocalOffset)(2)
         _ <- Fox
-          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ~> ("dtype_bucket_entries not supported")
+          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ~> "dtype_bucket_entries not supported"
         topLefts = segmentIndex.reader
           .uint16()
           .readMatrixBlockWithOffset("top_lefts", (topLeftEnd - topLeftStart).toInt, 3, topLeftStart, 0)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
@@ -107,7 +107,7 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
         topLeftStart = buckets(bucketLocalOffset)(1)
         topLeftEnd = buckets(bucketLocalOffset)(2)
         _ <- Fox
-          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ~> "dtype_bucket_entries not supported"
+          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ?~> "dtype_bucket_entries not supported"
         topLefts = segmentIndex.reader
           .uint16()
           .readMatrixBlockWithOffset("top_lefts", (topLeftEnd - topLeftStart).toInt, 3, topLeftStart, 0)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
@@ -20,6 +20,7 @@ import com.scalableminds.webknossos.datastore.models.{
   datasource
 }
 import com.scalableminds.webknossos.datastore.storage.{AgglomerateFileKey, CachedHdf5File, Hdf5FileCache}
+import net.liftweb.common.Box.tryo
 import net.liftweb.common.{Box, Full}
 import play.api.i18n.MessagesProvider
 
@@ -106,8 +107,9 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
         _ <- Fox.successful(())
         topLeftStart = buckets(bucketLocalOffset)(1)
         topLeftEnd = buckets(bucketLocalOffset)(2)
+        bucketEntriesDtype <- tryo(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries")).toFox
         _ <- Fox
-          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ?~> "value for dtype_bucket_entries in segment index file is not supported, only uint16 is supported"
+          .bool2Fox(bucketEntriesDtype == "uint16") ?~> "value for dtype_bucket_entries in segment index file is not supported, only uint16 is supported"
         topLefts = segmentIndex.reader
           .uint16()
           .readMatrixBlockWithOffset("top_lefts", (topLeftEnd - topLeftStart).toInt, 3, topLeftStart, 0)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
@@ -106,8 +106,10 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
         _ <- Fox.successful(())
         topLeftStart = buckets(bucketLocalOffset)(1)
         topLeftEnd = buckets(bucketLocalOffset)(2)
+        _ <- Fox
+          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ~> ("dtype_bucket_entries not supported")
         topLefts = segmentIndex.reader
-          .uint16() // Read datatype from attributes?
+          .uint16()
           .readMatrixBlockWithOffset("top_lefts", (topLeftEnd - topLeftStart).toInt, 3, topLeftStart, 0)
       } yield topLefts)
     } yield topLeftOpts

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
@@ -107,7 +107,7 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
         topLeftStart = buckets(bucketLocalOffset)(1)
         topLeftEnd = buckets(bucketLocalOffset)(2)
         _ <- Fox
-          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ?~> "dtype_bucket_entries not supported"
+          .bool2Fox(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries") == "uint16") ?~> "value for dtype_bucket_entries in segment index file is not supported, only uint16 is supported"
         topLefts = segmentIndex.reader
           .uint16()
           .readMatrixBlockWithOffset("top_lefts", (topLeftEnd - topLeftStart).toInt, 3, topLeftStart, 0)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
Tested using the correct segment index file and a file edited with h5py.

### Issues:
- fixes #7666 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
