### PR TITLE
Fix volume annotation downsampling

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added an appropriate placeholder to be rendered in case the timetracking overview is otherwise empty. [#7736](https://github.com/scalableminds/webknossos/pull/7736)
 - The overflow menu in the layer settings tab for layers with long names can now be opened comfortably. [#7747](https://github.com/scalableminds/webknossos/pull/7747)
 - Fixed a bug where segmentation data looked scrambled when reading uint32 segmentation layers with CompressedSegmentation codec. [#7757](https://github.com/scalableminds/webknossos/pull/7757)
+- Fixed a bug when downsampling a volume annotation that previously had only a restricted magnification set. [#7759](https://github.com/scalableminds/webknossos/pull/7759)
 
 ### Removed
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingDownsampling.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingDownsampling.scala
@@ -104,7 +104,7 @@ trait VolumeTracingDownsampling
                              dataLayer)
         requiredMag
       }
-      fallbackLayer <- tracingService.getFallbackLayer(tracingId)
+      fallbackLayer <- tracingService.getFallbackLayer(oldTracingId) // remote wk does not know the new id yet
       tracing <- tracingService.find(tracingId) ?~> "tracing.notFound"
       segmentIndexBuffer = new VolumeSegmentIndexBuffer(tracingId,
                                                         volumeSegmentIndexClient,


### PR DESCRIPTION
getFallbackLayer queries the dataset info from wk by the tracingId. But since downsampling is part of the duplicate route, the new tracingId is not yet known by the wk side. However, the fallback layer should not change in the duplicate, so using the old id is valid.

### Steps to test:
- Create volume annotation with resolution restriction, brush some (multiple sections)
- Hit downsample button in the sidebar, confirm
- Should work, yield valid annotation

### Issues:
- fixes #7758

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
