### PR TITLE
Trim firstName, lastName in the register form

### DIFF
--- a/frontend/javascripts/admin/auth/registration_form_generic.tsx
+++ b/frontend/javascripts/admin/auth/registration_form_generic.tsx
@@ -142,6 +142,7 @@ function RegistrationFormGeneric(props: Props) {
                 message: messages["auth.registration_firstName_input"],
               },
             ]}
+            normalize={(str) => str.trim()}
           >
             <Input
               prefix={
@@ -167,6 +168,7 @@ function RegistrationFormGeneric(props: Props) {
                 message: messages["auth.registration_lastName_input"],
               },
             ]}
+            normalize={(str) => str.trim()}
           >
             <Input
               prefix={

--- a/frontend/javascripts/admin/auth/registration_form_generic.tsx
+++ b/frontend/javascripts/admin/auth/registration_form_generic.tsx
@@ -32,7 +32,11 @@ function RegistrationFormGeneric(props: Props) {
         ? "/api/auth/createOrganizationWithAdmin"
         : "/api/auth/register",
       {
-        data: formValues,
+        data: {
+          ...formValues,
+          firstName: formValues.firstName.trim(),
+          lastName: formValues.lastName.trim(),
+        },
       },
     );
     Store.dispatch(setHasOrganizationsAction(true));

--- a/frontend/javascripts/admin/auth/registration_form_generic.tsx
+++ b/frontend/javascripts/admin/auth/registration_form_generic.tsx
@@ -142,7 +142,6 @@ function RegistrationFormGeneric(props: Props) {
                 message: messages["auth.registration_firstName_input"],
               },
             ]}
-            normalize={(str) => str.trim()}
           >
             <Input
               prefix={
@@ -168,7 +167,6 @@ function RegistrationFormGeneric(props: Props) {
                 message: messages["auth.registration_lastName_input"],
               },
             ]}
-            normalize={(str) => str.trim()}
           >
             <Input
               prefix={

--- a/frontend/javascripts/admin/auth/registration_form_wkorg.tsx
+++ b/frontend/javascripts/admin/auth/registration_form_wkorg.tsx
@@ -35,14 +35,14 @@ function RegistrationFormWKOrg(props: Props) {
     await Request.sendJSONReceiveJSON("/api/auth/createOrganizationWithAdmin", {
       data: {
         ...formValues,
-        firstName: formValues.firstName,
-        lastName: formValues.lastName,
+        firstName: formValues.firstName.trim(),
+        lastName: formValues.lastName.trim(),
         password: {
           password1: formValues.password.password1,
           password2: formValues.password.password1,
         },
         organization: organizationName.current,
-        organizationDisplayName: `${formValues.firstName} ${formValues.lastName} Lab`,
+        organizationDisplayName: `${formValues.firstName.trim()} ${formValues.lastName.trim()} Lab`,
       },
     });
     const [user, organization] = await loginUser({
@@ -67,7 +67,6 @@ function RegistrationFormWKOrg(props: Props) {
                 message: messages["auth.registration_firstName_input"],
               },
             ]}
-            normalize={(str) => str.trim()}
           >
             <Input
               prefix={
@@ -92,7 +91,6 @@ function RegistrationFormWKOrg(props: Props) {
                 message: messages["auth.registration_lastName_input"],
               },
             ]}
-            normalize={(str) => str.trim()}
           >
             <Input
               prefix={

--- a/frontend/javascripts/admin/auth/registration_form_wkorg.tsx
+++ b/frontend/javascripts/admin/auth/registration_form_wkorg.tsx
@@ -35,12 +35,14 @@ function RegistrationFormWKOrg(props: Props) {
     await Request.sendJSONReceiveJSON("/api/auth/createOrganizationWithAdmin", {
       data: {
         ...formValues,
+        firstName: formValues.firstName.trim(),
+        lastName: formValues.lastName.trim(),
         password: {
           password1: formValues.password.password1,
           password2: formValues.password.password1,
         },
         organization: organizationName.current,
-        organizationDisplayName: `${formValues.firstName} ${formValues.lastName} Lab`,
+        organizationDisplayName: `${formValues.firstName.trim()} ${formValues.lastName.trim()} Lab`,
       },
     });
     const [user, organization] = await loginUser({

--- a/frontend/javascripts/admin/auth/registration_form_wkorg.tsx
+++ b/frontend/javascripts/admin/auth/registration_form_wkorg.tsx
@@ -35,14 +35,14 @@ function RegistrationFormWKOrg(props: Props) {
     await Request.sendJSONReceiveJSON("/api/auth/createOrganizationWithAdmin", {
       data: {
         ...formValues,
-        firstName: formValues.firstName.trim(),
-        lastName: formValues.lastName.trim(),
+        firstName: formValues.firstName,
+        lastName: formValues.lastName,
         password: {
           password1: formValues.password.password1,
           password2: formValues.password.password1,
         },
         organization: organizationName.current,
-        organizationDisplayName: `${formValues.firstName.trim()} ${formValues.lastName.trim()} Lab`,
+        organizationDisplayName: `${formValues.firstName} ${formValues.lastName} Lab`,
       },
     });
     const [user, organization] = await loginUser({
@@ -67,6 +67,7 @@ function RegistrationFormWKOrg(props: Props) {
                 message: messages["auth.registration_firstName_input"],
               },
             ]}
+            normalize={(str) => str.trim()}
           >
             <Input
               prefix={
@@ -91,6 +92,7 @@ function RegistrationFormWKOrg(props: Props) {
                 message: messages["auth.registration_lastName_input"],
               },
             ]}
+            normalize={(str) => str.trim()}
           >
             <Input
               prefix={


### PR DESCRIPTION
My theory is that people started typing their full name in the register form’s »first name« field, and then removed their last name but not the space when they saw that there is a separate last name field. Let’s just trim the form field content and see if that helps for new users.

### Steps to test:
- set features.isWkOrgInstance=true in application.conf
- register new account, type spaces around your firstName
- should be trimmed in the resulting user name + organization name.

### Question
 - Should we repair existing users + organization display names? My assumption would be that it doesn’t hurt, as nothing should reference users directly by name. What do you think?

### Issues:
- fixes #7804

------
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
