### PR TITLE
add yarn/dbtool command insert-local-datastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "refresh-schema": "./tools/postgres/dbtool.js refresh-schema && rm -f target/scala-2.13/src_managed/schema/com/scalableminds/webknossos/schema/Tables.scala",
     "enable-jobs": "sed -i -e 's/jobsEnabled = false/jobsEnabled = true/g' ./conf/application.conf; sed -i -e 's/voxelyticsEnabled = false/voxelyticsEnabled = true/g' ./conf/application.conf; ./tools/postgres/dbtool.js enable-jobs",
     "disable-jobs": "sed -i -e 's/jobsEnabled = true/jobsEnabled = false/g' ./conf/application.conf; sed -i -e 's/voxelyticsEnabled = true/voxelyticsEnabled = false/g' ./conf/application.conf; ./tools/postgres/dbtool.js disable-jobs",
+    "insert-local-datastore": "./tools/postgres/dbtool.js insert-local-datastore",
     "coverage-local": "c8 report --reporter=html && echo Success! Open coverage/index.html",
     "coverage": "c8 report --reporter=text-lcov | coveralls",
     "postcheckout": "echo 'Deleting auto-generated typescript files...' && rm -f frontend/javascripts/test/snapshots/type-check/*.ts",

--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -388,7 +388,7 @@ program
     console.log("Inserting local datastore in the local database");
     console.log(
       callPsql(
-        `INSERT INTO webknossos.dataStores(name, url, publicUrl, key) VALUES('localhost', 'http://localhost:9000', 'http://localhost:9000', 'somethingSecure') ON CONFLICT DO NOTHING`,
+        `INSERT INTO webknossos.dataStores(name, url, publicUrl, key) VALUES('localhost', 'http://localhost:9000', 'http://localhost:9000', 'something-secure') ON CONFLICT DO NOTHING`,
       ),
     );
     console.log("✨✨ Done");

--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -382,6 +382,19 @@ program
   });
 
 program
+  .command("insert-local-datastore")
+  .description("Inserts local datastore (note that this is redundant to initialData on webknossos startup)")
+  .action(() => {
+    console.log("Inserting local datastore in the local data");
+    console.log(
+      callPsql(
+        `INSERT INTO webknossos.dataStores(name, url, publicUrl, key) VALUES('localhost', 'http://localhost:9000', 'http://localhost:9000', 'somethingSecure') ON CONFLICT DO NOTHING`,
+      ),
+    );
+    console.log("✨✨ Done");
+  });
+
+program
   .command("enable-jobs")
   .description("Activates jobs in WEBKNOSSOS by registering a worker")
   .action(() => {

--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -385,7 +385,7 @@ program
   .command("insert-local-datastore")
   .description("Inserts local datastore (note that this is redundant to initialData on webknossos startup)")
   .action(() => {
-    console.log("Inserting local datastore in the local data");
+    console.log("Inserting local datastore in the local database");
     console.log(
       callPsql(
         `INSERT INTO webknossos.dataStores(name, url, publicUrl, key) VALUES('localhost', 'http://localhost:9000', 'http://localhost:9000', 'somethingSecure') ON CONFLICT DO NOTHING`,


### PR DESCRIPTION
To make `yarn enable-jobs` possible without wk server startup, run `yarn insert-local-datastore` first.

### Steps to test:
- yarn refresh-schema
- yarn insert-local-datastore
- yarn enable-jobs
- should run through as expected
