### PR TITLE
Allow admins to view and cancel other users jobs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Changed
 - Some mesh-related actions were disabled in proofreading-mode when using meshfiles that were created for a mapping rather than an oversegmentation. [#8091](https://github.com/scalableminds/webknossos/pull/8091)
+- Admins can now see and cancel all jobs. The owner of the job is shown in the job list. [#8112](https://github.com/scalableminds/webknossos/pull/8112)
 
 ### Fixed
 - Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098) [#8103](https://github.com/scalableminds/webknossos/pull/8103)

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -141,7 +141,9 @@ class JobDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
      """
 
   private def listAccessQ(requestingUserId: ObjectId) =
-    q"""_owner = $requestingUserId"""
+    q"""_owner = $requestingUserId OR
+       ((SELECT u._organization FROM webknossos.users_ u WHERE u._id = _owner) IN (SELECT _organization FROM webknossos.users_ WHERE _id = $requestingUserId AND isAdmin))
+     """
 
   override def findAll(implicit ctx: DBAccessContext): Fox[List[Job]] =
     for {

--- a/app/models/job/JobService.scala
+++ b/app/models/job/JobService.scala
@@ -163,9 +163,11 @@ class JobService @Inject()(wkConf: WkConf,
       owner <- userDAO.findOne(job._owner) ?~> "user.notFound"
       organization <- organizationDAO.findOne(owner._organization) ?~> "organization.notFound"
       resultLink = job.resultLink(organization._id)
+      ownerJson <- userService.compactWrites(owner)
     } yield {
       Json.obj(
         "id" -> job._id.id,
+        "owner" -> ownerJson,
         "command" -> job.command,
         "commandArgs" -> (job.commandArgs - "webknossos_token" - "user_auth_token"),
         "state" -> job.state,

--- a/frontend/javascripts/admin/api/jobs.ts
+++ b/frontend/javascripts/admin/api/jobs.ts
@@ -16,6 +16,7 @@ import { assertResponseLimit } from "./api_utils";
 function transformBackendJobToAPIJob(job: any): APIJob {
   return {
     id: job.id,
+    owner: job.owner,
     type: job.command,
     datasetName: job.commandArgs.dataset_name,
     organizationId: job.commandArgs.organization_name,

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -15,7 +15,7 @@ import {
   InfoCircleOutlined,
 } from "@ant-design/icons";
 import type * as React from "react";
-import { type APIJob, APIJobType } from "types/api_flow_types";
+import { type APIJob, APIJobType, type APIUserBase } from "types/api_flow_types";
 import { getJobs, cancelJob } from "admin/admin_rest_api";
 import Persistence from "libs/persistence";
 import * as Utils from "libs/utils";
@@ -409,6 +409,18 @@ function JobListView() {
             render={(job) => <FormattedDate timestamp={job.createdAt} />}
             sorter={Utils.compareBy<APIJob>((job) => job.createdAt)}
             defaultSortOrder="descend"
+          />
+          <Column
+            title="Owner"
+            dataIndex="owner"
+            key="owner"
+            sorter={Utils.localeCompareBy<APIJob>((job) => job.owner.lastName)}
+            render={(owner: APIUserBase) => (
+              <>
+                <div>{owner.email ? `${owner.lastName}, ${owner.firstName}` : "-"}</div>
+                <div>{owner.email ? `(${owner.email})` : "-"}</div>
+              </>
+            )}
           />
           <Column
             title="State"

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -375,7 +375,7 @@ function JobListView() {
           </Tooltip>
         </a>
         <br />
-        WEBKNOSSOS will notfiy you via email when a job has finished or reload this page to track
+        WEBKNOSSOS will notify you via email when a job has finished or reload this page to track
         progress.
       </Typography.Paragraph>
       <div

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -711,6 +711,7 @@ export type WkLibsNdBoundingBox = BoundingBoxObject & {
 
 export type APIJob = {
   readonly id: string;
+  readonly owner: APIUserBase;
   readonly datasetName: string | null | undefined;
   readonly exportFileName: string | null | undefined;
   readonly layerName: string | null | undefined;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a job as a non admin user (Or create a job as an admin user and edit the owner in the DB)
- Be able to see it and cancel it
- Note that the owner is now displayed in the job list

### Notes

-  No changes were required to make canceling possible
- The SQL change is copied from the readAccessQ
- The frontend change (new column) is copied from the Project List

### Issues:
- fixes #7498

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] ~~Updated [documentation](../blob/master/docs) if applicable~~ The jobs page was already old before (e.g. screenshot  shows old logo, different UI), but the text is unchanged
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)