### PR TITLE
Allow negative min / max values for floating point color layers

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 - The "WEBKNOSSOS Changelog" modal now lazily loads its content potentially speeding up the initial loading time of WEBKNOSSOS and thus improving the UX. [#7843](https://github.com/scalableminds/webknossos/pull/7843)
+- Updated the min max settings for the histogram to allow floating point color layers to have negative min / max values. [#7873](https://github.com/scalableminds/webknossos/pull/7873)
 - From now on only project owner get a notification email upon project overtime. The organization specific email list `overTimeMailingList` was removed. [#7842](https://github.com/scalableminds/webknossos/pull/7842)
 - Replaced skeleton comment tab component with antd's `<Tree />`component. [#7802](https://github.com/scalableminds/webknossos/pull/7802)
 

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -237,10 +237,10 @@ export function getDefaultValueRangeOfLayer(
       return [0, 2 ** 63 - 1];
 
     case "float":
-      return [0, maxFloatValue];
+      return [-maxFloatValue, maxFloatValue];
 
     case "double":
-      return [0, maxDoubleValue];
+      return [-maxDoubleValue, maxDoubleValue];
 
     default:
       return [0, 255];


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a dataset with floating point layers
- Try to configure negative values for min and max (min needs to be lowered first). This should work.


### Issues:
- fixes #7715

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
