### PR TITLE
Don't show agglomerate zoom warning in case 3d viewport is maximized

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,7 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Replaced skeleton comment tab component with antd's `<Tree />`component. [#7802](https://github.com/scalableminds/webknossos/pull/7802)
 
 ### Fixed
-- Fixed a bug where the warning to zoom in to see the agglomerate mapping was shown to the user even when the 3D viewport was maximized an no volume data was shown 
+- Fixed a bug where the warning to zoom in to see the agglomerate mapping was shown to the user even when the 3D viewport was maximized and no volume data was shown. [#7865](https://github.com/scalableminds/webknossos/issues/7865) 
 - Fixed a bug where brushing on a fallback segmentation with active mapping and with segment index file would lead to failed saves. [#7833](https://github.com/scalableminds/webknossos/pull/7833)
 - Fixed a bug where sometimes old mismatching javascript code would be served after upgrades. [#7854](https://github.com/scalableminds/webknossos/pull/7854)
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Replaced skeleton comment tab component with antd's `<Tree />`component. [#7802](https://github.com/scalableminds/webknossos/pull/7802)
 
 ### Fixed
+- Fixed a bug where the warning to zoom in to see the agglomerate mapping was shown to the user even when the 3D viewport was maximized an no volume data was shown 
 - Fixed a bug where brushing on a fallback segmentation with active mapping and with segment index file would lead to failed saves. [#7833](https://github.com/scalableminds/webknossos/pull/7833)
 - Fixed a bug where sometimes old mismatching javascript code would be served after upgrades. [#7854](https://github.com/scalableminds/webknossos/pull/7854)
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -46,8 +46,8 @@ Option[String], openGraphImage: Option[String] )
       data-airbrake-project-key="@(conf.Airbrake.projectKey)"
       data-airbrake-environment-name="@(conf.Airbrake.environment)"
     ></script>
-    <script src="/assets/bundle/vendors~main.@(webknossos.BuildInfo.commitHash).js"></script>
-    <script src="/assets/bundle/main.@(webknossos.BuildInfo.commitHash).js"></script>
+    <script src="/assets/bundle/vendors~main.js?nocache=@(webknossos.BuildInfo.commitHash)"></script>
+    <script src="/assets/bundle/main.js?nocache=@(webknossos.BuildInfo.commitHash)"></script>
     <script type="text/javascript" src="https://app.olvy.co/script.js" defer="defer"></script>
   </head>
   <body>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -33,13 +33,13 @@ Option[String], openGraphImage: Option[String] )
       rel="stylesheet"
       type="text/css"
       media="screen"
-      href="/assets/bundle/vendors~main.@(webknossos.BuildInfo.commitHash).css"
+      href="/assets/bundle/vendors~main.css?nocache=@(webknossos.BuildInfo.commitHash)"
     />
     <link
       rel="stylesheet"
       type="text/css"
       media="screen"
-      href="/assets/bundle/main.@(webknossos.BuildInfo.commitHash).css"
+      href="/assets/bundle/main.css?nocache=@(webknossos.BuildInfo.commitHash)"
     />
     <script
       data-airbrake-project-id="@(conf.Airbrake.projectID)"

--- a/frontend/javascripts/oxalis/model/sagas/annotation_saga.tsx
+++ b/frontend/javascripts/oxalis/model/sagas/annotation_saga.tsx
@@ -125,7 +125,7 @@ function shouldDisplaySegmentationData(): boolean {
 
   const segmentationLayerName = segmentationLayer.name;
   const isSegmentationLayerDisabled =
-    Store.getState().datasetConfiguration.layers[segmentationLayerName].isDisabled;
+    state.datasetConfiguration.layers[segmentationLayerName].isDisabled;
   if (isSegmentationLayerDisabled) {
     return false;
   }

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_helper.ts
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_helper.ts
@@ -1,5 +1,6 @@
 import { Model, Actions, TabSetNode } from "flexlayout-react";
 import type { BorderOpenStatus } from "oxalis/store";
+import { ModelConfig } from "./flex_layout_types";
 
 export function getMaximizedItemId(model: Model): string | null | undefined {
   const maximizedTabset = model.getMaximizedTabset();
@@ -67,4 +68,21 @@ export function getPositionStatusOf(tabSetNode: TabSetNode): NodePositionStatus 
     isLeftMost,
     isRightMost,
   };
+}
+
+// Checking whether the TDViewport is maximized in the layout config via
+// searching for the td viewport component in the json config.
+export function is3dViewportMaximized(modelConfig: ModelConfig) {
+  return modelConfig.layout.children.some((child) => {
+    return (
+      child.type === "row" &&
+      child.children.some((rowChild) => {
+        return (
+          rowChild.type === "tabset" &&
+          rowChild.maximized &&
+          rowChild.children?.[0]?.id === "TDView"
+        );
+      })
+    );
+  });
 }

--- a/frontend/javascripts/oxalis/view/layouting/flex_layout_types.ts
+++ b/frontend/javascripts/oxalis/view/layouting/flex_layout_types.ts
@@ -11,6 +11,7 @@ export type TabsetNode = {
   weight?: number;
   selected?: number;
   children: Array<TabNode>;
+  maximized?: boolean;
 };
 
 export type RowOrTabsetNode = TabsetNode | RowNode;

--- a/frontend/javascripts/test/helpers/apiHelpers.ts
+++ b/frontend/javascripts/test/helpers/apiHelpers.ts
@@ -88,6 +88,12 @@ mockRequire(
     },
   }),
 );
+mockRequire("libs/user_local_storage", {
+  getItem: _.noop,
+  setItem: _.noop,
+  removeItem: _.noop,
+  clear: _.noop,
+});
 mockRequire("libs/request", Request);
 mockRequire("libs/error_handling", ErrorHandling);
 mockRequire("app", app);

--- a/frontend/javascripts/test/sagas/annotation_saga.spec.ts
+++ b/frontend/javascripts/test/sagas/annotation_saga.spec.ts
@@ -35,6 +35,12 @@ mockRequire("libs/toast", {
   close: _.noop,
   success: _.noop,
 });
+mockRequire("libs/user_local_storage", {
+  getItem: _.noop,
+  setItem: _.noop,
+  removeItem: _.noop,
+  clear: _.noop,
+});
 const { wkReadyAction } = mockRequire.reRequire("oxalis/model/actions/actions");
 const { acquireAnnotationMutexMaybe } = mockRequire.reRequire("oxalis/model/sagas/annotation_saga");
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "enzyme-adapter-react-16": "^1.9.1",
     "esbuild": "^0.20",
     "espree": "^3.5.4",
-    "git-revision-webpack-plugin": "^5.0.0",
     "husky": "^0.14.3",
     "jsdoc": "^3.5.5",
     "jsdom": "^23.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ module.exports = function (env = {}) {
   const webpack = require("webpack");
   const { EsbuildPlugin } = require("esbuild-loader");
   const path = require("path");
-  const { GitRevisionPlugin } = require("git-revision-webpack-plugin");
   const MiniCssExtractPlugin = require("mini-css-extract-plugin");
   const browserslistToEsbuild = require("browserslist-to-esbuild");
   const CopyPlugin = require("copy-webpack-plugin");
@@ -33,7 +32,7 @@ module.exports = function (env = {}) {
       process: "process/browser",
     }),
     new MiniCssExtractPlugin({
-      filename: "[name].[git-revision-hash].css",
+      filename: "[name].css",
       chunkFilename: "[name].[contenthash].css",
     }),
     new CopyPlugin({
@@ -45,7 +44,6 @@ module.exports = function (env = {}) {
         { from: "node_modules/@zip.js/zip.js/dist/z-worker.js", to: "[name][ext]" },
       ],
     }),
-    new GitRevisionPlugin(), // used to access the commit hash of the HEAD.
   ];
 
   const cssLoaderUrlFilter = {
@@ -61,8 +59,8 @@ module.exports = function (env = {}) {
     mode: env.production ? "production" : "development",
     output: {
       path: `${__dirname}/public/bundle`,
-      filename: "[name].[git-revision-hash].js",
-      sourceMapFilename: "[file].[git-revision-hash].map",
+      filename: "[name].js",
+      sourceMapFilename: "[file].[contenthash].map",
       chunkFilename: "[name].[contenthash].js",
       publicPath,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5436,11 +5436,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-revision-webpack-plugin@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-5.0.0.tgz#0683a6a110ece618499880431cd89e1eb597b536"
-  integrity sha512-RptQN/4UKcEPkCBmRy8kLPo5i8MnF8+XfAgFYN9gbwmKLTLx4YHsQw726H+C5+sIGDixDkmGL3IxPA2gKo+u4w==
-
 git-up@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/git-up/-/git-up-7.0.0.tgz#bace30786e36f56ea341b6f69adfd83286337467"


### PR DESCRIPTION
This PR suppresses the `Segmentation data which is mapped using an agglomerate file cannot be rendered in this magnification. Please zoom in further.` warning in case the user only has the 3d viewport maximized. This bug was noticed on a mobile device but can easily be reproduced on a normal screen.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a dataset with an agglomerate mapping and enable it.
- Zoom out until the described warning appears.
- Miximze the 3d viewport, the warning should be closed automatically and no longer appear.
- Un-maximiize the 3d viewport again, zoom out and the warning should appear again

### Additional Changes:
@hotzenklotz I also changed the fix regarding the cached webpack chunk files: https://scm.slack.com/archives/C5AKLAV0B/p1717429338824009
The fix included putting the latest git commit hash into the main chunk file's name. But this makes development quite tedious: When commit the hash changes, webpack takes notice of this and produces a different `main.<different_hash_then_preivous>.js` but scala does not notice this change and still references the old `main.<old_hash>.js` file. Which means in the current dev setup one needs to restart the backend server after each commit in order to load the newest js / CSS changes. Thus, I rolled back the part that included the hash in the file's name and reverted back to using a nocache query param. The chunk files which originally produced the problem of not getting cache busted, do still include their content hash in their name. Thus, the fix should still work and with my changes the local development should be back to its original comfort without having to restart the backend after each commit.  

### Issues:
- fixes #7865

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)

