### PR TITLE
Fix registering segments in bbox for segmentations with missing mag1

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -48,6 +48,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that the flood-filling action was available in the context menu although an editable mapping is active. Additionally volume related actions were removed from the context menu if only a skeleton layer is visible. [#7975](https://github.com/scalableminds/webknossos/pull/7975)
 - Fixed that activating the skeleton tab would always change the active position to the active node. [#7958](https://github.com/scalableminds/webknossos/pull/7958)
 - Fixed that skeleton groups couldn't be collapsed or expanded in locked annotations. [#7988](https://github.com/scalableminds/webknossos/pull/7988)
+- Fixed that registering segments for a bounding box did only work if the segmentation had mag 1. [#8009](https://github.com/scalableminds/webknossos/pull/8009)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -673,6 +673,14 @@ class TracingApi {
     }
 
     const segmentationLayerName = api.data.getSegmentationLayerNames()[0];
+    const layer = getLayerByName(Store.getState().dataset, segmentationLayerName);
+
+    const resolutionInfo = getResolutionInfo(layer.resolutions);
+    const finestResolution = resolutionInfo.getFinestResolution();
+    // By default, getDataForBoundingBox uses the finest existing magnification.
+    // We use that as strides to traverse the data array properly.
+    const [dx, dy, dz] = finestResolution;
+
     const data = await api.data.getDataForBoundingBox(segmentationLayerName, {
       min,
       max,
@@ -680,9 +688,9 @@ class TracingApi {
 
     const segmentIdToPosition = new Map();
     let idx = 0;
-    for (let z = min[2]; z < max[2]; z++) {
-      for (let y = min[1]; y < max[1]; y++) {
-        for (let x = min[0]; x < max[0]; x++) {
+    for (let z = min[2]; z < max[2]; z += dz) {
+      for (let y = min[1]; y < max[1]; y += dy) {
+        for (let x = min[0]; x < max[0]; x += dx) {
           const id = data[idx];
           if (id !== 0 && !segmentIdToPosition.has(id)) {
             segmentIdToPosition.set(id, [x, y, z]);

--- a/frontend/javascripts/oxalis/model/actions/volumetracing_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/volumetracing_actions.ts
@@ -234,8 +234,11 @@ export const updateSegmentAction = (
   layerName: string,
   timestamp: number = Date.now(),
   createsNewUndoState: boolean = false,
-) =>
-  ({
+) => {
+  if (segmentId == null) {
+    throw new Error("Segment ID must not be null.");
+  }
+  return {
     type: "UPDATE_SEGMENT",
     // TODO: Proper 64 bit support (#6921)
     segmentId: Number(segmentId),
@@ -243,7 +246,8 @@ export const updateSegmentAction = (
     layerName,
     timestamp,
     createsNewUndoState,
-  }) as const;
+  } as const;
+};
 
 export const removeSegmentAction = (
   segmentId: NumberLike,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a volume annotation without mag1 with fallback layer
- create a bbox
- use register all segments feature
- saving should work

### Issues:
- follow-up for #7979 

------
(Please delete unneeded items, merge only when none are left open)
- [X] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
