### PR TITLE
Disable proofreading actions for mapped meshes

### DIFF
--- a/frontend/javascripts/oxalis/view/context_menu.tsx
+++ b/frontend/javascripts/oxalis/view/context_menu.tsx
@@ -394,6 +394,7 @@ function getMeshItems(
   maybeUnmappedSegmentId: number | null | undefined,
   visibleSegmentationLayer: APIDataLayer | null | undefined,
   voxelSizeFactor: Vector3,
+  meshFileMapping: string | null | undefined,
 ): MenuItemType[] {
   if (
     clickedMeshId == null ||
@@ -422,7 +423,8 @@ function getMeshItems(
             !isProofreadingActive ||
             activeSegmentMissing ||
             clickedMeshId === activeCellId ||
-            maybeUnmappedSegmentId == null,
+            maybeUnmappedSegmentId == null ||
+            meshFileMapping != null,
           onClick: () => {
             if (maybeUnmappedSegmentId == null) {
               // Should not happen due to the disabled property.
@@ -437,9 +439,11 @@ function getMeshItems(
                   ? "Cannot merge because the proofreading tool is not active."
                   : maybeUnmappedSegmentId == null
                     ? "The mesh wasn't loaded in proofreading mode. Please reload the mesh."
-                    : activeSegmentMissing
-                      ? "Select a segment first."
-                      : null
+                    : meshFileMapping != null
+                      ? "This mesh was created for a mapping. Please use a meshfile that is based on an oversegmentation."
+                      : activeSegmentMissing
+                        ? "Select a segment first."
+                        : null
               }
             >
               Merge with active segment
@@ -454,7 +458,8 @@ function getMeshItems(
             clickedMeshId !== activeCellId ||
             maybeUnmappedSegmentId == null ||
             activeUnmappedSegmentId == null ||
-            maybeUnmappedSegmentId === activeUnmappedSegmentId,
+            maybeUnmappedSegmentId === activeUnmappedSegmentId ||
+            meshFileMapping != null,
           onClick: () => {
             if (maybeUnmappedSegmentId == null) {
               // Should not happen due to the disabled property.
@@ -471,9 +476,11 @@ function getMeshItems(
                   ? "Cannot split because the proofreading tool is not active."
                   : maybeUnmappedSegmentId == null
                     ? "The mesh wasn't loaded in proofreading mode. Please reload the mesh."
-                    : activeSegmentMissing
-                      ? "Select a segment first."
-                      : null
+                    : meshFileMapping != null
+                      ? "This mesh was created for a mapping. Please use a meshfile that is based on an oversegmentation."
+                      : activeSegmentMissing
+                        ? "Select a segment first."
+                        : null
               }
             >
               Split from active segment
@@ -482,7 +489,7 @@ function getMeshItems(
         },
         {
           key: "split-from-all-neighbors",
-          disabled: maybeUnmappedSegmentId == null,
+          disabled: maybeUnmappedSegmentId == null || meshFileMapping != null,
           onClick: () => {
             if (maybeUnmappedSegmentId == null) {
               // Should not happen due to the disabled property.
@@ -499,7 +506,9 @@ function getMeshItems(
                   ? "Cannot split because the proofreading tool is not active."
                   : maybeUnmappedSegmentId == null
                     ? "The mesh wasn't loaded in proofreading mode. Please reload the mesh."
-                    : null
+                    : meshFileMapping != null
+                      ? "This mesh was created for a mapping. Please use a meshfile that is based on an oversegmentation."
+                      : null
               }
             >
               Split from all neighboring segments
@@ -576,6 +585,7 @@ function getNodeContextMenuOptions({
   volumeTracing,
   infoRows,
   allowUpdate,
+  currentMeshFile,
 }: NodeContextMenuOptionsProps): ItemType[] {
   const state = Store.getState();
   const isProofreadingActive = state.uiInformation.activeTool === AnnotationToolEnum.PROOFREAD;
@@ -617,6 +627,7 @@ function getNodeContextMenuOptions({
     maybeUnmappedSegmentId,
     visibleSegmentationLayer,
     voxelSize.factor,
+    currentMeshFile?.mappingName,
   );
 
   const menuItems: ItemType[] = [
@@ -1251,6 +1262,7 @@ function getNoNodeContextMenuOptions(props: NoNodeContextMenuProps): ItemType[] 
     maybeUnmappedSegmentId,
     visibleSegmentationLayer,
     voxelSize.factor,
+    currentMeshFile?.mappingName,
   );
 
   if (isSkeletonToolActive) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
(see this comment too: https://github.com/scalableminds/webknossos/issues/7868#issuecomment-2361782931)
- Select a meshfile that was created for a mapping in proofreading mode (e.g. [this one](https://www.notion.so/scalableminds/Test-Datasets-c0563be9c4a4499dae4e16d9b2497cfb?pvs=4#10ab51644c63805faa63c2bd1dec22c1) ) 
- Load some meshes
- Open the context menu in the 3D vieport on a mesh
- If the option "Merge with active segment" is disabled with the tooltip "The mesh wasn't loaded in proofreading mode. Please reload the mesh.", you may need to refresh the meshes
- Afterwards, if you open the context menu for a mesh in the 3D viewport, the three entries "Merge with active segment", "Split from active segment" and "Split from all neighboring segments" should be disabled with a tooltip that explains that the current mesh file was created for a mapping, but one for the oversegmentation is needed. 

### Issues:
- fixes #7868 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
