### PR TITLE
Better error message in case of duplicate edge during min-cut

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
@@ -646,19 +646,20 @@ class EditableMappingService @Inject()(
       edgesWithPositions = annotateEdgesWithPositions(edgesToCut, agglomerateGraph)
     } yield edgesWithPositions
 
-  private def minCut(agglomerateGraph: AgglomerateGraph,
-                     segmentId1: Long,
-                     segmentId2: Long): Box[List[(Long, Long)]] = {
-    val g = new SimpleWeightedGraph[Long, DefaultWeightedEdge](classOf[DefaultWeightedEdge])
-    agglomerateGraph.segments.foreach { segmentId =>
-      g.addVertex(segmentId)
-    }
-    agglomerateGraph.edges.zip(agglomerateGraph.affinities).foreach {
-      case (edge, affinity) =>
-        val e = g.addEdge(edge.source, edge.target)
-        g.setEdgeWeight(e, affinity)
-    }
+  private def minCut(agglomerateGraph: AgglomerateGraph, segmentId1: Long, segmentId2: Long): Box[List[(Long, Long)]] =
     tryo {
+      val g = new SimpleWeightedGraph[Long, DefaultWeightedEdge](classOf[DefaultWeightedEdge])
+      agglomerateGraph.segments.foreach { segmentId =>
+        g.addVertex(segmentId)
+      }
+      agglomerateGraph.edges.zip(agglomerateGraph.affinities).foreach {
+        case (edge, affinity) =>
+          val e = g.addEdge(edge.source, edge.target)
+          if (e == null) {
+            throw new Exception("Duplicate edge in agglomerate graph. Please check the mapping file.")
+          }
+          g.setEdgeWeight(e, affinity)
+      }
       val minCutImpl = new PushRelabelMFImpl(g)
       minCutImpl.calculateMinCut(segmentId1, segmentId2)
       val sourcePartition: util.Set[Long] = minCutImpl.getSourcePartition
@@ -666,7 +667,6 @@ class EditableMappingService @Inject()(
       minCutEdges.asScala.toList.map(e =>
         setDirectionForCutting(g.getEdgeSource(e), g.getEdgeTarget(e), sourcePartition))
     }
-  }
 
   // the returned edges must be directed so that when they are passed to the split action, the source segment keeps its agglomerate id
   private def setDirectionForCutting(node1: Long, node2: Long, sourcePartition: util.Set[Long]): (Long, Long) =


### PR DESCRIPTION
Before, the »null« exception would just bubble up. Now, we get a proper error chain including a message about the root cause.