### PR TITLE
Tiny Fixes for docs and icon margins

### DIFF
--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -234,5 +234,4 @@ WEBKNOSSOS does not yet resolve changes made by multiple people annotating simul
 Please coordinate accordingly with your collaborators. We aim to improve this aspect in the future.
 
 !!! info
-  In addition to the integrated Sharing features, you can also [download annotations](./export.md) and send them via email to collaborators.
-```
+    In addition to the integrated Sharing features, you can also [download annotations](./export.md) and send them via email to collaborators.

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -436,7 +436,7 @@ function _ShareModalView(props: Props) {
           margin: "18px 0",
         }}
       >
-        <ShareAltOutlined className="icon-margin-right"/>
+        <ShareAltOutlined className="icon-margin-right" />
         Team Sharing
       </Divider>
       <PricingEnforcedBlur requiredPricingPlan={PricingPlanEnum.Team}>

--- a/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/share_modal_view.tsx
@@ -375,7 +375,7 @@ function _ShareModalView(props: Props) {
           margin: "18px 0",
         }}
       >
-        <i className={`fas fa-${iconMap[visibility]}`} />
+        <i className={`fas fa-${iconMap[visibility]} icon-margin-right`} />
         Visibility
       </Divider>
       {maybeShowWarning()}
@@ -436,7 +436,7 @@ function _ShareModalView(props: Props) {
           margin: "18px 0",
         }}
       >
-        <ShareAltOutlined />
+        <ShareAltOutlined className="icon-margin-right"/>
         Team Sharing
       </Divider>
       <PricingEnforcedBlur requiredPricingPlan={PricingPlanEnum.Team}>


### PR DESCRIPTION
This PR fixes two tiny bugs that I noticed today:

1. The docs contained incorrect markdown formatting for a "info" callout in the Sharing document. See http://localhost:8197/webknossos/sharing.html#team-sharing-collaboration 
<img width="872" alt="image" src="https://github.com/scalableminds/webknossos/assets/1105056/f0af7764-1555-47d0-a97b-7ef05f9ec0df">

2. The icons in the sharing modal headers did not have the correct margins / spacing towards the text.
![image](https://github.com/scalableminds/webknossos/assets/1105056/f81554bf-5fb0-4790-8702-692d2024574d)


### Steps to test:
- Nada

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
