### PR TITLE
detect neuroglancer precomputed and n5 datasets as needsConversion=false

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -47,6 +47,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that the flood-filling action was available in the context menu although an editable mapping is active. Additionally volume related actions were removed from the context menu if only a skeleton layer is visible. [#7975](https://github.com/scalableminds/webknossos/pull/7975)
 - Fixed that activating the skeleton tab would always change the active position to the active node. [#7958](https://github.com/scalableminds/webknossos/pull/7958)
 - Fixed that skeleton groups couldn't be collapsed or expanded in locked annotations. [#7988](https://github.com/scalableminds/webknossos/pull/7988)
+- Fixed uploading datasets in neuroglancer precomputed and n5 data format. [#8008](https://github.com/scalableminds/webknossos/pull/8008)
 
 ### Removed
 

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -556,11 +556,14 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
     }
 
     let needsConversion = true;
+    const fileBaseNames = fileNames.map((name) => name.split(/[\\/]/).pop());
     if (
       containsExtension("wkw") ||
-      containsExtension("zarray") ||
-      fileNames.includes("datasource-properties.json") ||
-      fileNames.includes("zarr.json")
+      containsExtension("zarray") || // zarr2
+      fileBaseNames.includes("datasource-properties.json") || // wk-ready dataset
+      fileBaseNames.includes("zarr.json") || // zarr 3
+      fileBaseNames.includes("info") || // neuroglancer precomputed
+      fileBaseNames.includes("attributes.json") // n5
     ) {
       needsConversion = false;
     }


### PR DESCRIPTION
The backend supports auto-writing a datasource-properties.json for neuroglancer-precomputed and n5 datasets as of https://github.com/scalableminds/webknossos/pull/7578 . However, the frontend apparently did not know that and starts a conversion job instead.

Also, I’m using the basenames for the file checks now, because in the zip case, a root directory may be prepended to the filenames. This may in theory cause false positives, but I guess those datasets will be broken and non-convertable anyway

I’d suggest not to adapt the docs/message, as we want to encourage using zarr (?) Or I guess the messages will be adapted anyway in https://github.com/scalableminds/webknossos/pull/7996

### Steps to test:
- upload test datasets from https://drive.google.com/drive/folders/1Yp7FRQ0_sG8Fetd-MwCRjaXmaDMkLw5M

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
