### PR TITLE
Unified annotation restore

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -112,6 +112,7 @@ class AnnotationController @Inject()(
     log() {
       for {
         annotation <- provider.provideAnnotation(id, request.identity) ~> NOT_FOUND
+        // This does not send the version information, but found a frontend workaround
         result <- info(annotation.typ.toString, id, timestamp)(request)
       } yield result
 

--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -112,7 +112,6 @@ class AnnotationController @Inject()(
     log() {
       for {
         annotation <- provider.provideAnnotation(id, request.identity) ~> NOT_FOUND
-        // This does not send the version information, but found a frontend workaround
         result <- info(annotation.typ.toString, id, timestamp)(request)
       } yield result
 

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -872,7 +872,7 @@ export async function acquireAnnotationMutex(
 export async function getTracingForAnnotationType(
   annotation: APIAnnotation,
   annotationLayerDescriptor: AnnotationLayerDescriptor,
-  version: number | null | undefined, // TODO: Use this parameter
+  version?: number | null | undefined, // TODO: Use this parameter
 ): Promise<ServerTracing> {
   const { tracingId, typ } = annotationLayerDescriptor;
   const tracingType = typ.toLowerCase() as "skeleton" | "volume";

--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -7,7 +7,6 @@ import { getConstructorForElementClass } from "oxalis/model/bucket_data_handling
 import { type APICompoundType, APICompoundTypeEnum, type ElementClass } from "types/api_flow_types";
 import { InputKeyboardNoLoop } from "libs/input";
 import { M4x4, type Matrix4x4, V3, type Vector16 } from "libs/mjs";
-import type { Versions } from "oxalis/view/version_view";
 import {
   addTreesAndGroupsAction,
   setActiveNodeAction,
@@ -1115,7 +1114,7 @@ class TracingApi {
     newMaybeCompoundType: APICompoundType | null,
     newAnnotationId: string,
     newControlMode: ControlMode,
-    versions?: Versions,
+    version?: number | undefined | null,
     keepUrlState: boolean = false,
   ) {
     if (newControlMode === ControlModeEnum.VIEW)
@@ -1134,7 +1133,7 @@ class TracingApi {
         type: newControlMode,
       },
       false,
-      versions,
+      version,
     );
     Store.dispatch(discardSaveQueuesAction());
     Store.dispatch(wkReadyAction());

--- a/frontend/javascripts/oxalis/controller.tsx
+++ b/frontend/javascripts/oxalis/controller.tsx
@@ -90,14 +90,12 @@ class Controller extends React.PureComponent<PropsWithRouter, State> {
   tryFetchingModel() {
     this.props.setControllerStatus("loading");
     // Preview a working annotation version if the showVersionRestore URL parameter is supplied
-    const versions = Utils.hasUrlParam("showVersionRestore")
-      ? {
-          skeleton: Utils.hasUrlParam("skeletonVersion")
-            ? Number.parseInt(Utils.getUrlParamValue("skeletonVersion"))
-            : 1,
-        }
+    const version = Utils.hasUrlParam("showVersionRestore")
+      ? Utils.hasUrlParam("version")
+        ? Number.parseInt(Utils.getUrlParamValue("version"))
+        : 1
       : undefined;
-    Model.fetch(this.props.initialMaybeCompoundType, this.props.initialCommandType, true, versions)
+    Model.fetch(this.props.initialMaybeCompoundType, this.props.initialCommandType, true, version)
       .then(() => this.modelFetchDone())
       .catch((error) => {
         this.props.setControllerStatus("failedLoading");

--- a/frontend/javascripts/oxalis/default_state.ts
+++ b/frontend/javascripts/oxalis/default_state.ts
@@ -177,6 +177,7 @@ const defaultState: OxalisState = {
     othersMayEdit: false,
     blockedByUser: null,
     annotationLayers: [],
+    version: 0,
   },
   save: {
     queue: [],

--- a/frontend/javascripts/oxalis/model.ts
+++ b/frontend/javascripts/oxalis/model.ts
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import type { Vector3 } from "oxalis/constants";
-import type { Versions } from "oxalis/view/version_view";
 import { getActiveSegmentationTracingLayer } from "oxalis/model/accessors/volumetracing_accessor";
 import { getActiveMagIndexForLayer } from "oxalis/model/accessors/flycam_accessor";
 import {
@@ -32,14 +31,14 @@ export class OxalisModel {
     initialMaybeCompoundType: APICompoundType | null,
     initialCommandType: TraceOrViewCommand,
     initialFetch: boolean,
-    versions?: Versions,
+    version?: number | undefined | null,
   ) {
     try {
       const initializationInformation = await initialize(
         initialMaybeCompoundType,
         initialCommandType,
         initialFetch,
-        versions,
+        version,
       );
 
       if (initializationInformation) {

--- a/frontend/javascripts/oxalis/model/actions/save_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/save_actions.ts
@@ -30,15 +30,11 @@ export type SaveAction =
 
 export const pushSaveQueueTransaction = (
   items: Array<UpdateAction>,
-  saveQueueType: SaveQueueType,
-  tracingId: string,
   transactionId: string = getUid(),
 ) =>
   ({
     type: "PUSH_SAVE_QUEUE_TRANSACTION",
     items,
-    saveQueueType,
-    tracingId,
     transactionId,
   }) as const;
 
@@ -70,16 +66,10 @@ export const setLastSaveTimestampAction = () =>
     timestamp: Date.now(),
   }) as const;
 
-export const setVersionNumberAction = (
-  version: number,
-  saveQueueType: SaveQueueType,
-  tracingId: string,
-) =>
+export const setVersionNumberAction = (version: number) =>
   ({
     type: "SET_VERSION_NUMBER",
     version,
-    saveQueueType,
-    tracingId,
   }) as const;
 
 export const undoAction = (callback?: () => void) =>

--- a/frontend/javascripts/oxalis/model/actions/save_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/save_actions.ts
@@ -30,12 +30,14 @@ export type SaveAction =
 
 export const pushSaveQueueTransaction = (
   items: Array<UpdateAction>,
+  tracingId: string,
   transactionId: string = getUid(),
 ) =>
   ({
     type: "PUSH_SAVE_QUEUE_TRANSACTION",
     items,
     transactionId,
+    tracingId,
   }) as const;
 
 export const saveNowAction = () =>

--- a/frontend/javascripts/oxalis/model/data_layer.ts
+++ b/frontend/javascripts/oxalis/model/data_layer.ts
@@ -21,7 +21,12 @@ class DataLayer {
   fallbackLayerInfo: DataLayerType | null | undefined;
   isSegmentation: boolean;
 
-  constructor(layerInfo: DataLayerType, textureWidth: number, dataTextureCount: number) {
+  constructor(
+    layerInfo: DataLayerType,
+    textureWidth: number,
+    dataTextureCount: number,
+    tracingId: string,
+  ) {
     this.name = layerInfo.name;
     this.fallbackLayer =
       "fallbackLayer" in layerInfo && layerInfo.fallbackLayer != null
@@ -46,7 +51,7 @@ class DataLayer {
       this.name,
     );
     this.pullQueue = new PullQueue(this.cube, layerInfo.name, dataset.dataStore);
-    this.pushQueue = new PushQueue(this.cube);
+    this.pushQueue = new PushQueue(this.cube, tracingId);
     this.cube.initializeWithQueues(this.pullQueue, this.pushQueue);
 
     if (this.isSegmentation) {

--- a/frontend/javascripts/oxalis/model/helpers/compaction/compact_toggle_actions.ts
+++ b/frontend/javascripts/oxalis/model/helpers/compaction/compact_toggle_actions.ts
@@ -7,7 +7,6 @@ import _ from "lodash";
 import type { SkeletonTracing, Tree, TreeGroup, TreeMap, VolumeTracing } from "oxalis/store";
 import type {
   UpdateAction,
-  UpdateActionWithTracingId,
   UpdateTreeVisibilityUpdateAction,
 } from "oxalis/model/sagas/update_actions";
 import { updateTreeGroupVisibility, updateTreeVisibility } from "oxalis/model/sagas/update_actions";

--- a/frontend/javascripts/oxalis/model/helpers/compaction/compact_update_actions.ts
+++ b/frontend/javascripts/oxalis/model/helpers/compaction/compact_update_actions.ts
@@ -7,7 +7,6 @@ import type {
   DeleteNodeUpdateAction,
   DeleteTreeUpdateAction,
   UpdateAction,
-  UpdateActionWithTracingId,
 } from "oxalis/model/sagas/update_actions";
 import { moveTreeComponent } from "oxalis/model/sagas/update_actions";
 import compactToggleActions from "oxalis/model/helpers/compaction/compact_toggle_actions";

--- a/frontend/javascripts/oxalis/model/reducers/save_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/save_reducer.ts
@@ -39,13 +39,6 @@ function SaveReducer(state: OxalisState, action: Action): OxalisState {
       // update actions.
       const dispatchedAction = action;
       const { items, transactionId } = dispatchedAction;
-      console.log(
-        "bool",
-        _.some(
-          dispatchedAction.items,
-          (ua) => ua.name !== "updateSkeletonTracing" && ua.name !== "updateVolumeTracing",
-        ),
-      );
       const stats: CombinedTracingStats | null = _.some(
         dispatchedAction.items,
         (ua) => ua.name !== "updateSkeletonTracing" && ua.name !== "updateVolumeTracing",

--- a/frontend/javascripts/oxalis/model/reducers/save_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/save_reducer.ts
@@ -4,13 +4,9 @@ import type { Action } from "oxalis/model/actions/actions";
 import type { OxalisState, SaveState } from "oxalis/store";
 import type { SetVersionNumberAction } from "oxalis/model/actions/save_actions";
 import { getActionLog } from "oxalis/model/helpers/action_logger_middleware";
-import { getStats } from "oxalis/model/accessors/annotation_accessor";
+import { type CombinedTracingStats, getStats } from "oxalis/model/accessors/annotation_accessor";
 import { MAXIMUM_ACTION_COUNT_PER_BATCH } from "oxalis/model/sagas/save_saga_constants";
-import { updateKey2 } from "oxalis/model/helpers/deep_update";
-import {
-  updateEditableMapping,
-  updateVolumeTracing,
-} from "oxalis/model/reducers/volumetracing_reducer_helpers";
+import { updateKey, updateKey2 } from "oxalis/model/helpers/deep_update";
 import Date from "libs/date";
 import type { UpdateAction, UpdateActionWithTracingId } from "../sagas/update_actions";
 
@@ -31,21 +27,9 @@ export function getTotalSaveQueueLength(queueObj: SaveState["queue"]) {
 }
 
 function updateVersion(state: OxalisState, action: SetVersionNumberAction) {
-  if (action.saveQueueType === "skeleton" && state.tracing.skeleton != null) {
-    return updateKey2(state, "tracing", "skeleton", {
-      version: action.version,
-    });
-  } else if (action.saveQueueType === "volume") {
-    return updateVolumeTracing(state, action.tracingId, {
-      version: action.version,
-    });
-  } else if (action.saveQueueType === "mapping") {
-    /*return updateEditableMapping(state, action.tracingId, {
-      version: action.version,
-    });*/
-  }
-
-  return state;
+  return updateKey(state, "tracing", {
+    version: action.version,
+  });
 }
 
 function SaveReducer(state: OxalisState, action: Action): OxalisState {
@@ -55,11 +39,14 @@ function SaveReducer(state: OxalisState, action: Action): OxalisState {
       // update actions.
       const dispatchedAction = action;
       const { items, transactionId } = dispatchedAction;
-      if (items.length === 0) {
-        return state;
-      }
-      // Only report tracing statistics, if a "real" update to the tracing happened
-      const stats = _.some(
+      console.log(
+        "bool",
+        _.some(
+          dispatchedAction.items,
+          (ua) => ua.name !== "updateSkeletonTracing" && ua.name !== "updateVolumeTracing",
+        ),
+      );
+      const stats: CombinedTracingStats | null = _.some(
         dispatchedAction.items,
         (ua) => ua.name !== "updateSkeletonTracing" && ua.name !== "updateVolumeTracing",
       )
@@ -96,7 +83,6 @@ function SaveReducer(state: OxalisState, action: Action): OxalisState {
       // caught by the following check. If the bug appears again, we can investigate with more
       // details thanks to airbrake.
       if (
-        dispatchedAction.saveQueueType === "skeleton" &&
         oldQueue.length > 0 &&
         newQueue.length > 0 &&
         newQueue.at(-1)?.actions.some((action) => NOT_IDEMPOTENT_ACTIONS.includes(action.name)) &&

--- a/frontend/javascripts/oxalis/model/reducers/save_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/save_reducer.ts
@@ -63,17 +63,14 @@ function SaveReducer(state: OxalisState, action: Action): OxalisState {
         dispatchedAction.items,
         (ua) => ua.name !== "updateSkeletonTracing" && ua.name !== "updateVolumeTracing",
       )
-        ? getStats(state.tracing, dispatchedAction.saveQueueType, dispatchedAction.tracingId)
+        ? getStats(state.tracing)
         : null;
       const { activeUser } = state;
       if (activeUser == null) {
         throw new Error("Tried to save something even though user is not logged in.");
       }
 
-      const updateActionChunks = _.chunk(
-        items,
-        MAXIMUM_ACTION_COUNT_PER_BATCH[dispatchedAction.saveQueueType],
-      );
+      const updateActionChunks = _.chunk(items, MAXIMUM_ACTION_COUNT_PER_BATCH);
 
       const transactionGroupCount = updateActionChunks.length;
       const actionLogInfo = JSON.stringify(getActionLog().slice(-10));

--- a/frontend/javascripts/oxalis/model/sagas/save_saga_constants.ts
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga_constants.ts
@@ -11,11 +11,7 @@ export const UNDO_HISTORY_SIZE = 20;
 export const SETTINGS_RETRY_DELAY = 15 * 1000;
 export const SETTINGS_MAX_RETRY_COUNT = 20; // 20 * 15s == 5m
 
-export const MAXIMUM_ACTION_COUNT_PER_BATCH = {
-  skeleton: 5000,
-  volume: 1000, // Since volume saving is slower, use a lower value here.
-  mapping: Number.POSITIVE_INFINITY, // The back-end does not accept transactions for mappings.
-} as const;
+export const MAXIMUM_ACTION_COUNT_PER_BATCH = 1000;
 
 // todop: should this be smarter?
 // export const MAXIMUM_ACTION_COUNT_PER_SAVE = {

--- a/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.tsx
+++ b/frontend/javascripts/oxalis/model/sagas/volumetracing_saga.tsx
@@ -947,11 +947,7 @@ function* handleDeleteSegmentData(): Saga<void> {
 
     yield* put(setBusyBlockingInfoAction(true, "Segment is being deleted."));
     yield* put(
-      pushSaveQueueTransaction(
-        [deleteSegmentDataVolumeAction(action.segmentId)],
-        "volume",
-        action.layerName,
-      ),
+      pushSaveQueueTransaction([deleteSegmentDataVolumeAction(action.segmentId)], action.layerName),
     );
     yield* call([Model, Model.ensureSavedState]);
 

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -105,6 +105,7 @@ import {
   isFeatureAllowedByPricingPlan,
 } from "admin/organization/pricing_plan_utils";
 import { convertServerAdditionalAxesToFrontEnd } from "./model/reducers/reducer_helpers";
+import { setVersionNumberAction } from "./model/actions/save_actions";
 
 export const HANDLED_ERROR = "error_was_handled";
 type DataLayerCollection = Record<string, DataLayer>;
@@ -293,6 +294,7 @@ function initializeTracing(
   // This method is not called for the View mode
   const { dataset } = Store.getState();
   let annotation = _annotation;
+  let version = 0;
   const { allowedModes, preferredMode } = determineAllowedModes(annotation.settings);
 
   _.extend(annotation.settings, {
@@ -324,6 +326,7 @@ function initializeTracing(
         getSegmentationLayers(dataset).length > 0,
         messages["tracing.volume_missing_segmentation"],
       );
+      version = Math.max(version, volumeTracing.version);
       Store.dispatch(initializeVolumeTracingAction(volumeTracing));
     });
 
@@ -335,8 +338,10 @@ function initializeTracing(
       // To generate a huge amount of dummy trees, use:
       // import generateDummyTrees from "./model/helpers/generate_dummy_trees";
       // tracing.trees = generateDummyTrees(1, 200000);
+      version = Math.max(version, skeletonTracing.version);
       Store.dispatch(initializeSkeletonTracingAction(skeletonTracing));
     }
+    Store.dispatch(setVersionNumberAction(version));
   }
 
   // Initialize 'flight', 'oblique' or 'orthogonal' mode

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -459,6 +459,7 @@ function initializeDataLayerInstances(gpuFactor: number | null | undefined): {
 
   for (const layer of layers) {
     const textureInformation = textureInformationPerLayer.get(layer);
+
     if (!textureInformation) {
       throw new Error("No texture information for layer?");
     }

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -454,7 +454,6 @@ function initializeDataLayerInstances(gpuFactor: number | null | undefined): {
 
   for (const layer of layers) {
     const textureInformation = textureInformationPerLayer.get(layer);
-
     if (!textureInformation) {
       throw new Error("No texture information for layer?");
     }
@@ -463,6 +462,7 @@ function initializeDataLayerInstances(gpuFactor: number | null | undefined): {
       layer,
       textureInformation.textureSize,
       textureInformation.textureCount,
+      layer.name, // In case of a volume tracing layer the layer name will equal its tracingId.
     );
   }
 

--- a/frontend/javascripts/oxalis/model_initialization.ts
+++ b/frontend/javascripts/oxalis/model_initialization.ts
@@ -11,7 +11,6 @@ import type {
   APICompoundType,
   APISegmentationLayer,
 } from "types/api_flow_types";
-import type { Versions } from "oxalis/view/version_view";
 import {
   computeDataTexturesSetup,
   getSupportedTextureSpecs,
@@ -114,7 +113,7 @@ export async function initialize(
   initialMaybeCompoundType: APICompoundType | null,
   initialCommandType: TraceOrViewCommand,
   initialFetch: boolean,
-  versions?: Versions,
+  version?: number | undefined | null,
 ): Promise<
   | {
       dataLayers: DataLayerCollection;
@@ -169,7 +168,7 @@ export async function initialize(
   const [dataset, initialUserSettings, serverTracings] = await fetchParallel(
     annotation,
     datasetId,
-    versions,
+    version,
   );
   const serverVolumeTracings = getServerVolumeTracings(serverTracings);
   const serverVolumeTracingIds = serverVolumeTracings.map((volumeTracing) => volumeTracing.id);
@@ -237,12 +236,12 @@ export async function initialize(
 async function fetchParallel(
   annotation: APIAnnotation | null | undefined,
   datasetId: APIDatasetId,
-  versions?: Versions,
+  version: number | undefined | null,
 ): Promise<[APIDataset, UserConfiguration, Array<ServerTracing>]> {
   return Promise.all([
     getDataset(datasetId, getSharingTokenFromUrlParameters()),
     getUserConfiguration(), // Fetch the actual tracing from the datastore, if there is an skeletonAnnotation
-    annotation ? getTracingsForAnnotation(annotation, versions) : [],
+    annotation ? getTracingsForAnnotation(annotation, version) : [],
   ]);
 }
 

--- a/frontend/javascripts/oxalis/store.ts
+++ b/frontend/javascripts/oxalis/store.ts
@@ -28,7 +28,7 @@ import type {
   AdditionalAxis,
   MetadataEntryProto,
 } from "types/api_flow_types";
-import type { TracingStats } from "oxalis/model/accessors/annotation_accessor";
+import type { CombinedTracingStats } from "oxalis/model/accessors/annotation_accessor";
 import type { Action } from "oxalis/model/actions/actions";
 import type {
   BoundingBoxType,
@@ -50,7 +50,7 @@ import type {
 } from "oxalis/constants";
 import type { BLEND_MODES, ControlModeEnum } from "oxalis/constants";
 import type { Matrix4x4 } from "libs/mjs";
-import type { UpdateAction, UpdateActionWithTracingId } from "oxalis/model/sagas/update_actions";
+import type { UpdateActionWithTracingId } from "oxalis/model/sagas/update_actions";
 import AnnotationReducer from "oxalis/model/reducers/annotation_reducer";
 import DatasetReducer from "oxalis/model/reducers/dataset_reducer";
 import type DiffableMap from "libs/diffable_map";
@@ -191,6 +191,7 @@ export type AnnotationVisibility = APIAnnotationVisibility;
 export type RestrictionsAndSettings = Restrictions & Settings;
 export type Annotation = {
   readonly annotationId: string;
+  readonly version: number;
   readonly restrictions: RestrictionsAndSettings;
   readonly visibility: AnnotationVisibility;
   readonly annotationLayers: Array<AnnotationLayerDescriptor>;
@@ -449,7 +450,7 @@ export type SaveQueueEntry = {
   transactionId: string;
   transactionGroupCount: number;
   transactionGroupIndex: number;
-  stats: TracingStats | null | undefined;
+  stats: CombinedTracingStats | null | undefined;
   info: string;
 };
 export type ProgressInfo = {

--- a/frontend/javascripts/oxalis/view/action-bar/save_button.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/save_button.tsx
@@ -13,7 +13,6 @@ import {
   LoadingOutlined,
 } from "@ant-design/icons";
 import ErrorHandling from "libs/error_handling";
-import * as Utils from "libs/utils";
 import FastTooltip from "components/fast_tooltip";
 import { Tooltip } from "antd";
 import { reuseInstanceOnEquality } from "oxalis/model/accessors/accessor_helpers";

--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
@@ -13,10 +13,7 @@ import {
   getResolutionUnion,
 } from "oxalis/model/accessors/dataset_accessor";
 import { getActiveResolutionInfo } from "oxalis/model/accessors/flycam_accessor";
-import {
-  getCombinedStats,
-  type CombinedTracingStats,
-} from "oxalis/model/accessors/annotation_accessor";
+import { getStats, type CombinedTracingStats } from "oxalis/model/accessors/annotation_accessor";
 import {
   setAnnotationNameAction,
   setAnnotationDescriptionAction,
@@ -272,7 +269,7 @@ export class DatasetInfoTabView extends React.PureComponent<Props, State> {
   getAnnotationStatistics() {
     if (this.props.isDatasetViewMode) return null;
 
-    return <AnnotationStats stats={getCombinedStats(this.props.annotation)} asInfoBlock />;
+    return <AnnotationStats stats={getStats(this.props.annotation)} asInfoBlock />;
   }
 
   getKeyboardShortcuts() {

--- a/frontend/javascripts/oxalis/view/right-border-tabs/skeleton_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/skeleton_tab_view.tsx
@@ -241,13 +241,7 @@ export async function importTracingFiles(files: Array<File>, createGroupForEachF
 
           if (oldVolumeTracing) {
             Store.dispatch(importVolumeTracingAction());
-            Store.dispatch(
-              setVersionNumberAction(
-                oldVolumeTracing.version + 1,
-                "volume",
-                oldVolumeTracing.tracingId,
-              ),
-            );
+            Store.dispatch(setVersionNumberAction(tracing.version + 1));
             Store.dispatch(setLargestSegmentIdAction(newLargestSegmentId));
             await clearCache(dataset, oldVolumeTracing.tracingId);
             await api.data.reloadBuckets(oldVolumeTracing.tracingId);

--- a/frontend/javascripts/oxalis/view/version_list.tsx
+++ b/frontend/javascripts/oxalis/view/version_list.tsx
@@ -192,7 +192,6 @@ function InnerVersionList(props: Props & { newestVersion: number }) {
 
   function fetchPaginatedVersions({ pageParam }: { pageParam?: number }) {
     // TODO: maybe refactor this so that this method is not calculated very rendering cycle
-    debugger;
     if (pageParam == null) {
       pageParam = Math.floor((newestVersion - initialVersion) / ENTRIES_PER_PAGE);
     }

--- a/frontend/javascripts/oxalis/view/version_view.tsx
+++ b/frontend/javascripts/oxalis/view/version_view.tsx
@@ -1,12 +1,10 @@
-import { Button, Alert, Tabs, type TabsProps } from "antd";
+import { Button, Alert } from "antd";
 import { CloseOutlined } from "@ant-design/icons";
 import { connect, useDispatch } from "react-redux";
 import * as React from "react";
-import { getReadableNameByVolumeTracingId } from "oxalis/model/accessors/volumetracing_accessor";
 import { setAnnotationAllowUpdateAction } from "oxalis/model/actions/annotation_actions";
 import { setVersionRestoreVisibilityAction } from "oxalis/model/actions/ui_actions";
 import type { OxalisState, Tracing } from "oxalis/store";
-import { type TracingType, TracingTypeEnum } from "types/api_flow_types";
 import Store from "oxalis/store";
 import VersionList, { previewVersion } from "oxalis/view/version_list";
 import { useState } from "react";
@@ -23,17 +21,13 @@ type OwnProps = {
   allowUpdate: boolean;
 };
 type Props = StateProps & OwnProps;
-type State = {
-  activeTracingType: TracingType;
-  initialAllowUpdate: boolean;
-};
 
-function VersionView(props: Props): React.FC<Props> {
-  const [initialAllowUpdate, _neverUpdated] = useState<boolean>(props.allowUpdate);
+const VersionView: React.FC<Props> = (props: Props) => {
+  const [initialAllowUpdate] = useState<boolean>(props.allowUpdate);
   const dispatch = useDispatch();
 
   useWillUnmount(() => {
-    Store.dispatch(setAnnotationAllowUpdateAction(initialAllowUpdate));
+    dispatch(setAnnotationAllowUpdateAction(initialAllowUpdate));
   });
 
   const handleClose = async () => {
@@ -43,118 +37,68 @@ function VersionView(props: Props): React.FC<Props> {
     Store.dispatch(setAnnotationAllowUpdateAction(initialAllowUpdate));
   };
 
-    if (this.props.tracing.skeleton != null)
-      tabs.push({
-        label: "Skeleton",
-        key: "skeleton",
-        children: (
-          <VersionList
-            versionedObjectType="skeleton"
-            tracing={this.props.tracing.skeleton}
-            allowUpdate={this.state.initialAllowUpdate}
-          />
-        ),
-      });
-
-    tabs.push(
-      ...this.props.tracing.volumes.map((volumeTracing) => ({
-        label: getReadableNameByVolumeTracingId(this.props.tracing, volumeTracing.tracingId),
-        key: volumeTracing.tracingId,
-        children: (
-          <VersionList
-            versionedObjectType="volume"
-            tracing={volumeTracing}
-            allowUpdate={this.state.initialAllowUpdate}
-          />
-        ),
-      })),
-    );
-
-    tabs.push(
-      ...this.props.tracing.mappings.map((mapping) => ({
-        label: `${getReadableNameByVolumeTracingId(
-          this.props.tracing,
-          mapping.tracingId,
-        )} (Editable Mapping)`,
-        key: mapping.tracingId,
-        children: (
-          <VersionList
-            versionedObjectType="mapping"
-            tracing={mapping}
-            allowUpdate={this.state.initialAllowUpdate}
-          />
-        ),
-      })),
-    );
-
-    return (
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
       <div
         style={{
-          display: "flex",
-          flexDirection: "column",
-          height: "100%",
+          flex: "0 1 auto",
+          padding: "0px 5px",
         }}
       >
-        <div
+        <h4
           style={{
-            flex: "0 1 auto",
-            padding: "0px 5px",
+            display: "inline-block",
+            marginLeft: 4,
           }}
         >
-          <h4
-            style={{
-              display: "inline-block",
-              marginLeft: 4,
-            }}
-          >
-            Version History
-          </h4>
-          <Button
-            className="close-button"
-            style={{
-              float: "right",
-              border: 0,
-            }}
-            onClick={handleClose}
-            shape="circle"
-            icon={<CloseOutlined />}
-          />
-          <div
-            style={{
-              fontSize: 12,
-              marginBottom: 8,
-            }}
-          >
-            <Alert
-              type="info"
-              message={
-                <React.Fragment>
-                  You are currently previewing older versions of this annotation. Either restore a
-                  version by selecting it or close this view to continue annotating. The shown
-                  annotation is in <b>read-only</b> mode as long as this view is opened.
-                </React.Fragment>
-              }
-            />
-          </div>
-        </div>
+          Version History
+        </h4>
+        <Button
+          className="close-button"
+          style={{
+            float: "right",
+            border: 0,
+          }}
+          onClick={handleClose}
+          shape="circle"
+          icon={<CloseOutlined />}
+        />
         <div
           style={{
-            flex: "1 1 auto",
-            overflowY: "auto",
-            paddingLeft: 2,
+            fontSize: 12,
+            marginBottom: 8,
           }}
         >
-          <Tabs
-            onChange={this.onChangeTab}
-            activeKey={this.state.activeTracingType}
-            tabBarStyle={{ marginLeft: 6 }}
-            items={tabs}
+          <Alert
+            type="info"
+            message={
+              <React.Fragment>
+                You are currently previewing older versions of this annotation. Either restore a
+                version by selecting it or close this view to continue annotating. The shown
+                annotation is in <b>read-only</b> mode as long as this view is opened.
+              </React.Fragment>
+            }
           />
         </div>
       </div>
-    );
-  }
-}
+      <div
+        style={{
+          flex: "1 1 auto",
+          overflowY: "auto",
+          paddingLeft: 2,
+        }}
+      >
+        <VersionList allowUpdate={initialAllowUpdate} />
+      </div>
+    </div>
+  );
+};
 
 function mapStateToProps(state: OxalisState): StateProps {
   return {

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -551,6 +551,7 @@ type APIAnnotationBase = APIAnnotationInfo & {
   readonly owner?: APIUserBase;
   // This `user` attribute is deprecated and should not be used, anymore. It only exists to satisfy e2e type checks
   readonly user?: APIUserBase;
+  readonly version: number;
   readonly contributors: APIUserBase[];
   readonly othersMayEdit: boolean;
 };

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/annotation/AnnotationLayerType.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/annotation/AnnotationLayerType.scala
@@ -14,7 +14,7 @@ object AnnotationLayerType extends ExtendedEnumeration {
     }
 
   def fromProto(p: AnnotationLayerTypeProto): AnnotationLayerType =
-    p match {
+    p match { // potential TODO: compiler says that this match may no be exhaustive.
       case AnnotationLayerTypeProto.skeleton => Skeleton
       case AnnotationLayerTypeProto.volume   => Volume
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/annotation/AnnotationLayerType.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/annotation/AnnotationLayerType.scala
@@ -14,8 +14,10 @@ object AnnotationLayerType extends ExtendedEnumeration {
     }
 
   def fromProto(p: AnnotationLayerTypeProto): AnnotationLayerType =
-    p match { // potential TODO: compiler says that this match may no be exhaustive.
+    p match {
       case AnnotationLayerTypeProto.skeleton => Skeleton
       case AnnotationLayerTypeProto.volume   => Volume
+      case AnnotationLayerTypeProto.Unrecognized(_) =>
+        Volume // unrecognized should never happen, artifact of proto code generation
     }
 }


### PR DESCRIPTION
This PR changes the version restore to use one single tab / a joined version restore for all layers

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open an annotation
- trace around :racing_car: incl. volume annotation
- open the version restore and preview some versions
- The volume actions should have their volume layer's name in the action description
- try out restoring an older version

### Issues:
- contributes to https://github.com/scalableminds/webknossos/pull/7917#issuecomment-2413488436
