### PR TITLE
Bump default docker tags in hosting webknossos==24.06.0, fossildb==master__489 for latest release

### DIFF
--- a/tools/hosting/docker-compose.yml
+++ b/tools/hosting/docker-compose.yml
@@ -58,7 +58,7 @@ services:
 
   # FossilDB
   fossildb:
-    image: scalableminds/fossildb:master__442
+    image: scalableminds/fossildb:master__489
     command:
       - fossildb
       - -c

--- a/tools/hosting/docker-compose.yml
+++ b/tools/hosting/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   webknossos:
-    image: scalableminds/webknossos:${DOCKER_TAG:-23.04.0}
+    image: scalableminds/webknossos:${DOCKER_TAG:-23.06.0}
     ports:
       - "127.0.0.1:9000:9000"
     depends_on:

--- a/tools/hosting/docker-compose.yml
+++ b/tools/hosting/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   webknossos:
-    image: scalableminds/webknossos:${DOCKER_TAG:-23.06.0}
+    image: scalableminds/webknossos:${DOCKER_TAG:-24.06.0}
     ports:
       - "127.0.0.1:9000:9000"
     depends_on:


### PR DESCRIPTION
Just a PR for clarity when deploying WebKNOSSOS locally based off of last released changelog https://github.com/scalableminds/webknossos/blob/7b95132dfa46d8c6a5a07e90830bf6144291918e/CHANGELOG.released.md?plain=1#L10

I noticed the discrepancy when I had initially installed 24.04.0, then bumped the version in Docker with a forked version of 24.06.0, thus seeing discrepancies.

Also, bumped compatible fossildb tag as well

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
