### PR TITLE
Fix visual flickering effect upon toast reopening

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - In the time tracking view, all annotations and tasks can be shown for each user by expanding the table. The individual time spans spent with a task or annotating an explorative annotation can be accessed via CSV export. The detail view including a chart for the individual spans has been removed. [#7733](https://github.com/scalableminds/webknossos/pull/7733)
 
 ### Fixed
+- Fixed a bug where a toast that was reopened had a flickering effect during the reopening animation. [#7793](https://github.com/scalableminds/webknossos/pull/7793)
 - Fixed a bug where some annotation times would be shown double. [#7787](https://github.com/scalableminds/webknossos/pull/7787)
 
 ### Removed

--- a/frontend/javascripts/libs/toast.tsx
+++ b/frontend/javascripts/libs/toast.tsx
@@ -111,6 +111,7 @@ const Toast = {
     if (!this.notificationAPI) {
       return;
     }
+    const localNotificationAPI = this.notificationAPI;
     const message = this.buildContentWithDetails(rawMessage, details);
     const timeout = config.timeout != null ? config.timeout : 6000;
     const key = config.key || (typeof message === "string" ? message : undefined);
@@ -171,8 +172,8 @@ const Toast = {
       };
       this.closePendingToastsEarlyMap[key] = closeToastEarly;
     }
-    // Show the toast.
-    this.notificationAPI[type](toastConfig);
+    // Show the toast deferred by some timeout as instantly reopening a toast leads to a flickering effect.
+    setTimeout(() => localNotificationAPI[type](toastConfig), 100);
   },
 
   info(message: React.ReactNode, config: ToastConfig = {}, details?: string | undefined): void {


### PR DESCRIPTION
This PR fixes a visual flickering effect that occurs sometimes when a toast is reopened.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- 

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1715170185598299

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
