### PR TITLE
Fix segments tab not rendering when a segment group does not have at least on direct child segment

### DIFF
--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -605,19 +605,20 @@ class SegmentsView extends React.Component<Props, State> {
         };
 
         const segmentsOfGroup = groupToSegmentsMap[group.groupId];
-        if (segmentsOfGroup == null) return;
-        segmentsOfGroup.some((segment) => {
-          const segmentMesh = meshes[segment.id];
-          // Only regard loaded, but invisible meshes
-          if (segmentMesh != null) {
-            visibilityEntry.areSomeSegmentsVisible ||= segmentMesh.isVisible;
-            visibilityEntry.areSomeSegmentsInvisible ||= !segmentMesh.isVisible;
-            return (
-              visibilityEntry.areSomeSegmentsInvisible && visibilityEntry.areSomeSegmentsVisible
-            );
-          }
-          return false;
-        });
+        if (segmentsOfGroup != null) {
+          segmentsOfGroup.some((segment) => {
+            const segmentMesh = meshes[segment.id];
+            // Only regard loaded, but invisible meshes
+            if (segmentMesh != null) {
+              visibilityEntry.areSomeSegmentsVisible ||= segmentMesh.isVisible;
+              visibilityEntry.areSomeSegmentsInvisible ||= !segmentMesh.isVisible;
+              return (
+                visibilityEntry.areSomeSegmentsInvisible && visibilityEntry.areSomeSegmentsVisible
+              );
+            }
+            return false;
+          });
+        }
         newVisibleMap[group.groupId] = visibilityEntry;
       };
       fillNewGroupsSegmentsVisibilityStateMap(rootGroup);


### PR DESCRIPTION
This PR fixes an error that crashes the segments tab in case the segments tab has a group with no direct segments as children. 

During the development of #7890 I missed the path where a segment group has no children. Please find my inline comment below.



### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Set up the following: 
![image](https://github.com/scalableminds/webknossos/assets/39529669/46d438b1-dfcd-4e0d-8c10-7accea4b5b1f)
- This should now work, and not result in a rendering error. On the master it should crash with a `TypeError: Cannot read properties of undefined (reading 'areSomeSegmentsVisible')` error.

### Issues:
- fixes a bug introduced with pr #7890


