### PR TITLE
Fix double triggering advanced checkbox of AI Training Modal

### DIFF
--- a/frontend/javascripts/oxalis/view/jobs/train_ai_model.tsx
+++ b/frontend/javascripts/oxalis/view/jobs/train_ai_model.tsx
@@ -194,7 +194,7 @@ export function CollapsibleWorkflowYamlEditor({
     <Collapse
       style={{ marginBottom: 8 }}
       onChange={() => setActive(!isActive)}
-      expandIcon={() => <Checkbox checked={isActive} onChange={() => setActive(!isActive)} />}
+      expandIcon={() => <Checkbox checked={isActive} />}
       items={[
         {
           key: "advanced",


### PR DESCRIPTION
Prior this pr, the advanced collapse of the ai training modal was triggered twice when hitting the checkbox. By simply removing the additional trigger on the checkbox this buggy behaviour is solved. The trigger on the collapse itself is enough.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open an annotatio
- Open the ai analysis modal and activate custom
- Trigger the advanced collapsable at the bottom of the modal via clicking its checkbox. It should behave normally

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1724766228885149

------
(Please delete unneeded items, merge only when none are left open)
- I'd say nothing is needed here
