### PR TITLE
Fewer hdf5 reads when loading precomputed meshes

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/ConnectomeFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/ConnectomeFileService.scala
@@ -118,10 +118,10 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
   def mappingNameForConnectomeFile(connectomeFilePath: Path): Fox[String] =
     for {
       cachedConnectomeFile <- tryo {
-        connectomeFileCache.withCache(connectomeFilePath)(CachedHdf5File.fromPath)
+        connectomeFileCache.getCachedHdf5File(connectomeFilePath)(CachedHdf5File.fromPath)
       } ?~> "connectome.file.open.failed"
       mappingName <- finishAccessOnFailure(cachedConnectomeFile) {
-        cachedConnectomeFile.reader.string().getAttr("/", "metadata/mapping_name")
+        cachedConnectomeFile.stringReader.getAttr("/", "metadata/mapping_name")
       } ?~> "connectome.file.readEncoding.failed"
       _ = cachedConnectomeFile.finishAccess()
     } yield mappingName
@@ -165,10 +165,10 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
   private def ingoingSynapsesForAgglomerate(connectomeFilePath: Path, agglomerateId: Long): Fox[List[Long]] =
     for {
       cachedConnectomeFile <- tryo {
-        connectomeFileCache.withCache(connectomeFilePath)(CachedHdf5File.fromPath)
+        connectomeFileCache.getCachedHdf5File(connectomeFilePath)(CachedHdf5File.fromPath)
       } ?~> "connectome.file.open.failed"
       fromAndToPtr: Array[Long] <- finishAccessOnFailure(cachedConnectomeFile) {
-        cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset("/CSC_indptr", 2, agglomerateId)
+        cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/CSC_indptr", 2, agglomerateId)
       } ?~> "Could not read offsets from connectome file"
       from <- fromAndToPtr.lift(0) ?~> "Could not read start offset from connectome file"
       to <- fromAndToPtr.lift(1) ?~> "Could not read end offset from connectome file"
@@ -176,21 +176,17 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
       agglomeratePairs: Array[Long] <- if (to - from == 0L) Fox.successful(Array.empty[Long])
       else
         finishAccessOnFailure(cachedConnectomeFile) {
-          cachedConnectomeFile.reader
-            .uint64()
-            .readArrayBlockWithOffset("/CSC_agglomerate_pair", (to - from).toInt, from)
+          cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/CSC_agglomerate_pair", (to - from).toInt, from)
         } ?~> "Could not read agglomerate pairs from connectome file"
       synapseIdsNested <- Fox.serialCombined(agglomeratePairs.toList) { agglomeratePair: Long =>
         for {
           from <- finishAccessOnFailure(cachedConnectomeFile) {
-            cachedConnectomeFile.reader
-              .uint64()
-              .readArrayBlockWithOffset("/agglomerate_pair_offsets", 1, agglomeratePair)
+            cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/agglomerate_pair_offsets", 1, agglomeratePair)
           }.flatMap(_.headOption)
           to <- finishAccessOnFailure(cachedConnectomeFile) {
-            cachedConnectomeFile.reader
-              .uint64()
-              .readArrayBlockWithOffset("/agglomerate_pair_offsets", 1, agglomeratePair + 1)
+            cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/agglomerate_pair_offsets",
+                                                                       1,
+                                                                       agglomeratePair + 1)
           }.flatMap(_.headOption)
         } yield List.range(from, to)
       } ?~> "Could not read ingoing synapses from connectome file"
@@ -200,18 +196,18 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
   private def outgoingSynapsesForAgglomerate(connectomeFilePath: Path, agglomerateId: Long): Fox[List[Long]] =
     for {
       cachedConnectomeFile <- tryo {
-        connectomeFileCache.withCache(connectomeFilePath)(CachedHdf5File.fromPath)
+        connectomeFileCache.getCachedHdf5File(connectomeFilePath)(CachedHdf5File.fromPath)
       } ?~> "connectome.file.open.failed"
       fromAndToPtr: Array[Long] <- finishAccessOnFailure(cachedConnectomeFile) {
-        cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset("/CSR_indptr", 2, agglomerateId)
+        cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/CSR_indptr", 2, agglomerateId)
       } ?~> "Could not read offsets from connectome file"
       fromPtr <- fromAndToPtr.lift(0) ?~> "Could not read start offset from connectome file"
       toPtr <- fromAndToPtr.lift(1) ?~> "Could not read end offset from connectome file"
       from <- finishAccessOnFailure(cachedConnectomeFile) {
-        cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset("/agglomerate_pair_offsets", 1, fromPtr)
+        cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/agglomerate_pair_offsets", 1, fromPtr)
       }.flatMap(_.headOption) ?~> "Could not synapses from connectome file"
       to <- finishAccessOnFailure(cachedConnectomeFile) {
-        cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset("/agglomerate_pair_offsets", 1, toPtr)
+        cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/agglomerate_pair_offsets", 1, toPtr)
       }.flatMap(_.headOption) ?~> "Could not synapses from connectome file"
     } yield List.range(from, to)
 
@@ -220,11 +216,11 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
       _ <- bool2Fox(direction == "src" || direction == "dst") ?~> s"Invalid synaptic partner direction: $direction"
       collection = s"/synapse_to_${direction}_agglomerate"
       cachedConnectomeFile <- tryo {
-        connectomeFileCache.withCache(connectomeFilePath)(CachedHdf5File.fromPath)
+        connectomeFileCache.getCachedHdf5File(connectomeFilePath)(CachedHdf5File.fromPath)
       } ?~> "connectome.file.open.failed"
       agglomerateIds <- Fox.serialCombined(synapseIds) { synapseId: Long =>
         finishAccessOnFailure(cachedConnectomeFile) {
-          cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset(collection, 1, synapseId)
+          cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset(collection, 1, synapseId)
         }.flatMap(_.headOption)
       }
     } yield agglomerateIds
@@ -232,11 +228,11 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
   def positionsForSynapses(connectomeFilePath: Path, synapseIds: List[Long]): Fox[List[List[Long]]] =
     for {
       cachedConnectomeFile <- tryo {
-        connectomeFileCache.withCache(connectomeFilePath)(CachedHdf5File.fromPath)
+        connectomeFileCache.getCachedHdf5File(connectomeFilePath)(CachedHdf5File.fromPath)
       } ?~> "connectome.file.open.failed"
       synapsePositions <- Fox.serialCombined(synapseIds) { synapseId: Long =>
         finishAccessOnFailure(cachedConnectomeFile) {
-          cachedConnectomeFile.reader.uint64().readMatrixBlockWithOffset("/synapse_positions", 1, 3, synapseId, 0)
+          cachedConnectomeFile.uint64Reader.readMatrixBlockWithOffset("/synapse_positions", 1, 3, synapseId, 0)
         }.flatMap(_.headOption)
       }
     } yield synapsePositions.map(_.toList)
@@ -244,12 +240,12 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
   def typesForSynapses(connectomeFilePath: Path, synapseIds: List[Long]): Fox[SynapseTypesWithLegend] =
     for {
       cachedConnectomeFile <- tryo {
-        connectomeFileCache.withCache(connectomeFilePath)(CachedHdf5File.fromPath)
+        connectomeFileCache.getCachedHdf5File(connectomeFilePath)(CachedHdf5File.fromPath)
       } ?~> "connectome.file.open.failed"
       typeNames = typeNamesForSynapsesOrEmpty(connectomeFilePath)
       synapseTypes <- Fox.serialCombined(synapseIds) { synapseId: Long =>
         finishAccessOnFailure(cachedConnectomeFile) {
-          cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset("/synapse_types", 1, synapseId)
+          cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/synapse_types", 1, synapseId)
         }.flatMap(_.headOption)
       }
     } yield SynapseTypesWithLegend(synapseTypes, typeNames)
@@ -269,19 +265,17 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
                                         dstAgglomerateId: Long): Fox[List[Long]] =
     for {
       cachedConnectomeFile <- tryo {
-        connectomeFileCache.withCache(connectomeFilePath)(CachedHdf5File.fromPath)
+        connectomeFileCache.getCachedHdf5File(connectomeFilePath)(CachedHdf5File.fromPath)
       } ?~> "connectome.file.open.failed"
       fromAndToPtr: Array[Long] <- finishAccessOnFailure(cachedConnectomeFile) {
-        cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset("/CSR_indptr", 2, srcAgglomerateId)
+        cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/CSR_indptr", 2, srcAgglomerateId)
       } ?~> "Could not read offsets from connectome file"
       fromPtr <- fromAndToPtr.lift(0) ?~> "Could not read start offset from connectome file"
       toPtr <- fromAndToPtr.lift(1) ?~> "Could not read end offset from connectome file"
       columnValues: Array[Long] <- if (toPtr - fromPtr == 0L) Fox.successful(Array.empty[Long])
       else
         finishAccessOnFailure(cachedConnectomeFile) {
-          cachedConnectomeFile.reader
-            .uint64()
-            .readArrayBlockWithOffset("/CSR_indices", (toPtr - fromPtr).toInt, fromPtr)
+          cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/CSR_indices", (toPtr - fromPtr).toInt, fromPtr)
         } ?~> "Could not read agglomerate pairs from connectome file"
       columnOffset <- searchSorted(columnValues, dstAgglomerateId)
       pairIndex = fromPtr + columnOffset
@@ -290,7 +284,7 @@ class ConnectomeFileService @Inject()(config: DataStoreConfig)(implicit ec: Exec
       else
         for {
           fromAndTo <- finishAccessOnFailure(cachedConnectomeFile) {
-            cachedConnectomeFile.reader.uint64().readArrayBlockWithOffset("/agglomerate_pair_offsets", 2, pairIndex)
+            cachedConnectomeFile.uint64Reader.readArrayBlockWithOffset("/agglomerate_pair_offsets", 2, pairIndex)
           }
           from <- fromAndTo.lift(0)
           to <- fromAndTo.lift(1)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSFullMeshService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSFullMeshService.scala
@@ -142,7 +142,7 @@ class DSFullMeshService @Inject()(dataSourceRepository: DataSourceRepository,
                                                                                            layerName,
                                                                                            meshFileName,
                                                                                            segmentIds)
-      allChunkRanges: List[MeshChunk] = chunkInfos.chunks.lods.head.chunks
+      allChunkRanges: List[MeshChunk] = chunkInfos.chunks.lods.head.chunks.toList
       stlEncodedChunks: Seq[Array[Byte]] <- Fox.serialCombined(allChunkRanges) { chunkRange: MeshChunk =>
         readMeshChunkAsStl(organizationId, datasetName, layerName, meshFileName, chunkRange, chunkInfos.transform)
       }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/MeshFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/MeshFileService.scala
@@ -3,9 +3,9 @@ package com.scalableminds.webknossos.datastore.services
 import com.google.common.io.LittleEndianDataInputStream
 import com.scalableminds.util.geometry.{Vec3Float, Vec3Int}
 import com.scalableminds.util.io.PathUtils
+import com.scalableminds.util.tools.JsonHelper.bool2Box
 import com.scalableminds.util.tools.{ByteUtils, Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.DataStoreConfig
-import com.scalableminds.webknossos.datastore.storage.CachedHdf5Utils.executeWithCachedHdf5
 import com.scalableminds.webknossos.datastore.storage.{CachedHdf5File, Hdf5FileCache}
 import com.typesafe.scalalogging.LazyLogging
 import net.liftweb.common.Box
@@ -136,7 +136,7 @@ case class MeshChunk(position: Vec3Float, byteOffset: Long, byteSize: Int, unmap
 object MeshChunk {
   implicit val jsonFormat: OFormat[MeshChunk] = Json.format[MeshChunk]
 }
-case class MeshLodInfo(scale: Int, vertexOffset: Vec3Float, chunkShape: Vec3Float, chunks: List[MeshChunk])
+case class MeshLodInfo(scale: Int, vertexOffset: Vec3Float, chunkShape: Vec3Float, chunks: Seq[MeshChunk])
 
 object MeshLodInfo {
   implicit val jsonFormat: OFormat[MeshLodInfo] = Json.format[MeshLodInfo]
@@ -146,24 +146,29 @@ case class MeshSegmentInfo(chunkShape: Vec3Float, gridOrigin: Vec3Float, lods: L
 object MeshSegmentInfo {
   implicit val jsonFormat: OFormat[MeshSegmentInfo] = Json.format[MeshSegmentInfo]
 }
-case class WebknossosSegmentInfo(transform: Array[Array[Double]], meshFormat: String, chunks: MeshSegmentInfo) {
-  def merge(that: WebknossosSegmentInfo): WebknossosSegmentInfo =
-    // assume that transform, meshFormat, chunkShape, gridOrigin, scale and vertexOffset are the same
-    WebknossosSegmentInfo(
-      transform,
-      meshFormat,
-      chunks = MeshSegmentInfo(
-        chunks.chunkShape,
-        chunks.gridOrigin,
-        lods = chunks.lods
-          .lazyZip(that.chunks.lods)
-          .map((lod1, lod2) => MeshLodInfo(lod1.scale, lod1.vertexOffset, lod1.chunkShape, lod1.chunks ::: lod2.chunks))
-      )
-    )
-}
+case class WebknossosSegmentInfo(transform: Array[Array[Double]], meshFormat: String, chunks: MeshSegmentInfo)
 
 object WebknossosSegmentInfo {
   implicit val jsonFormat: OFormat[WebknossosSegmentInfo] = Json.format[WebknossosSegmentInfo]
+
+  def fromMeshInfosAndMetadata(chunkInfos: Seq[MeshSegmentInfo],
+                               encoding: String,
+                               transform: Array[Array[Double]]): Option[WebknossosSegmentInfo] =
+    chunkInfos.headOption.flatMap { firstChunkInfo =>
+      tryo {
+        WebknossosSegmentInfo(
+          transform,
+          meshFormat = encoding,
+          chunks = firstChunkInfo.copy(lods = chunkInfos.map(_.lods).transpose.map(mergeLod).toList)
+        )
+      }
+    }
+
+  private def mergeLod(thisLodFromAllChunks: Seq[MeshLodInfo]): MeshLodInfo = {
+    val first = thisLodFromAllChunks.head
+    first.copy(chunks = thisLodFromAllChunks.flatMap(_.chunks))
+  }
+
 }
 
 class MeshFileService @Inject()(config: DataStoreConfig)(implicit ec: ExecutionContext)
@@ -211,8 +216,8 @@ class MeshFileService @Inject()(config: DataStoreConfig)(implicit ec: ExecutionC
    */
   private def mappingNameForMeshFile(meshFilePath: Path, meshFileVersion: Long): Fox[String] = {
     val attributeName = if (meshFileVersion == 0) "metadata/mapping_name" else "mapping_name"
-    executeWithCachedHdf5(meshFilePath, meshFileCache) { cachedMeshFile =>
-      cachedMeshFile.reader.string().getAttr("/", attributeName)
+    meshFileCache.withCachedHdf5(meshFilePath) { cachedMeshFile =>
+      cachedMeshFile.stringReader.getAttr("/", attributeName)
     } ?~> "mesh.file.readEncoding.failed"
   }
 
@@ -228,77 +233,79 @@ class MeshFileService @Inject()(config: DataStoreConfig)(implicit ec: ExecutionC
         .resolve(dataLayerName)
         .resolve(meshesDir)
         .resolve(s"$meshFileName.$hdf5FileExtension")
-    executeWithCachedHdf5(meshFilePath, meshFileCache) { cachedMeshFile =>
-      cachedMeshFile.reader.string().getAttr("/", "mapping_name")
-    }.toOption.flatMap { value =>
-      Option(value) // catch null
-    }
+    meshFileCache
+      .withCachedHdf5(meshFilePath) { cachedMeshFile =>
+        cachedMeshFile.stringReader.getAttr("/", "mapping_name")
+      }
+      .toOption
+      .flatMap { value =>
+        Option(value) // catch null
+      }
   }
 
   private def versionForMeshFile(meshFilePath: Path): Long =
-    executeWithCachedHdf5(meshFilePath, meshFileCache) { cachedMeshFile =>
-      cachedMeshFile.reader.int64().getAttr("/", "artifact_schema_version")
-    }.toOption.getOrElse(0)
+    meshFileCache
+      .withCachedHdf5(meshFilePath) { cachedMeshFile =>
+        cachedMeshFile.int64Reader.getAttr("/", "artifact_schema_version")
+      }
+      .toOption
+      .getOrElse(0)
 
-  def listMeshChunksForSegmentsMerged(
-      organizationId: String,
-      datasetName: String,
-      dataLayerName: String,
-      meshFileName: String,
-      segmentIds: Seq[Long])(implicit m: MessagesProvider): Fox[WebknossosSegmentInfo] = {
-    val meshChunksForUnmappedSegments =
-      listMeshChunksForSegmentsNested(organizationId, datasetName, dataLayerName, meshFileName, segmentIds)
+  def listMeshChunksForSegmentsMerged(organizationId: String,
+                                      datasetName: String,
+                                      dataLayerName: String,
+                                      meshFileName: String,
+                                      segmentIds: Seq[Long])(implicit m: MessagesProvider): Fox[WebknossosSegmentInfo] =
     for {
-      _ <- bool2Fox(meshChunksForUnmappedSegments.nonEmpty) ?~> "zero chunks" ?~> Messages(
-        "mesh.file.listChunks.failed",
-        segmentIds.mkString(","),
-        meshFileName)
-      chunkInfos = meshChunksForUnmappedSegments.reduce(_.merge(_))
-    } yield chunkInfos
-  }
-
-  private def listMeshChunksForSegmentsNested(organizationId: String,
-                                              datasetName: String,
-                                              dataLayerName: String,
-                                              meshFileName: String,
-                                              segmentIds: Seq[Long]): Seq[WebknossosSegmentInfo] = {
-    val meshFilePath =
-      dataBaseDir
+      _ <- Fox.successful(())
+      meshFilePath: Path = dataBaseDir
         .resolve(organizationId)
         .resolve(datasetName)
         .resolve(dataLayerName)
         .resolve(meshesDir)
         .resolve(s"$meshFileName.$hdf5FileExtension")
+      (encoding, lodScaleMultiplier, transform) <- readMeshfileMetadata(meshFilePath).toFox
+      meshChunksForUnmappedSegments: Seq[MeshSegmentInfo] = listMeshChunksForSegments(meshFilePath,
+                                                                                      segmentIds,
+                                                                                      lodScaleMultiplier)
+      _ <- bool2Fox(meshChunksForUnmappedSegments.nonEmpty) ?~> "zero chunks" ?~> Messages(
+        "mesh.file.listChunks.failed",
+        segmentIds.mkString(","),
+        meshFileName)
+      wkChunkInfos <- WebknossosSegmentInfo.fromMeshInfosAndMetadata(meshChunksForUnmappedSegments, encoding, transform)
+    } yield wkChunkInfos
 
-    executeWithCachedHdf5(meshFilePath, meshFileCache) { cachedMeshFile: CachedHdf5File =>
-      val encoding = cachedMeshFile.reader.string().getAttr("/", "mesh_format")
-      val lodScaleMultiplier = cachedMeshFile.reader.float64().getAttr("/", "lod_scale_multiplier")
-      val transform = cachedMeshFile.reader.float64().getMatrixAttr("/", "transform")
+  private def listMeshChunksForSegments(meshFilePath: Path,
+                                        segmentIds: Seq[Long],
+                                        lodScaleMultiplier: Double): Seq[MeshSegmentInfo] =
+    meshFileCache
+      .withCachedHdf5(meshFilePath) { cachedMeshFile: CachedHdf5File =>
+        segmentIds.flatMap(segmentId => listMeshChunksForSegment(cachedMeshFile, segmentId, lodScaleMultiplier))
+      }
+      .toOption
+      .getOrElse(Seq.empty)
 
-      segmentIds.flatMap(segmentId =>
-        listMeshChunksForSegment(cachedMeshFile, segmentId, encoding, transform, lodScaleMultiplier))
-    }.toOption.getOrElse(Seq.empty)
-
-  }
+  private def readMeshfileMetadata(meshFilePath: Path): Box[(String, Double, Array[Array[Double]])] =
+    meshFileCache.withCachedHdf5(meshFilePath) { cachedMeshFile =>
+      val encoding = cachedMeshFile.stringReader.getAttr("/", "mesh_format")
+      val lodScaleMultiplier = cachedMeshFile.float64Reader.getAttr("/", "lod_scale_multiplier")
+      val transform = cachedMeshFile.float64Reader.getMatrixAttr("/", "transform")
+      (encoding, lodScaleMultiplier, transform)
+    }
 
   private def listMeshChunksForSegment(cachedMeshFile: CachedHdf5File,
                                        segmentId: Long,
-                                       encoding: String,
-                                       transform: Array[Array[Double]],
-                                       lodScaleMultiplier: Double): Box[WebknossosSegmentInfo] =
+                                       lodScaleMultiplier: Double): Box[MeshSegmentInfo] =
     tryo {
       val (neuroglancerSegmentManifestStart, neuroglancerSegmentManifestEnd) =
         getNeuroglancerSegmentManifestOffsets(segmentId, cachedMeshFile)
 
-      val manifestBytes = cachedMeshFile.reader
-        .uint8()
-        .readArrayBlockWithOffset("/neuroglancer",
-                                  (neuroglancerSegmentManifestEnd - neuroglancerSegmentManifestStart).toInt,
-                                  neuroglancerSegmentManifestStart)
+      val manifestBytes = cachedMeshFile.uint8Reader.readArrayBlockWithOffset(
+        "/neuroglancer",
+        (neuroglancerSegmentManifestEnd - neuroglancerSegmentManifestStart).toInt,
+        neuroglancerSegmentManifestStart)
       val segmentManifest = NeuroglancerSegmentManifest.fromBytes(manifestBytes)
-      val enrichedSegmentManifest =
-        enrichSegmentInfo(segmentManifest, lodScaleMultiplier, neuroglancerSegmentManifestStart, segmentId)
-      WebknossosSegmentInfo(transform = transform, meshFormat = encoding, chunks = enrichedSegmentManifest)
+      enrichSegmentInfo(segmentManifest, lodScaleMultiplier, neuroglancerSegmentManifestStart, segmentId)
     }
 
   private def enrichSegmentInfo(segmentInfo: NeuroglancerSegmentManifest,
@@ -346,19 +353,18 @@ class MeshFileService @Inject()(config: DataStoreConfig)(implicit ec: ExecutionC
   }
 
   private def getNeuroglancerSegmentManifestOffsets(segmentId: Long, cachedMeshFile: CachedHdf5File): (Long, Long) = {
-    val nBuckets = cachedMeshFile.reader.uint64().getAttr("/", "n_buckets")
-    val hashName = cachedMeshFile.reader.string().getAttr("/", "hash_function")
-
-    val bucketIndex = getHashFunction(hashName)(segmentId) % nBuckets
-    val bucketOffsets = cachedMeshFile.reader.uint64().readArrayBlockWithOffset("bucket_offsets", 2, bucketIndex)
+    val bucketIndex = cachedMeshFile.hashFunction(segmentId) % cachedMeshFile.nBuckets
+    val bucketOffsets = cachedMeshFile.uint64Reader.readArrayBlockWithOffset("bucket_offsets", 2, bucketIndex)
     val bucketStart = bucketOffsets(0)
     val bucketEnd = bucketOffsets(1)
 
     if (bucketEnd - bucketStart == 0) throw new Exception(s"No entry for segment $segmentId")
 
-    val buckets = cachedMeshFile.reader
-      .uint64()
-      .readMatrixBlockWithOffset("buckets", (bucketEnd - bucketStart + 1).toInt, 3, bucketStart, 0)
+    val buckets = cachedMeshFile.uint64Reader.readMatrixBlockWithOffset("buckets",
+                                                                        (bucketEnd - bucketStart + 1).toInt,
+                                                                        3,
+                                                                        bucketStart,
+                                                                        0)
 
     val bucketLocalOffset = buckets.map(_(0)).indexOf(segmentId)
     if (bucketLocalOffset < 0) throw new Exception(s"SegmentId $segmentId not in bucket list")
@@ -372,34 +378,43 @@ class MeshFileService @Inject()(config: DataStoreConfig)(implicit ec: ExecutionC
                     datasetName: String,
                     dataLayerName: String,
                     meshChunkDataRequests: MeshChunkDataRequestList,
-  ): Fox[(Array[Byte], String)] =
+  ): Fox[(Array[Byte], String)] = {
+    val meshFilePath = dataBaseDir
+      .resolve(organizationId)
+      .resolve(datasetName)
+      .resolve(dataLayerName)
+      .resolve(meshesDir)
+      .resolve(s"${meshChunkDataRequests.meshFile}.$hdf5FileExtension")
     for {
-      // Sort the requests by byte offset to optimize for spinning disk access
-      data: List[(Array[Byte], String, Int)] <- Fox.serialCombined(
-        meshChunkDataRequests.requests.zipWithIndex.sortBy(requestAndIndex => requestAndIndex._1.byteOffset).toList
-      )(requestAndIndex => {
-        val meshChunkDataRequest = requestAndIndex._1
-        val meshFilePath = dataBaseDir
-          .resolve(organizationId)
-          .resolve(datasetName)
-          .resolve(dataLayerName)
-          .resolve(meshesDir)
-          .resolve(s"${meshChunkDataRequests.meshFile}.$hdf5FileExtension")
+      resultBox <- meshFileCache.withCachedHdf5(meshFilePath) { cachedMeshFile =>
+        readMeshChunkFromCachedMeshfile(cachedMeshFile, meshChunkDataRequests)
+      }
+      (output, encoding) <- resultBox
+    } yield (output, encoding)
+  }
 
-        executeWithCachedHdf5(meshFilePath, meshFileCache) { cachedMeshFile =>
-          val meshFormat = cachedMeshFile.reader.string().getAttr("/", "mesh_format")
-          val data =
-            cachedMeshFile.reader
-              .uint8()
-              .readArrayBlockWithOffset("neuroglancer", meshChunkDataRequest.byteSize, meshChunkDataRequest.byteOffset)
-          (data, meshFormat, requestAndIndex._2)
-        } ?~> "mesh.file.readData.failed"
-      })
-      dataSorted = data.sortBy(d => d._3)
-      _ <- Fox.bool2Fox(data.map(d => d._2).toSet.size == 1) ?~> "Different encodings for the same mesh chunk request found."
+  private def readMeshChunkFromCachedMeshfile(
+      cachedMeshFile: CachedHdf5File,
+      meshChunkDataRequests: MeshChunkDataRequestList): Box[(Array[Byte], String)] = {
+    val meshFormat = cachedMeshFile.meshFormat
+    // Sort the requests by byte offset to optimize for spinning disk access
+    val requestsReordered =
+      meshChunkDataRequests.requests.zipWithIndex.sortBy(requestAndIndex => requestAndIndex._1.byteOffset).toList
+    val data: List[(Array[Byte], String, Int)] = requestsReordered.map { requestAndIndex =>
+      val meshChunkDataRequest = requestAndIndex._1
+      val data =
+        cachedMeshFile.uint8Reader.readArrayBlockWithOffset("neuroglancer",
+                                                            meshChunkDataRequest.byteSize,
+                                                            meshChunkDataRequest.byteOffset)
+      (data, meshFormat, requestAndIndex._2)
+    }
+    val dataSorted = data.sortBy(d => d._3)
+    for {
+      _ <- bool2Box(data.map(d => d._2).toSet.size == 1) ?~! "Different encodings for the same mesh chunk request found."
       encoding <- data.map(d => d._2).headOption
       output = dataSorted.flatMap(d => d._1).toArray
     } yield (output, encoding)
+  }
 
   def clearCache(organizationId: String, datasetName: String, layerNameOpt: Option[String]): Int = {
     val datasetPath = dataBaseDir.resolve(organizationId).resolve(datasetName)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/SegmentIndexFileService.scala
@@ -58,12 +58,11 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
                        segmentId: Long): Fox[Array[Vec3Int]] =
     for {
       segmentIndexPath <- getSegmentIndexFile(organizationId, datasetName, dataLayerName).toFox
-      segmentIndex = fileHandleCache.withCache(segmentIndexPath)(CachedHdf5File.fromPath)
-      hashFunction = getHashFunction(segmentIndex.reader.string().getAttr("/", "hash_function"))
-      nBuckets = segmentIndex.reader.uint64().getAttr("/", "n_hash_buckets")
+      segmentIndex = fileHandleCache.getCachedHdf5File(segmentIndexPath)(CachedHdf5File.fromPath)
+      nBuckets = segmentIndex.uint64Reader.getAttr("/", "n_hash_buckets")
 
-      bucketIndex = hashFunction(segmentId) % nBuckets
-      bucketOffsets = segmentIndex.reader.uint64().readArrayBlockWithOffset("hash_bucket_offsets", 2, bucketIndex)
+      bucketIndex = segmentIndex.hashFunction(segmentId) % nBuckets
+      bucketOffsets = segmentIndex.uint64Reader.readArrayBlockWithOffset("hash_bucket_offsets", 2, bucketIndex)
       bucketStart = bucketOffsets(0)
       bucketEnd = bucketOffsets(1)
 
@@ -79,8 +78,8 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
   def readFileMag(organizationId: String, datasetName: String, dataLayerName: String): Fox[Vec3Int] =
     for {
       segmentIndexPath <- getSegmentIndexFile(organizationId, datasetName, dataLayerName).toFox
-      segmentIndex = fileHandleCache.withCache(segmentIndexPath)(CachedHdf5File.fromPath)
-      mag <- Vec3Int.fromArray(segmentIndex.reader.uint64().getArrayAttr("/", "mag").map(_.toInt)).toFox
+      segmentIndex = fileHandleCache.getCachedHdf5File(segmentIndexPath)(CachedHdf5File.fromPath)
+      mag <- Vec3Int.fromArray(segmentIndex.uint64Reader.getArrayAttr("/", "mag").map(_.toInt)).toFox
     } yield mag
 
   private def readTopLefts(segmentIndex: CachedHdf5File,
@@ -89,20 +88,24 @@ class SegmentIndexFileService @Inject()(config: DataStoreConfig,
                            segmentId: Long): Fox[Option[Array[Array[Short]]]] =
     for {
       _ <- Fox.successful(())
-      buckets = segmentIndex.reader
-        .uint64()
-        .readMatrixBlockWithOffset("hash_buckets", (bucketEnd - bucketStart + 1).toInt, 3, bucketStart, 0)
+      buckets = segmentIndex.uint64Reader.readMatrixBlockWithOffset("hash_buckets",
+                                                                    (bucketEnd - bucketStart + 1).toInt,
+                                                                    3,
+                                                                    bucketStart,
+                                                                    0)
       bucketLocalOffset = buckets.map(_(0)).indexOf(segmentId)
       topLeftOpts <- Fox.runIf(bucketLocalOffset >= 0)(for {
         _ <- Fox.successful(())
         topLeftStart = buckets(bucketLocalOffset)(1)
         topLeftEnd = buckets(bucketLocalOffset)(2)
-        bucketEntriesDtype <- tryo(segmentIndex.reader.string().getAttr("/", "dtype_bucket_entries")).toFox
+        bucketEntriesDtype <- tryo(segmentIndex.stringReader.getAttr("/", "dtype_bucket_entries")).toFox
         _ <- Fox
           .bool2Fox(bucketEntriesDtype == "uint16") ?~> "value for dtype_bucket_entries in segment index file is not supported, only uint16 is supported"
-        topLefts = segmentIndex.reader
-          .uint16()
-          .readMatrixBlockWithOffset("top_lefts", (topLeftEnd - topLeftStart).toInt, 3, topLeftStart, 0)
+        topLefts = segmentIndex.uint16Reader.readMatrixBlockWithOffset("top_lefts",
+                                                                       (topLeftEnd - topLeftStart).toInt,
+                                                                       3,
+                                                                       topLeftStart,
+                                                                       0)
       } yield topLefts)
     } yield topLeftOpts
 


### PR DESCRIPTION
Saves some reads both in the chunk list request and when reading actual chunk data
 - mostly don’t re-read constant attributes for every segment
 - allocate fewer java objects in merge step of list chunks request (no more `reduce(mergeTwo)`)

### URL of deployed dev instance (used for testing):
- https://meshfileloadingperf.webknossos.xyz

### Steps to test:
- Load precomputed meshes, both computed for a mapping, and computed for the oversegmentation, should still work
- Especially when using an oversegmentation meshfile, but loading meshes *with mapping* (so it’s applied on-the-fly), there should be a speedup.

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
