### PR TITLE
support reading zstd-compressed zarr2 datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - It is now saved whether segment groups are collapsed or expanded, so this information doesn't get lost e.g. upon page reload. [#7928](https://github.com/scalableminds/webknossos/pull/7928/)
 - The context menu entry "Focus in Segment List" expands all necessary segment groups in the segments tab to show the highlighted segment. [#7950](https://github.com/scalableminds/webknossos/pull/7950)
 - In the proofreading mode, you can enable/disable that only the active segment and the hovered segment are rendered. [#7654](https://github.com/scalableminds/webknossos/pull/7654)
+- Added support for reading zstd-compressed zarr2 datasets [#7964](https://github.com/scalableminds/webknossos/pull/7964)
 
 ### Changed
 - The warning about a mismatch between the scale of a pre-computed mesh and the dataset scale's factor now also considers all supported mags of the active segmentation layer. This reduces the false posive rate regarding this warning. [#7921](https://github.com/scalableminds/webknossos/pull/7921/)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrCompressorFactory.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrCompressorFactory.scala
@@ -4,9 +4,11 @@ import com.scalableminds.webknossos.datastore.datareaders.{
   BloscCompressor,
   CompressionSetting,
   Compressor,
+  IntCompressionSetting,
   NullCompressor,
   StringCompressionSetting,
-  ZlibCompressor
+  ZlibCompressor,
+  ZstdCompressor
 }
 
 object ZarrCompressorFactory {
@@ -23,6 +25,13 @@ object ZarrCompressorFactory {
       case "null"  => nullCompressor
       case "zlib"  => new ZlibCompressor(properties)
       case "blosc" => new BloscCompressor(properties)
-      case _       => throw new IllegalArgumentException("Compressor id:'" + id + "' not supported.")
+      case "zstd" => {
+        val level = properties.get("level") match {
+          case Some(IntCompressionSetting(l)) => l
+          case _                              => throw new IllegalArgumentException("Zstd level must be int")
+        }
+        new ZstdCompressor(level, checksum = false)
+      }
+      case _ => throw new IllegalArgumentException("Compressor id:'" + id + "' not supported.")
     }
 }


### PR DESCRIPTION
I didn’t find details about the zarr2 specification for the zstd compressor, so I’m just taking what I saw in the example dataset (just "level"). That means that for datasets with non-integer level or a different feature like checksums it may still not work. Let’s work on that when we notice problems.

### URL of deployed dev instance (used for testing):
- https://zarrzstd.webknossos.xyz

### Steps to test:
- Add a zstd-compressed remote dataset, e.g. `s3://janelia-cosem-datasets/jrc_mus-nacc-4/jrc_mus-nacc-4.zarr/`
- Should load correctly (note: the contrast of that dataset is very low compared to the int16 data range)

### Issues:
- fixes #7894 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
