### PR TITLE
Fix timespan summing for annotations due to annotationLayer join

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - In the time tracking view, all annotations and tasks can be shown for each user by expanding the table. The individual time spans spent with a task or annotating an explorative annotation can be accessed via CSV export. The detail view including a chart for the individual spans has been removed. [#7733](https://github.com/scalableminds/webknossos/pull/7733)
 
 ### Fixed
+- Fixed a bug where some annotation times would be shown double. [#7787](https://github.com/scalableminds/webknossos/pull/7787)
 
 ### Removed
 


### PR DESCRIPTION
Joining in the annotation layers created duplicate entries for annotations with multiple layers (most of them). This would result in their timespans being counted twice for the SUM.

Extracting this into a WITH statement fixes that.

### URL of deployed dev instance (used for testing):
- https://timetrackingfixjoin.webknossos.xyz

### Steps to test:
- Create some annotations, trace some
- Timetracking should show sensible values (user sum should be sum of user annotations)

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1715064386815799?thread_ts=1715010849.424359&cid=C5AKLAV0B

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
