### PR TITLE
Fix not being able to save dataset settings 

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed a bug where the warning to zoom in to see the agglomerate mapping was shown to the user even when the 3D viewport was maximized and no volume data was shown. [#7865](https://github.com/scalableminds/webknossos/issues/7865) 
+- Fixed a bug that prevented saving new dataset settings. [#7903](https://github.com/scalableminds/webknossos/pull/7903)
 - Fixed a bug where brushing on a fallback segmentation with active mapping and with segment index file would lead to failed saves. [#7833](https://github.com/scalableminds/webknossos/pull/7833)
 - Fixed a bug where sometimes old mismatching javascript code would be served after upgrades. [#7854](https://github.com/scalableminds/webknossos/pull/7854)
 - Fixed a bug where dataset uploads of zipped tiff data via the UI would be rejected. [#7856](https://github.com/scalableminds/webknossos/pull/7856)

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -65,7 +65,7 @@ type State = {
   isLoading: boolean;
   activeDataSourceEditMode: "simple" | "advanced";
   activeTabKey: TabKey;
-  dataSource: APIDataSource | null | undefined;
+  savedDataSourceOnServer: APIDataSource | null | undefined;
 };
 export type FormData = {
   dataSource: APIDataSource;
@@ -90,7 +90,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
     messages: [],
     activeDataSourceEditMode: "simple",
     activeTabKey: "data",
-    dataSource: null,
+    savedDataSourceOnServer: null,
   };
 
   async componentDidMount() {
@@ -155,7 +155,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
 
       // Ensure that zarr layers (which aren't inferred by the back-end) are still
       // included in the inferred data source
-      this.setState({ dataSource });
+      this.setState({ savedDataSourceOnServer: dataSource });
 
       if (dataSource == null) {
         throw new Error("No datasource received from server.");
@@ -276,8 +276,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
   }
 
   didDatasourceChange(dataSource: Record<string, any>) {
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'Readonly<MutableAPIDataSource> |... Remove this comment to see the full error message
-    return _.size(diffObjects(dataSource, this.state.savedDataSourceOnServer)) > 0;
+    return _.size(diffObjects(dataSource, this.state.savedDataSourceOnServer || {})) > 0;
   }
 
   isOnlyDatasourceIncorrectAndNotEdited() {
@@ -366,7 +365,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
     if (dataset != null && this.didDatasourceChange(dataSource)) {
       await updateDatasetDatasource(this.props.datasetId.name, dataset.dataStore.url, dataSource);
       this.setState({
-        dataSource,
+        savedDataSourceOnServer: dataSource,
       });
     }
 


### PR DESCRIPTION
Likely due to the frontend changes of #7697, the dataset settings got messed up. The reason is, that the current state of the component does not have the state field `savedDataSourceOnServer`, but it is referenced in a diffiing operation of the datasource schema. See

https://github.com/scalableminds/webknossos/blob/c50a81860b5e9882b24677e5a750b10f63c5d6a8/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx#L277-L282

The diffing is used to decide whether the frontend should send an update of the datasource schema to the backend. But in the current version of the master, the diff check always fails as the state field `savedDataSourceOnServer` is always undefined (it does not exist in the state). My fix re-added this field to the state (by renaming the unused `dataSource` to  `savedDataSourceOnServer`)  and adds a default empty object to the diff, to avoid such an error in any case. Moreover, the type of `savedDataSourceOnServer` says it can be undefined / null thus the additional optional empty object is needed for the diff. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Check whether you can do changes in the dataset settings of one dataset on the master (e.g.: https://master.webknossos.xyz/datasets/sample_organization/ROI2017_wkw/edit) this should not work.
- Do the same on the dev instance for this branch. This should now work. 
- Open the dev tools, in `dataset_settings_view.tsx` in `submit` in line 365 set a break point. Do not edit the datasource settings and hit submit. The debugging should show, that now update is set to the server. Alternatively, just record the sent requests to the server. Only when the datasource settings were modified, an update should be sent to the server.

### Issues:
- Not issue exists for this

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
