### PR TITLE
Quickfix materialize volume annotation job via adding default named outputSegmentationLayerName param

### DIFF
--- a/frontend/javascripts/admin/api/jobs.ts
+++ b/frontend/javascripts/admin/api/jobs.ts
@@ -238,10 +238,12 @@ function startSegmentationAnnotationDependentJob(
   if (volumeLayerName != null) {
     requestURL.searchParams.append("volumeLayerName", volumeLayerName);
   }
+  const layerName = volumeLayerName || fallbackLayerName;
   requestURL.searchParams.append("fallbackLayerName", fallbackLayerName);
   requestURL.searchParams.append("annotationId", annotationId);
   requestURL.searchParams.append("annotationType", annotationType);
   requestURL.searchParams.append("newDatasetName", newDatasetName);
+  requestURL.searchParams.append("outputSegmentationLayerName", `${layerName}_materialized`);
   if (mergeSegments != null) {
     requestURL.searchParams.append("mergeSegments", mergeSegments.toString());
   }


### PR DESCRIPTION
Quick fix for https://github.com/scalableminds/webknossos/issues/8117. But does not completely fix the issue as the user is not able to enter the desired name of the materialized volume layer
