### PR TITLE
Fix reading CompressedSegmentation with uint32 data

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where users that have no team memberships were omitted from the user list. [#7721](https://github.com/scalableminds/webknossos/pull/7721)
 - Added an appropriate placeholder to be rendered in case the timetracking overview is otherwise empty. [#7736](https://github.com/scalableminds/webknossos/pull/7736)
 - The overflow menu in the layer settings tab for layers with long names can now be opened comfortably. [#7747](https://github.com/scalableminds/webknossos/pull/7747)
+- Fixed a bug where segmentation data looked scrambled when reading uint32 segmentation layers with CompressedSegmentation codec. [#7757](https://github.com/scalableminds/webknossos/pull/7757)
 
 ### Removed
 

--- a/util/src/main/scala/com/scalableminds/util/tools/ByteUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/ByteUtils.scala
@@ -20,4 +20,19 @@ trait ByteUtils {
     }
     result.reverse
   }
+
+  /**
+    *
+    * @param i a 32 bit number
+    * @return i as array of 8 bytes, little endian
+    */
+  def intToBytes(i: Int): Array[Byte] = {
+    var w = i
+    val result = new Array[Byte](4)
+    for (i <- 3 to 0 by -1) {
+      result(i) = (w & 0xFF).toByte
+      w >>= 4
+    }
+    result.reverse
+  }
 }


### PR DESCRIPTION
The old code padded every 32-bit output value with another 32 zeroes due to the to-long conversion.

As mentioned in https://github.com/scalableminds/webknossos/pull/6947 we didn’t have a uint32 test dataset yet when implementing this.

I also removed some superfluous parentheses.

### Steps to test:
- Import neuroglancer precomputed dataset with compressed uint32 segmentation, e.g. from https://scm.slack.com/archives/C5AKLAV0B/p1713253591614229
- Segmentation should look plausible

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
