### PR TITLE
Added type definitions for @scalableminds/prop-types

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Creating and deleting edges is now possible with ctrl+(alt/shift)+leftclick in orthogonal, flight and oblique mode. Also, the flight and oblique modes allow selecting nodes with leftclick, creating new trees with 'c' and deleting the active node with 'del'. [#7678](https://github.com/scalableminds/webknossos/pull/7678)
+- Added Typescript defintions for @scalableminds/prop-types package. [#7744](https://github.com/scalableminds/webknossos/pull/7744)
 
 ### Changed
 - Improved task list to sort tasks by project date, add option to expand all tasks at once and improve styling. [#7709](https://github.com/scalableminds/webknossos/pull/7709)

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -1,5 +1,4 @@
 import _ from "lodash";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { confirmAsync } from "dashboard/dataset/helper_components";
 import { Link } from "react-router-dom";

--- a/frontend/javascripts/admin/project/project_list_view.tsx
+++ b/frontend/javascripts/admin/project/project_list_view.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Table, Spin, Button, Input, Tooltip, App } from "antd";
 import {

--- a/frontend/javascripts/admin/scripts/script_list_view.tsx
+++ b/frontend/javascripts/admin/scripts/script_list_view.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Table, Spin, Button, Input, App } from "antd";
 import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Table, Tag, Spin, Button, Input, Modal, Card, Alert, App } from "antd";
 import {

--- a/frontend/javascripts/admin/task/task_search_form.tsx
+++ b/frontend/javascripts/admin/task/task_search_form.tsx
@@ -1,6 +1,5 @@
 import { Form, Row, Dropdown, Col, Button, Input, Select } from "antd";
 import { DownloadOutlined, DownOutlined, RetweetOutlined } from "@ant-design/icons";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import React, { useEffect, useState } from "react";
 import _ from "lodash";

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Table, Tag, Spin, Button, Input, App } from "antd";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message

--- a/frontend/javascripts/admin/team/team_list_view.tsx
+++ b/frontend/javascripts/admin/team/team_list_view.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Table, Spin, Button, Input, Alert, Tag, App } from "antd";
 import { DeleteOutlined, PlusOutlined, UserOutlined } from "@ant-design/icons";

--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -1,6 +1,5 @@
 import type { RouteComponentProps } from "react-router-dom";
 import { Link } from "react-router-dom";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Table, Tag, Spin, Button, Input, Modal, Alert, Row, Col, Tooltip, App } from "antd";
 import {

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -10,7 +10,6 @@ import {
   UserAddOutlined,
 } from "@ant-design/icons";
 import { Link } from "react-router-dom";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { connect } from "react-redux";
 // @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'reac... Remove this comment to see the full error message

--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -23,7 +23,6 @@ import {
   HourglassOutlined,
   SearchOutlined,
 } from "@ant-design/icons";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import type { APIJob, APIDatasetCompact, APIUser, FolderItem } from "types/api_flow_types";
 import DatasetTable from "dashboard/advanced_dataset/dataset_table";

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import { Spin, Input, Table, Button, Modal, Tooltip, Tag, Row, Col, Card } from "antd";
 import {

--- a/frontend/javascripts/libs/persistence.ts
+++ b/frontend/javascripts/libs/persistence.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module '@sca... Remove this comment to see the full error message
 import { PropTypes } from "@scalableminds/prop-types";
 import _ from "lodash";
 import ErrorHandling from "libs/error_handling";

--- a/frontend/javascripts/types/prop-types.d.ts
+++ b/frontend/javascripts/types/prop-types.d.ts
@@ -1,0 +1,148 @@
+// Adapted from https://github.com/DefinitelyTyped/DefinitelyTyped
+// License: MIT
+// Source: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/prop-types/index.d.ts
+
+declare module "@scalableminds/prop-types" {
+    
+  export type ReactComponentLike =
+    | string
+    | ((props: any, context?: any) => any)
+    | (new (
+        props: any,
+        context?: any,
+      ) => any);
+
+  export interface ReactElementLike {
+    type: ReactComponentLike;
+    props: any;
+    key: string | null;
+  }
+
+  export interface ReactNodeArray extends Iterable<ReactNodeLike> {}
+
+  export type ReactNodeLike =
+    | ReactElementLike
+    | ReactNodeArray
+    | string
+    | number
+    | boolean
+    | null
+    | undefined;
+
+  export const nominalTypeHack: unique symbol;
+
+  export type IsOptional<T> = undefined extends T ? true : false;
+
+  export type RequiredKeys<V> = {
+    [K in keyof V]-?: Exclude<V[K], undefined> extends Validator<infer T>
+      ? IsOptional<T> extends true
+        ? never
+        : K
+      : never;
+  }[keyof V];
+  export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
+  export type InferPropsInner<V> = { [K in keyof V]-?: InferType<V[K]> };
+
+  export interface Validator<T> {
+    (
+      props: { [key: string]: any },
+      propName: string,
+      componentName: string,
+      location: string,
+      propFullName: string,
+    ): Error | null;
+    [nominalTypeHack]?:
+      | {
+          type: T;
+        }
+      | undefined;
+  }
+
+  export interface Requireable<T> extends Validator<T | undefined | null> {
+    isRequired: Validator<NonNullable<T>>;
+  }
+
+  export type ValidationMap<T> = { [K in keyof T]?: Validator<T[K]> };
+
+  /**
+   * Like {@link ValidationMap} but treats `undefined`, `null` and optional properties the same.
+   * This type is only added as a migration path in React 19 where this type was removed from React.
+   * Runtime and compile time types would mismatch since you could see `undefined` at runtime when your types don't expect this type.
+   */
+  export type WeakValidationMap<T> = {
+    [K in keyof T]?: null extends T[K]
+      ? Validator<T[K] | null | undefined>
+      : undefined extends T[K]
+        ? Validator<T[K] | null | undefined>
+        : Validator<T[K]>;
+  };
+
+  export type InferType<V> = V extends Validator<infer T> ? T : any;
+  export type InferProps<V> = InferPropsInner<Pick<V, RequiredKeys<V>>> &
+    Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
+
+  const any: Requireable<any>;
+  const array: Requireable<any[]>;
+  const bool: Requireable<boolean>;
+  const func: Requireable<(...args: any[]) => any>;
+  const number: Requireable<number>;
+  const object: Requireable<object>;
+  const string: Requireable<string>;
+  const node: Requireable<ReactNodeLike>;
+  const element: Requireable<ReactElementLike>;
+  const symbol: Requireable<symbol>;
+  const elementType: Requireable<ReactComponentLike>;
+  function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
+  function oneOf<T>(types: readonly T[]): Requireable<T>;
+  function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
+  function arrayOf<T>(type: Validator<T>): Requireable<T[]>;
+  function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T }>;
+  function shape<P extends ValidationMap<any>>(type: P): Requireable<InferProps<P>>;
+  function exact<P extends ValidationMap<any>>(type: P): Requireable<Required<InferProps<P>>>;
+
+  /**
+   * Assert that the values match with the type specs.
+   * Error messages are memorized and will only be shown once.
+   *
+   * @param typeSpecs Map of name to a ReactPropType
+   * @param values Runtime values that need to be type-checked
+   * @param location e.g. "prop", "context", "child context"
+   * @param componentName Name of the component for error messages
+   * @param getStack Returns the component stack
+   */
+  export function checkPropTypes(
+    typeSpecs: any,
+    values: any,
+    location: string,
+    componentName: string,
+    getStack?: () => any,
+  ): void;
+
+  /**
+   * Only available if NODE_ENV=production
+   */
+  export function resetWarningCache(): void;
+
+  export const PropTypes = {
+    any,
+    array,
+    bool,
+    func,
+    number,
+    object,
+    string,
+    node,
+    element,
+    symbol,
+    elementType,
+    instanceOf,
+    oneOf,
+    oneOfType,
+    arrayOf,
+    objectOf,
+    shape,
+    exact,
+    checkPropTypes,
+    resetWarningCache,
+  };
+}


### PR DESCRIPTION
I added the Typescript types definitions for the `@scalableminds/prop-types` package. Since we forked the package, we can not just install `@types/prop-types`. Therefore, I copied the type definition (MIT license) and adjusted them to fit out package structure.

### Steps to test:
- Run typechecker

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
