### PR TITLE
Format infer_mitochondria job in job list view

### DIFF
--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -64,7 +64,7 @@ case class Job(
         case JobCommand.export_tiff | JobCommand.render_animation =>
           Some(s"/api/jobs/${this._id}/export")
         case JobCommand.infer_nuclei | JobCommand.infer_neurons | JobCommand.materialize_volume_annotation |
-            JobCommand.infer_with_model =>
+            JobCommand.infer_with_model | JobCommand.infer_mitochondria =>
           returnValue.map { resultDatasetName =>
             s"/datasets/$organizationName/$resultDatasetName/view"
           }

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -214,6 +214,20 @@ function JobListView() {
         </span>
       );
     } else if (
+      job.type === APIJobType.INFER_MITOCHONDRIA &&
+      job.organizationName &&
+      job.datasetName &&
+      job.layerName
+    ) {
+      return (
+        <span>
+          Mitochondria inferral for layer {job.layerName} of{" "}
+          <Link to={`/datasets/${job.organizationName}/${job.datasetName}/view`}>
+            {job.datasetName}
+          </Link>{" "}
+        </span>
+      );
+    } else if (
       job.type === APIJobType.MATERIALIZE_VOLUME_ANNOTATION &&
       job.organizationName &&
       job.datasetName
@@ -298,7 +312,8 @@ function JobListView() {
       job.type === APIJobType.INFER_NEURONS ||
       job.type === APIJobType.MATERIALIZE_VOLUME_ANNOTATION ||
       job.type === APIJobType.COMPUTE_MESH_FILE ||
-      job.type === APIJobType.INFER_WITH_MODEL
+      job.type === APIJobType.INFER_WITH_MODEL ||
+      job.type === APIJobType.INFER_MITOCHONDRIA
     ) {
       return (
         <span>

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -678,6 +678,7 @@ export enum APIJobType {
   MATERIALIZE_VOLUME_ANNOTATION = "materialize_volume_annotation",
   TRAIN_MODEL = "train_model",
   INFER_WITH_MODEL = "infer_with_model",
+  INFER_MITOCHONDRIA = "infer_mitochondria",
 }
 
 export type APIJob = {


### PR DESCRIPTION
The job list view should be able to handle infer_mitochondria jobs being present. This new job command was introduced in #7752 .

Before this change, the list view crashed with an assertion error.

Note: the worker job in the current voxelytics master does not yet return the new dataset name, so for old jobs, the view button will not be available. However, I’ll change that in the worker in the coming days so new jobs will then have the view button (already tested that locally).

### Steps to test:
- I tested locally that the infer_mitos entry looks good in the job list view:
![image](https://github.com/scalableminds/webknossos/assets/1390035/77bdeca1-9633-4e52-b409-6f18252977c1)

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)