### PR TITLE
(Re-)Center login forms [not urgent]

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug where the warning to zoom in to see the agglomerate mapping was shown to the user even when the 3D viewport was maximized and no volume data was shown. [#7865](https://github.com/scalableminds/webknossos/issues/7865) 
 - Fixed a bug that prevented saving new dataset settings. [#7903](https://github.com/scalableminds/webknossos/pull/7903)
+- Fixed that on large screens the login forms were not horizontally centered. [#7909](https://github.com/scalableminds/webknossos/pull/7909)
 - Fixed a bug where brushing on a fallback segmentation with active mapping and with segment index file would lead to failed saves. [#7833](https://github.com/scalableminds/webknossos/pull/7833)
 - Fixed a bug where the "Hide Meshes" / "Show Meshes" options of the context menu for segment groups were not available although at leas one mesh was set to visible / invisible. [#7890](https://github.com/scalableminds/webknossos/pull/7890)
 - Fixed a bug where sometimes old mismatching javascript code would be served after upgrades. [#7854](https://github.com/scalableminds/webknossos/pull/7854)

--- a/frontend/javascripts/admin/auth/login_view.tsx
+++ b/frontend/javascripts/admin/auth/login_view.tsx
@@ -30,7 +30,7 @@ function LoginView({ history, redirect }: Props) {
   return (
     <Row justify="center" align="middle" className="login-view">
       <Col xs={22} sm={20} md={16} lg={12} xl={8}>
-        <Card className="login-content">
+        <Card className="login-content" style={{ margin: "0 auto" }}>
           <h3>Login</h3>
           <LoginForm layout="horizontal" onLoggedIn={onLoggedIn} />
         </Card>

--- a/frontend/javascripts/components/brain_spinner.tsx
+++ b/frontend/javascripts/components/brain_spinner.tsx
@@ -107,8 +107,10 @@ export function CoverWithLogin({ onLoggedIn }: { onLoggedIn: () => void }) {
         align="middle"
       >
         <Col xs={22} sm={20} md={16} lg={12} xl={8}>
-          <h3>Try logging in to view the dataset.</h3>
-          <LoginForm layout="horizontal" onLoggedIn={onLoggedIn} />
+          <span style={{ margin: "0 auto", display: "table" }}>
+            <h3>Try logging in to view the dataset.</h3>
+            <LoginForm layout="horizontal" onLoggedIn={onLoggedIn} />
+          </span>
         </Col>
       </Row>
     </div>

--- a/frontend/javascripts/components/brain_spinner.tsx
+++ b/frontend/javascripts/components/brain_spinner.tsx
@@ -4,7 +4,7 @@ import { AsyncButton } from "components/async_clickables";
 import { switchToOrganization } from "admin/admin_rest_api";
 import messages from "messages";
 import { Link } from "react-router-dom";
-import { Button, Col, Row } from "antd";
+import { Button, Card, Col, Row } from "antd";
 import LoginForm from "admin/auth/login_form";
 
 type Props = {
@@ -98,21 +98,13 @@ export function BrainSpinnerWithError({
 
 export function CoverWithLogin({ onLoggedIn }: { onLoggedIn: () => void }) {
   return (
-    <div className="cover-whole-screen">
-      <Row
-        justify="center"
-        style={{
-          padding: 50,
-        }}
-        align="middle"
-      >
-        <Col xs={22} sm={20} md={16} lg={12} xl={8}>
-          <span style={{ margin: "0 auto", display: "table" }}>
-            <h3>Try logging in to view the dataset.</h3>
-            <LoginForm layout="horizontal" onLoggedIn={onLoggedIn} />
-          </span>
-        </Col>
-      </Row>
-    </div>
+    <Row justify="center" align="middle" className="login-view">
+      <Col xs={22} sm={20} md={16} lg={12} xl={8}>
+        <Card className="login-content">
+          <h3>Try logging in to view the dataset.</h3>
+          <LoginForm layout="horizontal" onLoggedIn={onLoggedIn} />
+        </Card>
+      </Col>
+    </Row>
   );
 }

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -616,11 +616,12 @@ button.narrow {
     min-height: calc(100vh - var(--navbar-height));
     background: var(--background-blue-neurons);
   }
-
+  
   .login-content {
     max-width: 600px;
     padding: 80px;
-
+    margin: 0 auto;
+    
     @media @smartphones {
       padding: 20px;
       margin: 20px;


### PR DESCRIPTION
Due to the recent PR #7876 making wk a little more accessible for mobile devices, the login forms were not centered anymore on devices with a high screen width. This PR aims to fix this.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the login view of the dev instance. Zoom the page out. The login form should always be horizontally centered. Compare it to the current master version where the login form is not always centered.
- Create an annotation of a non-public dataset. Then, share this annotation as public, copy the link and log out from the dev instance. Open the annotation. The annotation should not be opened as the underlying dataset it not public instead the other version of the login form should be rendered. This login form should be center horizontally as well regardless of the zooming :) 


### Issues:
- No issue exists for this

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)