### PR TITLE
Ensure user has edit permissions before deleting sharing token

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098) [#8103](https://github.com/scalableminds/webknossos/pull/8103)
 - Fixed a bug where you could not create annotations for public datasets of other organizations. [#8107](https://github.com/scalableminds/webknossos/pull/8107)
+- Users without edit permissions to a dataset can no longer delete sharing tokens via the API. [#8083](https://github.com/scalableminds/webknossos/issues/8083)
 
 ### Removed
 

--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -369,6 +369,9 @@ class DatasetController @Inject()(userService: UserService,
       for {
         organization <- organizationDAO.findOne(organizationId)
         _ <- bool2Fox(organization._id == request.identity._organization) ~> FORBIDDEN
+        dataset <- datasetDAO
+          .findOneByNameAndOrganization(datasetName, organizationId) ?~> notFoundMessage(datasetName) ~> NOT_FOUND
+        _ <- Fox.assertTrue(datasetService.isEditableBy(dataset, Some(request.identity))) ?~> "notAllowed" ~> FORBIDDEN
         _ <- datasetDAO.updateSharingTokenByName(datasetName, organization._id, None)
       } yield Ok
   }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Create a sharing token
- Share the dataset with a user (for viewing)
- Use the API route to delete the sharing token. Fail in this endeavor.

### Issues:
- fixes #8083

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
