### PR TITLE
Avoid object creation when segment groups are collapsed/expanded

### DIFF
--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -530,7 +530,8 @@ class SegmentsView extends React.Component<Props, State> {
       this.setState({ isRootGroupExpanded: true });
     }
     const newGroups = mapGroups(this.props.segmentGroups, (group) => {
-      if (expandedKeySet.has(getKeyForGroupId(group.groupId))) {
+      const shouldBeExpanded = expandedKeySet.has(getKeyForGroupId(group.groupId));
+      if (shouldBeExpanded !== group.isExpanded) {
         return {
           ...group,
           isExpanded: true,
@@ -551,7 +552,7 @@ class SegmentsView extends React.Component<Props, State> {
     if (this.props.visibleSegmentationLayer == null) return;
     const groupsToCollapseSet = new Set(groupsToCollapse);
     const newGroups = mapGroups(this.props.segmentGroups, (group) => {
-      if (groupsToCollapseSet.has(getKeyForGroupId(group.groupId))) {
+      if (groupsToCollapseSet.has(getKeyForGroupId(group.groupId)) && group.isExpanded) {
         return {
           ...group,
           isExpanded: false,

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -532,17 +532,14 @@ class SegmentsView extends React.Component<Props, State> {
     const newGroups = mapGroups(this.props.segmentGroups, (group) => {
       const shouldBeExpanded = expandedKeySet.has(getKeyForGroupId(group.groupId));
       if (shouldBeExpanded !== group.isExpanded) {
+        // Close all groups that are not in the expanded list so this method
+        // can be called for every update, e.g. when a group is collapsed.
         return {
           ...group,
-          isExpanded: true,
+          isExpanded: shouldBeExpanded,
         };
       } else {
-        return {
-          ...group,
-          isExpanded: false,
-          // Close all groups that are not in the expanded list so this method
-          // can be called for every update, e.g. when a group is collapsed.
-        };
+        return group;
       }
     });
     Store.dispatch(setSegmentGroupsAction(newGroups, this.props.visibleSegmentationLayer?.name));


### PR DESCRIPTION
### Steps to test:
- Go to segments tab and collapse and expand segment groups 
- Expand/Collapse all sub groups

### Issues:
- follow-up for #7928