### PR TITLE
Lower z-index for "Remove layer" trashcans in remote dataset import

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug that allowed the default newly created bounding box to appear outside the dataset. In case the whole bounding box would be outside it is created regardless. [#7892](https://github.com/scalableminds/webknossos/pull/7892)
 - Fixed a rare bug that could cause hanging dataset uploads. [#7932](https://github.com/scalableminds/webknossos/pull/7932)
+- Fixed that trashcan icons to remove layers during remote dataset upload were floating above the navbar. [#7954](https://github.com/scalableminds/webknossos/pull/7954)
 
 ### Removed
 

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
@@ -367,7 +367,7 @@ function SimpleLayerForm({
       }}
     >
       {mayLayerBeRemoved && (
-        <div style={{ position: "absolute", top: 12, right: 0, zIndex: 1000 }}>
+        <div style={{ position: "absolute", top: 12, right: 0, zIndex: 500 }}>
           <Tooltip title="Remove Layer">
             <Button shape="circle" icon={<DeleteOutlined />} onClick={() => onRemoveLayer(layer)} />
           </Tooltip>


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://floatingtrashcansremotedsimport.webknossos.xyz/

### Steps to test:
- Upload remote dataset and add another layer
- make viewport smaller so that you can scroll layers (see issue for GIF)
- make sure trashcans to remove layer dont float above the navbar

### TODOs:
- [x] see whether issue after import persists (again, floating trashcans) -> couldnt reproduce it
- [x] look for alternative to z-index hacking (didnt really find anythings thats suitable https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context)

### Issues:
- fixes #7303

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
