### PR TITLE
Fix lock explorative annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ coverage-ts
 temp-webknossos-schema**
 conf/application.conf-e
 .env
+.bloop
+.metals
+metals.sbt

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -309,41 +309,40 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
           >
             Download
           </AsyncLink>
-          <br />
           {this.isTracingEditable(tracing) ? (
-            <AsyncLink
-              href="#"
-              onClick={() => this.finishOrReopenAnnotation("finish", tracing)}
-              icon={<InboxOutlined key="inbox" className="icon-margin-right" />}
-              disabled={tracing.isLockedByOwner}
-              title={tracing.isLockedByOwner ? "Locked annotations cannot be archived." : undefined}
-            >
-              Archive
-            </AsyncLink>
+            <>
+              <br />
+              <AsyncLink
+                href="#"
+                onClick={() => this.finishOrReopenAnnotation("finish", tracing)}
+                icon={<InboxOutlined key="inbox" className="icon-margin-right" />}
+                disabled={tracing.isLockedByOwner}
+                title={
+                  tracing.isLockedByOwner ? "Locked annotations cannot be archived." : undefined
+                }
+              >
+                Archive
+              </AsyncLink>
+            </>
           ) : null}
-          <br />
-          <AsyncLink
-            href="#"
-            title={
-              !isActiveUserOwner
-                ? `Only the owner can ${
-                    tracing.isLockedByOwner ? "unlock" : "lock"
-                  } this annotation.`
-                : undefined
-            }
-            disabled={!isActiveUserOwner}
-            onClick={() => this.setLockedState(tracing, !tracing.isLockedByOwner)}
-            icon={
-              tracing.isLockedByOwner ? (
-                <LockOutlined key="lock" className="icon-margin-right" />
-              ) : (
-                <UnlockOutlined key="unlock" className="icon-margin-right" />
-              )
-            }
-          >
-            {tracing.isLockedByOwner ? "Unlock" : "Lock"}
-          </AsyncLink>
-          <br />
+          {!isActiveUserOwner ? (
+            <>
+              <br />
+              <AsyncLink
+                href="#"
+                onClick={() => this.setLockedState(tracing, !tracing.isLockedByOwner)}
+                icon={
+                  tracing.isLockedByOwner ? (
+                    <LockOutlined key="lock" className="icon-margin-right" />
+                  ) : (
+                    <UnlockOutlined key="unlock" className="icon-margin-right" />
+                  )
+                }
+              >
+                {tracing.isLockedByOwner ? "Unlock" : "Lock"}
+              </AsyncLink>
+            </>
+          ) : null}
         </div>
       );
     } else {

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -325,7 +325,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
               </AsyncLink>
             </>
           ) : null}
-          {!isActiveUserOwner ? (
+          {isActiveUserOwner ? (
             <>
               <br />
               <AsyncLink


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- as Non admin user create an annotation
- log in as admin sample user. In the explorative annotations table the annotation of the non admin user should appear without the option to lock this annotation
- as the non admin user, lock the annotation
- the annotation should also appear locked in the admin's annotation table
- no weird newlines between action items should be visible


### Issues:
- No issue exists for this. Follow up of #7801
