### PR TITLE
fix bug that user in url was not selected

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The time tracking api route `/api/users/:id/loggedTime`, which is used by the webknossos-libs client, and groups the times by month, now uses UTC when determining month limits, rather than the server’s local timezone. [#7524](https://github.com/scalableminds/webknossos/pull/7524)
 
 ### Fixed
+- Moving from the time tracking overview to its detail view, the selected user was not preselected in the next view. [#7722](https://github.com/scalableminds/webknossos/pull/7722)
 
 ### Removed
 


### PR DESCRIPTION
Bug: Clicked user in overview was not preselected in detail view. The reason seems to be that the data is fetched while the state is not yet updated.

### Steps to test:
- Go to time tracking overview and click details for a specific user
- make sure this user is selected in the detail view, in the dropdown 

### Issues:
- follow up for #7524 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
