### PR TITLE
Fix antd "info color" and markdown editing issues

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -55,6 +55,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where the annotation list would show teams the annotation is shared with multiple times. [#7659](https://github.com/scalableminds/webknossos/pull/7659)
 - Fixed incorrect menu position that could occur sometimes when clicking the ... button next to a segment. [#7680](https://github.com/scalableminds/webknossos/pull/7680)
 - Fixed an error in the Loki integration to support Loki 2.9+. [#7684](https://github.com/scalableminds/webknossos/pull/7684)
+- Fixed inconsistent style of antd components and odd behavior of dataset/annotation description Markdown input. [#7700](https://github.com/scalableminds/webknossos/pull/7700)
 
 ### Removed
 - Removed the integration with BrainTracing user databases. [#7693](https://github.com/scalableminds/webknossos/pull/7693)

--- a/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
+++ b/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
@@ -73,7 +73,7 @@ export function MarkdownModal({
       <Row gutter={16}>
         <Col span={12}>
           <TextArea
-            value={source}
+            defaultValue={source}
             placeholder={placeholderText}
             onChange={onChange}
             rows={5}

--- a/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
+++ b/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
@@ -1,8 +1,7 @@
-import { Alert, Modal, Button, Row, Col } from "antd";
+import { Alert, Modal, Button, Row, Col, Input } from "antd";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import Markdown from "react-remarkable";
 import * as React from "react";
-import TextArea from "antd/lib/input/TextArea";
 
 function getFirstLine(comment: string) {
   const newLineIndex = comment.indexOf("\n");
@@ -72,7 +71,7 @@ export function MarkdownModal({
       />
       <Row gutter={16}>
         <Col span={12}>
-          <TextArea
+          <Input.TextArea
             defaultValue={source}
             placeholder={placeholderText}
             onChange={onChange}

--- a/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
+++ b/frontend/javascripts/oxalis/view/components/markdown_modal.tsx
@@ -29,13 +29,16 @@ export function MarkdownModal({
   onOk,
   onChange,
   label,
+  placeholder,
 }: {
   source: string;
   label: string;
   isOpen?: boolean;
+  placeholder?: string;
   onOk: () => void;
   onChange: React.ChangeEventHandler<HTMLTextAreaElement>;
 }) {
+  const placeholderText = placeholder ? placeholder : `Add ${label}`;
   return (
     <Modal
       key="comment-markdown-modal"
@@ -71,7 +74,7 @@ export function MarkdownModal({
         <Col span={12}>
           <TextArea
             value={source}
-            placeholder={`Add ${label}`}
+            placeholder={placeholderText}
             onChange={onChange}
             rows={5}
             autoSize={{

--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
@@ -497,7 +497,8 @@ export class DatasetInfoTabView extends React.PureComponent<Props, State> {
           </div>
           <MarkdownModal
             label="Annotation Description"
-            source={annotationDescription}
+            placeholder="[No description]"
+            source={this.props.annotation.description}
             isOpen={this.state.isMarkdownModalOpen}
             onOk={() => this.setState({ isMarkdownModalOpen: false })}
             onChange={this.setAnnotationDescription}

--- a/frontend/javascripts/theme.tsx
+++ b/frontend/javascripts/theme.tsx
@@ -47,6 +47,7 @@ export function getAntdTheme(userTheme: Theme) {
     colorPrimary: ColorWKBlue,
     colorLink: ColorWKBlue,
     colorLinkHover: ColorWKLinkHover,
+    colorInfo: ColorWKBlue,
     blue: ColorWKBlue,
     borderRadius: 4,
     fontFamily:


### PR DESCRIPTION
Small PR to fix 
- the ant design `info color`.
- and the annotation description text input have various issues

From the [antd docs](https://ant.design/components/alert#design-token):
<img width="1223" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/e5ea41cc-eba7-43d9-b5a1-81b4f165d69c">

### Before
![image](https://github.com/scalableminds/webknossos/assets/1105056/04e4c601-af9e-40d4-afa4-faf92835aed8)

### After
<img width="1659" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/fbcf3bb4-e2c7-4c6e-8e31-a7bd21fc6bdd">

## Testing
- Change a dataset description
- Change an annotation description. 
- In both scenarios: 
  - Cursor should not jump. 
  - Empty value should reset to `[no description]`. 
  - Completely empty textarea should be possible to start typing from "scratch".

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1710500598948909?thread_ts=1704808962.879799&cid=C5AKLAV0B
- Contributes to #6861 
- fixes #7699

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
