### PR TITLE
Follow up fix for lock annotations

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/tracing_actions_view.tsx
@@ -457,6 +457,8 @@ class TracingActionsView extends React.PureComponent<Props, State> {
   handleChangeLockedStateOfAnnotation = async (isLocked: boolean) => {
     try {
       const { annotationId, annotationType } = this.props;
+      // Ensure saved state, before (un)locking the annotation and then reloading.
+      await Model.ensureSavedState();
       await editLockedState(annotationId, annotationType, isLocked);
       Toast.success(
         isLocked ? messages["annotation.lock.success"] : messages["annotation.unlock.success"],

--- a/frontend/javascripts/oxalis/view/right-border-tabs/bounding_box_tab.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/bounding_box_tab.tsx
@@ -126,7 +126,7 @@ export default function BoundingBoxTab() {
             onVisibilityChange={_.partial(setBoundingBoxVisibility, bb.id)}
             onNameChange={_.partial(setBoundingBoxName, bb.id)}
             onColorChange={_.partial(setBoundingBoxColor, bb.id)}
-            disabled={allowUpdate}
+            disabled={!allowUpdate}
             isLockedByOwner={isLockedByOwner}
             isOwner={isOwner}
           />


### PR DESCRIPTION
Currently, it is not possible to modify user bounding boxes in the boudning box tab due to an inverted logic bug.
This pr fixes this and ensures all pending annotation updates are sent to the server updating an annotations locked state from within the annotations view.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a new annotation on some dataset
- The boudning box tab should not be disabled
- Fast create some bounding boxes and then lock the annotation via the menu in the nav bar. This should happen before the annotation view reached a saved state.
- The locking should first push all pending updates to the server (the sandclock icon should turn into a checkmark) and then update the locked state, show a toast and reload the webpage
- The annotation state should now be "locked"

### Issues:
- No issue exists for this

