### PR TITLE
Fix node picking regression

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that the Command modifier on MacOS wasn't treated correctly for some shortcuts. Also, instead of the Alt key, the ⌥ key is shown as a hint in the status bar on MacOS. [#7659](https://github.com/scalableminds/webknossos/pull/7659)
 - Moving from the time tracking overview to its detail view, the selected user was not preselected in the next view. [#7722](https://github.com/scalableminds/webknossos/pull/7722)
 - Fixed incorrect position of WEBKNOSSOS logo in screenshots. [#7726](https://github.com/scalableminds/webknossos/pull/7726)
+- Fixed that invisible nodes could be selected when using the skeleton tool. [#7732](https://github.com/scalableminds/webknossos/pull/7732)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/rendering_utils.ts
+++ b/frontend/javascripts/oxalis/view/rendering_utils.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { saveAs } from "file-saver";
 import Store from "oxalis/store";
-import { OrthoView } from "oxalis/constants";
+import { ARBITRARY_CAM_DISTANCE, OrthoView } from "oxalis/constants";
 import constants, {
   ArbitraryViewport,
   OrthoViewColors,
@@ -59,25 +59,28 @@ export function renderToTexture(
   // Don't respect withFarClipping for the TDViewport as we don't do any clipping for
   // nodes there.
   if (withFarClipping && plane !== OrthoViews.TDView) {
-    function adaptCameraToCurrentClippingDistance(
-      camera: THREE.OrthographicCamera | THREE.PerspectiveCamera,
-    ) {
+    function adaptCameraToCurrentClippingDistance<
+      T extends THREE.OrthographicCamera | THREE.PerspectiveCamera,
+    >(camera: T): T {
       const isArbitraryMode = constants.MODES_ARBITRARY.includes(
         state.temporaryConfiguration.viewMode,
       );
-      camera = camera.clone();
+      camera = camera.clone() as T;
+      // The near value is already set in the camera (done in the CameraController/ArbitraryView).
       if (isArbitraryMode) {
-        camera.far = state.userConfiguration.clippingDistanceArbitrary;
+        // The far value has to be set, since in normal rendering the far clipping is
+        // achieved by the data plane which is not rendered during node picking
+        camera.far = ARBITRARY_CAM_DISTANCE;
       } else {
-        // The near value is already set in the camera (done in the CameraController).
         // The far value has to be set, since in normal rendering the far clipping is
         // achieved by offsetting the plane instead of setting the far property.
         camera.far = state.userConfiguration.clippingDistance;
       }
       camera.updateProjectionMatrix();
+      return camera;
     }
 
-    adaptCameraToCurrentClippingDistance(camera);
+    camera = adaptCameraToCurrentClippingDistance(camera);
   }
 
   clearColor = clearColor != null ? clearColor : 0x000000;


### PR DESCRIPTION
The regression allowed to select nodes in orthogonal mode that were not visible.
Also, I fixed the far clipping distance for flight/oblique mode which allowed to select nodes that were not visible. In contrast to orthogonal mode, nodes that are clipping-distance-behind the plane cannot be seen in flight/oblique mode which needed to be done similarly during node picking.

### URL of deployed dev instance (used for testing):
- https://fixnodepickingregression.webknossos.xyz

### Steps to test:
- Set some nodes and move forward/backward until they cannot be seen any longer. You should not be able to select them. When moving so you can just about see them, you should be able to select them. Test in orthogonal and flight mode.

### Issues:
- fixes internal bug report
- contributes to https://github.com/scalableminds/webknossos/issues/7725

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
