### PR TITLE
Improve case handling of segment group child mesh visibility options

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,9 +30,10 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where the warning to zoom in to see the agglomerate mapping was shown to the user even when the 3D viewport was maximized and no volume data was shown. [#7865](https://github.com/scalableminds/webknossos/issues/7865) 
 - Fixed a bug where brushing on a fallback segmentation with active mapping and with segment index file would lead to failed saves. [#7833](https://github.com/scalableminds/webknossos/pull/7833)
+- Fixed a bug where the "Hide Meshes" / "Show Meshes" options of the context menu for segment groups were not available although at leas one mesh was set to visible / invisible. [#7890](https://github.com/scalableminds/webknossos/pull/7890)
 - Fixed a bug where sometimes old mismatching javascript code would be served after upgrades. [#7854](https://github.com/scalableminds/webknossos/pull/7854)
 - Fixed a bug where dataset uploads of zipped tiff data via the UI would be rejected. [#7856](https://github.com/scalableminds/webknossos/pull/7856)
-- Fixed a bug with incorrect valiation of layer names in the animation modal. [#7882](https://github.com/scalableminds/webknossos/pull/7882)
+- Fixed a bug with incorrect validation of layer names in the animation modal. [#7882](https://github.com/scalableminds/webknossos/pull/7882)
 - Fixed a bug in the fullMesh.stl route used by the render_animation worker job, where some meshes in proofreading annotations could not be loaded. [#7887](https://github.com/scalableminds/webknossos/pull/7887)
 
 ### Removed

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -610,10 +610,8 @@ class SegmentsView extends React.Component<Props, State> {
           const segmentMesh = meshes[segment.id];
           // Only regard loaded, but invisible meshes
           if (segmentMesh != null) {
-            visibilityEntry.areSomeSegmentsVisible =
-              visibilityEntry.areSomeSegmentsVisible || segmentMesh.isVisible;
-            visibilityEntry.areSomeSegmentsInvisible =
-              visibilityEntry.areSomeSegmentsInvisible || !segmentMesh.isVisible;
+            visibilityEntry.areSomeSegmentsVisible ||= segmentMesh.isVisible;
+            visibilityEntry.areSomeSegmentsInvisible ||= !segmentMesh.isVisible;
           }
         });
         newVisibleMap[group.groupId] = visibilityEntry;

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -121,6 +121,7 @@ import { SegmentStatisticsModal } from "./segment_statistics_modal";
 import { APIJobType, type AdditionalCoordinate } from "types/api_flow_types";
 import { DataNode } from "antd/lib/tree";
 import { ensureSegmentIndexIsLoadedAction } from "oxalis/model/actions/dataset_actions";
+import { ValueOf } from "types/globals";
 
 const { confirm } = Modal;
 const { Option } = Select;
@@ -318,7 +319,9 @@ type State = {
   searchableTreeItemList: SegmentHierarchyNode[];
   prevProps: Props | null | undefined;
   groupToDelete: number | null | undefined;
-  areSegmentsInGroupVisible: { [groupId: number]: boolean };
+  groupsSegmentsVisibilityStateMap: {
+    [groupId: number]: { areSomeSegmentsVisible: boolean; areSomeSegmentsInvisible: boolean };
+  };
   activeStatisticsModalGroupId: number | null;
 };
 
@@ -397,7 +400,7 @@ class SegmentsView extends React.Component<Props, State> {
     searchableTreeItemList: [],
     prevProps: null,
     groupToDelete: null,
-    areSegmentsInGroupVisible: {},
+    groupsSegmentsVisibilityStateMap: {},
     activeStatisticsModalGroupId: null,
   };
   tree: React.RefObject<RcTree>;
@@ -582,28 +585,44 @@ class SegmentsView extends React.Component<Props, State> {
       };
     }
     if (prevState.prevProps?.meshes !== meshes) {
-      // Derive the areSegmentsInGroupVisible state so that we know per group
+      // Derive the groupsSegmentsVisibilityStateMap state so that we know per group
       // if it contains only visible elements. This is used to know whether "Show meshes" or
       // "Hide meshes" context item should be shown.
       // If any segment is invisible, set the visibility of the group to false, so that the preferred
       // action is to make all meshes visible.
-      const newVisibleMap: { [groupId: number]: boolean } = {};
-      const segmentGroupsWithRoot = [...segmentGroups, rootGroup];
-      segmentGroupsWithRoot.forEach((group) => {
+      const newVisibleMap: State["groupsSegmentsVisibilityStateMap"] = {};
+
+      const fillNewGroupsSegmentsVisibilityStateMap = (group: SegmentGroup) => {
+        group.children.forEach(fillNewGroupsSegmentsVisibilityStateMap);
+
+        const visibilityEntry = {
+          areSomeSegmentsVisible: group.children.some(
+            (childGroup) => newVisibleMap[childGroup.groupId].areSomeSegmentsVisible,
+          ),
+          areSomeSegmentsInvisible: group.children.some(
+            (childGroup) => newVisibleMap[childGroup.groupId].areSomeSegmentsInvisible,
+          ),
+        };
+
         const segmentsOfGroup = groupToSegmentsMap[group.groupId];
         if (segmentsOfGroup == null) return;
-        const isSomeSegmentLoadedAndInvisible = segmentsOfGroup.some((segment) => {
+        segmentsOfGroup.forEach((segment) => {
           const segmentMesh = meshes[segment.id];
           // Only regard loaded, but invisible meshes
-          return segmentMesh != null && !meshes[segment.id].isVisible;
+          if (segmentMesh != null) {
+            visibilityEntry.areSomeSegmentsVisible =
+              visibilityEntry.areSomeSegmentsVisible || segmentMesh.isVisible;
+            visibilityEntry.areSomeSegmentsInvisible =
+              visibilityEntry.areSomeSegmentsInvisible || !segmentMesh.isVisible;
+          }
         });
-
-        newVisibleMap[group.groupId] = !isSomeSegmentLoadedAndInvisible;
-      });
+        newVisibleMap[group.groupId] = visibilityEntry;
+      };
+      fillNewGroupsSegmentsVisibilityStateMap(rootGroup);
       return {
         ...updateStateObject, //may be null
         prevProps: nextProps,
-        areSegmentsInGroupVisible: newVisibleMap,
+        groupsSegmentsVisibilityStateMap: newVisibleMap,
       };
     }
     return {
@@ -1243,50 +1262,57 @@ class SegmentsView extends React.Component<Props, State> {
       : null;
   };
 
-  areSelectedSegmentsMeshesVisible = () => {
+  visibilityStateOfSelectedMeshes = (): ValueOf<State["groupsSegmentsVisibilityStateMap"]> => {
     const selectedSegments = this.getSelectedSegments();
     const meshes = this.props.meshes;
-    const isSomeMeshLoadedAndInvisible = selectedSegments.some((segment) => {
+    const areSomeSegmentsInvisible = selectedSegments.some((segment) => {
+      const segmentMesh = meshes[segment.id];
+      return segmentMesh != null && !meshes[segment.id].isVisible;
+    });
+    const areSomeSegmentsVisible = selectedSegments.some((segment) => {
       const segmentMesh = meshes[segment.id];
       return segmentMesh != null && !meshes[segment.id].isVisible;
     });
     // show "Hide meshes" if no mesh is loaded and invisible
-    return !isSomeMeshLoadedAndInvisible;
+    return { areSomeSegmentsInvisible, areSomeSegmentsVisible };
   };
 
-  getShowMeshesMenuItem = (groupId: number | null): ItemType => {
-    const areGroupOrSelectedSegmentMeshesVisible: boolean =
+  maybeGetShowOrHideMeshesMenuItems = (groupId: number | null): ItemType[] => {
+    if (!this.doesGroupHaveAnyMeshes(groupId)) {
+      return [];
+    }
+    const { areSomeSegmentsInvisible, areSomeSegmentsVisible } =
       groupId == null
-        ? this.areSelectedSegmentsMeshesVisible()
-        : this.state.areSegmentsInGroupVisible[groupId]; //toggle between hide and show
-
-    const showHideMeshesLabel = areGroupOrSelectedSegmentMeshesVisible
-      ? { icon: <EyeInvisibleOutlined />, text: "Hide" }
-      : { icon: <EyeOutlined />, text: "Show" };
-    return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
-      ? {
-          key: "showMeshesOfGroup",
-          icon: showHideMeshesLabel.icon,
-          label: (
-            <div
-              onClick={() => {
-                if (this.props.visibleSegmentationLayer == null) {
-                  // Satisfy TS
-                  return;
-                }
-                this.handleChangeMeshVisibilityInGroup(
-                  this.props.visibleSegmentationLayer.name,
-                  groupId,
-                  !areGroupOrSelectedSegmentMeshesVisible,
-                );
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              {showHideMeshesLabel.text} Meshes
-            </div>
-          ),
-        }
-      : null;
+        ? this.visibilityStateOfSelectedMeshes()
+        : this.state.groupsSegmentsVisibilityStateMap[groupId]; //toggle between hide and show
+    const menuOptions: ItemType[] = [];
+    const changeVisibility = (isVisible: boolean) => {
+      if (this.props.visibleSegmentationLayer == null) {
+        // Satisfy TS
+        return;
+      }
+      this.handleChangeMeshVisibilityInGroup(
+        this.props.visibleSegmentationLayer.name,
+        groupId,
+        isVisible,
+      );
+      this.closeSegmentOrGroupDropdown();
+    };
+    if (areSomeSegmentsInvisible) {
+      menuOptions.push({
+        key: "showMeshes",
+        icon: <EyeOutlined />,
+        label: <div onClick={() => changeVisibility(true)}>Show All Meshes</div>,
+      });
+    }
+    if (areSomeSegmentsVisible) {
+      menuOptions.push({
+        key: "hideMeshes",
+        icon: <EyeInvisibleOutlined />,
+        label: <div onClick={() => changeVisibility(false)}>Hide All Meshes</div>,
+      });
+    }
+    return menuOptions;
   };
 
   setGroupColor(groupId: number | null, color: Vector3 | null) {
@@ -1587,17 +1613,19 @@ class SegmentsView extends React.Component<Props, State> {
             const doSelectedSegmentsHaveAnyMeshes = this.doesGroupHaveAnyMeshes(null);
             const multiSelectMenu = (): MenuProps => {
               return {
-                items: [
+                items: _.flatten([
                   this.getLoadMeshesFromFileMenuItem(null),
                   this.getComputeMeshesAdHocMenuItem(null),
-                  doSelectedSegmentsHaveAnyMeshes ? this.getShowMeshesMenuItem(null) : null,
+                  doSelectedSegmentsHaveAnyMeshes
+                    ? this.maybeGetShowOrHideMeshesMenuItems(null)
+                    : null,
                   doSelectedSegmentsHaveAnyMeshes ? this.getReloadMenuItem(null) : null,
                   doSelectedSegmentsHaveAnyMeshes ? this.getRemoveMeshesMenuItem(null) : null,
                   doSelectedSegmentsHaveAnyMeshes ? this.getDownLoadMeshesMenuItem(null) : null,
                   this.getSetGroupColorMenuItem(null),
                   this.getResetGroupColorMenuItem(null),
                   this.getRemoveFromSegmentListMenuItem(null),
-                ],
+                ]),
               };
             };
 
@@ -1640,7 +1668,7 @@ class SegmentsView extends React.Component<Props, State> {
                 const { id, name } = treeItem;
                 const isEditingDisabled = !this.props.allowUpdate;
                 const menu: MenuProps = {
-                  items: [
+                  items: _.flatten([
                     {
                       key: "create",
                       onClick: () => {
@@ -1673,9 +1701,9 @@ class SegmentsView extends React.Component<Props, State> {
                     this.getComputeMeshesAdHocMenuItem(id),
                     this.getReloadMenuItem(id),
                     this.getRemoveMeshesMenuItem(id),
-                    this.getShowMeshesMenuItem(id),
+                    this.maybeGetShowOrHideMeshesMenuItems(id),
                     this.getDownLoadMeshesMenuItem(id),
-                  ],
+                  ]),
                 };
 
                 // Make sure the displayed name is not empty

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -606,13 +606,17 @@ class SegmentsView extends React.Component<Props, State> {
 
         const segmentsOfGroup = groupToSegmentsMap[group.groupId];
         if (segmentsOfGroup == null) return;
-        segmentsOfGroup.forEach((segment) => {
+        segmentsOfGroup.some((segment) => {
           const segmentMesh = meshes[segment.id];
           // Only regard loaded, but invisible meshes
           if (segmentMesh != null) {
             visibilityEntry.areSomeSegmentsVisible ||= segmentMesh.isVisible;
             visibilityEntry.areSomeSegmentsInvisible ||= !segmentMesh.isVisible;
+            return (
+              visibilityEntry.areSomeSegmentsInvisible && visibilityEntry.areSomeSegmentsVisible
+            );
           }
+          return false;
         });
         newVisibleMap[group.groupId] = visibilityEntry;
       };

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1302,14 +1302,14 @@ class SegmentsView extends React.Component<Props, State> {
       menuOptions.push({
         key: "showMeshes",
         icon: <EyeOutlined />,
-        label: <div onClick={() => changeVisibility(true)}>Show All Meshes</div>,
+        label: <div onClick={() => changeVisibility(true)}>Show Meshes</div>,
       });
     }
     if (areSomeSegmentsVisible) {
       menuOptions.push({
         key: "hideMeshes",
         icon: <EyeInvisibleOutlined />,
-        label: <div onClick={() => changeVisibility(false)}>Hide All Meshes</div>,
+        label: <div onClick={() => changeVisibility(false)}>Hide Meshes</div>,
       });
     }
     return menuOptions;


### PR DESCRIPTION
Prior to this PR, the decision whether to show the "Hide Meshes" or "Show Meshes" option was not case complete. This PR adds support for all cases that might occur:
- A group has some segments that are invisible, some that are visible -> show both options.
- A group has only invisible segments -> only show "Show Meshes"
- A group has only visible segments -> only show "Hide Meshes"
- A group has no loaded meshes -> Show none of the options

Moreover, this PR fixes that the property saving whether a group had visible meshes now also considers its own groups' meshes (recursive checking). Furthermore, this calculation is done for all groups and not only for the groups of the children of the root group (and the root group itself).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open an annotation with a segmentation
- Load some segments and group them in nested levels via groups. Kinda like this:
  ![image](https://github.com/scalableminds/webknossos/assets/39529669/4aab61f9-b031-4bad-8491-e47e0b8748cb)
- Load all their meshes.
- Now the "Show Meshes" action should not be shown for the groups.
- Hide some meshes in a nested group. On a parent -> parent group the option to "Show Meshes" should be available (hide as well).
- Test whether the options do what they are supposed to do and whether they are properly working recursively and do not only affect their immediate children
- Play a little more around. The options should be visible whenever at least one child segment is loaded but (not) visible.


### Issues:
- No issue exists for this. See https://scm.slack.com/archives/C02H5T8Q08P/p1718784540270399

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
