### PR TITLE
Make color layers transparent if color value is out of range

### DIFF
--- a/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.ts
+++ b/frontend/javascripts/oxalis/geometries/materials/plane_material_factory.ts
@@ -264,8 +264,15 @@ class PlaneMaterialFactory {
       this.uniforms[`${name}_color`] = {
         value: DEFAULT_COLOR,
       };
+      this.uniforms[`${name}_min_lim`] = {
+        value: 0.0,
+      };
       this.uniforms[`${name}_min`] = {
         value: 0.0,
+      };
+
+      this.uniforms[`${name}_max_lim`] = {
+        value: 1.0,
       };
       this.uniforms[`${name}_max`] = {
         value: 1.0,
@@ -853,7 +860,8 @@ class PlaneMaterialFactory {
     elementClass: ElementClass,
     isSegmentationLayer: boolean,
   ): void {
-    const { alpha, intensityRange, isDisabled, isInverted, gammaCorrectionValue } = settings;
+    const { alpha, intensityRange, isDisabled, isInverted, gammaCorrectionValue, min, max } =
+      settings;
 
     // In UnsignedByte textures the byte values are scaled to [0, 1], in Float textures they are not
     if (!isSegmentationLayer) {
@@ -861,6 +869,10 @@ class PlaneMaterialFactory {
       if (intensityRange) {
         this.uniforms[`${name}_min`].value = intensityRange[0] / divisor;
         this.uniforms[`${name}_max`].value = intensityRange[1] / divisor;
+      }
+      if (min != null && max != null) {
+        this.uniforms[`${name}_min_lim`].value = min / divisor;
+        this.uniforms[`${name}_max_lim`].value = max / divisor;
       }
       this.uniforms[`${name}_is_inverted`].value = isInverted ? 1.0 : 0;
 

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -210,6 +210,7 @@ export function getDefaultValueRangeOfLayer(
   const minFloatValue = -3.40282347e38;
   // biome-ignore lint/correctness/noPrecisionLoss: This number literal will lose precision at runtime. The value at runtime will be inf.
   const maxDoubleValue = 1.79769313486232e308;
+  // biome-ignore lint/correctness/noPrecisionLoss: This number literal will lose precision at runtime. The value at runtime will be inf.
   const minDoubleValue = -1.79769313486232e308;
   const elementClass = getElementClass(dataset, layerName);
 

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -207,8 +207,10 @@ export function getDefaultValueRangeOfLayer(
   layerName: string,
 ): [number, number] {
   const maxFloatValue = 3.40282347e38;
+  const minFloatValue = -3.40282347e38;
   // biome-ignore lint/correctness/noPrecisionLoss: This number literal will lose precision at runtime. The value at runtime will be inf.
   const maxDoubleValue = 1.79769313486232e308;
+  const minDoubleValue = -1.79769313486232e308;
   const elementClass = getElementClass(dataset, layerName);
 
   switch (elementClass) {
@@ -237,10 +239,10 @@ export function getDefaultValueRangeOfLayer(
       return [0, 2 ** 63 - 1];
 
     case "float":
-      return [0, maxFloatValue];
+      return [minFloatValue, maxFloatValue];
 
     case "double":
-      return [0, maxDoubleValue];
+      return [minDoubleValue, maxDoubleValue];
 
     default:
       return [0, 255];

--- a/frontend/javascripts/oxalis/shaders/blending.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/blending.glsl.ts
@@ -19,7 +19,7 @@ export const getBlendLayersCover: ShaderModule = {
       vec4 current_color,
       vec4 layer_color,
       bool used_fallback_color,
-      bool is_color_out_of_bounds_any
+      float is_any_color_part_out_of_bounds
     ) {
       float mixed_alpha_factor = (1.0 - current_color.a) * layer_color.a;
       float mixed_alpha = mixed_alpha_factor + current_color.a;
@@ -29,7 +29,7 @@ export const getBlendLayersCover: ShaderModule = {
       vec4 cover_color = vec4(cover_color_rgb / (mixed_alpha + is_mixed_alpha_zero), mixed_alpha);
       cover_color = mix(cover_color, vec4(0.0), is_mixed_alpha_zero);
       // TODO: here also mix with whether outside of bounds
-      cover_color = mix(cover_color, vec4(0.0), float(is_color_out_of_bounds_any));
+      cover_color = mix(cover_color, vec4(0.0), is_any_color_part_out_of_bounds);
       // Do not overwrite current_color if the fallback color has been used.
       float is_current_color_valid = float(!used_fallback_color);
       cover_color = mix(current_color, cover_color, is_current_color_valid);

--- a/frontend/javascripts/oxalis/shaders/blending.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/blending.glsl.ts
@@ -14,11 +14,12 @@ export const getBlendLayersAdditive: ShaderModule = {
 export const getBlendLayersCover: ShaderModule = {
   code: `
     // Applying alpha blending to merge the layers where the top most layer has priority.
-    // See https://en.wikipedia.org/wiki/Alpha_compositing#Alpha_blending for details.
+    // See https://en.wikipedia.org/wiki/Alpha_compositing#Alpha_blending for details. 
     vec4 blendLayersCover(
       vec4 current_color,
       vec4 layer_color,
-      bool used_fallback_color
+      bool used_fallback_color,
+      bool is_color_out_of_bounds_any
     ) {
       float mixed_alpha_factor = (1.0 - current_color.a) * layer_color.a;
       float mixed_alpha = mixed_alpha_factor + current_color.a;
@@ -27,6 +28,8 @@ export const getBlendLayersCover: ShaderModule = {
       float is_mixed_alpha_zero = float(mixed_alpha == 0.0);
       vec4 cover_color = vec4(cover_color_rgb / (mixed_alpha + is_mixed_alpha_zero), mixed_alpha);
       cover_color = mix(cover_color, vec4(0.0), is_mixed_alpha_zero);
+      // TODO: here also mix with whether outside of bounds
+      cover_color = mix(cover_color, vec4(0.0), float(is_color_out_of_bounds_any));
       // Do not overwrite current_color if the fallback color has been used.
       float is_current_color_valid = float(!used_fallback_color);
       cover_color = mix(current_color, cover_color, is_current_color_valid);

--- a/frontend/javascripts/oxalis/shaders/main_data_shaders.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/main_data_shaders.glsl.ts
@@ -74,7 +74,9 @@ uniform highp uint LOOKUP_CUCKOO_TWIDTH;
 
 <% _.each(colorLayerNames, function(name) { %>
   uniform vec3 <%= name %>_color;
+  uniform float <%= name %>_min_lim;
   uniform float <%= name %>_min;
+  uniform float <%= name %>_max_lim;
   uniform float <%= name %>_max;
   uniform float <%= name %>_is_inverted;
 <% }) %>
@@ -234,11 +236,11 @@ void main() {
         <% } %>
 
         vec3 is_color_out_of_bounds = vec3(
-          color_value.r < <%= name %>_min || color_value.r > <%= name %>_max ? 1.0 : 0.0,
-          color_value.g < <%= name %>_min || color_value.g > <%= name %>_max ? 1.0 : 0.0,
-          color_value.b < <%= name %>_min || color_value.b > <%= name %>_max ? 1.0 : 0.0
+          color_value.r < <%= name %>_min_lim || color_value.r > <%= name %>_max_lim ? 1.0 : 0.0,
+          color_value.g < <%= name %>_min_lim || color_value.g > <%= name %>_max_lim ? 1.0 : 0.0,
+          color_value.b < <%= name %>_min_lim || color_value.b > <%= name %>_max_lim ? 1.0 : 0.0
         );
-        bool is_color_out_of_bounds_any = bool(is_color_out_of_bounds.x + is_color_out_of_bounds.y + is_color_out_of_bounds.z > 0.0);
+        float is_any_color_part_out_of_bounds = float(is_color_out_of_bounds.x + is_color_out_of_bounds.y + is_color_out_of_bounds.z > 0.0);
 
         // Keep the color in bounds of min and max
         color_value = clamp(color_value, <%= name %>_min, <%= name %>_max);
@@ -261,7 +263,7 @@ void main() {
         // Calculating the cover color for the current layer in case blendMode == 1.0.
         vec4 additive_color = blendLayersAdditive(data_color, layer_color);
         // Calculating the cover color for the current layer in case blendMode == 0.0.
-        vec4 cover_color = blendLayersCover(data_color, layer_color, used_fallback, is_color_out_of_bounds_any);
+        vec4 cover_color = blendLayersCover(data_color, layer_color, used_fallback, is_any_color_part_out_of_bounds);
         // Choose color depending on blendMode.
         data_color = mix(cover_color, additive_color, float(blendMode == 1.0));
       }

--- a/frontend/javascripts/oxalis/shaders/main_data_shaders.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/main_data_shaders.glsl.ts
@@ -232,6 +232,14 @@ void main() {
           // Workaround for 16-bit color layers
           color_value = vec3(color_value.g * 256.0 + color_value.r);
         <% } %>
+
+        vec3 is_color_out_of_bounds = vec3(
+          color_value.r < <%= name %>_min || color_value.r > <%= name %>_max ? 1.0 : 0.0,
+          color_value.g < <%= name %>_min || color_value.g > <%= name %>_max ? 1.0 : 0.0,
+          color_value.b < <%= name %>_min || color_value.b > <%= name %>_max ? 1.0 : 0.0
+        );
+        bool is_color_out_of_bounds_any = bool(is_color_out_of_bounds.x + is_color_out_of_bounds.y + is_color_out_of_bounds.z > 0.0);
+
         // Keep the color in bounds of min and max
         color_value = clamp(color_value, <%= name %>_min, <%= name %>_max);
         // Scale the color value according to the histogram settings.
@@ -253,7 +261,7 @@ void main() {
         // Calculating the cover color for the current layer in case blendMode == 1.0.
         vec4 additive_color = blendLayersAdditive(data_color, layer_color);
         // Calculating the cover color for the current layer in case blendMode == 0.0.
-        vec4 cover_color = blendLayersCover(data_color, layer_color, used_fallback);
+        vec4 cover_color = blendLayersCover(data_color, layer_color, used_fallback, is_color_out_of_bounds_any);
         // Choose color depending on blendMode.
         data_color = mix(cover_color, additive_color, float(blendMode == 1.0));
       }


### PR DESCRIPTION
This PR lets cover layers "shine / see through" for each voxel where the color value is out of the range configured as the histogram min and max bounds. This setting can be adjusted by the user and therefore this feature is independent of the exact color layer value range.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a dataset with multiple color layers. Preferably one with affine transformations.
- Turn on cover blend mode in the settings tab.
- In the layer settings adjust the min & max settings of the histogram (can be turned on via the menu in the top right corner of the histogram view)
- The lower color layers should now shine through the upper color layer

### Issues:
- No issue exists for this.

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
