### PR TITLE
Remove the await in NmlParser/AnnotationUploadService

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -24,6 +24,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   GenericDataSource,
   SegmentationLayer
 }
+import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeDataZipFormat.VolumeDataZipFormat
 import com.scalableminds.webknossos.tracingstore.tracings.volume.{
@@ -39,7 +40,7 @@ import models.annotation.AnnotationState._
 import models.annotation._
 import models.annotation.nml.NmlResults.{NmlParseResult, NmlParseSuccess}
 import models.annotation.nml.{NmlResults, NmlWriter}
-import models.dataset.{Dataset, DatasetDAO, DatasetService}
+import models.dataset.{DataStoreDAO, Dataset, DatasetDAO, DatasetService, WKRemoteDataStoreClient}
 import models.organization.OrganizationDAO
 import models.project.ProjectDAO
 import models.task._
@@ -68,7 +69,9 @@ class AnnotationIOController @Inject()(
     annotationService: AnnotationService,
     analyticsService: AnalyticsService,
     conf: WkConf,
+    rpc: RPC,
     sil: Silhouette[WkEnv],
+    dataStoreDAO: DataStoreDAO,
     provider: AnnotationInformationProvider,
     annotationUploadService: AnnotationUploadService)(implicit ec: ExecutionContext, val materializer: Materializer)
     extends Controller
@@ -129,7 +132,7 @@ class AnnotationIOController @Inject()(
                                                            tracingStoreClient,
                                                            parsedFiles.otherFiles,
                                                            usableDataSource)
-            mergedSkeletonLayers <- mergeAndSaveSkeletonLayers(skeletonTracings, tracingStoreClient, usableDataSource)
+            mergedSkeletonLayers <- mergeAndSaveSkeletonLayers(skeletonTracings, tracingStoreClient)
             annotation <- annotationService.createFrom(request.identity,
                                                        dataset,
                                                        mergedSkeletonLayers ::: mergedVolumeLayers,
@@ -190,8 +193,7 @@ class AnnotationIOController @Inject()(
     }
 
   private def mergeAndSaveSkeletonLayers(skeletonTracings: List[SkeletonTracing],
-                                         tracingStoreClient: WKRemoteTracingStoreClient,
-                                         dataSource: DataSourceLike): Fox[List[AnnotationLayer]] =
+                                         tracingStoreClient: WKRemoteTracingStoreClient): Fox[List[AnnotationLayer]] =
     if (skeletonTracings.isEmpty)
       Fox.successful(List())
     else {
@@ -283,15 +285,29 @@ class AnnotationIOController @Inject()(
                                                  dataset: Dataset): Fox[List[List[UploadedVolumeLayer]]] =
     for {
       dataSource <- datasetService.dataSourceFor(dataset).flatMap(_.toUsable)
-      allAdapted = volumeLayersGrouped.map { volumeLayers =>
-        volumeLayers.map { volumeLayer =>
-          volumeLayer.copy(tracing = adaptPropertiesToFallbackLayer(volumeLayer.tracing, dataSource))
+      dataStore <- dataStoreDAO.findOneByName(dataset._dataStore.trim)(GlobalAccessContext) ?~> "dataStore.notFoundForDataset"
+      organization <- organizationDAO.findOne(dataset._organization)(GlobalAccessContext)
+      remoteDataStoreClient = new WKRemoteDataStoreClient(dataStore, rpc)
+      allAdapted <- Fox.serialCombined(volumeLayersGrouped) { volumeLayers =>
+        Fox.serialCombined(volumeLayers) { volumeLayer =>
+          for {
+            adaptedTracing <- adaptPropertiesToFallbackLayer(volumeLayer.tracing,
+                                                             dataSource,
+                                                             dataset,
+                                                             organization.name,
+                                                             remoteDataStoreClient)
+            adaptedAnnotationLayer = volumeLayer.copy(tracing = adaptedTracing)
+          } yield adaptedAnnotationLayer
         }
       }
     } yield allAdapted
 
-  private def adaptPropertiesToFallbackLayer[T <: DataLayerLike](volumeTracing: VolumeTracing,
-                                                                 dataSource: GenericDataSource[T]): VolumeTracing = {
+  private def adaptPropertiesToFallbackLayer[T <: DataLayerLike](
+      volumeTracing: VolumeTracing,
+      dataSource: GenericDataSource[T],
+      dataset: Dataset,
+      organizationName: String,
+      remoteDataStoreClient: WKRemoteDataStoreClient): Fox[VolumeTracing] = {
     val fallbackLayerOpt = dataSource.dataLayers.flatMap {
       case layer: SegmentationLayer if volumeTracing.fallbackLayer contains layer.name         => Some(layer)
       case layer: AbstractSegmentationLayer if volumeTracing.fallbackLayer contains layer.name => Some(layer)
@@ -303,16 +319,35 @@ class AnnotationIOController @Inject()(
     val elementClass = fallbackLayerOpt
       .map(layer => elementClassToProto(layer.elementClass))
       .getOrElse(elementClassToProto(VolumeTracingDefaults.elementClass))
-    volumeTracing.copy(
-      boundingBox = bbox,
-      elementClass = elementClass,
-      fallbackLayer = fallbackLayerOpt.map(_.name),
-      largestSegmentId =
-        annotationService.combineLargestSegmentIdsByPrecedence(volumeTracing.largestSegmentId,
-                                                               fallbackLayerOpt.map(_.largestSegmentId)),
-      resolutions = VolumeTracingDownsampling.magsForVolumeTracing(dataSource, fallbackLayerOpt).map(vec3IntToProto)
-    )
+    for {
+      tracingCanHaveSegmentIndex <- canHaveSegmentIndex(organizationName,
+                                                        dataset.name,
+                                                        fallbackLayerOpt.map(_.name),
+                                                        remoteDataStoreClient)
+    } yield
+      volumeTracing.copy(
+        boundingBox = bbox,
+        elementClass = elementClass,
+        fallbackLayer = fallbackLayerOpt.map(_.name),
+        largestSegmentId =
+          annotationService.combineLargestSegmentIdsByPrecedence(volumeTracing.largestSegmentId,
+                                                                 fallbackLayerOpt.map(_.largestSegmentId)),
+        resolutions = VolumeTracingDownsampling.magsForVolumeTracing(dataSource, fallbackLayerOpt).map(vec3IntToProto),
+        hasSegmentIndex = Some(tracingCanHaveSegmentIndex)
+      )
   }
+
+  private def canHaveSegmentIndex(
+      organizationName: String,
+      datasetName: String,
+      fallbackLayerName: Option[String],
+      remoteDataStoreClient: WKRemoteDataStoreClient)(implicit ec: ExecutionContext): Fox[Boolean] =
+    fallbackLayerName match {
+      case Some(layerName) =>
+        remoteDataStoreClient.hasSegmentIndexFile(organizationName, datasetName, layerName)
+      case None =>
+        Fox.successful(true)
+    }
 
   // NML or Zip file containing skeleton and/or volume data of this annotation. In case of Compound annotations, multiple such annotations wrapped in another zip
   def download(typ: String,

--- a/app/models/annotation/AnnotationUploadService.scala
+++ b/app/models/annotation/AnnotationUploadService.scala
@@ -1,46 +1,31 @@
 package models.annotation
 
-import com.scalableminds.util.accesscontext.GlobalAccessContext
-
 import java.io.{File, FileInputStream, InputStream}
 import java.nio.file.{Files, Path, StandardCopyOption}
 import com.scalableminds.util.io.ZipIO
-import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, TreeGroup}
 import com.scalableminds.webknossos.datastore.VolumeTracing.{SegmentGroup, VolumeTracing}
-import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.scalalogging.LazyLogging
 import files.TempFileService
 
 import javax.inject.Inject
 import models.annotation.nml.NmlResults._
 import models.annotation.nml.{NmlParser, NmlResults}
-import models.dataset.{DatasetDAO, DatasetService, WKRemoteDataStoreClient}
-import models.organization.OrganizationDAO
 import net.liftweb.common.{Box, Empty, Failure, Full}
 import net.liftweb.common.Box.tryo
 import play.api.i18n.MessagesProvider
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.DurationInt
 
 case class UploadedVolumeLayer(tracing: VolumeTracing, dataZipLocation: String, name: Option[String]) {
   def getDataZipFrom(otherFiles: Map[String, File]): Option[File] =
     otherFiles.get(dataZipLocation)
 }
 
-class AnnotationUploadService @Inject()(tempFileService: TempFileService,
-                                        datasetService: DatasetService,
-                                        datasetDAO: DatasetDAO,
-                                        organizationDAO: OrganizationDAO,
-                                        rpc: RPC)
-    extends LazyLogging {
+class AnnotationUploadService @Inject()(tempFileService: TempFileService) extends LazyLogging {
 
-  private def extractFromNmlFile(
-      file: File,
-      name: String,
-      overwritingDatasetName: Option[String],
-      isTaskUpload: Boolean)(implicit m: MessagesProvider, ec: ExecutionContext): NmlParseResult =
+  private def extractFromNmlFile(file: File,
+                                 name: String,
+                                 overwritingDatasetName: Option[String],
+                                 isTaskUpload: Boolean)(implicit m: MessagesProvider): NmlParseResult =
     extractFromNml(new FileInputStream(file), name, overwritingDatasetName, isTaskUpload)
 
   private def formatChain(chain: Box[Failure]): String = chain match {
@@ -49,29 +34,23 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService,
     case _ => ""
   }
 
-  def extractFromNml(
-      inputStream: InputStream,
-      name: String,
-      overwritingDatasetName: Option[String],
-      isTaskUpload: Boolean,
-      basePath: Option[String] = None)(implicit m: MessagesProvider, ec: ExecutionContext): NmlParseResult =
-    NmlParser.parse(name,
-                    inputStream,
-                    overwritingDatasetName,
-                    isTaskUpload,
-                    basePath,
-                    (a, b) => getRemoteDatastoreClientForDatasetNameAndOrg(a, b)) match {
+  private def extractFromNml(inputStream: InputStream,
+                             name: String,
+                             overwritingDatasetName: Option[String],
+                             isTaskUpload: Boolean,
+                             basePath: Option[String] = None)(implicit m: MessagesProvider): NmlParseResult =
+    NmlParser.parse(name, inputStream, overwritingDatasetName, isTaskUpload, basePath) match {
       case Full((skeletonTracing, uploadedVolumeLayers, description, wkUrl)) =>
         NmlParseSuccess(name, skeletonTracing, uploadedVolumeLayers, description, wkUrl)
       case Failure(msg, _, chain) => NmlParseFailure(name, msg + chain.map(_ => formatChain(chain)).getOrElse(""))
       case Empty                  => NmlParseEmpty(name)
     }
 
-  def extractFromZip(file: File,
-                     zipFileName: Option[String] = None,
-                     useZipName: Boolean,
-                     overwritingDatasetName: Option[String],
-                     isTaskUpload: Boolean)(implicit m: MessagesProvider, ec: ExecutionContext): MultiNmlParseResult = {
+  private def extractFromZip(file: File,
+                             zipFileName: Option[String],
+                             useZipName: Boolean,
+                             overwritingDatasetName: Option[String],
+                             isTaskUpload: Boolean)(implicit m: MessagesProvider): MultiNmlParseResult = {
     val name = zipFileName getOrElse file.getName
     var otherFiles = Map.empty[String, File]
     var parseResults = List.empty[NmlParseResult]
@@ -154,11 +133,10 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService,
     }
   }
 
-  def extractFromFiles(
-      files: Seq[(File, String)],
-      useZipName: Boolean,
-      overwritingDatasetName: Option[String] = None,
-      isTaskUpload: Boolean = false)(implicit m: MessagesProvider, ec: ExecutionContext): MultiNmlParseResult =
+  def extractFromFiles(files: Seq[(File, String)],
+                       useZipName: Boolean,
+                       overwritingDatasetName: Option[String] = None,
+                       isTaskUpload: Boolean = false)(implicit m: MessagesProvider): MultiNmlParseResult =
     files.foldLeft(NmlResults.MultiNmlParseResult()) {
       case (acc, (file, name)) =>
         if (name.endsWith(".zip"))
@@ -180,11 +158,11 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService,
           acc.combineWith(extractFromFile(file, name, useZipName, overwritingDatasetName, isTaskUpload))
     }
 
-  def extractFromFile(file: File,
-                      fileName: String,
-                      useZipName: Boolean,
-                      overwritingDatasetName: Option[String],
-                      isTaskUpload: Boolean)(implicit m: MessagesProvider, ec: ExecutionContext): MultiNmlParseResult =
+  private def extractFromFile(file: File,
+                              fileName: String,
+                              useZipName: Boolean,
+                              overwritingDatasetName: Option[String],
+                              isTaskUpload: Boolean)(implicit m: MessagesProvider): MultiNmlParseResult =
     if (fileName.endsWith(".zip")) {
       logger.trace("Extracting from Zip file")
       extractFromZip(file, Some(fileName), useZipName, overwritingDatasetName, isTaskUpload)
@@ -193,16 +171,5 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService,
       val parseResult = extractFromNmlFile(file, fileName, overwritingDatasetName, isTaskUpload)
       MultiNmlParseResult(List(parseResult), Map.empty)
     }
-
-  def getRemoteDatastoreClientForDatasetNameAndOrg(datasetName: String, organizationName: String)(
-      implicit ec: ExecutionContext): Option[WKRemoteDataStoreClient] = {
-    val fox = for {
-      _ <- Fox.successful(())
-      organizationObjectId <- organizationDAO.findIdByName(organizationName)(GlobalAccessContext)
-      dataset <- datasetDAO.findOneByNameAndOrganization(datasetName, organizationObjectId)(GlobalAccessContext)
-      dataStore <- datasetService.dataStoreFor(dataset)(GlobalAccessContext)
-    } yield new WKRemoteDataStoreClient(dataStore, rpc)
-    fox.await("No fox context in AnnotationUploadService, see #7551", 1 minute).toOption
-  }
 
 }


### PR DESCRIPTION
Implementing the suggestion from here https://github.com/scalableminds/webknossos/issues/7551#issuecomment-1913085950 (move the determination of hasSegmentIndex to adaptPropertiesToFallbackLayer, which happens *after* the NML parsing)

### URL of deployed dev instance (used for testing):
- https://nmlparserremoveawait.webknossos.xyz

### Steps to test:
- [x] Download + Reupload volume annotation  without fallback layer, should work
- [x] Download + Reupload volume annotation with fallback layer, should work

### Issues:
- fixes #7551

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
