### PR TITLE
Fix animation modal color layer validation

### DIFF
--- a/frontend/javascripts/oxalis/view/action-bar/create_animation_modal.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/create_animation_modal.tsx
@@ -230,7 +230,8 @@ function CreateAnimationModal(props: Props) {
       cameraPosition: selectedCameraPosition,
     };
 
-    if (!validateAnimationOptions(colorLayer, boundingBox, meshes)) return;
+    const selectedColor = colorLayers.find((layer => layer.name === selectedColorLayerName))!;
+    if (!validateAnimationOptions(selectedColor, boundingBox, meshes)) return;
 
     startRenderAnimationJob(state.dataset.owningOrganization, state.dataset.name, animationOptions);
 
@@ -395,7 +396,7 @@ function CreateAnimationModal(props: Props) {
           <Row gutter={[8, 20]}>
             <Alert
               type="error"
-              style={{ marginTop: 18 }}
+              style={{ marginTop: 18, width: "100%" }}
               message={
                 <ul>
                   {validationErrors.map((errorMessage) => (


### PR DESCRIPTION
This PR fixes animation modal color layer validation. Unfortunately, the animation validation would always try the first color layer and not the selected one. 


### Steps to test:
- Enable jobs. (Worker is not required to be running)
- Create a dataset with two color layers.
  - Copy an existing layer on disc
  - Modify the new layer's properties to be dtype "uint24".
- Launch the animation modal, select the `uint24` color layer, submit --> validation error
- Launch the animation modal, select the other `uint8` color layer, submit --> success

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1718347143968619

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
