### PR TITLE
Timetracking Overview Improvements

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Within the proofreading tool, the user can now interact with the super voxels of a mesh in the 3D viewport. For example, this allows to merge or cut super voxels from another. As before, the proofreading tool requires an agglomerate file. [#7742](https://github.com/scalableminds/webknossos/pull/7742)
+- Minor improvements for the timetracking overview (faster data loding, styling). [#7789](https://github.com/scalableminds/webknossos/pull/7789)
 
 ### Changed
 - Non-admin or -manager users can no longer start long-running jobs that create datasets. This includes annotation materialization and AI inferrals. [#7753](https://github.com/scalableminds/webknossos/pull/7753)

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -51,8 +51,8 @@ class TimeController @Inject()(userService: UserService,
                                     start: Long,
                                     end: Long,
                                     annotationTypes: String,
-                                    projectIds: Option[String],
-                                    annotationStates: String): Action[AnyContent] = sil.SecuredAction.async {
+                                    annotationStates: String,
+                                    projectIds: Option[String]): Action[AnyContent] = sil.SecuredAction.async {
     implicit request =>
       for {
         userIdValidated <- ObjectId.fromString(userId)
@@ -75,8 +75,8 @@ class TimeController @Inject()(userService: UserService,
                       start: Long,
                       end: Long,
                       annotationTypes: String,
-                      projectIds: Option[String],
-                      annotationStates: String): Action[AnyContent] =
+                      annotationStates: String,
+                      projectIds: Option[String]): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {
         userIdValidated <- ObjectId.fromString(userId)
@@ -98,9 +98,9 @@ class TimeController @Inject()(userService: UserService,
   def timeOverview(start: Long,
                    end: Long,
                    annotationTypes: String,
+                   annotationStates: String,
                    teamIds: Option[String],
-                   projectIds: Option[String],
-                   annotationStates: String): Action[AnyContent] =
+                   projectIds: Option[String]): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {
         teamIdsValidated <- ObjectId.fromCommaSeparated(teamIds) ?~> "invalidTeamId"

--- a/app/models/user/time/TimeSpan.scala
+++ b/app/models/user/time/TimeSpan.scala
@@ -3,6 +3,7 @@ package models.user.time
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables._
+import models.annotation.AnnotationState.AnnotationState
 import models.annotation.AnnotationType.AnnotationType
 import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import slick.lifted.Rep
@@ -73,6 +74,7 @@ class TimeSpanDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
                                 start: Instant,
                                 end: Instant,
                                 annotationTypes: List[AnnotationType],
+                                annotationStates: List[AnnotationState],
                                 projectIds: List[ObjectId]): Fox[JsValue] =
     if (annotationTypes.isEmpty) Fox.successful(Json.arr())
     else {
@@ -98,6 +100,7 @@ class TimeSpanDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
           AND ts.created < $end
           AND $projectQuery
           AND a.typ IN ${SqlToken.tupleFromList(annotationTypes)}
+          AND a.state IN ${SqlToken.tupleFromList(annotationStates)}
           GROUP BY a._id, t._id, p.name
           ORDER BY a._id
          """.as[(String, Option[String], Option[String], Long, String)]
@@ -119,6 +122,7 @@ class TimeSpanDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
                             start: Instant,
                             end: Instant,
                             annotationTypes: List[AnnotationType],
+                            annotationStates: List[AnnotationState],
                             projectIds: List[ObjectId]): Fox[JsValue] =
     if (annotationTypes.isEmpty) Fox.successful(Json.arr())
     else {
@@ -141,6 +145,7 @@ class TimeSpanDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
                         AND ts.created < $end
                         AND $projectQuery
                         AND a.typ IN ${SqlToken.tupleFromList(annotationTypes)}
+                        AND a.state IN ${SqlToken.tupleFromList(annotationStates)}
             """.as[(String,
                     String,
                     String,
@@ -192,6 +197,7 @@ class TimeSpanDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
                    end: Instant,
                    users: List[ObjectId],
                    annotationTypes: List[AnnotationType],
+                   annotationStates: List[AnnotationState],
                    projectIds: List[ObjectId]): Fox[List[JsObject]] =
     if (users.isEmpty || annotationTypes.isEmpty) Fox.successful(List.empty)
     else {
@@ -208,6 +214,7 @@ class TimeSpanDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
           WHERE $projectQuery
           AND u._id IN ${SqlToken.tupleFromList(users)}
           AND a.typ IN ${SqlToken.tupleFromList(annotationTypes)}
+          AND a.state IN ${SqlToken.tupleFromList(annotationStates)}
           AND ts.time > 0
           AND ts.created >= $start
           AND ts.created < $end

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -78,7 +78,7 @@ pekko.actor.default-dispatcher {
 webKnossos {
   tabTitle = "WEBKNOSSOS"
   user {
-    timeTrackingPause = 10 seconds
+    timeTrackingPause = 60 seconds
     timeTrackingOnlyWithSignificantChanges = false
     inviteExpiry = 14 days
     ssoKey = ""

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -78,7 +78,7 @@ pekko.actor.default-dispatcher {
 webKnossos {
   tabTitle = "WEBKNOSSOS"
   user {
-    timeTrackingPause = 60 seconds
+    timeTrackingPause = 10 seconds
     timeTrackingOnlyWithSignificantChanges = false
     inviteExpiry = 14 days
     ssoKey = ""

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -250,9 +250,9 @@ GET           /termsOfService/acceptanceNeeded                                  
 
 # Time Tracking
 # Note, there is also /users/:id/loggedTime
-GET           /time/user/:userId/spans                                                          controllers.TimeController.timeSpansOfUser(userId: String, start: Long, end: Long, annotationTypes: String, projectIds: Option[String])
-GET           /time/user/:userId/summedByAnnotation                                             controllers.TimeController.timeSummedByAnnotationForUser(userId: String, start: Long, end: Long, annotationTypes: String, projectIds: Option[String])
-GET           /time/overview                                                                    controllers.TimeController.timeOverview(start: Long, end: Long, annotationTypes: String, teamIds: Option[String], projectIds: Option[String])
+GET           /time/user/:userId/spans                                                          controllers.TimeController.timeSpansOfUser(userId: String, start: Long, end: Long, annotationTypes: String, projectIds: Option[String], annotationStates: String)
+GET           /time/user/:userId/summedByAnnotation                                             controllers.TimeController.timeSummedByAnnotationForUser(userId: String, start: Long, end: Long, annotationTypes: String, projectIds: Option[String], annotationStates: String)
+GET           /time/overview                                                                    controllers.TimeController.timeOverview(start: Long, end: Long, annotationTypes: String, teamIds: Option[String], projectIds: Option[String], annotationStates: String)
 
 # Long-Running Jobs
 GET           /jobs/request                                                                     controllers.WKRemoteWorkerController.requestJobs(key: String)

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -250,9 +250,9 @@ GET           /termsOfService/acceptanceNeeded                                  
 
 # Time Tracking
 # Note, there is also /users/:id/loggedTime
-GET           /time/user/:userId/spans                                                          controllers.TimeController.timeSpansOfUser(userId: String, start: Long, end: Long, annotationTypes: String, projectIds: Option[String], annotationStates: String)
-GET           /time/user/:userId/summedByAnnotation                                             controllers.TimeController.timeSummedByAnnotationForUser(userId: String, start: Long, end: Long, annotationTypes: String, projectIds: Option[String], annotationStates: String)
-GET           /time/overview                                                                    controllers.TimeController.timeOverview(start: Long, end: Long, annotationTypes: String, teamIds: Option[String], projectIds: Option[String], annotationStates: String)
+GET           /time/user/:userId/spans                                                          controllers.TimeController.timeSpansOfUser(userId: String, start: Long, end: Long, annotationTypes: String, annotationStates: String, projectIds: Option[String])
+GET           /time/user/:userId/summedByAnnotation                                             controllers.TimeController.timeSummedByAnnotationForUser(userId: String, start: Long, end: Long, annotationTypes: String, annotationStates: String, projectIds: Option[String])
+GET           /time/overview                                                                    controllers.TimeController.timeOverview(start: Long, end: Long, annotationTypes: String, annotationStates: String, teamIds: Option[String], projectIds: Option[String])
 
 # Long-Running Jobs
 GET           /jobs/request                                                                     controllers.WKRemoteWorkerController.requestJobs(key: String)

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -2016,6 +2016,7 @@ export async function getTimeTrackingForUserSummedPerAnnotation(
   if (annotationTypes != null) params.append("annotationTypes", annotationTypes);
   if (projectIds != null && projectIds.length > 0)
     params.append("projectIds", projectIds.join(","));
+  params.append("annotationStates", "Active,Finished");
   const timeTrackingData = await Request.receiveJSON(
     `/api/time/user/${userId}/summedByAnnotation?${params}`,
   );
@@ -2037,6 +2038,7 @@ export async function getTimeTrackingForUserSpans(
   if (annotationTypes != null) params.append("annotationTypes", annotationTypes);
   if (projectIds != null && projectIds.length > 0)
     params.append("projectIds", projectIds.join(","));
+  params.append("annotationStates", "Active,Finished");
   return await Request.receiveJSON(`/api/time/user/${userId}/spans?${params}`);
 }
 
@@ -2055,6 +2057,7 @@ export async function getTimeEntries(
   // Omit empty parameters in request
   if (projectIds.length > 0) params.append("projectIds", projectIds.join(","));
   if (teamIds.length > 0) params.append("teamIds", teamIds.join(","));
+  params.append("annotationStates", "Active,Finished");
   return await Request.receiveJSON(`api/time/overview?${params}`);
 }
 

--- a/frontend/javascripts/admin/statistic/project_and_annotation_type_dropdown.tsx
+++ b/frontend/javascripts/admin/statistic/project_and_annotation_type_dropdown.tsx
@@ -106,6 +106,7 @@ function ProjectAndAnnotationTypeDropdown({
       placeholder="Filter type or projects"
       style={style}
       options={filterOptions}
+      optionFilterProp="label"
       value={selectedFilters}
       onDeselect={(removedKey: string) => onDeselect(removedKey)}
       onSelect={(newSelection: string) => setSelectedProjects(selectedFilters, newSelection)}

--- a/frontend/javascripts/admin/statistic/time_tracking_detail_view.tsx
+++ b/frontend/javascripts/admin/statistic/time_tracking_detail_view.tsx
@@ -17,8 +17,8 @@ type TimeTrackingDetailViewProps = {
   projectIds: string[];
 };
 
-const ANNOTATION_OR_TASK_NAME_SPAN = 12;
-const STATISTICS_SPAN = 8;
+const ANNOTATION_OR_TASK_NAME_SPAN = 16;
+const STATISTICS_SPAN = 4;
 const TIMESPAN_SPAN = 4;
 
 const STYLING_CLASS_NAME = "time-tracking-details";
@@ -38,7 +38,7 @@ const renderRow = (
           <Col span={ANNOTATION_OR_TASK_NAME_SPAN}>
             <a href={`annotations/${timeEntry.annotation}`}>Annotation: {timeEntry.annotation} </a>
           </Col>
-          <Col span={STATISTICS_SPAN}>
+          <Col span={STATISTICS_SPAN} style={{textAlign: "left"}}>
             <AnnotationStats
               stats={aggregateStatsForAllLayers(timeEntry.annotationLayerStats)}
               asInfoBlock={false}

--- a/frontend/javascripts/admin/statistic/time_tracking_detail_view.tsx
+++ b/frontend/javascripts/admin/statistic/time_tracking_detail_view.tsx
@@ -38,7 +38,7 @@ const renderRow = (
           <Col span={ANNOTATION_OR_TASK_NAME_SPAN}>
             <a href={`annotations/${timeEntry.annotation}`}>Annotation: {timeEntry.annotation} </a>
           </Col>
-          <Col span={STATISTICS_SPAN} style={{ textAlign: "left" }}>
+          <Col span={STATISTICS_SPAN}>
             <AnnotationStats
               stats={aggregateStatsForAllLayers(timeEntry.annotationLayerStats)}
               asInfoBlock={false}

--- a/frontend/javascripts/admin/statistic/time_tracking_detail_view.tsx
+++ b/frontend/javascripts/admin/statistic/time_tracking_detail_view.tsx
@@ -38,7 +38,7 @@ const renderRow = (
           <Col span={ANNOTATION_OR_TASK_NAME_SPAN}>
             <a href={`annotations/${timeEntry.annotation}`}>Annotation: {timeEntry.annotation} </a>
           </Col>
-          <Col span={STATISTICS_SPAN} style={{textAlign: "left"}}>
+          <Col span={STATISTICS_SPAN} style={{ textAlign: "left" }}>
             <AnnotationStats
               stats={aggregateStatsForAllLayers(timeEntry.annotationLayerStats)}
               asInfoBlock={false}

--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
@@ -212,7 +212,7 @@ export function AnnotationStats({
   const formatLabel = (str: string) => (asInfoBlock ? str : "");
   const useStyleWithMargin = withMargin != null ? withMargin : true;
   const styleWithLargeMarginBottom = { marginBottom: 14 };
-  const styleWithSmallMargin = { margin: "2px auto" };
+  const styleWithSmallMargin = { margin: 2 };
 
   return (
     <div


### PR DESCRIPTION
Contributes to #7788 by fixing
 - left-aligned annotation stats in table
 - faster sql query for time summed by annotation (on a production database with 6M annotations: before: 7000ms, after: 100ms)
 - prepares backend to filter by annotation state
 - search in dropdown by typing project name instead of id

Not included for now:
 - frontend for filtering by annotation state
 - include annotation state in csv and displayed table

### URL of deployed dev instance (used for testing):
- https://timetrackingfilterbyannotationstate.webknossos.xyz

### Steps to test:
- Annotate some, open timetracking page, expand user entries, should be fast, look pretty even for annotations with many trees.

### Issues:
- contributes to #7788

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
webknossos/webknossos/client) if relevant API parts change
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
