### PR TITLE
Only show train job info in actions column on success of the job

### DIFF
--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -343,8 +343,8 @@ function JobListView() {
     } else if (job.type === APIJobType.TRAIN_MODEL) {
       return (
         <span>
-          The model may now be selected from the &quot;AI Analysis&quot; button when viewing a
-          dataset.
+          {job.state === "SUCCESS" &&
+            "The model may now be selected from the &quot;AI Analysis&quot; button when viewing a dataset."}
         </span>
       );
     } else {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Honestly: it is not worth testing this minor change as this would consume too much time in proportion to the change.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1719923978212419
