### PR TITLE
Save expanded/collapsed state of segment groups

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added option to expand or collapse all subgroups of a segment group in the segments tab. [#7911](https://github.com/scalableminds/webknossos/pull/7911)
 - The context menu that is opened upon right-clicking a segment in the dataview port now contains the segment's name. [#7920](https://github.com/scalableminds/webknossos/pull/7920) 
 - Upgraded backend dependencies for improved performance and stability. [#7922](https://github.com/scalableminds/webknossos/pull/7922)
+- It is now saved whether segment groups are collapsed or expanded, so this information doesn't get lost e.g. upon page reload. [#7928](https://github.com/scalableminds/webknossos/pull/7928/)
 
 ### Changed
 - The warning about a mismatch between the scale of a pre-computed mesh and the dataset scale's factor now also considers all supported mags of the active segmentation layer. This reduces the false posive rate regarding this warning. [#7921](https://github.com/scalableminds/webknossos/pull/7921/)

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -690,6 +690,7 @@ class TracingApi {
       name: name || `Group ${newGroupId}`,
       groupId: newGroupId,
       children: [],
+      isExpanded: false,
     };
 
     if (parentGroupId === MISSING_GROUP_ID) {

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -309,7 +309,6 @@ function VolumeTracingReducer(
 
     case "SET_SEGMENT_GROUPS": {
       const { segmentGroups } = action;
-      console.log(segmentGroups);
       return setSegmentGroups(state, action.layerName, segmentGroups);
     }
 

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -309,6 +309,7 @@ function VolumeTracingReducer(
 
     case "SET_SEGMENT_GROUPS": {
       const { segmentGroups } = action;
+      console.log(segmentGroups);
       return setSegmentGroups(state, action.layerName, segmentGroups);
     }
 

--- a/frontend/javascripts/oxalis/store.ts
+++ b/frontend/javascripts/oxalis/store.ts
@@ -160,6 +160,7 @@ export type Tree = {
 export type TreeGroupTypeFlat = {
   readonly name: string;
   readonly groupId: number;
+  readonly isExpanded?: boolean;
 };
 export type TreeGroup = TreeGroupTypeFlat & {
   readonly children: Array<TreeGroup>;

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1277,6 +1277,7 @@ class SegmentsView extends React.Component<Props, State> {
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
+    console.log("rerender", groupId);
     return this.props.selectedIds != null
       ? {
         key: "moveHere",

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -121,7 +121,7 @@ import AdvancedSearchPopover from "../advanced_search_popover";
 import ButtonComponent from "oxalis/view/components/button_component";
 import { SegmentStatisticsModal } from "./segment_statistics_modal";
 import { APIJobType, type AdditionalCoordinate } from "types/api_flow_types";
-import { DataNode } from "antd/lib/tree";
+import { DataNode, EventDataNode } from "antd/lib/tree";
 import { ensureSegmentIndexIsLoadedAction } from "oxalis/model/actions/dataset_actions";
 import { ValueOf } from "types/globals";
 
@@ -554,7 +554,7 @@ class SegmentsView extends React.Component<Props, State> {
               ),
             );
           },
-          onCancel() {},
+          onCancel() { },
         });
       } else {
         // If only one segment is selected, select group without warning (and vice-versa) even though ctrl is pressed.
@@ -850,9 +850,9 @@ class SegmentsView extends React.Component<Props, State> {
 
       const maybeMappingName =
         !isEditableMapping &&
-        mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
-        mappingInfo.mappingType === "HDF5" &&
-        mappingInfo.mappingName != null
+          mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
+          mappingInfo.mappingType === "HDF5" &&
+          mappingInfo.mappingName != null
           ? mappingInfo.mappingName
           : undefined;
 
@@ -1222,81 +1222,81 @@ class SegmentsView extends React.Component<Props, State> {
   getReloadMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "reloadMeshes",
-          icon: <ReloadOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.handleRefreshMeshes(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Refresh Meshes
-            </div>
-          ),
-        }
+        key: "reloadMeshes",
+        icon: <ReloadOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.handleRefreshMeshes(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Refresh Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getRemoveMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "removeMeshes",
-          icon: <DeleteOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.handleRemoveMeshes(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Remove Meshes
-            </div>
-          ),
-        }
+        key: "removeMeshes",
+        icon: <DeleteOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.handleRemoveMeshes(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Remove Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getDownLoadMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "downloadAllMeshes",
-          icon: <DownloadOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.downloadAllMeshesForGroup(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Download Meshes
-            </div>
-          ),
-        }
+        key: "downloadAllMeshes",
+        icon: <DownloadOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.downloadAllMeshesForGroup(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Download Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
     return this.props.selectedIds != null
       ? {
-          key: "moveHere",
-          onClick: () => {
-            if (this.props.visibleSegmentationLayer == null) {
-              // Satisfy TS
-              return;
-            }
-            this.props.updateSegments(
-              this.props.selectedIds.segments,
-              { groupId },
-              this.props.visibleSegmentationLayer.name,
-              true,
-            );
-            this.closeSegmentOrGroupDropdown();
-          },
-          disabled: !this.props.allowUpdate,
-          icon: <ArrowRightOutlined />,
-          label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
-        }
+        key: "moveHere",
+        onClick: () => {
+          if (this.props.visibleSegmentationLayer == null) {
+            // Satisfy TS
+            return;
+          }
+          this.props.updateSegments(
+            this.props.selectedIds.segments,
+            { groupId },
+            this.props.visibleSegmentationLayer.name,
+            true,
+          );
+          this.closeSegmentOrGroupDropdown();
+        },
+        disabled: !this.props.allowUpdate,
+        icon: <ArrowRightOutlined />,
+        label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
+      }
       : null;
   };
 
@@ -1813,11 +1813,10 @@ class SegmentsView extends React.Component<Props, State> {
                   {isSegmentHierarchyEmpty ? (
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description={`There are no segments yet. ${
-                        this.props.allowUpdate && this.props.hasVolumeTracing
-                          ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
-                          : "Select or click existing segments to add them to this list."
-                      }`}
+                      description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
+                        ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
+                        : "Select or click existing segments to add them to this list."
+                        }`}
                     />
                   ) : (
                     /* Without the default height, height will be 0 on the first render, leading to tree virtualization being disabled.
@@ -1883,6 +1882,17 @@ class SegmentsView extends React.Component<Props, State> {
         </DomVisibilityObserver>
       </div>
     );
+  }
+  expandOrCollapseChilden(groupId: number | null) {
+    return {
+      key: "expandAll",
+      disabled: !this.props.allowUpdate,
+      onClick: () => {
+        this.expandOrCollapseGroup(groupId)
+      },
+      icon: <DeleteOutlined />,
+      label: "Expand or collapse children",
+    }
   }
 
   getExpandSubgroupsItem(groupId: number) {

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -121,7 +121,7 @@ import AdvancedSearchPopover from "../advanced_search_popover";
 import ButtonComponent from "oxalis/view/components/button_component";
 import { SegmentStatisticsModal } from "./segment_statistics_modal";
 import { APIJobType, type AdditionalCoordinate } from "types/api_flow_types";
-import { DataNode, EventDataNode } from "antd/lib/tree";
+import { DataNode } from "antd/lib/tree";
 import { ensureSegmentIndexIsLoadedAction } from "oxalis/model/actions/dataset_actions";
 import { ValueOf } from "types/globals";
 
@@ -1882,17 +1882,6 @@ class SegmentsView extends React.Component<Props, State> {
         </DomVisibilityObserver>
       </div>
     );
-  }
-  expandOrCollapseChilden(groupId: number | null) {
-    return {
-      key: "expandAll",
-      disabled: !this.props.allowUpdate,
-      onClick: () => {
-        this.expandOrCollapseGroup(groupId)
-      },
-      icon: <DeleteOutlined />,
-      label: "Expand or collapse children",
-    }
   }
 
   getExpandSubgroupsItem(groupId: number) {

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -624,7 +624,7 @@ class SegmentsView extends React.Component<Props, State> {
               ),
             );
           },
-          onCancel() {},
+          onCancel() { },
         });
       } else {
         // If only one segment is selected, select group without warning (and vice-versa) even though ctrl is pressed.
@@ -919,9 +919,9 @@ class SegmentsView extends React.Component<Props, State> {
 
       const maybeMappingName =
         !isEditableMapping &&
-        mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
-        mappingInfo.mappingType === "HDF5" &&
-        mappingInfo.mappingName != null
+          mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
+          mappingInfo.mappingType === "HDF5" &&
+          mappingInfo.mappingName != null
           ? mappingInfo.mappingName
           : undefined;
 
@@ -1291,81 +1291,81 @@ class SegmentsView extends React.Component<Props, State> {
   getReloadMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "reloadMeshes",
-          icon: <ReloadOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.handleRefreshMeshes(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Refresh Meshes
-            </div>
-          ),
-        }
+        key: "reloadMeshes",
+        icon: <ReloadOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.handleRefreshMeshes(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Refresh Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getRemoveMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "removeMeshes",
-          icon: <DeleteOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.handleRemoveMeshes(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Remove Meshes
-            </div>
-          ),
-        }
+        key: "removeMeshes",
+        icon: <DeleteOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.handleRemoveMeshes(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Remove Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getDownLoadMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-          key: "downloadAllMeshes",
-          icon: <DownloadOutlined />,
-          label: (
-            <div
-              onClick={() => {
-                this.downloadAllMeshesForGroup(groupId);
-                this.closeSegmentOrGroupDropdown();
-              }}
-            >
-              Download Meshes
-            </div>
-          ),
-        }
+        key: "downloadAllMeshes",
+        icon: <DownloadOutlined />,
+        label: (
+          <div
+            onClick={() => {
+              this.downloadAllMeshesForGroup(groupId);
+              this.closeSegmentOrGroupDropdown();
+            }}
+          >
+            Download Meshes
+          </div>
+        ),
+      }
       : null;
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
     return this.props.selectedIds != null
       ? {
-          key: "moveHere",
-          onClick: () => {
-            if (this.props.visibleSegmentationLayer == null) {
-              // Satisfy TS
-              return;
-            }
-            this.props.updateSegments(
-              this.props.selectedIds.segments,
-              { groupId },
-              this.props.visibleSegmentationLayer.name,
-              true,
-            );
-            this.closeSegmentOrGroupDropdown();
-          },
-          disabled: !this.props.allowUpdate,
-          icon: <ArrowRightOutlined />,
-          label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
-        }
+        key: "moveHere",
+        onClick: () => {
+          if (this.props.visibleSegmentationLayer == null) {
+            // Satisfy TS
+            return;
+          }
+          this.props.updateSegments(
+            this.props.selectedIds.segments,
+            { groupId },
+            this.props.visibleSegmentationLayer.name,
+            true,
+          );
+          this.closeSegmentOrGroupDropdown();
+        },
+        disabled: !this.props.allowUpdate,
+        icon: <ArrowRightOutlined />,
+        label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
+      }
       : null;
   };
 
@@ -1882,11 +1882,10 @@ class SegmentsView extends React.Component<Props, State> {
                   {isSegmentHierarchyEmpty ? (
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description={`There are no segments yet. ${
-                        this.props.allowUpdate && this.props.hasVolumeTracing
+                      description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
                           ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
                           : "Select or click existing segments to add them to this list."
-                      }`}
+                        }`}
                     />
                   ) : (
                     /* Without the default height, height will be 0 on the first render, leading to tree virtualization being disabled.
@@ -1962,12 +1961,13 @@ class SegmentsView extends React.Component<Props, State> {
     if (areAllChildrenExpanded && isGroupItselfExpanded) {
       return null;
     }
-    const groupsToExpand = children;
-    groupsToExpand.push(this.getKeyForGroupId(groupId));
+    const allExpandedGroups = children.concat(this.state.expandedGroupKeys ?? []);
+    // still not good TODO_c
+    if (!isGroupItselfExpanded) allExpandedGroups.push(this.getKeyForGroupId(groupId));
     return {
       key: "expandAll",
       onClick: () => {
-        this.expandGroups(groupsToExpand);
+        this.expandGroups(allExpandedGroups);
         this.closeSegmentOrGroupDropdown();
       },
       icon: <ExpandAltOutlined />,

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -614,7 +614,7 @@ class SegmentsView extends React.Component<Props, State> {
               ),
             );
           },
-          onCancel() { },
+          onCancel() {},
         });
       } else {
         // If only one segment is selected, select group without warning (and vice-versa) even though ctrl is pressed.
@@ -913,9 +913,9 @@ class SegmentsView extends React.Component<Props, State> {
 
       const maybeMappingName =
         !isEditableMapping &&
-          mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
-          mappingInfo.mappingType === "HDF5" &&
-          mappingInfo.mappingName != null
+        mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
+        mappingInfo.mappingType === "HDF5" &&
+        mappingInfo.mappingName != null
           ? mappingInfo.mappingName
           : undefined;
 
@@ -1285,81 +1285,81 @@ class SegmentsView extends React.Component<Props, State> {
   getReloadMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "reloadMeshes",
-        icon: <ReloadOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.handleRefreshMeshes(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Refresh Meshes
-          </div>
-        ),
-      }
+          key: "reloadMeshes",
+          icon: <ReloadOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.handleRefreshMeshes(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Refresh Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getRemoveMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "removeMeshes",
-        icon: <DeleteOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.handleRemoveMeshes(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Remove Meshes
-          </div>
-        ),
-      }
+          key: "removeMeshes",
+          icon: <DeleteOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.handleRemoveMeshes(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Remove Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getDownLoadMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "downloadAllMeshes",
-        icon: <DownloadOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.downloadAllMeshesForGroup(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Download Meshes
-          </div>
-        ),
-      }
+          key: "downloadAllMeshes",
+          icon: <DownloadOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.downloadAllMeshesForGroup(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Download Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
     return this.props.selectedIds != null
       ? {
-        key: "moveHere",
-        onClick: () => {
-          if (this.props.visibleSegmentationLayer == null) {
-            // Satisfy TS
-            return;
-          }
-          this.props.updateSegments(
-            this.props.selectedIds.segments,
-            { groupId },
-            this.props.visibleSegmentationLayer.name,
-            true,
-          );
-          this.closeSegmentOrGroupDropdown();
-        },
-        disabled: !this.props.allowUpdate,
-        icon: <ArrowRightOutlined />,
-        label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
-      }
+          key: "moveHere",
+          onClick: () => {
+            if (this.props.visibleSegmentationLayer == null) {
+              // Satisfy TS
+              return;
+            }
+            this.props.updateSegments(
+              this.props.selectedIds.segments,
+              { groupId },
+              this.props.visibleSegmentationLayer.name,
+              true,
+            );
+            this.closeSegmentOrGroupDropdown();
+          },
+          disabled: !this.props.allowUpdate,
+          icon: <ArrowRightOutlined />,
+          label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
+        }
       : null;
   };
 
@@ -1876,10 +1876,11 @@ class SegmentsView extends React.Component<Props, State> {
                   {isSegmentHierarchyEmpty ? (
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
-                        ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
-                        : "Select or click existing segments to add them to this list."
-                        }`}
+                      description={`There are no segments yet. ${
+                        this.props.allowUpdate && this.props.hasVolumeTracing
+                          ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
+                          : "Select or click existing segments to add them to this list."
+                      }`}
                     />
                   ) : (
                     /* Without the default height, height will be 0 on the first render, leading to tree virtualization being disabled.

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -516,9 +516,11 @@ class SegmentsView extends React.Component<Props, State> {
     return allSegmentGroups.map((group) => getKeyForGroupId(group));
   };
 
-  expandGroups = (newExpandedGroups: Key[]) => {
+  setExpandedGroups = (newExpandedGroups: Key[]) => {
     if (this.props.visibleSegmentationLayer == null) return;
     const expandedKeySet = new Set(newExpandedGroups);
+    // Set the state of the root group according to the new expanded groups
+    // so that its expansion state is updated when the root group is expanded/collapsed.
     if (this.state.isRootGroupExpanded && !expandedKeySet.has(getKeyForGroupId(MISSING_GROUP_ID))) {
       this.setState({ isRootGroupExpanded: false });
     } else if (
@@ -1921,7 +1923,7 @@ class SegmentsView extends React.Component<Props, State> {
                               overflow: "auto", // use hidden when not using virtualization
                             }}
                             ref={this.tree}
-                            onExpand={this.expandGroups}
+                            onExpand={this.setExpandedGroups}
                             expandedKeys={this.state.expandedGroupKeys}
                           />
                         </div>
@@ -1961,7 +1963,7 @@ class SegmentsView extends React.Component<Props, State> {
       onClick: () => {
         const allExpandedGroups = children.concat(this.state.expandedGroupKeys);
         if (!isGroupItselfExpanded) allExpandedGroups.push(getKeyForGroupId(groupId));
-        this.expandGroups(allExpandedGroups);
+        this.setExpandedGroups(allExpandedGroups);
         this.closeSegmentOrGroupDropdown();
       },
       icon: <ExpandAltOutlined />,

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -367,8 +367,8 @@ function renderEmptyMeshFileSelect() {
   );
 }
 
-const getExpandedKeys = (treeData: TreeGroup[]) => {
-  return treeData.reduce((expandedKeysAcc: string[], node) => {
+const getExpandedKeys = (segmentGroups: TreeGroup[]) => {
+  return segmentGroups.reduce((expandedKeysAcc: string[], node) => {
     if (node.isExpanded || node.isExpanded == null) {
       expandedKeysAcc.push(getKeyForGroupId(node.groupId));
     }
@@ -464,7 +464,10 @@ class SegmentsView extends React.Component<Props, State> {
     Store.dispatch(ensureSegmentIndexIsLoadedAction(this.props.visibleSegmentationLayer?.name));
 
     this.setState({
-      expandedGroupKeys: getExpandedKeysWithRoot(this.props.segmentGroups, this.state.isRootGroupExpanded),
+      expandedGroupKeys: getExpandedKeysWithRoot(
+        this.props.segmentGroups,
+        this.state.isRootGroupExpanded,
+      ),
     });
   }
 
@@ -541,8 +544,8 @@ class SegmentsView extends React.Component<Props, State> {
         return {
           ...group,
           isExpanded: false,
-          // Close all groups that are not in the expanded list because this method
-          // is (a.o.) called for every update, e.g. when a group is collapsed.
+          // Close all groups that are not in the expanded list so this method
+          // can be called for every update, e.g. when a group is collapsed.
         };
       }
     });
@@ -681,10 +684,13 @@ class SegmentsView extends React.Component<Props, State> {
         searchableTreeItemList.push(item);
       });
       updateStateObject = {
-        expandedGroupKeys: getExpandedKeysWithRoot(nextProps.segmentGroups, prevState.isRootGroupExpanded),
         groupTree: generatedGroupTree,
         searchableTreeItemList,
         prevProps: nextProps,
+        expandedGroupKeys: getExpandedKeysWithRoot(
+          nextProps.segmentGroups,
+          prevState.isRootGroupExpanded,
+        ),
       };
     }
     if (prevState.prevProps?.meshes !== meshes) {
@@ -1877,8 +1883,8 @@ class SegmentsView extends React.Component<Props, State> {
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
                       description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
-                        ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
-                        : "Select or click existing segments to add them to this list."
+                          ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
+                          : "Select or click existing segments to add them to this list."
                         }`}
                     />
                   ) : (

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -452,8 +452,8 @@ class SegmentsView extends React.Component<Props, State> {
       if (node.type === "segment") return acc;
       if (node.isExpanded || node.isExpanded == null) {
         acc.push(node.key);
-        if (node.children.length > 0) acc.push(...this.getExpandedKeys(node.children));
       }
+      if (node.children.length > 0) acc.push(...this.getExpandedKeys(node.children));
       return acc;
     }, []);
   };
@@ -467,11 +467,12 @@ class SegmentsView extends React.Component<Props, State> {
     } */
 
   componentDidUpdate(prevProps: Props) {
-    if (this.props.segmentGroups[0] !== prevProps.segmentGroups[0])
+    if (this.props.segmentGroups[0] !== prevProps.segmentGroups[0]) {
       // TODO_c find correct way to determine if update is necessary
       this.setState({
         expandedGroupKeys: this.getExpandedKeys(this.state.groupTree),
       });
+    }
 
     if (prevProps.visibleSegmentationLayer !== this.props.visibleSegmentationLayer) {
       Store.dispatch(

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -523,19 +523,17 @@ class SegmentsView extends React.Component<Props, State> {
 
   expandGroups = (newExpandedGroups: Key[]) => {
     if (this.props.visibleSegmentationLayer == null) return;
-    if (
-      this.state.isRootGroupExpanded &&
-      !newExpandedGroups.includes(getKeyForGroupId(MISSING_GROUP_ID))
-    ) {
+    const expandedKeySet = new Set(newExpandedGroups);
+    if (this.state.isRootGroupExpanded && !expandedKeySet.has(getKeyForGroupId(MISSING_GROUP_ID))) {
       this.setState({ isRootGroupExpanded: false });
     } else if (
       !this.state.isRootGroupExpanded &&
-      newExpandedGroups.includes(getKeyForGroupId(MISSING_GROUP_ID))
+      expandedKeySet.has(getKeyForGroupId(MISSING_GROUP_ID))
     ) {
       this.setState({ isRootGroupExpanded: true });
     }
     const newGroups = mapGroups(this.props.segmentGroups, (group) => {
-      if (newExpandedGroups.includes(getKeyForGroupId(group.groupId))) {
+      if (expandedKeySet.has(getKeyForGroupId(group.groupId))) {
         return {
           ...group,
           isExpanded: true,
@@ -554,8 +552,9 @@ class SegmentsView extends React.Component<Props, State> {
 
   collapseGroups = (groupsToCollapse: Key[]) => {
     if (this.props.visibleSegmentationLayer == null) return;
+    const groupsToCollapseSet = new Set(groupsToCollapse);
     const newGroups = mapGroups(this.props.segmentGroups, (group) => {
-      if (groupsToCollapse.includes(getKeyForGroupId(group.groupId))) {
+      if (groupsToCollapseSet.has(getKeyForGroupId(group.groupId))) {
         return {
           ...group,
           isExpanded: false,
@@ -1883,8 +1882,8 @@ class SegmentsView extends React.Component<Props, State> {
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
                       description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
-                          ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
-                          : "Select or click existing segments to add them to this list."
+                        ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
+                        : "Select or click existing segments to add them to this list."
                         }`}
                     />
                   ) : (
@@ -1954,7 +1953,7 @@ class SegmentsView extends React.Component<Props, State> {
   }
 
   getExpandSubgroupsItem(groupId: number) {
-    const children = this.getSubGroupsAsTreeNodes(groupId);
+    const children: Key[] = this.getSubGroupsAsTreeNodes(groupId);
     const expandedKeySet = new Set(this.state.expandedGroupKeys);
     const areAllChildrenExpanded = children.every((childNode) => expandedKeySet.has(childNode));
     const isGroupItselfExpanded = expandedKeySet.has(getKeyForGroupId(groupId));

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1277,7 +1277,6 @@ class SegmentsView extends React.Component<Props, State> {
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
-    console.log("rerender", groupId);
     return this.props.selectedIds != null
       ? {
         key: "moveHere",

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -464,7 +464,7 @@ class SegmentsView extends React.Component<Props, State> {
     return this.state.isRootGroupExpanded
       ? [this.getKeyForGroupId(MISSING_GROUP_ID), ...expandedGroups]
       : expandedGroups;
-  }
+  };
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.segmentGroups[0] !== prevProps.segmentGroups[0]) {
@@ -624,7 +624,7 @@ class SegmentsView extends React.Component<Props, State> {
               ),
             );
           },
-          onCancel() { },
+          onCancel() {},
         });
       } else {
         // If only one segment is selected, select group without warning (and vice-versa) even though ctrl is pressed.
@@ -919,9 +919,9 @@ class SegmentsView extends React.Component<Props, State> {
 
       const maybeMappingName =
         !isEditableMapping &&
-          mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
-          mappingInfo.mappingType === "HDF5" &&
-          mappingInfo.mappingName != null
+        mappingInfo.mappingStatus !== MappingStatusEnum.DISABLED &&
+        mappingInfo.mappingType === "HDF5" &&
+        mappingInfo.mappingName != null
           ? mappingInfo.mappingName
           : undefined;
 
@@ -1291,81 +1291,81 @@ class SegmentsView extends React.Component<Props, State> {
   getReloadMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "reloadMeshes",
-        icon: <ReloadOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.handleRefreshMeshes(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Refresh Meshes
-          </div>
-        ),
-      }
+          key: "reloadMeshes",
+          icon: <ReloadOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.handleRefreshMeshes(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Refresh Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getRemoveMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "removeMeshes",
-        icon: <DeleteOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.handleRemoveMeshes(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Remove Meshes
-          </div>
-        ),
-      }
+          key: "removeMeshes",
+          icon: <DeleteOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.handleRemoveMeshes(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Remove Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getDownLoadMeshesMenuItem = (groupId: number | null): ItemType => {
     return this.state != null && this.doesGroupHaveAnyMeshes(groupId)
       ? {
-        key: "downloadAllMeshes",
-        icon: <DownloadOutlined />,
-        label: (
-          <div
-            onClick={() => {
-              this.downloadAllMeshesForGroup(groupId);
-              this.closeSegmentOrGroupDropdown();
-            }}
-          >
-            Download Meshes
-          </div>
-        ),
-      }
+          key: "downloadAllMeshes",
+          icon: <DownloadOutlined />,
+          label: (
+            <div
+              onClick={() => {
+                this.downloadAllMeshesForGroup(groupId);
+                this.closeSegmentOrGroupDropdown();
+              }}
+            >
+              Download Meshes
+            </div>
+          ),
+        }
       : null;
   };
 
   getMoveSegmentsHereMenuItem = (groupId: number): ItemType => {
     return this.props.selectedIds != null
       ? {
-        key: "moveHere",
-        onClick: () => {
-          if (this.props.visibleSegmentationLayer == null) {
-            // Satisfy TS
-            return;
-          }
-          this.props.updateSegments(
-            this.props.selectedIds.segments,
-            { groupId },
-            this.props.visibleSegmentationLayer.name,
-            true,
-          );
-          this.closeSegmentOrGroupDropdown();
-        },
-        disabled: !this.props.allowUpdate,
-        icon: <ArrowRightOutlined />,
-        label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
-      }
+          key: "moveHere",
+          onClick: () => {
+            if (this.props.visibleSegmentationLayer == null) {
+              // Satisfy TS
+              return;
+            }
+            this.props.updateSegments(
+              this.props.selectedIds.segments,
+              { groupId },
+              this.props.visibleSegmentationLayer.name,
+              true,
+            );
+            this.closeSegmentOrGroupDropdown();
+          },
+          disabled: !this.props.allowUpdate,
+          icon: <ArrowRightOutlined />,
+          label: `Move active ${pluralize("segment", this.props.selectedIds.segments.length)} here`,
+        }
       : null;
   };
 
@@ -1882,10 +1882,11 @@ class SegmentsView extends React.Component<Props, State> {
                   {isSegmentHierarchyEmpty ? (
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description={`There are no segments yet. ${this.props.allowUpdate && this.props.hasVolumeTracing
-                        ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
-                        : "Select or click existing segments to add them to this list."
-                        }`}
+                      description={`There are no segments yet. ${
+                        this.props.allowUpdate && this.props.hasVolumeTracing
+                          ? "Use the volume tools (e.g., the brush) to create a segment. Alternatively, select or click existing segments to add them to this list."
+                          : "Select or click existing segments to add them to this list."
+                      }`}
                     />
                   ) : (
                     /* Without the default height, height will be 0 on the first render, leading to tree virtualization being disabled.
@@ -1962,8 +1963,7 @@ class SegmentsView extends React.Component<Props, State> {
       return null;
     }
     const groupsToExpand = children;
-    // It doesn't make sense to expand subgroups if the group itself is collapsed, so also expand the group.
-    if (!isGroupItselfExpanded) groupsToExpand.push(this.getKeyForGroupId(groupId));
+    groupsToExpand.push(this.getKeyForGroupId(groupId));
     return {
       key: "expandAll",
       onClick: () => {

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view_helper.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view_helper.tsx
@@ -21,6 +21,7 @@ export type SegmentHierarchyGroup = {
   name: string | null | undefined;
   id: number;
   key: string;
+  isExpanded?: boolean;
   children: Array<SegmentHierarchyNode>;
 };
 

--- a/test/backend/VolumeUpdateActionsUnitTestSuite.scala
+++ b/test/backend/VolumeUpdateActionsUnitTestSuite.scala
@@ -76,7 +76,7 @@ class VolumeUpdateActionsUnitTestSuite extends PlaySpec with ProtoGeometryImplic
     "update a top level segment group" in {
       val updatedName = "Segment Group 2 updated"
       val updateSegmentGroupsVolumeAction = new UpdateSegmentGroupsVolumeAction(
-        List(UpdateActionSegmentGroup(updatedName, 2, List()))
+        List(UpdateActionSegmentGroup(updatedName, 2, isExpanded = Some(true), List()))
       )
       val result = applyUpdateAction(updateSegmentGroupsVolumeAction)
       assert(result.segments == Dummies.volumeTracing.segments)
@@ -87,7 +87,7 @@ class VolumeUpdateActionsUnitTestSuite extends PlaySpec with ProtoGeometryImplic
       val updatedNameTop = "Segment Group 1 updated"
       val updatedNameNested = "Segment Group 3 updated"
       val updateSegmentGroupsVolumeAction = new UpdateSegmentGroupsVolumeAction(
-        List(UpdateActionSegmentGroup(updatedNameTop, 1, List(UpdateActionSegmentGroup(updatedNameNested, 3, List()))))
+        List(UpdateActionSegmentGroup(updatedNameTop, 1, isExpanded = Some(true), List(UpdateActionSegmentGroup(updatedNameNested, 3, isExpanded = Some(false), List()))))
       )
       val result = applyUpdateAction(updateSegmentGroupsVolumeAction)
       assert(result.segments == Dummies.volumeTracing.segments)

--- a/webknossos-datastore/proto/VolumeTracing.proto
+++ b/webknossos-datastore/proto/VolumeTracing.proto
@@ -52,6 +52,7 @@ message SegmentGroup {
   required string name = 1;
   required int32 groupId = 2;
   repeated SegmentGroup children = 3;
+  optional bool isExpanded = 4;
 }
 
 message VolumeTracingOpt {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/UpdateActionSegmentGroup.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/UpdateActionSegmentGroup.scala
@@ -2,7 +2,10 @@ package com.scalableminds.webknossos.tracingstore.tracings.volume
 
 import play.api.libs.json.{Json, OFormat}
 
-case class UpdateActionSegmentGroup(name: String, groupId: Int, children: List[UpdateActionSegmentGroup])
+case class UpdateActionSegmentGroup(name: String,
+                                    groupId: Int,
+                                    isExpanded: Option[Boolean],
+                                    children: List[UpdateActionSegmentGroup])
 
 object UpdateActionSegmentGroup {
   implicit val jsonFormat: OFormat[UpdateActionSegmentGroup] = Json.format[UpdateActionSegmentGroup]

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
@@ -19,7 +19,10 @@ trait VolumeUpdateActionHelper {
       if (segment.segmentId == segmentId) transformSegment(segment) else segment)
 
   protected def convertSegmentGroup(aSegmentGroup: UpdateActionSegmentGroup): SegmentGroup =
-    SegmentGroup(aSegmentGroup.name, aSegmentGroup.groupId, aSegmentGroup.children.map(convertSegmentGroup))
+    SegmentGroup(aSegmentGroup.name,
+                 aSegmentGroup.groupId,
+                 aSegmentGroup.children.map(convertSegmentGroup),
+                 aSegmentGroup.isExpanded)
 
 }
 


### PR DESCRIPTION
### Steps to test:
- Open an annotation and go to segments tab. Create a group hierarchy (around three levels min) with some segments in each group.
- Expand and collapse some groups, remember state.
- Change to another tab and back. The state (groups expanded/collapsed) should be the same.
- Reload the page. The state should still be the same 
- Test that old behavior is still working. Expanding and collapsing via arrow icon, expansion/collapse of all subgroups etc.

### TODOs:
- [x] fix bug that expand children on root doesnt work after collapsing all subgroups

### Issues:
- fixes #7825 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
