### PR TITLE
Revert wk name in vx workflow list

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,7 +14,6 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added the option for the owner to lock explorative annotations. Locked annotations cannot be modified by any user. An annotation can be locked in the annotations table and when viewing the annotation via the navbar dropdown menu. [#7801](https://github.com/scalableminds/webknossos/pull/7801)
 - Uploading an annotation into a dataset that it was not created for now also works if the dataset is in a different organization. [#7816](https://github.com/scalableminds/webknossos/pull/7816)
 - When downloading + reuploading an annotation that is based on a segmentation layer with active mapping, that mapping is now still be selected after the reupload. [#7822](https://github.com/scalableminds/webknossos/pull/7822)
-- In the Voxelytics workflow list, the name of the WEBKNOSSOS user who started the job is displayed. [#7794](https://github.com/scalableminds/webknossos/pull/7795)
 
 ### Changed
 - The "WEBKNOSSOS Changelog" modal now lazily loads its content potentially speeding up the initial loading time of WEBKNOSSOS and thus improving the UX. [#7843](https://github.com/scalableminds/webknossos/pull/7843)

--- a/app/controllers/VoxelyticsController.scala
+++ b/app/controllers/VoxelyticsController.scala
@@ -78,15 +78,15 @@ class VoxelyticsController @Inject()(
     for {
       _ <- bool2Fox(runs.nonEmpty) // just asserting once more
       workflowTaskCounts <- voxelyticsDAO.findWorkflowTaskCounts(request.identity,
-                                                                 runs.map(_.workflowHash).toSet,
+                                                                 runs.map(_.workflow_hash).toSet,
                                                                  conf.staleTimeout)
       _ <- bool2Fox(workflowTaskCounts.nonEmpty) ?~> "voxelytics.noTaskFound" ~> NOT_FOUND
       workflows <- voxelyticsDAO.findWorkflowsByHashAndOrganization(request.identity._organization,
-                                                                    runs.map(_.workflowHash).toSet)
+                                                                    runs.map(_.workflow_hash).toSet)
       _ <- bool2Fox(workflows.nonEmpty) ?~> "voxelytics.noWorkflowFound" ~> NOT_FOUND
 
       workflowsAsJson = JsArray(workflows.flatMap(workflow => {
-        val workflowRuns = runs.filter(run => run.workflowHash == workflow.hash)
+        val workflowRuns = runs.filter(run => run.workflow_hash == workflow.hash)
         if (workflowRuns.nonEmpty) {
           val state = workflowRuns.maxBy(_.beginTime).state
           val beginTime = workflowRuns.map(_.beginTime).min
@@ -145,14 +145,14 @@ class VoxelyticsController @Inject()(
 
         // Assemble workflow report JSON
         result = Json.obj(
-          "config" -> voxelyticsService.workflowConfigPublicWrites(mostRecentRun.workflowConfig, tasks),
+          "config" -> voxelyticsService.workflowConfigPublicWrites(mostRecentRun.workflow_config, tasks),
           "artifacts" -> voxelyticsService.artifactsPublicWrites(artifacts),
           "runs" -> sortedRuns,
           "tasks" -> voxelyticsService.taskRunsPublicWrites(combinedTaskRuns, allTaskRuns),
           "workflow" -> Json.obj(
             "name" -> workflow.name,
             "hash" -> workflowHash,
-            "yamlContent" -> mostRecentRun.workflowYamlContent
+            "yamlContent" -> mostRecentRun.workflow_yamlContent
           )
         )
       } yield JsonOk(result)

--- a/app/models/voxelytics/VoxelyticsService.scala
+++ b/app/models/voxelytics/VoxelyticsService.scala
@@ -13,12 +13,12 @@ import scala.util.Try
 
 case class RunEntry(id: ObjectId,
                     name: String,
-                    hostUserName: String,
-                    hostName: String,
+                    username: String,
+                    hostname: String,
                     voxelyticsVersion: String,
-                    workflowHash: String,
-                    workflowYamlContent: String,
-                    workflowConfig: JsObject,
+                    workflow_hash: String,
+                    workflow_yamlContent: String,
+                    workflow_config: JsObject,
                     state: VoxelyticsRunState,
                     beginTime: Option[Instant],
                     endTime: Option[Instant])
@@ -77,16 +77,14 @@ object ChunkCounts {
 
 case class WorkflowListingRunEntry(id: ObjectId,
                                    name: String,
-                                   hostUserName: String,
-                                   hostName: String,
+                                   username: String,
+                                   hostname: String,
                                    voxelyticsVersion: String,
-                                   workflowHash: String,
+                                   workflow_hash: String,
                                    state: VoxelyticsRunState,
                                    beginTime: Option[Instant],
                                    endTime: Option[Instant],
-                                   taskCounts: TaskCounts,
-                                   userFirstName: Option[String],
-                                   userLastName: Option[String])
+                                   taskCounts: TaskCounts)
 
 object WorkflowListingRunEntry {
   implicit val jsonFormat: OFormat[WorkflowListingRunEntry] = Json.format[WorkflowListingRunEntry]

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -565,7 +565,7 @@ export default function TaskListView({
     workflow: { name: readableWorkflowName },
   } = report;
   const runBeginTimeString = report.runs.reduce(
-    (r, a) => Math.min(r, a.beginTime != null ? a.beginTime.getTime() : Infinity),
+    (r, a) => Math.min(r, a.beginTime.getTime()),
     Infinity,
   );
 

--- a/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
@@ -212,7 +212,7 @@ export default function WorkflowListView() {
           },
           {
             title: "Host",
-            dataIndex: "hostName",
+            dataIndex: "hostname",
             key: "host",
             filters: uniqueify(renderRuns.map((run) => run.hostName)).map((hostname) => ({
               text: hostname,

--- a/frontend/javascripts/admin/voxelytics/workflow_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_view.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import {
   APIOrganization,
+  VoxelyticsRunInfo,
   VoxelyticsRunState,
   VoxelyticsTaskConfig,
   VoxelyticsTaskConfigWithHierarchy,
@@ -138,11 +139,14 @@ function parseReport(report: VoxelyticsWorkflowReport): VoxelyticsWorkflowReport
       tasks: Object.fromEntries(dag.nodes.map((t) => [t.id, report.config.tasks[t.id]])),
     },
     dag,
-    runs: report.runs.map((run) => ({
-      ...run,
-      beginTime: run.beginTime == null ? null : new Date(run.beginTime),
-      endTime: run.endTime == null ? null : new Date(run.endTime),
-    })),
+    runs: report.runs.map(
+      (run) =>
+        ({
+          ...run,
+          beginTime: run.beginTime != null ? new Date(run.beginTime) : null,
+          endTime: run.endTime != null ? new Date(run.endTime) : null,
+        }) as VoxelyticsRunInfo,
+    ),
     tasks,
   };
 }

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -864,7 +864,6 @@ export enum VoxelyticsRunState {
   CANCELLED = "CANCELLED",
   STALE = "STALE",
 }
-
 type DistributionConfig = {
   strategy: string;
   resources?: Record<string, string>;
@@ -900,15 +899,27 @@ export type VoxelyticsArtifactConfig = {
   };
 };
 
-export type VoxelyticsRunInfo = {
+export type VoxelyticsRunInfo = (
+  | {
+      state: VoxelyticsRunState.RUNNING;
+      beginTime: Date;
+      endTime: null;
+    }
+  | {
+      state:
+        | VoxelyticsRunState.COMPLETE
+        | VoxelyticsRunState.FAILED
+        | VoxelyticsRunState.CANCELLED
+        | VoxelyticsRunState.STALE;
+      beginTime: Date;
+      endTime: Date;
+    }
+) & {
   id: string;
   name: string;
-  userName: string;
-  hostName: string;
+  username: string;
+  hostname: string;
   voxelyticsVersion: string;
-  state: VoxelyticsRunState;
-  beginTime: Date | null;
-  endTime: Date | null;
 };
 
 export type VoxelyticsWorkflowDagEdge = { source: string; target: string; label: string };
@@ -983,18 +994,28 @@ export type VoxelyticsWorkflowReport = {
   };
 };
 
-export type VoxelyticsWorkflowListingRun = {
+export type VoxelyticsWorkflowListingRun = (
+  | {
+      state: VoxelyticsRunState.RUNNING;
+      beginTime: Date;
+      endTime: null;
+    }
+  | {
+      state:
+        | VoxelyticsRunState.COMPLETE
+        | VoxelyticsRunState.FAILED
+        | VoxelyticsRunState.CANCELLED
+        | VoxelyticsRunState.STALE;
+      beginTime: Date;
+      endTime: Date;
+    }
+) & {
   id: string;
   name: string;
-  hostUserName: string;
-  hostName: string;
+  username: string;
+  hostname: string;
   voxelyticsVersion: string;
   taskCounts: TaskCounts;
-  userFirstName: string;
-  userLastName: string;
-  state: VoxelyticsRunState;
-  beginTime: Date | null;
-  endTime: Date | null;
 };
 
 export type VoxelyticsWorkflowListing = {


### PR DESCRIPTION
reverts https://github.com/scalableminds/webknossos/pull/7794 and https://github.com/scalableminds/webknossos/pull/7852 because user and host are empty in production

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
