### PR TITLE
Forbid editing other orga’s public annotations

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 - The warning about a mismatch between the scale of a pre-computed mesh and the dataset scale's factor now also considers all supported mags of the active segmentation layer. This reduces the false posive rate regarding this warning. [#7921](https://github.com/scalableminds/webknossos/pull/7921/)
+- It is no longer allowed to edit annotations of other organizations, even if they are set to public and to others-may-edit. [#7923](https://github.com/scalableminds/webknossos/pull/7923)
 
 ### Fixed
 

--- a/app/models/annotation/AnnotationRestrictions.scala
+++ b/app/models/annotation/AnnotationRestrictions.scala
@@ -68,9 +68,13 @@ class AnnotationRestrictionDefaults @Inject()(userService: UserService)(implicit
       override def allowUpdate(user: Option[User]): Fox[Boolean] =
         for {
           accessAllowed <- allowAccess(user)
+          annotationOwner <- userService.findOneCached(annotation._user)(GlobalAccessContext)
         } yield
           user.exists { user =>
-            (annotation._user == user._id || accessAllowed && annotation.othersMayEdit) && !(annotation.state == Finished) && !annotation.isLockedByOwner
+            (annotation._user == user._id || (accessAllowed && annotation.othersMayEdit)) &&
+            !(annotation.state == Finished) &&
+            !annotation.isLockedByOwner &&
+            annotationOwner._organization == user._organization
           }
 
       override def allowFinish(userOption: Option[User]): Fox[Boolean] =


### PR DESCRIPTION
### Issues:
- fixes #7914

### Steps to test:
- create two orgas
- create an annotation for a public dataset, set it to public and to others-may-edit
- another user from the same organization should be able to edit it (respecting mutex)
- another user from a *different* organization should be able to view it but never edit it

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
