### PR TITLE
Auto-expand relevant groups when focussing segment

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - The context menu that is opened upon right-clicking a segment in the dataview port now contains the segment's name. [#7920](https://github.com/scalableminds/webknossos/pull/7920) 
 - Upgraded backend dependencies for improved performance and stability. [#7922](https://github.com/scalableminds/webknossos/pull/7922)
 - It is now saved whether segment groups are collapsed or expanded, so this information doesn't get lost e.g. upon page reload. [#7928](https://github.com/scalableminds/webknossos/pull/7928/)
+- The context menu entry "Focus in Segment List" expands all necessary segment groups in the segments tab to show the highlighted segment. [#7950](https://github.com/scalableminds/webknossos/pull/7950)
 
 ### Changed
 - The warning about a mismatch between the scale of a pre-computed mesh and the dataset scale's factor now also considers all supported mags of the active segmentation layer. This reduces the false posive rate regarding this warning. [#7921](https://github.com/scalableminds/webknossos/pull/7921/)

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -13,6 +13,7 @@ import type {
   UpdateSegmentAction,
   SetSegmentsAction,
   RemoveSegmentAction,
+  ClickSegmentAction,
 } from "oxalis/model/actions/volumetracing_actions";
 import {
   convertServerAdditionalAxesToFrontEnd,
@@ -22,6 +23,7 @@ import {
 import {
   getRequestedOrVisibleSegmentationLayer,
   getSegmentationLayerForTracing,
+  getVisibleSegments,
   getVolumeTracingById,
 } from "oxalis/model/accessors/volumetracing_accessor";
 import {
@@ -50,6 +52,8 @@ import {
   getMappingInfo,
   getMaximumSegmentIdForLayer,
 } from "oxalis/model/accessors/dataset_accessor";
+import { mapGroups } from "../accessors/skeletontracing_accessor";
+import { findParentIdForGroupId } from "oxalis/view/right-border-tabs/tree_hierarchy_view_helpers";
 type SegmentUpdateInfo =
   | {
       readonly type: "UPDATE_VOLUME_TRACING";
@@ -194,6 +198,37 @@ function handleUpdateSegment(state: OxalisState, action: UpdateSegmentAction) {
   });
 }
 
+function handleFocusSegment(state: OxalisState, action: ClickSegmentAction) {
+  if (action.layerName == null) return state;
+  const getNewGroups = () => {
+    const { segments, segmentGroups } = getVisibleSegments(state);
+    if (action.layerName == null || segments == null) return segmentGroups;
+    const { segmentId } = action;
+    const segmentForId = segments.getNullable(segmentId);
+    if (segmentForId == null) return segmentGroups;
+    // Expand recursive parents of group too, if necessary
+    let pathToRoot = [];
+    if (segmentForId.groupId != null) {
+      let currentParent = findParentIdForGroupId(segmentGroups, segmentForId.groupId);
+      while (currentParent != null) {
+        pathToRoot.push(currentParent);
+        currentParent = findParentIdForGroupId(segmentGroups, currentParent);
+      }
+    }
+    const pathToRootSet = new Set(pathToRoot);
+    return mapGroups(segmentGroups, (group) => {
+      if (
+        (pathToRootSet.has(group.groupId) || group.groupId === segmentForId.groupId) &&
+        !group.isExpanded
+      ) {
+        return { ...group, isExpanded: true };
+      }
+      return group;
+    });
+  };
+  return setSegmentGroups(state, action.layerName, getNewGroups());
+}
+
 export function serverVolumeToClientVolumeTracing(tracing: ServerVolumeTracing): VolumeTracing {
   // As the frontend doesn't know all cells, we have to keep track of the highest id
   // and cannot compute it
@@ -310,6 +345,10 @@ function VolumeTracingReducer(
     case "SET_SEGMENT_GROUPS": {
       const { segmentGroups } = action;
       return setSegmentGroups(state, action.layerName, segmentGroups);
+    }
+
+    case "CLICK_SEGMENT": {
+      return handleFocusSegment(state, action);
     }
 
     default: // pass

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -207,20 +207,16 @@ function handleFocusSegment(state: OxalisState, action: ClickSegmentAction) {
     const segmentForId = segments.getNullable(segmentId);
     if (segmentForId == null) return segmentGroups;
     // Expand recursive parents of group too, if necessary
-    let pathToRoot = [];
+    const pathToRoot = new Set([segmentForId.groupId]);
     if (segmentForId.groupId != null) {
       let currentParent = findParentIdForGroupId(segmentGroups, segmentForId.groupId);
       while (currentParent != null) {
-        pathToRoot.push(currentParent);
+        pathToRoot.add(currentParent);
         currentParent = findParentIdForGroupId(segmentGroups, currentParent);
       }
     }
-    const pathToRootSet = new Set(pathToRoot);
     return mapGroups(segmentGroups, (group) => {
-      if (
-        (pathToRootSet.has(group.groupId) || group.groupId === segmentForId.groupId) &&
-        !group.isExpanded
-      ) {
+      if (pathToRoot.has(group.groupId) && !group.isExpanded) {
         return { ...group, isExpanded: true };
       }
       return group;

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -198,7 +198,7 @@ function handleUpdateSegment(state: OxalisState, action: UpdateSegmentAction) {
   });
 }
 
-function handleFocusSegment(state: OxalisState, action: ClickSegmentAction) {
+function expandSegmentParents(state: OxalisState, action: ClickSegmentAction) {
   if (action.layerName == null) return state;
   const getNewGroups = () => {
     const { segments, segmentGroups } = getVisibleSegments(state);
@@ -344,7 +344,7 @@ function VolumeTracingReducer(
     }
 
     case "CLICK_SEGMENT": {
-      return handleFocusSegment(state, action);
+      return expandSegmentParents(state, action);
     }
 
     default: // pass

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1896,6 +1896,7 @@ class SegmentsView extends React.Component<Props, State> {
                             titleRender={titleRender}
                             style={{
                               marginTop: 12,
+                              marginLeft: -26, // hide switcherIcon for root group
                               flex: "1 1 auto",
                               overflow: "auto", // use hidden when not using virtualization
                             }}

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -377,6 +377,7 @@ const getExpandedKeys = (segmentGroups: TreeGroup[]) => {
 
 const getExpandedKeysWithRoot = (segmentGroups: TreeGroup[]) => {
   const expandedGroups = getExpandedKeys(segmentGroups);
+  expandedGroups.unshift(getKeyForGroupId(MISSING_GROUP_ID));
   return expandedGroups;
 };
 
@@ -1903,7 +1904,6 @@ class SegmentsView extends React.Component<Props, State> {
                             ref={this.tree}
                             onExpand={this.setExpandedGroups}
                             expandedKeys={this.state.expandedGroupKeys}
-                            autoExpandParent
                           />
                         </div>
                       )}


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://focussegmentincollapsedgroupforreal.webknossos.xyz/

### Steps to test:
- open an annotation and go to segments tab
- focus a segment, remember where it is in the viewport
- close the containing group (must not be root group)
- click on segment in view port, open context menu and "focus segment in list"
- see that containing group is opened again and that segment is focused in list
### other changes
- moreover, the root group in the segment tab is now always expanded

### TODOs:
- [x] fix that SwitcherIcon is still displayed

### Issues:
- fixes #7827 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
