### PR TITLE
Fix error reporting for unhandled rejections

### DIFF
--- a/.circleci/not-on-master.sh
+++ b/.circleci/not-on-master.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [ "${CIRCLE_BRANCH}" == "master" ]; then
+# if [ "${CIRCLE_BRANCH}" == "master" ]; then
   echo "Skipping this step on master..."
-else
-  exec "$@"
-fi
+# else
+#   exec "$@"
+# fi

--- a/.circleci/not-on-master.sh
+++ b/.circleci/not-on-master.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# if [ "${CIRCLE_BRANCH}" == "master" ]; then
+if [ "${CIRCLE_BRANCH}" == "master" ]; then
   echo "Skipping this step on master..."
-# else
-#   exec "$@"
-# fi
+else
+  exec "$@"
+fi

--- a/frontend/javascripts/libs/error_handling.ts
+++ b/frontend/javascripts/libs/error_handling.ts
@@ -128,15 +128,19 @@ class ErrorHandling {
       // Create our own error for unhandled rejections here to get additional information for [Object object] errors in airbrake
       const reasonAsString = event.reason instanceof Error ? event.reason.toString() : event.reason;
       let wrappedError = event.reason instanceof Error ? event.reason : new Error(event.reason);
-      wrappedError = {
-        ...wrappedError,
-        // The message property is read-only in newer browser versions which is why
-        // the object is copied shallowly.
-        message: UNHANDLED_REJECTION_PREFIX + JSON.stringify(reasonAsString).slice(0, 80),
-      };
+
+      const newMessage = UNHANDLED_REJECTION_PREFIX + JSON.stringify(reasonAsString).slice(0, 80);
+      try {
+        // In the past, we had records of the following line not working because message was read-only.
+        // However, with Chrome, Firefox, Safari and Edge, that bug could not be reproduced in July 2024.
+        // Therefore, we assume that the code should work. If not, we don't augment the error message.
+        // Instead, the exceptionType is passed to the notify() method below.
+        wrappedError.message = newMessage;
+      } catch {}
 
       this.notify(wrappedError, {
         originalError: reasonAsString,
+        exceptionType: "unhandledrejection",
       });
     });
 


### PR DESCRIPTION
At some point I "fixed" that the reporting of unhandled rejections failed because the message property couldn't be written. I did so by shallowy copying the object with an object spread. However, this copy wasn't an "Error" instance anymore (but a plain object). I couldn't reproduce the original problem with setting the `message` which is why I re-added it. I put it into a try-catch to be extra safe. Having the unchanged message should not be a deal breaker, anyway.

### URL of deployed dev instance (used for testing):
- https://fixerrorreportingforunhandledrejections.webknossos.xyz/dashboard/datasets/Datasets-66a1249301000001006bc00c

### Steps to test:
- I executed `new Promise((res, rej) => rej(new Error("blaaa")))` in the devtools on the dev instance and on master
- Here is a screenshot of airbrake how it looks with the fixed reporting:
![image](https://github.com/user-attachments/assets/1b621143-fd62-4b61-999e-9524de7aa1b9)