### PR TITLE
Revive segment index migration route

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -156,7 +156,7 @@ class AnnotationLayerDAO @Inject()(SQLClient: SqlClient)(implicit ec: ExecutionC
   def findAllVolumeLayers: Fox[List[AnnotationLayer]] =
     for {
       rows <- run(
-        q"select _annotation, tracingId, typ, name from webknossos.annotation_layers where typ = 'Volume'"
+        q"select _annotation, tracingId, typ, name, statistics from webknossos.annotation_layers where typ = 'Volume'"
           .as[AnnotationLayersRow])
       parsed <- Fox.serialCombined(rows.toList)(parse)
     } yield parsed

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -922,9 +922,10 @@ class VolumeTracingService @Inject()(
   def checkIfSegmentIndexMayBeAdded(tracingId: String, tracing: VolumeTracing, userToken: Option[String])(
       implicit ec: ExecutionContext): Fox[Boolean] =
     for {
-      fallbackLayer <- remoteFallbackLayerFromVolumeTracing(tracing, tracingId)
+      fallbackLayerOpt <- Fox.runIf(tracing.fallbackLayer.isDefined)(
+        remoteFallbackLayerFromVolumeTracing(tracing, tracingId))
       canHaveSegmentIndex <- VolumeSegmentIndexService.canHaveSegmentIndex(remoteDatastoreClient,
-                                                                           Some(fallbackLayer),
+                                                                           fallbackLayerOpt,
                                                                            userToken)
       alreadyHasSegmentIndex = tracing.hasSegmentIndex.getOrElse(false)
     } yield canHaveSegmentIndex && !alreadyHasSegmentIndex


### PR DESCRIPTION
### Steps to test:
- Import volume tracings with no segment index data into your fossilDB
- call `curl -X PATCH "http://localhost:9000/api/annotations/addSegmentIndicesToAll?parallelBatchCount=1&dryRun=false" -H 'X-Auth-Token: secretSampleUserToken'`
- Logging should show success, segment stats features should be available for the 