### PR TITLE
Fix moving non zipped uploaded dataset to target folder

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,7 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Some mesh-related actions were disabled in proofreading-mode when using meshfiles that were created for a mapping rather than an oversegmentation. [#8091](https://github.com/scalableminds/webknossos/pull/8091)
 
 ### Fixed
-- Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098)
+- Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098) [#8103](https://github.com/scalableminds/webknossos/pull/8103)
 
 ### Removed
 

--- a/conf/messages
+++ b/conf/messages
@@ -111,6 +111,7 @@ dataset.upload.couldNotLoadUnfinishedUploads=Could not load unfinished uploads o
 dataset.upload.noFiles=Tried to finish upload with no files. May be a retry of a failed finish request, see previous errors.
 dataset.upload.storageExceeded=Cannot upload dataset because the storage quota of the organization is exceeded.
 dataset.upload.finishFailed=Failed to finalize dataset upload.
+dataset.upload.moveToTarget.failed=Failed to move uploaded dataset to target directory.
 dataset.explore.failed.readFile=Failed to read remote file
 dataset.explore.magDtypeMismatch=Element class must be the same for all mags of a layer. Got {0}
 dataset.explore.autoAdd.failed=Failed to automatically import the explored dataset.

--- a/frontend/javascripts/admin/dataset/dataset_add_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_view.tsx
@@ -303,7 +303,7 @@ const getPostUploadModal = (
         }}
       >
         The dataset was {addTypeToVerb[datasetAddType]} successfully
-        {datasetNeedsConversion ? " and a conversion job was started." : null}.
+        {datasetNeedsConversion ? " and a conversion job was started" : null}.
         <br />
         <div
           style={{

--- a/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/PathUtils.scala
@@ -181,7 +181,7 @@ trait PathUtils extends LazyLogging {
   private def removeOneName(path: Path): Path =
     if (path.getNameCount == 1) {
       Paths.get("")
-    } else path.subpath(0, path.getNameCount - 1)
+    } else path.getParent
 
   def deleteDirectoryRecursively(path: Path): Box[Unit] = {
     val directory = new Directory(new File(path.toString))


### PR DESCRIPTION
Fix bug for uploading datasets in case a baseFolder is configured for the datastore. The error is caused by `path.subpath` always returning a relative path even in case the path is absolute. This is intended behaviour by the [docs](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#getParent--) :see_no_evil: 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Test locally. Configure a in `application.conf`:
  ```
  datastore {
  baseFolder = `<absolute_path_to_binary_folder>`
  ```
- run `yarn enable-jobs`
- Test uploading a zip file, a single file (e.g. tiff) and multiple files e.g. multiple jpegs.
- Every try should succeed

### Issues:
- follow up of #8098

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
