### PR TITLE
Send baseMappingName when forwarding FullMeshRequest from TS to DS

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where sometimes old mismatching javascript code would be served after upgrades. [#7854](https://github.com/scalableminds/webknossos/pull/7854)
 - Fixed a bug where dataset uploads of zipped tiff data via the UI would be rejected. [#7856](https://github.com/scalableminds/webknossos/pull/7856)
 - Fixed a bug with incorrect valiation of layer names in the animation modal. [#7882](https://github.com/scalableminds/webknossos/pull/7882)
+- Fixed a bug in the fullMesh.stl route used by the render_animation worker job, where some meshes in proofreading annotations could not be loaded. [#7887](https://github.com/scalableminds/webknossos/pull/7887)
 
 ### Removed
 - If the datasource-properties.json file for a dataset is missing or contains errors, WEBKNOSSOS no longer attempts to guess its contents from the raw data. Exploring remote datasets will still create the file. [#7697](https://github.com/scalableminds/webknossos/pull/7697)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSMeshController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSMeshController.scala
@@ -44,6 +44,7 @@ class DSMeshController @Inject()(
                                            the oversegmentation. Collect mesh chunks of all *unmapped* segment ids
                                            belonging to the supplied agglomerate id.
                                            If it is not set, use meshfile as is, assume passed id is present in meshfile
+                                  Note: in case of an editable mapping, targetMappingName is its baseMapping name.
                                 */
                                targetMappingName: Option[String],
                                editableMappingTracingId: Option[String]): Action[ListMeshChunksRequest] =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/MeshMappingHelper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/MeshMappingHelper.scala
@@ -52,6 +52,8 @@ trait MeshMappingHelper {
           }
         } yield segmentIds
       case (Some(mappingName), Some(tracingId)) =>
+        // An editable mapping tracing id is supplied. Ask the tracingstore for the segment ids. If it doesn’t know,
+        // use the mappingName (here the editable mapping’s base mapping) to look it up from file.
         for {
           tracingstoreUri <- dsRemoteWebknossosClient.getTracingstoreUri
           segmentIdsResult <- dsRemoteTracingstoreClient.getEditableMappingSegmentIdsForAgglomerate(tracingstoreUri,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteDatastoreClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteDatastoreClient.scala
@@ -133,7 +133,7 @@ class TSRemoteDatastoreClient @Inject()(
   def querySegmentIndex(remoteFallbackLayer: RemoteFallbackLayer,
                         segmentId: Long,
                         mag: Vec3Int,
-                        mappingName: Option[String],
+                        mappingName: Option[String], // should be the baseMappingName in case of editable mappings
                         editableMappingTracingId: Option[String],
                         userToken: Option[String]): Fox[Seq[Vec3Int]] =
     for {
@@ -152,12 +152,13 @@ class TSRemoteDatastoreClient @Inject()(
       indices = positions.map(_.scale(1f / DataLayer.bucketLength)) // Route returns positions to use the same interface as tracing store, we want indices
     } yield indices
 
-  def querySegmentIndexForMultipleSegments(remoteFallbackLayer: RemoteFallbackLayer,
-                                           segmentIds: Seq[Long],
-                                           mag: Vec3Int,
-                                           mappingName: Option[String],
-                                           editableMappingTracingId: Option[String],
-                                           userToken: Option[String]): Fox[Seq[(Long, Seq[Vec3Int])]] =
+  def querySegmentIndexForMultipleSegments(
+      remoteFallbackLayer: RemoteFallbackLayer,
+      segmentIds: Seq[Long],
+      mag: Vec3Int,
+      mappingName: Option[String], // should be the baseMappingName in case of editable mappings
+      editableMappingTracingId: Option[String],
+      userToken: Option[String]): Fox[Seq[(Long, Seq[Vec3Int])]] =
     for {
       remoteLayerUri <- getRemoteLayerUri(remoteFallbackLayer)
       result <- rpc(s"$remoteLayerUri/segmentIndex")

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/TSFullMeshService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/TSFullMeshService.scala
@@ -44,8 +44,9 @@ class TSFullMeshService @Inject()(volumeTracingService: VolumeTracingService,
       fullMeshRequest: FullMeshRequest)(implicit ec: ExecutionContext): Fox[Array[Byte]] =
     for {
       remoteFallbackLayer <- remoteFallbackLayerFromVolumeTracing(tracing, tracingId)
+      baseMappingName <- volumeTracingService.baseMappingName(tracing)
       fullMeshRequestAdapted = if (tracing.mappingIsEditable.getOrElse(false))
-        fullMeshRequest.copy(mappingName = tracing.mappingName,
+        fullMeshRequest.copy(mappingName = baseMappingName,
                              editableMappingTracingId = Some(tracingId),
                              mappingType = Some("HDF5"))
       else fullMeshRequest


### PR DESCRIPTION
Fixes a rare bug that occurs when the fullMesh.stl route is used on an editable mapping, but for an agglomerate ID that has not been edited.

In this case, the tracingstore (TS) redirects the request to the datastore (DS), and sends the mapping name so that the datastore can use the hdf5 mapping file to look up the segment ids for the agglomerate. The bug was that in this case, the editable mapping id was sent as mapping name, rather than the base mapping name, which corresponds to the hdf5 file.

While fixing this, I also restructured the logic of the `MeshMappingHelper` to more explicitly check the different combinations of the optional mappingName and tracingId.

Also added a few comments concerning baseMapping name in a few method signatures.

### Steps to test:
- I tested with the render_animation worker job, which uses the fullMesh.stl route. The animation now correctly contained all selected meshes.

### Issues:
- fixes #7885

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
