### PR TITLE
Make filePaths for reserve upload route optional

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -58,6 +58,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that trashcan icons to remove layers during remote dataset upload were floating above the navbar. [#7954](https://github.com/scalableminds/webknossos/pull/7954)
 - Fixed that the flood-filling action was available in the context menu although an editable mapping is active. Additionally volume related actions were removed from the context menu if only a skeleton layer is visible. [#7975](https://github.com/scalableminds/webknossos/pull/7975)
 - Fixed that activating the skeleton tab would always change the active position to the active node. [#7958](https://github.com/scalableminds/webknossos/pull/7958)
+- Made the newly added `filePaths` argument of the reserve upload route (see [#7981](https://github.com/scalableminds/webknossos/pull/7981)) optional to be backwards compatible with wklibs. [#8045](https://github.com/scalableminds/webknossos/pull/8045)
 - Fixed that skeleton groups couldn't be collapsed or expanded in locked annotations. [#7988](https://github.com/scalableminds/webknossos/pull/7988)
 - Fixed that the dashboard didn't notify the user about new datasets in the table. [#8025](https://github.com/scalableminds/webknossos/pull/8025)
 - Fixed that registering segments for a bounding box did only work if the segmentation had mag 1. [#8009](https://github.com/scalableminds/webknossos/pull/8009)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -438,7 +438,7 @@ class DataSourceController @Inject()(
               name = datasetName,
               organization = organizationId,
               totalFileCount = 1,
-              filePaths = Some(List.empty),
+              filePaths = None,
               layersToLink = None,
               initialTeams = List.empty,
               folderId = folderId,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -438,7 +438,7 @@ class DataSourceController @Inject()(
               name = datasetName,
               organization = organizationId,
               totalFileCount = 1,
-              filePaths = List.empty,
+              filePaths = Some(List.empty),
               layersToLink = None,
               initialTeams = List.empty,
               folderId = folderId,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/ComposeService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/ComposeService.scala
@@ -71,7 +71,7 @@ class ComposeService @Inject()(dataSourceRepository: DataSourceRepository,
                                                    composeRequest.newDatasetName,
                                                    composeRequest.organizationId,
                                                    1,
-                                                   Some(List.empty),
+                                                   None,
                                                    None,
                                                    List(),
                                                    Some(composeRequest.targetFolderId))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/ComposeService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/ComposeService.scala
@@ -71,7 +71,7 @@ class ComposeService @Inject()(dataSourceRepository: DataSourceRepository,
                                                    composeRequest.newDatasetName,
                                                    composeRequest.organizationId,
                                                    1,
-                                                   List.empty,
+                                                   Some(List.empty),
                                                    None,
                                                    List(),
                                                    Some(composeRequest.targetFolderId))

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
@@ -33,7 +33,7 @@ case class ReserveUploadInformation(
     name: String, // dataset name
     organization: String,
     totalFileCount: Long,
-    filePaths: List[String],
+    filePaths: Option[List[String]],
     layersToLink: Option[List[LinkedLayerIdentifier]],
     initialTeams: List[String], // team ids
     folderId: Option[String])
@@ -154,7 +154,7 @@ class UploadService @Inject()(dataSourceRepository: DataSourceRepository,
         redisKeyForUploadId(DataSourceId(reserveUploadInformation.name, reserveUploadInformation.organization)),
         reserveUploadInformation.uploadId
       )
-      filePaths = Json.stringify(Json.toJson(reserveUploadInformation.filePaths))
+      filePaths = Json.stringify(Json.toJson(reserveUploadInformation.filePaths.getOrElse(List.empty)))
       _ <- runningUploadMetadataStore.insert(redisKeyForFilePaths(reserveUploadInformation.uploadId), filePaths)
       _ <- runningUploadMetadataStore.insert(
         redisKeyForLinkedLayerIdentifier(reserveUploadInformation.uploadId),


### PR DESCRIPTION
While improving the resumable upload in pr #7981, a new field was added to the reserve requests. Unluckly this new field was not made optional, which breaks the current wklibs version.
This PR makes this field optional, thereby fixing the current wklibs version.
But the wklibs should be patched to include sending all file names included in the upload to aid the sanity checking functionality of the resumable uploadl.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Try uploading a dataset to the wkdev instance
- wklibs command: 
```python
from webknossos import Dataset
from webknossos.client.context import webknossos_context

def main() -> None:
    small_dataset = Dataset.open("<path to small dataset>")
    small_dataset.compress()
    with webknossos_context(token="<token>", url="https://resumableuploadfilepathsoptional.webknossos.xyz/"):
        dataset = small_dataset.upload("micha-wklibs-test-compressed", None, None)

if __name__ == "__main__":
    main()
```


### Issues:
- fixes https://github.com/scalableminds/webknossos-libs/issues/1181

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
