### PR TITLE
Start Job Modal Improvements

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/starting_job_modals.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/starting_job_modals.tsx
@@ -587,9 +587,9 @@ function StartJobForm(props: StartJobFormProps) {
     initialLayerName = fixedSelectedLayer.name;
     initialOutputSegmentationLayerName = getReadableNameOfVolumeLayer(fixedSelectedLayer, tracing);
   }
-  initialOutputSegmentationLayerName = `${
-    initialOutputSegmentationLayerName || "segmentation"
-  }_corrected`;
+  initialOutputSegmentationLayerName = `${initialOutputSegmentationLayerName || "segmentation"}${
+    fixedSelectedLayer ? "_corrected" : "_inferred"
+  }`;
   const hasOutputSegmentationLayer =
     jobTypeWithConfigurableOutputSegmentationLayerName.indexOf(jobName) > -1;
   const notAllowedOutputLayerNames = allLayers
@@ -854,7 +854,6 @@ function CustomAiModelInferenceForm() {
             rules={[{ required: true }]}
           >
             <Select
-              style={{ width: 120 }}
               loading={isLoading}
               options={aiModels.map((aiModel) => ({ value: aiModel.id, label: aiModel.name }))}
             />


### PR DESCRIPTION
`_corrected` doesn’t make sense for jobs that don’t process a layer, but rather create a new one.

Also, the model dropdown select was too narrow so that the full name of the model could not be read.