### PR TITLE
Fix context menu for skeletons in 3d viewport

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where some annotation times would be shown double. [#7787](https://github.com/scalableminds/webknossos/pull/7787)
 - Fixed a bug where no columns were shown in the time tracking overview. [#7803](https://github.com/scalableminds/webknossos/pull/7803)
 - Fixed a bug where ad-hoc meshes for coarse magnifications would have gaps. [#7799](https://github.com/scalableminds/webknossos/pull/7799)
+- Fixed that the context menu didn't open correctly in the 3D viewport when right-clicking a node. [#7809](https://github.com/scalableminds/webknossos/pull/7809)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/controller/td_controller.tsx
+++ b/frontend/javascripts/oxalis/controller/td_controller.tsx
@@ -254,18 +254,15 @@ class TDController extends React.PureComponent<Props> {
       rightClick: (pos: Point2, plane: OrthoView, event: MouseEvent, isTouch: boolean) => {
         if (this.props.planeView == null) return null;
         const intersection = this.getMeshIntersection(pos);
-        if (intersection == null) {
-          return;
-        }
         handleOpenContextMenu(
           this.props.planeView,
           pos,
           plane,
           isTouch,
           event,
-          intersection.meshId,
-          intersection.meshClickedPosition,
-          intersection.unmappedSegmentId,
+          intersection?.meshId,
+          intersection?.meshClickedPosition,
+          intersection?.unmappedSegmentId,
         );
       },
     };


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a skeleton
- rightclick a node in the 3d viewport
- context menu should open

### Issues:
- follow-up for #7313 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
