### PR TITLE
Assert unique volume layer names when parsing NML

### DIFF
--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -2,6 +2,7 @@ package models.annotation.nml
 
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
 import com.scalableminds.util.tools.ExtendedTypes.{ExtendedDouble, ExtendedString}
+import com.scalableminds.util.tools.JsonHelper.bool2Box
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.SkeletonTracing._
 import com.scalableminds.webknossos.datastore.VolumeTracing.{Segment, SegmentGroup, VolumeTracing}
@@ -68,6 +69,8 @@ object NmlParser extends LazyLogging with ProtoGeometryImplicits with ColorGener
         organizationName = if (overwritingDatasetName.isDefined) None
         else parseOrganizationName(parameters \ "experiment")
         remoteDataStoreClientOpt = getRemoteDataStoreClient(datasetName, organizationName.getOrElse(""))
+        _ <- bool2Box(volumes.length == volumes.map(_.name).distinct.length) ?~ Messages(
+          "nml.duplicateVolumeLayerNames")
         canHaveSegmentIndexBools <- Fox
           .combined(
             volumes

--- a/conf/messages
+++ b/conf/messages
@@ -158,6 +158,7 @@ nml.treegroup.id.invalid=Invalid tree group id {0}
 nml.segmentGroup.id.invalid=Invalid segment group id {0}
 nml.boundingbox.id.invalid=Invalid user bounding box id {0}
 nml.additionalCoordinates.notUnique=Additional coordinates do not have unique names
+nml.duplicateVolumeLayerNames=Annotations with multiple volume layers must have a unique name for each layer.
 
 project.name.alreadyTaken=The name “{0}” is already being used for a different project. Please choose a different name.
 project.name.invalidChars=The project name contains invalid characters. Please use only letters and numbers.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://nmluniquelayernames.webknossos.xyz

### Steps to test:
- In an NML file, duplicate the <volume> block, set new ID, but use duplicate name
- Upload should fail with readable error message
- If the name is not duplicated, upload should work

### Issues:
- fixes #7775 

