### PR TITLE
Add option to expand and collapse all children of segment group

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -11,6 +11,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 [Commits](https://github.com/scalableminds/webknossos/compare/24.07.0...HEAD)
 
 ### Added
+- Added option to expand or collapse all subgroups of a segment group in the segments tab. [#7911](https://github.com/scalableminds/webknossos/pull/7911)
 
 ### Changed
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -548,7 +548,7 @@ class SegmentsView extends React.Component<Props, State> {
               ),
             );
           },
-          onCancel() {},
+          onCancel() { },
         });
       } else {
         // If only one segment is selected, select group without warning (and vice-versa) even though ctrl is pressed.
@@ -849,9 +849,9 @@ class SegmentsView extends React.Component<Props, State> {
 
       const maybeMappingName =
         !isEditableMapping &&
-        mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
-        mappingInfo.mappingType === "HDF5" &&
-        mappingInfo.mappingName != null
+          mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
+          mappingInfo.mappingType === "HDF5" &&
+          mappingInfo.mappingName != null
           ? mappingInfo.mappingName
           : undefined;
 
@@ -1221,81 +1221,81 @@ class SegmentsView extends React.Component<Props, State> {
   getReloadMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "reloadMeshes",
-          icon: <ReloadOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.handleRefreshMeshes(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Refresh Meshes
-            </div>
-          ),
-        }
+        key: "reloadMeshes",
+        icon: <ReloadOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.handleRefreshMeshes(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Refresh Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getRemoveMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "removeMeshes",
-          icon: <DeleteOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.handleRemoveMeshes(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Remove Meshes
-            </div>
-          ),
-        }
+        key: "removeMeshes",
+        icon: <DeleteOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.handleRemoveMeshes(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Remove Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getDownLoadMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "downloadAllMeshes",
-          icon: <DownloadOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.downloadAllMeshesForGroup(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Download Meshes
-            </div>
-          ),
-        }
+        key: "downloadAllMeshes",
+        icon: <DownloadOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.downloadAllMeshesForGroup(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Download Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
     return this.props.selectedIds != null
       ? {
-          key: "moveHere",
-          onClick: () => {
-            if (this.props.visibleSegmentationLayer == null) {
-              // Satisfy TS
-              return;
-            }
-            this.props.updateSegments(
-              this.props.selectedIds.segments,
-              { groupId },
-              this.props.visibleSegmentationLayer.name,
-              true,
-            );
-            this.closeSegmentOrGroupDropdown();
-          },
-          disabled: !this.props.allowUpdate,
-          icon: <ArrowRightOutlined />,
-          label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
-        }
+        key: "moveHere",
+        onClick: () => {
+          if (this.props.visibleSegmentationLayer == null) {
+            // Satisfy TS
+            return;
+          }
+          this.props.updateSegments(
+            this.props.selectedIds.segments,
+            { groupId },
+            this.props.visibleSegmentationLayer.name,
+            true,
+          );
+          this.closeSegmentOrGroupDropdown();
+        },
+        disabled: !this.props.allowUpdate,
+        icon: <ArrowRightOutlined />,
+        label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
+      }
       : null;
   };
 
@@ -1726,7 +1726,8 @@ class SegmentsView extends React.Component<Props, State> {
                       icon: <DeleteOutlined />,
                       label: "Delete group",
                     },
-                    this.expandOrCollapseChilden(id),
+                    this.getExpandSubgroupsItem(id),
+                    this.getCollapseSubgroupsItem(id),
                     this.getMoveSegmentsHereMenuItem(id),
                     {
                       key: "groupAndMeshActionDivider",
@@ -1812,11 +1813,10 @@ class SegmentsView extends React.Component<Props, State> {
                   {isSegmentHierarchyEmpty ? (
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description={`There are no segments yet. ${
-                        this.props.allowUpdate && this.props.hasVolumeTracing
-                          ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
-                          : "Select or click existing segments to add them to this list."
-                      }`}
+                      description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
+                        ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
+                        : "Select or click existing segments to add them to this list."
+                        }`}
                     />
                   ) : (
                     /* Without the default height, height will be 0 on the first render, leading to tree virtualization being disabled.
@@ -1883,7 +1883,9 @@ class SegmentsView extends React.Component<Props, State> {
       </div>
     );
   }
-  expandOrCollapseChilden(groupId: number | undefined) {
+
+  getExpandSubgroupsItem(groupId: number | undefined) {
+    // TODO_c disable if all subgroups are already expanded
     const isExpanded = this.state.expandedKeys?.includes(`group-${groupId}`);
     return {
       key: "expandAll",
@@ -1892,8 +1894,23 @@ class SegmentsView extends React.Component<Props, State> {
         this.expandOrCollapseGroup(groupId);
         this.closeSegmentOrGroupDropdown();
       },
-      icon: isExpanded ? <ShrinkOutlined /> : <ExpandAltOutlined />,
-      label: `${isExpanded ? "Collapse" : "Expand"} all subgroups`,
+      icon: <ExpandAltOutlined />,
+      label: "Expand all subgroup",
+    };
+  }
+
+  getCollapseSubgroupsItem(groupId: number | undefined) {
+    // TODO_c disable if all subgroups are already collapsed
+    const isExpanded = this.state.expandedKeys?.includes(`group-${groupId}`);
+    return {
+      key: "collapseAll",
+      disabled: !this.props.allowUpdate,
+      onClick: () => {
+        this.expandOrCollapseGroup(groupId);
+        this.closeSegmentOrGroupDropdown();
+      },
+      icon: <ShrinkOutlined />,
+      label: "Collapse all subgroups",
     };
   }
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1277,7 +1277,6 @@ class SegmentsView extends React.Component<Props, State> {
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
-    console.log("rerender", groupId);
     return this.props.selectedIds != null
       ? {
           key: "moveHere",
@@ -1892,7 +1891,6 @@ class SegmentsView extends React.Component<Props, State> {
     const areAllChildrenExpanded =
       children.filter((childNode) => this.state.expandedKeys?.includes(childNode)).length ===
       children.length;
-    //console.log("getExpandSubgroupsItem", groupId, children, areAllChildrenExpanded) //todo_c
     if (areAllChildrenExpanded) {
       return null;
     }
@@ -1912,7 +1910,6 @@ class SegmentsView extends React.Component<Props, State> {
     const children = this.getSubGroupsAsTreeNodes(groupId);
     const areAllChildrenCollapsed =
       children.filter((childNode) => this.state.expandedKeys?.includes(childNode)).length === 0;
-    //console.log("getCollapseSubgroupsItem", groupId, children, areAllChildrenCollapsed) //todo_c
     if (areAllChildrenCollapsed) {
       return null;
     }

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1904,7 +1904,7 @@ class SegmentsView extends React.Component<Props, State> {
     }
     const groupsToExpand = children;
     // It doesn't make sense to expand subgroups if the group itself is collapsed, so also expand the group.
-    groupsToExpand.push(this.getKeyForGroupId(groupId));
+    if (!isGroupItselfExpanded) groupsToExpand.push(this.getKeyForGroupId(groupId));
     return {
       key: "expandAll",
       disabled: !this.props.allowUpdate,

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1887,12 +1887,9 @@ class SegmentsView extends React.Component<Props, State> {
 
   getExpandSubgroupsItem(groupId: number) {
     const children = this.getSubGroupsAsTreeNodes(groupId);
-    const areAllChildrenExpanded =
-      children.filter((childNode) => this.state.expandedGroupKeys?.includes(childNode)).length ===
-      children.length;
-    const isGroupItselfExpanded = this.state.expandedGroupKeys?.includes(
-      this.getKeyForGroupId(groupId),
-    );
+    const expandedKeySet = new Set(this.state.expandedGroupKeys);
+    const areAllChildrenExpanded = children.every((childNode) => expandedKeySet.has(childNode));
+    const isGroupItselfExpanded = expandedKeySet.has(this.getKeyForGroupId(groupId));
     if (areAllChildrenExpanded && isGroupItselfExpanded) {
       return null;
     }
@@ -1901,7 +1898,6 @@ class SegmentsView extends React.Component<Props, State> {
     if (!isGroupItselfExpanded) groupsToExpand.push(this.getKeyForGroupId(groupId));
     return {
       key: "expandAll",
-      disabled: !this.props.allowUpdate,
       onClick: () => {
         this.expandGroups(groupsToExpand);
         this.closeSegmentOrGroupDropdown();
@@ -1913,18 +1909,15 @@ class SegmentsView extends React.Component<Props, State> {
 
   getCollapseSubgroupsItem(groupId: number) {
     const children = this.getSubGroupsAsTreeNodes(groupId);
+    const expandedKeySet = new Set(this.state.expandedGroupKeys);
     const areAllChildrenCollapsed =
-      children.filter((childNode) => this.state.expandedGroupKeys?.includes(childNode)).length ===
-      0;
-    const isGroupItselfCollapsed = !this.state.expandedGroupKeys?.includes(
-      this.getKeyForGroupId(groupId),
-    );
+      children.filter((childNode) => expandedKeySet.has(childNode)).length === 0;
+    const isGroupItselfCollapsed = !expandedKeySet.has(this.getKeyForGroupId(groupId));
     if (areAllChildrenCollapsed || isGroupItselfCollapsed) {
       return null;
     }
     return {
       key: "collapseAll",
-      disabled: !this.props.allowUpdate,
       onClick: () => {
         this.collapseGroups(children);
         this.closeSegmentOrGroupDropdown();

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -119,7 +119,7 @@ import AdvancedSearchPopover from "../advanced_search_popover";
 import ButtonComponent from "oxalis/view/components/button_component";
 import { SegmentStatisticsModal } from "./segment_statistics_modal";
 import { APIJobType, type AdditionalCoordinate } from "types/api_flow_types";
-import { DataNode, EventDataNode } from "antd/lib/tree";
+import { DataNode } from "antd/lib/tree";
 import { ensureSegmentIndexIsLoadedAction } from "oxalis/model/actions/dataset_actions";
 import { ValueOf } from "types/globals";
 
@@ -463,9 +463,9 @@ class SegmentsView extends React.Component<Props, State> {
     }
   }
 
-  onExpandTree = (expandedKeys: Key[], newlyExpanded: { node: EventDataNode<SegmentHierarchyNode>; expanded: boolean; nativeEvent: MouseEvent; } | null) => {
+  onExpandTree = (expandedKeys: Key[]) => {
     this.setState({ expandedKeys });
-  }
+  };
 
   // TODO_c
   // icon
@@ -473,20 +473,30 @@ class SegmentsView extends React.Component<Props, State> {
   // default: all expanded
   // recursively expand subgroups
 
-  expandOrCollapseGroup = (groupId: number | null) => {
+  getSubGroups = (groupId: number | undefined) => {
+    if (groupId !== MISSING_GROUP_ID)
+      return getGroupByIdWithSubgroups(this.props.segmentGroups, groupId);
+    const recursiveSubGroups = this.props.segmentGroups.flatMap((group) =>
+      getGroupByIdWithSubgroups(this.props.segmentGroups, group.groupId),
+    );
+    return recursiveSubGroups.concat([MISSING_GROUP_ID]);
+  };
+
+  expandOrCollapseGroup = (groupId: number | undefined) => {
     const currentGroupId = groupId != null ? groupId : MISSING_GROUP_ID;
     const isGroupExpanded = this.state.expandedKeys?.includes(`group-${currentGroupId}`);
     if (isGroupExpanded) {
       this.setState({
         expandedKeys: this.state.expandedKeys?.filter((key) => key !== `group-${currentGroupId}`),
       });
-    }
-    else {
+    } else {
+      const groupWithChildren = this.getSubGroups(groupId);
+      const expandedNodes = groupWithChildren.map((group) => `group-${group}`);
       this.setState({
-        expandedKeys: this.state.expandedKeys?.concat(`group-${currentGroupId}`),
+        expandedKeys: this.state.expandedKeys?.concat(expandedNodes),
       });
     }
-  }
+  };
 
   onSelectTreeItem = (
     keys: Key[],
@@ -541,7 +551,7 @@ class SegmentsView extends React.Component<Props, State> {
               ),
             );
           },
-          onCancel() { },
+          onCancel() {},
         });
       } else {
         // If only one segment is selected, select group without warning (and vice-versa) even though ctrl is pressed.
@@ -842,9 +852,9 @@ class SegmentsView extends React.Component<Props, State> {
 
       const maybeMappingName =
         !isEditableMapping &&
-          mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
-          mappingInfo.mappingType === "HDF5" &&
-          mappingInfo.mappingName != null
+        mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
+        mappingInfo.mappingType === "HDF5" &&
+        mappingInfo.mappingName != null
           ? mappingInfo.mappingName
           : undefined;
 
@@ -1214,81 +1224,81 @@ class SegmentsView extends React.Component<Props, State> {
   getReloadMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "reloadMeshes",
-        icon: <ReloadOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.handleRefreshMeshes(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Refresh Meshes
-          </div>
-        ),
-      }
+          key: "reloadMeshes",
+          icon: <ReloadOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.handleRefreshMeshes(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Refresh Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getRemoveMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "removeMeshes",
-        icon: <DeleteOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.handleRemoveMeshes(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Remove Meshes
-          </div>
-        ),
-      }
+          key: "removeMeshes",
+          icon: <DeleteOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.handleRemoveMeshes(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Remove Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getDownLoadMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "downloadAllMeshes",
-        icon: <DownloadOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.downloadAllMeshesForGroup(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Download Meshes
-          </div>
-        ),
-      }
+          key: "downloadAllMeshes",
+          icon: <DownloadOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.downloadAllMeshesForGroup(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Download Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
     return this.props.selectedIds != null
       ? {
-        key: "moveHere",
-        onClick: () => {
-          if (this.props.visibleSegmentationLayer == null) {
-            // Satisfy TS
-            return;
-          }
-          this.props.updateSegments(
-            this.props.selectedIds.segments,
-            { groupId },
-            this.props.visibleSegmentationLayer.name,
-            true,
-          );
-          this.closeSegmentOrGroupDropdown();
-        },
-        disabled: !this.props.allowUpdate,
-        icon: <ArrowRightOutlined />,
-        label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
-      }
+          key: "moveHere",
+          onClick: () => {
+            if (this.props.visibleSegmentationLayer == null) {
+              // Satisfy TS
+              return;
+            }
+            this.props.updateSegments(
+              this.props.selectedIds.segments,
+              { groupId },
+              this.props.visibleSegmentationLayer.name,
+              true,
+            );
+            this.closeSegmentOrGroupDropdown();
+          },
+          disabled: !this.props.allowUpdate,
+          icon: <ArrowRightOutlined />,
+          label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
+        }
       : null;
   };
 
@@ -1805,10 +1815,11 @@ class SegmentsView extends React.Component<Props, State> {
                   {isSegmentHierarchyEmpty ? (
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
-                        ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
-                        : "Select or click existing segments to add them to this list."
-                        }`}
+                      description={`There are no segments yet. ${
+                        this.props.allowUpdate && this.props.hasVolumeTracing
+                          ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
+                          : "Select or click existing segments to add them to this list."
+                      }`}
                     />
                   ) : (
                     /* Without the default height, height will be 0 on the first render, leading to tree virtualization being disabled.
@@ -1876,16 +1887,16 @@ class SegmentsView extends React.Component<Props, State> {
       </div>
     );
   }
-  expandOrCollapseChilden(groupId: number | null) {
+  expandOrCollapseChilden(groupId: number | undefined) {
     return {
       key: "expandAll",
       disabled: !this.props.allowUpdate,
       onClick: () => {
-        this.expandOrCollapseGroup(groupId)
+        this.expandOrCollapseGroup(groupId);
       },
       icon: <DeleteOutlined />,
       label: "Expand or collapse children",
-    }
+    };
   }
 
   createGroup(parentGroupId: number): void {


### PR DESCRIPTION
### Dev instance
https://collapseallsegmentgroupchildren.webknossos.xyz/

### Steps to test:
- go to segments tab in any annotation
- click some segments and create some groups, groups should be nested for at least three levels
- right click any group to access group context menu
- if the segment group has any subgroups, there should be one or two new items: "expand/collapse all subgroups".
- if the group is expanded and some subgroups are expanded and some are collapsed, both entries should be shown
- if the group itself is expanded and all subgroups are collapsed, you should only be able to expand them. the opposite is true if all subgroups are expanded.
- if the group itself is collapsed, you should only be able to expand all subgroups. the group itself will be expanded aswell.
~~- # 7827: Focus in segment list should also work for segments in a collapsed group~~

### TODOs:

- [x] icon
- [x] switch label
- [x] default: all expanded
- [x] recursively expand subgroups

### Issues:
- fixes #7829 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
