### PR TITLE
Fix position of context menu in layer settings for layers with long names

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,7 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that invisible nodes could be selected when using the skeleton tool. [#7732](https://github.com/scalableminds/webknossos/pull/7732)
 - Fixed a bug where users that have no team memberships were omitted from the user list. [#7721](https://github.com/scalableminds/webknossos/pull/7721)
 - Added an appropriate placeholder to be rendered in case the timetracking overview is otherwise empty. [#7736](https://github.com/scalableminds/webknossos/pull/7736)
-- The context menu for a layer with a long name can now be opened comfortably. [#7747](https://github.com/scalableminds/webknossos/pull/7747)
+- The overflow menu in the layer settings tab for layers with long names can now be opened comfortably. [#7747](https://github.com/scalableminds/webknossos/pull/7747)
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,6 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that invisible nodes could be selected when using the skeleton tool. [#7732](https://github.com/scalableminds/webknossos/pull/7732)
 - Fixed a bug where users that have no team memberships were omitted from the user list. [#7721](https://github.com/scalableminds/webknossos/pull/7721)
 - Added an appropriate placeholder to be rendered in case the timetracking overview is otherwise empty. [#7736](https://github.com/scalableminds/webknossos/pull/7736)
+- The context menu for a layer with a long name can now be opened comfortably. [#77xx]()
 
 ### Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -29,7 +29,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that invisible nodes could be selected when using the skeleton tool. [#7732](https://github.com/scalableminds/webknossos/pull/7732)
 - Fixed a bug where users that have no team memberships were omitted from the user list. [#7721](https://github.com/scalableminds/webknossos/pull/7721)
 - Added an appropriate placeholder to be rendered in case the timetracking overview is otherwise empty. [#7736](https://github.com/scalableminds/webknossos/pull/7736)
-- The context menu for a layer with a long name can now be opened comfortably. [#77xx]()
+- The context menu for a layer with a long name can now be opened comfortably. [#7747](https://github.com/scalableminds/webknossos/pull/7747)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -816,13 +816,13 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
             {isColorLayer ? null : this.getOptionalDownsampleVolumeIcon(maybeVolumeTracing)}
           </div>
         </div>
-        <Dropdown menu={{ items }} trigger={["hover"]} placement="bottomRight">
-          <div className="flex-container" style={{ cursor: "pointer" }}>
-            <div className="flex-item">
+        <div className="flex-container" style={{ cursor: "pointer" }}>
+          <div className="flex-item">
+            <Dropdown menu={{ items }} trigger={["hover"]} placement="bottomRight">
               <EllipsisOutlined />
-            </div>
+            </Dropdown>
           </div>
-        </Dropdown>
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
### Steps to test:
- Open annotation, create new layer with a very long name
- open the context menu for said layer

### Issues:
- fixes this: https://scm.slack.com/archives/C5AKLAV0B/p1712602844542619

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
