### PR TITLE
Allow Compose only on Datastores with allowsUpload

### DIFF
--- a/frontend/javascripts/admin/dataset/composition_wizard/04_configure_new_dataset.tsx
+++ b/frontend/javascripts/admin/dataset/composition_wizard/04_configure_new_dataset.tsx
@@ -133,10 +133,10 @@ export function ConfigureNewDataset(props: WizardComponentProps) {
       }));
     }
 
-    // Don't check datastore.allowsUpdate for dataset composition
-    const datastoreToUse = props.datastores[0];
+    const uploadableDatastores = props.datastores.filter((datastore) => datastore.allowsUpload);
+    const datastoreToUse = uploadableDatastores[0];
     if (!datastoreToUse) {
-      Toast.error("Could not find datastore for creating new dataset.");
+      Toast.error("Could not find datastore that allows uploading.");
       return;
     }
 


### PR DESCRIPTION
Undoes part of https://github.com/scalableminds/webknossos/pull/7643 because in multi-datastore-setup, the wrong one was selected.

If this feature is needed again, a more sophisticated selection logic is required.