### PR TITLE
extend segment search to default name used in segments list

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - It is now possible to add metadata in annotations to Trees and Segments. [#7875](https://github.com/scalableminds/webknossos/pull/7875)
 - Added a summary row to the time tracking overview, where times and annotations/tasks are summed. [#8092](https://github.com/scalableminds/webknossos/pull/8092)
 - Most sliders have been improved: Wheeling above a slider now changes its value and double-clicking its knob resets it to its default value. [#8095](https://github.com/scalableminds/webknossos/pull/8095)
+- It is now possible to search for unnamed segments with the full default name instead of only their id. [#8133](https://github.com/scalableminds/webknossos/pull/8133)
 - Increased loading speed for precomputed meshes. [#8110](https://github.com/scalableminds/webknossos/pull/8110)
 
 ### Changed

--- a/frontend/javascripts/oxalis/model/accessors/volumetracing_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/volumetracing_accessor.ts
@@ -58,6 +58,7 @@ import {
 import { Store } from "oxalis/singletons";
 import { setSelectedSegmentsOrGroupAction } from "../actions/volumetracing_actions";
 import _ from "lodash";
+import type { SegmentHierarchyNode } from "oxalis/view/right-border-tabs/segments_tab/segments_view_helper";
 
 export function getVolumeTracings(tracing: Tracing): Array<VolumeTracing> {
   return tracing.volumes;
@@ -655,7 +656,10 @@ export function getLabelActionFromPreviousSlice(
   );
 }
 
-export function getSegmentName(segment: Segment, fallbackToId: boolean = false): string {
+export function getSegmentName(
+  segment: Segment | SegmentHierarchyNode,
+  fallbackToId: boolean = false,
+): string {
   const fallback = fallbackToId ? `${segment.id}` : `Segment ${segment.id}`;
   return segment.name || fallback;
 }

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -50,6 +50,7 @@ import { getAdditionalCoordinatesAsString } from "oxalis/model/accessors/flycam_
 import {
   getActiveSegmentationTracing,
   getMeshesForCurrentAdditionalCoordinates,
+  getSegmentName,
   getSelectedIds,
   getVisibleSegments,
   hasEditableMapping,
@@ -1829,7 +1830,7 @@ class SegmentsView extends React.Component<Props, State> {
                   <AdvancedSearchPopover
                     onSelect={this.handleSearchSelect}
                     data={this.state.searchableTreeItemList}
-                    searchKey={(item) => item.name ?? `${item.id}` ?? ""}
+                    searchKey={(item) => getSegmentName(item)}
                     provideShortcut
                     targetId={segmentsTabId}
                   >


### PR DESCRIPTION
In the segments list the default name of an unnamed segment is `Segment <id>` but it was only possible to search for unnamend segments via `<id>` in the search popover. This pr changes this behaviour so that it is possible to search for the full default name `Segment <id>`. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open an annotation with a segmentation.
- click on some segments to add them to the segments list
- use the search an enter the term "segm"
- It should be possible to cycle through all segments via the search


### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1729236392212679?thread_ts=1729151014.410219&cid=C5AKLAV0B

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
