### PR TITLE
Only show wrong mesh scale warning in console if not matching to any segmentation layer resolution 

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The context menu that is opened upon right-clicking a segment in the dataview port now contains the segment's name. [#7920](https://github.com/scalableminds/webknossos/pull/7920) 
 
 ### Changed
+- The warning about a mismatch between the scale of a pre-computed mesh and the dataset scale's factor now also considers all supported mags of the active segmentation layer. This reduces the false posive rate regarding this warning. [#7921](https://github.com/scalableminds/webknossos/pull/7921/)
 
 ### Fixed
 

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -1080,6 +1080,10 @@ export function diffObjects(
   return changes(object, base);
 }
 
+export function areVec3AlmostEqual(a: Vector3, b: Vector3, epsilon: number = 1e-6): boolean {
+  return _.every(a.map((v, i) => Math.abs(v - b[i]) < epsilon));
+}
+
 export function coalesce<T extends {}>(e: T, token: any): T[keyof T] | null {
   return Object.values(e).includes(token as T[keyof T]) ? token : null;
 }


### PR DESCRIPTION
Currently, the warning that the scale of a loaded pre-computed mesh does not match the dataset scale factor is printed even in case, the mesh was calculated in a valid lower res mag. The changes of this PR now check whether the provided scale of the mesh matches any of the resolutions supported by the active segmentation layer multiplied with the dataset scale. Only in case none matches, the warning is printed to the console.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
Please test locally. I was unable to prepare a dev instance testing scenario due to not having an already uploaded dataset with a meshfile creating the mesh scale mismatch warning on the current state of the master.

I suggest testing with the l4_sample dataset. The one on the dev instances does not seem to have the mesh files triggering the warning. The mesh files likely were computed in the finest mag.


1. Checkout the master branch.
2. View the  l4_sample dataset
4. Load a pre-computed mesh. **A** warning should appear in the console regarding the scale of the loaded mesh.
5. Switch to this branch.
6. View the l4_sample dataset.
7. Load a pre-computed mesh. **No** warning should appear in the console regarding the scale of the loaded mesh.


### Issues:
- https://scm.slack.com/archives/C5AKLAV0B/p1721041726717299
