### PR TITLE
Add text in case no data is shown in timetracking overview

### DIFF
--- a/frontend/javascripts/admin/statistic/time_tracking_overview.tsx
+++ b/frontend/javascripts/admin/statistic/time_tracking_overview.tsx
@@ -113,6 +113,15 @@ function TimeTrackingOverview() {
     { label: "Last 30 Days", value: [dayjs().subtract(30, "d").startOf("day"), currentTime] },
   ];
 
+  const renderPlaceholder = () => {
+    return (
+      <p>
+        There is no user activity recorded for the selected time span. Please adjust the time
+        settings and filters above.
+      </p>
+    );
+  };
+
   return mayUserAccessView ? (
     <Card
       title={"Annotation Time per User"}
@@ -169,6 +178,9 @@ function TimeTrackingOverview() {
             marginBottom: 30,
           }}
           pagination={false}
+          locale={{
+            emptyText: renderPlaceholder(),
+          }}
         >
           <Column
             title="User"


### PR DESCRIPTION
### Steps to test:
- Go to time tracking overview and select a range/filters without any tracked times.
- Make sure an appropriate text is displayed, rather than "no data"

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Removed dev-only changes like prints and application.conf edits
