### PR TITLE
Fix dataset upload for absolute baseFolder paths

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098)
 
 ### Removed
 

--- a/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
@@ -38,8 +38,12 @@ trait PathUtils extends LazyLogging {
   def isTheSame(p1: Path, p2: Path): Boolean =
     p1.toAbsolutePath.compareTo(p2.toAbsolutePath) == 0
 
-  def commonPrefix(p1: Path, p2: Path): Path =
-    Paths.get(p1.iterator.asScala.zip(p2.iterator.asScala).takeWhile(Function.tupled(_ == _)).map(_._1).mkString("/"))
+  def commonPrefix(p1: Path, p2: Path): Path = {
+    val elements = p1.iterator.asScala.zip(p2.iterator.asScala).takeWhile(Function.tupled(_ == _)).map(_._1)
+    val joined = elements.mkString("/")
+    val absoluteIfNeeded = if (p1.startsWith("/")) f"/$joined" else joined
+    Paths.get(absoluteIfNeeded)
+  }
 
   def commonPrefix(ps: List[Path]): Path =
     ps.reduce(commonPrefix)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -216,7 +216,8 @@ class DataSourceController @Inject()(
           result <- accessTokenService.validateAccess(UserAccessRequest.writeDataSource(dataSourceId),
                                                       urlOrHeaderToken(token, request)) {
             for {
-              (dataSourceId, datasetSizeBytes) <- uploadService.finishUpload(request.body) ?~> "finishUpload.failed"
+              (dataSourceId, datasetSizeBytes) <- uploadService
+                .finishUpload(request.body) ?~> "dataset.upload.finishFailed"
               _ <- remoteWebknossosClient.reportUpload(
                 dataSourceId,
                 datasetSizeBytes,


### PR DESCRIPTION
The commonPrefix method, used by the finishUpload call, dropped the starting `/` of absolute paths, thus returning invalid paths.

Since the baseFolder was changed to absolute, this broke uploads of non-zipped datasets.

### Steps to test:
- in application.conf set datastore.baseFolder to an absolute path
- upload a non-zipped dataset via the UI
- should work

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1727248592960659

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
