### PR TITLE
Fix NML download with skipVolumeData

### DIFF
--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -260,9 +260,6 @@ class NmlWriter @Inject()(implicit ec: ExecutionContext) extends FoxImplicits {
         case Right(volumeTracing) =>
           volumeTracing.fallbackLayer.foreach(writer.writeAttribute("fallbackLayer", _))
           volumeTracing.largestSegmentId.foreach(id => writer.writeAttribute("largestSegmentId", id.toString))
-          if (skipVolumeData) {
-            writer.writeComment(f"Note that volume data was omitted when downloading this annotation.")
-          }
           if (!volumeTracing.mappingIsEditable.getOrElse(false)) {
             volumeTracing.mappingName.foreach { mappingName =>
               writer.writeAttribute("mappingName", mappingName)
@@ -270,6 +267,9 @@ class NmlWriter @Inject()(implicit ec: ExecutionContext) extends FoxImplicits {
             if (volumeTracing.mappingIsLocked.getOrElse(false)) {
               writer.writeAttribute("mappingIsLocked", true.toString)
             }
+          }
+          if (skipVolumeData) {
+            writer.writeComment(f"Note that volume data was omitted when downloading this annotation.")
           }
           writeVolumeSegmentMetadata(volumeTracing.segments)
           Xml.withinElementSync("groups")(writeSegmentGroupsAsXml(volumeTracing.segmentGroups))


### PR DESCRIPTION
The writeComment for the `skipVolumeData` hint closed the current tag. That means that if we want to add more attributes to that tag, we have to do that first.

Regression from #7822 