### PR TITLE
Fix create-mesh-file button

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Updated React to version 18. Updated many peer dependencies inlcuding Redux, React-Router, antd, and FlexLayout. [#8048](https://github.com/scalableminds/webknossos/pull/8048)
 
 ### Fixed
+- Fixed that the precompute-meshfile button did not work in the segments tab. [#8077](https://github.com/scalableminds/webknossos/pull/8077)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1049,11 +1049,11 @@ class SegmentsView extends React.Component<Props, State> {
           Reload from Server
         </ReloadOutlined>
       </FastTooltip>
-      <Popover content={this.getPreComputeMeshesPopover} trigger="click" placement="bottom">
-        <FastTooltip title="Add a precomputed mesh file">
+      <FastTooltip title="Add a precomputed mesh file">
+        <Popover content={this.getPreComputeMeshesPopover} trigger="click" placement="bottom">
           <PlusOutlined className="icon-margin-right" />
-        </FastTooltip>
-      </Popover>
+        </Popover>
+      </FastTooltip>
       {this.state.activeMeshJobId != null ? (
         <FastTooltip title='A mesh file is currently being computed. See "Processing Jobs" for more information.'>
           <LoadingOutlined className="icon-margin-right" />


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open a dataset or annotation
- in the segments view, click on the plus button -> a popover should open

![image](https://github.com/user-attachments/assets/93544c5e-36fa-4f02-bc94-cc1d2977503e)

### Issues:
- fixes a regression from #7958 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
