### PR TITLE
More compact repeated logging

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
@@ -19,10 +19,12 @@ class Application @Inject()(redisClient: DataStoreRedisStore, applicationHealthS
   def health: Action[AnyContent] = Action.async { implicit request =>
     log() {
       for {
-        before <- Fox.successful(Instant.now)
+        before <- Fox.successful(System.currentTimeMillis())
         _ <- redisClient.checkHealth
+        afterRedis = System.currentTimeMillis()
         _ <- Fox.bool2Fox(applicationHealthService.getRecentProblem().isEmpty) ?~> "Java Internal Errors detected"
-        _ = logger.info(s"Answering ok for Datastore health check, took ${Instant.since(before)}")
+        _ = logger.info(
+          s"Answering ok for Datastore health check, took ${afterRedis - before} ms (Redis at ${redisClient.authority} ${afterRedis - before} ms)")
       } yield Ok("Ok")
     }
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/Application.scala
@@ -1,6 +1,5 @@
 package com.scalableminds.webknossos.datastore.controllers
 
-import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.services.ApplicationHealthService
 import com.scalableminds.webknossos.datastore.storage.DataStoreRedisStore

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -104,7 +104,11 @@ class DataSourceService @Inject()(
       }
     }
 
-    if (emptyDirs.nonEmpty) logger.warn(s"Empty organization dataset dirs: ${emptyDirs.mkString(", ")}")
+    if (emptyDirs.nonEmpty) {
+      val limit = 5
+      val moreLabel = if (emptyDirs.length > limit) s", ... (${emptyDirs.length} total)" else ""
+      logger.warn(s"Empty organization dataset dirs: ${emptyDirs.take(limit).mkString(", ")}$moreLabel")
+    }
   }
 
   def exploreMappings(organizationName: String, datasetName: String, dataLayerName: String): Set[String] =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RedisTemporaryStore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RedisTemporaryStore.scala
@@ -11,6 +11,7 @@ trait RedisTemporaryStore extends LazyLogging {
   implicit def ec: ExecutionContext
   protected def address: String
   protected def port: Int
+  lazy val authority: String = f"$address:$port"
   private lazy val r = new RedisClient(address, port)
 
   def find(id: String): Fox[Option[String]] =
@@ -68,7 +69,6 @@ trait RedisTemporaryStore extends LazyLogging {
     try {
       val reply = r.ping
       if (!reply.contains("PONG")) throw new Exception(reply.getOrElse("No Reply"))
-      logger.info(s"Successfully tested Redis health at $address:$port. Reply: $reply)")
       Fox.successful(())
     } catch {
       case e: Exception =>

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
@@ -25,7 +25,7 @@ class Application @Inject()(tracingDataStore: TracingDataStore, redisClient: Tra
         _ <- redisClient.checkHealth
         afterRedis = System.currentTimeMillis()
         _ = logger.info(
-          s"Answering ok for Tracingstore health check, took ${afterRedis - before} ms (FossilDB at ${tracingDataStore.healthClient.authority}: ${afterFossil - before} ms, Redis at ${redisClient.authority} ${afterRedis - afterFossil} ms).")
+          s"Answering ok for Tracingstore health check, took ${afterRedis - before} ms (FossilDB at ${tracingDataStore.healthClient.authority} ${afterFossil - before} ms, Redis at ${redisClient.authority} ${afterRedis - afterFossil} ms).")
       } yield Ok("Ok")
     }
   }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/Application.scala
@@ -20,12 +20,12 @@ class Application @Inject()(tracingDataStore: TracingDataStore, redisClient: Tra
     log() {
       for {
         before <- Fox.successful(System.currentTimeMillis())
-        _ <- tracingDataStore.healthClient.checkHealth
+        _ <- tracingDataStore.healthClient.checkHealth()
         afterFossil = System.currentTimeMillis()
         _ <- redisClient.checkHealth
         afterRedis = System.currentTimeMillis()
         _ = logger.info(
-          s"Answering ok for Tracingstore health check, took ${afterRedis - before} ms (FossilDB ${afterFossil - before} ms, Redis ${afterRedis - afterFossil} ms).")
+          s"Answering ok for Tracingstore health check, took ${afterRedis - before} ms (FossilDB at ${tracingDataStore.healthClient.authority}: ${afterFossil - before} ms, Redis at ${redisClient.authority} ${afterRedis - afterFossil} ms).")
       } yield Ok("Ok")
     }
   }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
@@ -18,7 +18,7 @@ class TracingDataStore @Inject()(config: TracingStoreConfig,
 
   val healthClient = new FossilDBClient("healthCheckOnly", config, slackNotificationService)
 
-  system.scheduler.scheduleOnce(5 seconds)(healthClient.checkHealth)
+  system.scheduler.scheduleOnce(5 seconds)(healthClient.checkHealth(verbose = true))
 
   lazy val skeletons = new FossilDBClient("skeletons", config, slackNotificationService)
 


### PR DESCRIPTION
These lines were always logged together and don’t really offer much additional insight.

I moved away from our Instant class for this one usage because it logs "milliseconds", while here I’d prefer the shorter "ms"