### PR TITLE
Segment name in contextmenu of dataviewport

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added route `/import?url=<url_to_datasource>` to automatically import and view remote datasets. [#7844](https://github.com/scalableminds/webknossos/pull/7844)
+- The context menu that is opened upon right-clicking a segment in the dataview port now contains the segment's name. [#7920](https://github.com/scalableminds/webknossos/pull/7920) 
 
 ### Changed
 

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -1652,16 +1652,16 @@ function ContextMenuInner(propsWithInputRef: Props) {
   }
 
   if (wasSegmentOrMeshClicked) {
-    /*     infoRows.push(
-          getInfoMenuItem(
-            "copy-cell",
-            <>
-              <div className="cell-context-icon" />
-              Segment ID: {`${clickedSegmentOrMeshId}`}{" "}
-              {copyIconWithTooltip(clickedSegmentOrMeshId, "Copy Segment ID")}
-            </>,
-          ),
-        ); */
+    infoRows.push(
+      getInfoMenuItem(
+        "copy-cell",
+        <>
+          <div className="cell-context-icon" />
+          Segment ID: {`${clickedSegmentOrMeshId}`}{" "}
+          {copyIconWithTooltip(clickedSegmentOrMeshId, "Copy Segment ID")}
+        </>,
+      ),
+    );
   }
   if (segments != null) {
     const segmentName = segments.getNullable(clickedSegmentOrMeshId)?.name;
@@ -1672,24 +1672,20 @@ function ContextMenuInner(propsWithInputRef: Props) {
         getInfoMenuItem(
           "copy-cell",
           <>
-            <div className="cell-context-icon" />
-            Segment ID: {`${clickedSegmentOrMeshId}`}{" "}
-            {copyIconWithTooltip(clickedSegmentOrMeshId, "Copy Segment ID")}
-            <div style={{ marginLeft: 22, marginTop: -5 }}>
-              <Tooltip title={segmentName.length > maxNameLengthSecondLine ? segmentName : null}>
-                Segment Name:{" "}
-                {segmentName.length < maxNameLengthFirstLine &&
-                  truncateStringToLength(segmentName, maxNameLengthFirstLine)}
-                {segmentName.length < maxNameLengthFirstLine &&
+            <i className="fas fa-tag segment-context-icon" />
+            <Tooltip title={segmentName.length > maxNameLengthSecondLine ? segmentName : null}>
+              Segment Name:{" "}
+              {segmentName.length < maxNameLengthFirstLine &&
+                truncateStringToLength(segmentName, maxNameLengthFirstLine)}
+              {segmentName.length < maxNameLengthFirstLine &&
+                copyIconWithTooltip(segmentName, "Copy Segment Name")}
+              <div style={{ marginLeft: 22, marginTop: -5 }}>
+                {segmentName.length > maxNameLengthFirstLine &&
+                  truncateStringToLength(segmentName, maxNameLengthSecondLine)}
+                {segmentName.length > maxNameLengthFirstLine &&
                   copyIconWithTooltip(segmentName, "Copy Segment Name")}
-                <div style={{ marginTop: -5 }}>
-                  {segmentName.length > maxNameLengthFirstLine &&
-                    truncateStringToLength(segmentName, maxNameLengthSecondLine)}
-                  {segmentName.length > maxNameLengthFirstLine &&
-                    copyIconWithTooltip(segmentName, "Copy Segment Name")}
-                </div>
-              </Tooltip>
-            </div>
+              </div>
+            </Tooltip>
           </>,
         ),
       );

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -921,11 +921,14 @@ function getNoNodeContextMenuOptions(props: NoNodeContextMenuProps): ItemType[] 
     mappingInfo,
     infoRows,
     allowUpdate,
+    segments,
   } = props;
 
   const state = Store.getState();
   const isAgglomerateMappingEnabled = hasAgglomerateMapping(state);
   const isConnectomeMappingEnabled = hasConnectomeFile(state);
+
+  //const segments = visibleSegmentationLayer == null ? [] : getSegmentsForLayer(state, visibleSegmentationLayer?.name);
 
   const isProofreadingActive = state.uiInformation.activeTool === AnnotationToolEnum.PROOFREAD;
 
@@ -1160,6 +1163,24 @@ function getNoNodeContextMenuOptions(props: NoNodeContextMenuProps): ItemType[] 
   }
 
   const meshFileMappingName = currentMeshFile != null ? currentMeshFile.mappingName : undefined;
+
+  const getSegmentNameItem = (): MenuItemType | null => {
+    if (segments == null) return null;
+    const segmentName = segments.getNullable(segmentIdAtPosition)?.name;
+    if (segmentName == null) return null;
+    return {
+      key: "segment-name",
+      label: `Segment Name: ${segmentName}`,
+    };
+  };
+  const segmentIdItem: MenuItemType | null =
+    segments != null
+      ? {
+          key: "segment-id",
+          label: `Segment ID: ${segmentIdAtPosition}`,
+        }
+      : null;
+
   const focusInSegmentListItem: MenuItemType = {
     key: "focus-in-segment-list",
     onClick: maybeFocusSegment,
@@ -1185,6 +1206,8 @@ function getNoNodeContextMenuOptions(props: NoNodeContextMenuProps): ItemType[] 
   const nonSkeletonActions: ItemType[] =
     volumeTracing != null && globalPosition != null
       ? [
+          segmentIdItem,
+          getSegmentNameItem(),
           // Segment 0 cannot/shouldn't be made active (as this
           // would be an eraser effectively).
           segmentIdAtPosition > 0
@@ -1198,7 +1221,7 @@ function getNoNodeContextMenuOptions(props: NoNodeContextMenuProps): ItemType[] 
                 disabled: segmentIdAtPosition === getActiveCellId(volumeTracing),
                 label: (
                   <>
-                    Activate Segment ({segmentIdAtPosition}){" "}
+                    Activate Segment
                     {isVolumeBasedToolActive ? shortcutBuilder(["Shift", "leftMouse"]) : null}
                   </>
                 ),

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -1160,7 +1160,6 @@ function getNoNodeContextMenuOptions(props: NoNodeContextMenuProps): ItemType[] 
   }
 
   const meshFileMappingName = currentMeshFile != null ? currentMeshFile.mappingName : undefined;
-
   const focusInSegmentListItem: MenuItemType = {
     key: "focus-in-segment-list",
     onClick: maybeFocusSegment,

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -1663,10 +1663,10 @@ function ContextMenuInner(propsWithInputRef: Props) {
       ),
     );
   }
-  if (segments != null) {
+  if (segments != null && wasSegmentOrMeshClicked) {
     const segmentName = segments.getNullable(clickedSegmentOrMeshId)?.name;
-    const maxNameLength = 20;
     if (segmentName != null) {
+      const maxNameLength = 20;
       infoRows.push(
         getInfoMenuItem(
           "copy-cell",

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -1652,16 +1652,16 @@ function ContextMenuInner(propsWithInputRef: Props) {
   }
 
   if (wasSegmentOrMeshClicked) {
-    infoRows.push(
-      getInfoMenuItem(
-        "copy-cell",
-        <>
-          <div className="cell-context-icon" />
-          Segment ID: {`${clickedSegmentOrMeshId}`}{" "}
-          {copyIconWithTooltip(clickedSegmentOrMeshId, "Copy Segment ID")}
-        </>,
-      ),
-    );
+    /*     infoRows.push(
+          getInfoMenuItem(
+            "copy-cell",
+            <>
+              <div className="cell-context-icon" />
+              Segment ID: {`${clickedSegmentOrMeshId}`}{" "}
+              {copyIconWithTooltip(clickedSegmentOrMeshId, "Copy Segment ID")}
+            </>,
+          ),
+        ); */
   }
   if (segments != null) {
     const segmentName = segments.getNullable(clickedSegmentOrMeshId)?.name;
@@ -1672,20 +1672,24 @@ function ContextMenuInner(propsWithInputRef: Props) {
         getInfoMenuItem(
           "copy-cell",
           <>
-            <i className="fas fa-tag segment-context-icon" />
-            <Tooltip title={segmentName.length > maxNameLengthSecondLine ? segmentName : null}>
-              Segment Name:{" "}
-              {segmentName.length < maxNameLengthFirstLine &&
-                truncateStringToLength(segmentName, maxNameLengthFirstLine)}
-              {segmentName.length < maxNameLengthFirstLine &&
-                copyIconWithTooltip(segmentName, "Copy Segment Name")}
-              <div style={{ marginLeft: 22, marginTop: -5 }}>
-                {segmentName.length > maxNameLengthFirstLine &&
-                  truncateStringToLength(segmentName, maxNameLengthSecondLine)}
-                {segmentName.length > maxNameLengthFirstLine &&
+            <div className="cell-context-icon" />
+            Segment ID: {`${clickedSegmentOrMeshId}`}{" "}
+            {copyIconWithTooltip(clickedSegmentOrMeshId, "Copy Segment ID")}
+            <div style={{ marginLeft: 22, marginTop: -5 }}>
+              <Tooltip title={segmentName.length > maxNameLengthSecondLine ? segmentName : null}>
+                Segment Name:{" "}
+                {segmentName.length < maxNameLengthFirstLine &&
+                  truncateStringToLength(segmentName, maxNameLengthFirstLine)}
+                {segmentName.length < maxNameLengthFirstLine &&
                   copyIconWithTooltip(segmentName, "Copy Segment Name")}
-              </div>
-            </Tooltip>
+                <div style={{ marginTop: -5 }}>
+                  {segmentName.length > maxNameLengthFirstLine &&
+                    truncateStringToLength(segmentName, maxNameLengthSecondLine)}
+                  {segmentName.length > maxNameLengthFirstLine &&
+                    copyIconWithTooltip(segmentName, "Copy Segment Name")}
+                </div>
+              </Tooltip>
+            </div>
           </>,
         ),
       );

--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -1665,27 +1665,18 @@ function ContextMenuInner(propsWithInputRef: Props) {
   }
   if (segments != null) {
     const segmentName = segments.getNullable(clickedSegmentOrMeshId)?.name;
-    const maxNameLengthFirstLine = 20;
-    const maxNameLengthSecondLine = 40;
+    const maxNameLength = 20;
     if (segmentName != null) {
       infoRows.push(
         getInfoMenuItem(
           "copy-cell",
           <>
             <i className="fas fa-tag segment-context-icon" />
-            <Tooltip title={segmentName.length > maxNameLengthSecondLine ? segmentName : null}>
-              Segment Name:{" "}
-              {segmentName.length < maxNameLengthFirstLine &&
-                truncateStringToLength(segmentName, maxNameLengthFirstLine)}
-              {segmentName.length < maxNameLengthFirstLine &&
-                copyIconWithTooltip(segmentName, "Copy Segment Name")}
-              <div style={{ marginLeft: 22, marginTop: -5 }}>
-                {segmentName.length > maxNameLengthFirstLine &&
-                  truncateStringToLength(segmentName, maxNameLengthSecondLine)}
-                {segmentName.length > maxNameLengthFirstLine &&
-                  copyIconWithTooltip(segmentName, "Copy Segment Name")}
-              </div>
-            </Tooltip>
+            Segment Name:{" "}
+            {segmentName.length > maxNameLength
+              ? truncateStringToLength(segmentName, maxNameLength)
+              : segmentName}
+            {copyIconWithTooltip(segmentName, "Copy Segment Name")}
           </>,
         ),
       );


### PR DESCRIPTION
### Steps to test:
- Open context menu of a segment in data view port. 
- If the segment has a name, you should see it at the bottom of the context menu.
- Otherwise, nothing should change.
- You should be able to copy the name. 
- Long and short names should be displayed nicely.

### TODOs:
- [x] decide icon

### Issues:
- fixes #7828 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
