### PR TITLE
Fix creating annotation for public dataset of other orga

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098) [#8103](https://github.com/scalableminds/webknossos/pull/8103)
+- Fixed a bug where you could not create annotations for public datasets of other organizations. [#8107](https://github.com/scalableminds/webknossos/pull/8107)
 
 ### Removed
 

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -391,7 +391,7 @@ class AnnotationService @Inject()(
     for {
       dataset <- datasetDAO.findOne(datasetId) ?~> "dataset.noAccessById"
       dataSource <- datasetService.dataSourceFor(dataset)
-      datasetOrganization <- organizationDAO.findOne(dataset._organization)
+      datasetOrganization <- organizationDAO.findOne(dataset._organization)(GlobalAccessContext) ?~> "organization.notFound"
       usableDataSource <- dataSource.toUsable ?~> Messages("dataset.notImported", dataSource.id.name)
       annotationLayers <- createTracingsForExplorational(dataset,
                                                          usableDataSource,


### PR DESCRIPTION
### Steps to test:
- in application.conf set isWkOrgInstance=true
- in private window, create organization with new account
- open a public dataset (of original organization), hit “create annotation”, should work.

### Issues:
- fixes #8105

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
