### PR TITLE
Fix timetracking table colums

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where a toast that was reopened had a flickering effect during the reopening animation. [#7793](https://github.com/scalableminds/webknossos/pull/7793)
 - Fixed a bug where some annotation times would be shown double. [#7787](https://github.com/scalableminds/webknossos/pull/7787)
+- Fixed a bug where no columns were shown in the time tracking overview. [#7803](https://github.com/scalableminds/webknossos/pull/7803)
 - Fixed a bug where ad-hoc meshes for coarse magnifications would have gaps. [#7799](https://github.com/scalableminds/webknossos/pull/7799)
 
 ### Removed

--- a/frontend/javascripts/admin/statistic/time_tracking_overview.tsx
+++ b/frontend/javascripts/admin/statistic/time_tracking_overview.tsx
@@ -1,5 +1,5 @@
 import { getTeams, getTimeEntries, getTimeTrackingForUserSpans } from "admin/admin_rest_api";
-import { Card, Select, Spin, Table, Button, DatePicker, type TimeRangePickerProps } from "antd";
+import { Card, Select, Spin, Button, DatePicker, type TimeRangePickerProps } from "antd";
 import { useFetch } from "libs/react_helpers";
 import _ from "lodash";
 import React, { useState } from "react";
@@ -20,7 +20,6 @@ import * as Utils from "libs/utils";
 import { APITimeTrackingPerUser } from "types/api_flow_types";
 import { useSelector } from "react-redux";
 import { OxalisState } from "oxalis/store";
-const { Column } = Table;
 const { RangePicker } = DatePicker;
 
 const TIMETRACKING_CSV_HEADER_PER_USER = ["userId,userFirstName,userLastName,timeTrackedInSeconds"];
@@ -146,6 +145,59 @@ function TimeTrackingOverview() {
     );
   };
 
+  const timeTrackingTableColumns = [
+    {
+      title: "User",
+      dataIndex: "user",
+      key: "user",
+      render: (user: APITimeTrackingPerUser["user"]) =>
+        `${user.lastName}, ${user.firstName} (${user.email})`,
+      sorter: Utils.localeCompareBy<APITimeTrackingPerUser>(
+        (timeEntry) =>
+          `${timeEntry.user.lastName}, ${timeEntry.user.firstName} (${timeEntry.user.email})`,
+      ),
+    },
+    {
+      title: "No. tasks / annotations",
+      dataIndex: "annotationCount",
+      key: "numberAnn",
+      sorter: Utils.compareBy<APITimeTrackingPerUser>((timeEntry) => timeEntry.annotationCount),
+    },
+    {
+      title: "Avg. time per task / annotation",
+      key: "avgTime",
+      render: (item: APITimeTrackingPerUser) =>
+        formatMilliseconds(item.timeMillis / item.annotationCount),
+      sorter: Utils.compareBy<APITimeTrackingPerUser>(
+        (timeEntry) => timeEntry.timeMillis / timeEntry.annotationCount,
+      ),
+    },
+    {
+      title: "Total time",
+      dataIndex: "timeMillis",
+      key: "tracingTimes",
+      render: (tracingTimeInMs: APITimeTrackingPerUser["timeMillis"]) =>
+        formatMilliseconds(tracingTimeInMs),
+      sorter: Utils.compareBy<APITimeTrackingPerUser>((timeEntry) => timeEntry.timeMillis),
+    },
+    {
+      key: "details",
+      dataIndex: "user",
+      render: (user: APITimeTrackingPerUser["user"]) => {
+        return (
+          <LinkButton
+            onClick={async () => {
+              downloadTimeSpans(user.id, startDate, endDate, selectedTypes, selectedProjectIds);
+            }}
+          >
+            <DownloadOutlined className="icon-margin-right" />
+            Download time spans
+          </LinkButton>
+        );
+      },
+    },
+  ];
+
   return (
     <Card
       title={"Annotation Time per User"}
@@ -203,6 +255,7 @@ function TimeTrackingOverview() {
             marginBottom: 30,
           }}
           pagination={false}
+          columns={timeTrackingTableColumns}
           expandable={{
             expandedRowRender: (entry) => (
               <TimeTrackingDetailView
@@ -216,63 +269,7 @@ function TimeTrackingOverview() {
           locale={{
             emptyText: renderPlaceholder(),
           }}
-        >
-          <Column
-            title="User"
-            dataIndex="user"
-            key="user"
-            render={(user) => `${user.lastName}, ${user.firstName} (${user.email})`}
-            sorter={Utils.localeCompareBy<APITimeTrackingPerUser>(
-              (timeEntry) =>
-                `${timeEntry.user.lastName}, ${timeEntry.user.firstName} (${timeEntry.user.email})`,
-            )}
-          />
-          <Column
-            title="No. tasks / annotations"
-            dataIndex="annotationCount"
-            key="numberAnn"
-            sorter={Utils.compareBy<APITimeTrackingPerUser>(
-              (timeEntry) => timeEntry.annotationCount,
-            )}
-          />
-          <Column
-            title="Avg. time per task / annotation"
-            key="avgTime"
-            render={(item) => formatMilliseconds(item.timeMillis / item.annotationCount)}
-            sorter={Utils.compareBy<APITimeTrackingPerUser>(
-              (timeEntry) => timeEntry.timeMillis / timeEntry.annotationCount,
-            )}
-          />
-          <Column
-            title="Total time"
-            dataIndex="timeMillis"
-            key="tracingTimes"
-            render={(tracingTimeInMs) => formatMilliseconds(tracingTimeInMs)}
-            sorter={Utils.compareBy<APITimeTrackingPerUser>((timeEntry) => timeEntry.timeMillis)}
-          />
-          <Column
-            key="details"
-            dataIndex="user"
-            render={(user) => {
-              return (
-                <LinkButton
-                  onClick={async () => {
-                    downloadTimeSpans(
-                      user.id,
-                      startDate,
-                      endDate,
-                      selectedTypes,
-                      selectedProjectIds,
-                    );
-                  }}
-                >
-                  <DownloadOutlined className="icon-margin-right" />
-                  Download time spans
-                </LinkButton>
-              );
-            }}
-          />
-        </FixedExpandableTable>
+        />
       </Spin>
       <Button
         type="primary"

--- a/frontend/javascripts/components/fixed_expandable_table.tsx
+++ b/frontend/javascripts/components/fixed_expandable_table.tsx
@@ -52,7 +52,7 @@ export default class FixedExpandableTable extends React.PureComponent<TableProps
         onClick={() => this.setState({ expandedRows: [] })}
       />
     );
-    const columnsWithAdjustedFixedProp: TableProps["columns"] = (this.props.columns || []).map(
+    const columnsWithAdjustedFixedProp: TableProps["columns"] = this.props.columns?.map(
       (column) => {
         const columnFixed = expandedRows.length > 0 ? false : column.fixed;
         return { ...column, fixed: columnFixed };

--- a/frontend/javascripts/components/fixed_expandable_table.tsx
+++ b/frontend/javascripts/components/fixed_expandable_table.tsx
@@ -12,6 +12,7 @@ type State = {
  *  and the scroll prop as this is already done by the wrapper.
  */
 
+// Enforce the "columns" prop which is optional by default otherwise 
 type OwnTableProps<RecordType = any> = TableProps<RecordType> & {
   columns: ColumnsType<RecordType>;
 };

--- a/frontend/javascripts/components/fixed_expandable_table.tsx
+++ b/frontend/javascripts/components/fixed_expandable_table.tsx
@@ -12,7 +12,7 @@ type State = {
  *  and the scroll prop as this is already done by the wrapper.
  */
 
-// Enforce the "columns" prop which is optional by default otherwise 
+// Enforce the "columns" prop which is optional by default otherwise
 type OwnTableProps<RecordType = any> = TableProps<RecordType> & {
   columns: ColumnsType<RecordType>;
 };

--- a/frontend/javascripts/components/fixed_expandable_table.tsx
+++ b/frontend/javascripts/components/fixed_expandable_table.tsx
@@ -1,5 +1,5 @@
 import { Button, Table, TableProps } from "antd";
-import { GetRowKey } from "antd/lib/table/interface";
+import { ColumnsType, GetRowKey } from "antd/lib/table/interface";
 import React from "react";
 
 type State = {
@@ -12,7 +12,10 @@ type State = {
  *  and the scroll prop as this is already done by the wrapper.
  */
 
-export default class FixedExpandableTable extends React.PureComponent<TableProps, State> {
+type OwnTableProps<RecordType = any> = TableProps<RecordType> & {
+  columns: ColumnsType<RecordType>;
+};
+export default class FixedExpandableTable extends React.PureComponent<OwnTableProps, State> {
   state: State = {
     expandedRows: [],
   };
@@ -52,12 +55,10 @@ export default class FixedExpandableTable extends React.PureComponent<TableProps
         onClick={() => this.setState({ expandedRows: [] })}
       />
     );
-    const columnsWithAdjustedFixedProp: TableProps["columns"] = this.props.columns?.map(
-      (column) => {
-        const columnFixed = expandedRows.length > 0 ? false : column.fixed;
-        return { ...column, fixed: columnFixed };
-      },
-    );
+    const columnsWithAdjustedFixedProp: TableProps["columns"] = this.props.columns.map((column) => {
+      const columnFixed = expandedRows.length > 0 ? false : column.fixed;
+      return { ...column, fixed: columnFixed };
+    });
     const expandableProp = {
       ...expandable,
       expandedRowKeys: expandedRows,


### PR DESCRIPTION
This PR fixes the timetracking columns not being rendered by two angles:
1. Refactor the columns into an array of objects and pass this to the FixedExpandableTable, which is the new way of how to write columns for antd table.
2. Fix the FixedExpandableTable to still work with columns being passed as children. In the previous version, it always had an array of empty column props which likely took precedence of the passed children column props to FixedExpandableTable and thus the children column props were ignored and 0 columns were rendered instead.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Do some tracing
- Open the time tracking view. It should render all expected columns

### TODOs:
- [x] Check whether point 2. is acutally fixed by this PR.

### Issues:
- No issue exists for this

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
