### PR TITLE
Tiny fixes

### DIFF
--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -590,7 +590,7 @@ export default function TaskListView({
         <h4 style={{ color: "#51686e" }}>
           {formatDateMedium(new Date(runBeginTimeString))}{" "}
           <Tooltip title={formatDurationStrict(totalRuntime)}>
-            <FieldTimeOutlined style={{ marginLeft: 20 }} />
+            <FieldTimeOutlined style={{ marginLeft: 20 }} className="icon-margin-right" />
             {totalRuntime.humanize()}
           </Tooltip>
         </h4>

--- a/frontend/javascripts/oxalis/view/action-bar/create_animation_modal.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/create_animation_modal.tsx
@@ -357,7 +357,7 @@ function CreateAnimationModal(props: Props) {
             >
               <Space direction="vertical">
                 <Radio.Button value={MOVIE_RESOLUTIONS.SD}>
-                  Standard Definition (640 × 480)
+                  Standard Definition (640 × 360)
                 </Radio.Button>
                 <Radio.Button value={MOVIE_RESOLUTIONS.HD} disabled={!arePaidFeaturesAllowed}>
                   <PricingEnforcedSpan requiredPricingPlan={PricingPlanEnum.Team}>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- Two super small fixes:
  - In VX report, the hour icon does not have any margin-right. Before:
<img width="967" alt="Screenshot 2024-07-25 at 14 22 26" src="https://github.com/user-attachments/assets/ef37d0f8-54c0-43d4-8d11-5176bf9f109a">
  - In "Create animation" modal, update the standard-definition label to "640 x 360" to align with the recent worker changes.


### Steps to test:
- None


### Issues:
- fixes #nada

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
