### PR TITLE
Include docker-compose steps in hosting for localized database backups

### DIFF
--- a/tools/hosting/docker-compose.yml
+++ b/tools/hosting/docker-compose.yml
@@ -135,6 +135,15 @@ services:
     networks:
       - webknossos_default
 
+  # Postgres backup
+  postgres-backup:
+    image: postgres
+    command: [ "/bin/bash", "-c", "PGPASSWORD=postgres pg_dump -Fc -h postgres -U postgres webknossos | gzip > /backups/backup_$(date +%Y-%m-%d_%H-%M).sql.gz" ]
+    volumes:
+      - ./backups:/backups
+    depends_on:
+      - postgres
+
 # Explicitly declare networks for fossil-db-backup connectivity
 networks:
   webknossos_default:

--- a/tools/hosting/docker-compose.yml
+++ b/tools/hosting/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - VIRTUAL_HOST=${PUBLIC_HOST}
       - LETSENCRYPT_HOST=${PUBLIC_HOST}
     user: ${USER_UID:-1000}:${USER_GID:-1000}
+    networks:
+      - webknossos_default
 
   # Postgres
   postgres:
@@ -59,6 +61,7 @@ services:
   # FossilDB
   fossildb:
     image: scalableminds/fossildb:master__489
+    container_name: webknossos-fossildb-1
     command:
       - fossildb
       - -c
@@ -97,6 +100,7 @@ services:
     labels:
       - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
 
+  # Nginx-Lets-Encrypt
   nginx-letsencrypt:
     image: nginxproxy/acme-companion
     environment:
@@ -108,3 +112,30 @@ services:
       - ./persistent/nginx/certs:/etc/nginx/certs
       - ./persistent/nginx/vhost.d:/etc/nginx/vhost.d
       - ./persistent/nginx/html:/usr/share/nginx/html
+
+  # FossilDB Backup -- backup located to ../persistent/fossildb/backup/private after completion
+  # Example command: docker-compose run --rm fossil-db-backup
+  fossil-db-backup:
+    image: scalableminds/fossildb-client:master
+    depends_on:
+      fossildb:
+        condition: service_healthy
+    command: ["webknossos-fossildb-1", "backup"]
+    networks:
+      - webknossos_default
+
+  # FossilDB Restore
+  # Example command: docker-compose run --rm fossil-db-restore
+  fossil-db-restore:
+    image: scalableminds/fossildb-client:master
+    depends_on:
+      fossildb:
+        condition: service_healthy
+    command: [ "webknossos-fossildb-1", "restore" ]
+    networks:
+      - webknossos_default
+
+# Explicitly declare networks for fossil-db-backup connectivity
+networks:
+  webknossos_default:
+    external: true


### PR DESCRIPTION
Provides docker-compose steps that allow an end user to easily access and run commands for data integrity and reliability against a local fossil-db and postgres instances

Cc @kabilar 

### URL of deployed dev instance (used for testing):
N/A

### Steps to test:
- Create a deployment of WebKNOSSOS via instructions on https://docs.webknossos.org/webknossos/installation.html
- Once all containers are healthly on your local EC2, run `docker-compose run --rm fossil-db-backup`
- Confirm backup is present in `/persistent/fossildb/backup/private` on EC2 instance
- Run `docker-compose run --rm fossil-db-restore` to observe successful restoration
(additionally, you can destroy the local `fossildb` instance and see if you can re-populate via `restore`)

### TODOs:
- [x] Include similar docker-compose scripts for `pg_dump` equivalent 

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
