### PR TITLE
Allow for the deletion of workflow reports

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Increased loading speed for precomputed meshes. [#8110](https://github.com/scalableminds/webknossos/pull/8110)
 - Unified wording in UI and code: “Magnification”/“mag” is now used in place of “Resolution“ most of the time, compare [https://docs.webknossos.org/webknossos/terminology.html](terminology document). [#8111](https://github.com/scalableminds/webknossos/pull/8111)
 - Added support for adding remote OME-Zarr NGFF version 0.5 datasets. [#8122](https://github.com/scalableminds/webknossos/pull/8122)
+- Workflow reports may be deleted. [#8156](https://github.com/scalableminds/webknossos/pull/8156)
 
 ### Changed
 - Some mesh-related actions were disabled in proofreading-mode when using meshfiles that were created for a mapping rather than an oversegmentation. [#8091](https://github.com/scalableminds/webknossos/pull/8091)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Added a button to the search popover in the skeleton and segment tab to select all matching non-group results. [#8123](https://github.com/scalableminds/webknossos/pull/8123)
 - Unified wording in UI and code: “Magnification”/“mag” is now used in place of “Resolution“ most of the time, compare [https://docs.webknossos.org/webknossos/terminology.html](terminology document). [#8111](https://github.com/scalableminds/webknossos/pull/8111)
 - Added support for adding remote OME-Zarr NGFF version 0.5 datasets. [#8122](https://github.com/scalableminds/webknossos/pull/8122)
-- Workflow reports may be deleted. [#8156](https://github.com/scalableminds/webknossos/pull/8156)
+- Workflow reports may be deleted by superusers. [#8156](https://github.com/scalableminds/webknossos/pull/8156)
 
 ### Changed
 - Some mesh-related actions were disabled in proofreading-mode when using meshfiles that were created for a mapping rather than an oversegmentation. [#8091](https://github.com/scalableminds/webknossos/pull/8091)

--- a/app/controllers/VoxelyticsController.scala
+++ b/app/controllers/VoxelyticsController.scala
@@ -3,6 +3,7 @@ package controllers
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import models.organization.OrganizationDAO
+import models.user.UserService
 import models.voxelytics._
 import play.api.libs.json._
 import play.api.mvc._
@@ -19,6 +20,7 @@ class VoxelyticsController @Inject()(
     organizationDAO: OrganizationDAO,
     voxelyticsDAO: VoxelyticsDAO,
     voxelyticsService: VoxelyticsService,
+    userService: UserService,
     lokiClient: LokiClient,
     wkConf: WkConf,
     sil: Silhouette[WkEnv])(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
@@ -156,6 +158,17 @@ class VoxelyticsController @Inject()(
           )
         )
       } yield JsonOk(result)
+    }
+
+  def deleteWorkflow(workflowHash: String): Action[AnyContent] =
+    sil.SecuredAction.async { implicit request =>
+      for {
+        _ <- bool2Fox(wkConf.Features.voxelyticsEnabled) ?~> "voxelytics.disabled"
+        _ <- userService.assertIsSuperUser(request.identity)
+        _ <- voxelyticsDAO.findWorkflowByHash(workflowHash) ?~> "voxelytics.workflowNotFound" ~> NOT_FOUND
+        _ = logger.info(s"Deleting workflow with hash $workflowHash")
+        _ <- voxelyticsDAO.deleteWorkflow(workflowHash)
+      } yield Ok
     }
 
   def storeWorkflowEvents(workflowHash: String, runName: String): Action[List[WorkflowEvent]] =

--- a/app/controllers/VoxelyticsController.scala
+++ b/app/controllers/VoxelyticsController.scala
@@ -166,8 +166,8 @@ class VoxelyticsController @Inject()(
         _ <- bool2Fox(wkConf.Features.voxelyticsEnabled) ?~> "voxelytics.disabled"
         _ <- userService.assertIsSuperUser(request.identity)
         _ <- voxelyticsDAO.findWorkflowByHash(workflowHash) ?~> "voxelytics.workflowNotFound" ~> NOT_FOUND
-        _ = logger.info(s"Deleting workflow with hash $workflowHash")
-        _ <- voxelyticsDAO.deleteWorkflow(workflowHash)
+        _ = logger.info(s"Deleting workflow with hash $workflowHash in organization ${request.identity._organization}")
+        _ <- voxelyticsDAO.deleteWorkflow(workflowHash, request.identity._organization)
       } yield Ok
     }
 

--- a/app/models/voxelytics/VoxelyticsDAO.scala
+++ b/app/models/voxelytics/VoxelyticsDAO.scala
@@ -1135,4 +1135,17 @@ class VoxelyticsDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContex
         """.asUpdate)
     } yield ()
 
+  def deleteWorkflow(hash: String): Fox[Unit] =
+    for {
+      _ <- run(q"""
+                  DELETE FROM webknossos.voxelytics_workflows
+                  WHERE hash = $hash;
+                  """.asUpdate)
+      _ <- run(q"""
+                  UPDATE webknossos.jobs
+                  SET _voxelytics_workflowhash = NULL
+                  WHERE _voxelytics_workflowhash = $hash;
+        """.asUpdate)
+    } yield ()
+
 }

--- a/app/models/voxelytics/VoxelyticsDAO.scala
+++ b/app/models/voxelytics/VoxelyticsDAO.scala
@@ -1135,16 +1135,17 @@ class VoxelyticsDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContex
         """.asUpdate)
     } yield ()
 
-  def deleteWorkflow(hash: String): Fox[Unit] =
+  def deleteWorkflow(hash: String, organizationId: String): Fox[Unit] =
     for {
       _ <- run(q"""
                   DELETE FROM webknossos.voxelytics_workflows
-                  WHERE hash = $hash;
+                  WHERE hash = $hash
+                  AND _organization = $organizationId;
                   """.asUpdate)
       _ <- run(q"""
                   UPDATE webknossos.jobs
-                  SET _voxelytics_workflowhash = NULL
-                  WHERE _voxelytics_workflowhash = $hash;
+                  SET _voxelytics_workflowHash = NULL
+                  WHERE _voxelytics_workflowHash = $hash;
         """.asUpdate)
     } yield ()
 

--- a/app/models/voxelytics/VoxelyticsDAO.scala
+++ b/app/models/voxelytics/VoxelyticsDAO.scala
@@ -1145,7 +1145,8 @@ class VoxelyticsDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContex
       _ <- run(q"""
                   UPDATE webknossos.jobs
                   SET _voxelytics_workflowHash = NULL
-                  WHERE _voxelytics_workflowHash = $hash;
+                  WHERE _voxelytics_workflowHash = $hash
+                  AND (SELECT _organization FROM webknossos.users  AS u WHERE u._id = _owner) = $organizationId;
         """.asUpdate)
     } yield ()
 

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -308,6 +308,7 @@ POST          /verifyEmail                                                      
 POST          /voxelytics/workflows                                                             controllers.VoxelyticsController.storeWorkflow()
 GET           /voxelytics/workflows                                                             controllers.VoxelyticsController.listWorkflows()
 GET           /voxelytics/workflows/:workflowHash                                               controllers.VoxelyticsController.getWorkflow(workflowHash: String, runId: Option[String])
+DELETE        /voxelytics/workflows/:workflowHash                                               controllers.VoxelyticsController.deleteWorkflow(workflowHash: String)
 POST          /voxelytics/workflows/:workflowHash/events                                        controllers.VoxelyticsController.storeWorkflowEvents(workflowHash: String, runName: String)
 GET           /voxelytics/workflows/:workflowHash/chunkStatistics                               controllers.VoxelyticsController.getChunkStatistics(workflowHash: String, runId: Option[String], taskName: String)
 GET           /voxelytics/workflows/:workflowHash/artifactChecksums                             controllers.VoxelyticsController.getArtifactChecksums(workflowHash: String, runId: Option[String], taskName: String, artifactName: Option[String])

--- a/frontend/javascripts/admin/admin_rest_api.ts
+++ b/frontend/javascripts/admin/admin_rest_api.ts
@@ -2501,6 +2501,12 @@ export function getVoxelyticsArtifactChecksums(
   );
 }
 
+export function deleteWorkflow(workflowHash: string): Promise<void> {
+  return Request.triggerRequest(`/api/voxelytics/workflows/${workflowHash}`, {
+    method: "DELETE",
+  });
+}
+
 // ### Help / Feedback userEmail
 export function sendHelpEmail(message: string) {
   return Request.receiveJSON(

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -429,7 +429,7 @@ export default function TaskListView({
     await modal.confirm({
       title: "Delete Workflow Report",
       content:
-        "Are you sure you want to delete this workflow report?\nNote that if the workflow is still running, this may cause it to fail.",
+        "Are you sure you want to delete this workflow report? This can not be undone. Note that if the workflow is still running, this may cause it to fail.",
       okText: "Delete",
       okButtonProps: { danger: true },
       onOk: async () => {

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -125,7 +125,7 @@ function TaskStateTag({ taskInfo }: { taskInfo: VoxelyticsTaskInfo }) {
             (taskInfo.chunkCounts.complete +
               taskInfo.chunkCounts.failed +
               taskInfo.chunkCounts.cancelled)) *
-            (taskInfo.chunkCounts.total - taskInfo.chunkCounts.skipped) -
+          (taskInfo.chunkCounts.total - taskInfo.chunkCounts.skipped) -
           currentDuration;
         const estimatedEndTime = new Date(Date.now() + estimatedRemainingDuration);
         return (
@@ -274,10 +274,7 @@ export default function TaskListView({
   const highlightedTask = params.highlightedTask || "";
   const location = useLocation();
 
-  const isCurrentUserSuperUser = useSelector((state: OxalisState) => {
-    const activeUser = state.activeUser;
-    return activeUser?.isSuperUser;
-  });
+  const isCurrentUserSuperUser = useSelector((state: OxalisState) => state.activeUser?.isSuperUser);
 
   const singleRunId = report.runs.length === 1 ? report.runs[0].id : runId;
 

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -424,7 +424,7 @@ export default function TaskListView({
   async function deleteWorkflowReport() {
     await modal.confirm({
       title: "Delete Workflow Report",
-      content: "Are you sure you want to delete this workflow report?",
+      content: "Are you sure you want to delete this workflow report?\nNote that if the workflow is still running, this may cause it to fail.",
       okText: "Delete",
       okButtonProps: { danger: true },
       onOk: async () => {
@@ -459,7 +459,7 @@ export default function TaskListView({
           ),
       },
       { key: "5", onClick: showArtifactsDiskUsageList, label: "Show Disk Usage of Artifacts" },
-      { key: "6", onClick: deleteWorkflowReport, label: "Delete Workflow Report" },
+      { key: "6", onClick: deleteWorkflowReport, label: "Delete Workflow Report"},
     ],
   };
 

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -50,7 +50,7 @@ import TaskView from "./task_view";
 import { formatLog } from "./log_tab";
 import { addAfterPadding, addBeforePadding } from "./utils";
 import { LOG_LEVELS } from "oxalis/constants";
-import { getVoxelyticsLogs } from "admin/admin_rest_api";
+import { getVoxelyticsLogs, deleteWorkflow } from "admin/admin_rest_api";
 import ArtifactsDiskUsageList from "./artifacts_disk_usage_list";
 import { notEmpty } from "libs/utils";
 import type { ArrayElement } from "types/globals";
@@ -421,6 +421,25 @@ export default function TaskListView({
     }
   }
 
+  async function deleteWorkflowReport() {
+    await modal.confirm({
+      title: "Delete Workflow Report",
+      content: "Are you sure you want to delete this workflow report?",
+      okText: "Delete",
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          await deleteWorkflow(report.workflow.hash);
+          history.push("/workflows");
+          message.success("Workflow report deleted.");
+        } catch (error) {
+          console.error(error);
+          message.error("Could not delete workflow report.");
+        }
+      },
+    });
+  }
+
   const overflowMenu: MenuProps = {
     items: [
       { key: "1", onClick: copyAllArtifactPaths, label: "Copy All Artifact Paths" },
@@ -440,6 +459,7 @@ export default function TaskListView({
           ),
       },
       { key: "5", onClick: showArtifactsDiskUsageList, label: "Show Disk Usage of Artifacts" },
+      { key: "6", onClick: deleteWorkflowReport, label: "Delete Workflow Report" },
     ],
   };
 

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -54,6 +54,8 @@ import { getVoxelyticsLogs, deleteWorkflow } from "admin/admin_rest_api";
 import ArtifactsDiskUsageList from "./artifacts_disk_usage_list";
 import { notEmpty } from "libs/utils";
 import type { ArrayElement } from "types/globals";
+import { useSelector } from "react-redux";
+import type { OxalisState } from "oxalis/store";
 
 const { Search } = Input;
 
@@ -272,6 +274,11 @@ export default function TaskListView({
   const highlightedTask = params.highlightedTask || "";
   const location = useLocation();
 
+  const isCurrentUserSuperUser = useSelector((state: OxalisState) => {
+    const activeUser = state.activeUser;
+    return activeUser?.isSuperUser;
+  });
+
   const singleRunId = report.runs.length === 1 ? report.runs[0].id : runId;
 
   useEffect(() => {
@@ -424,7 +431,8 @@ export default function TaskListView({
   async function deleteWorkflowReport() {
     await modal.confirm({
       title: "Delete Workflow Report",
-      content: "Are you sure you want to delete this workflow report?\nNote that if the workflow is still running, this may cause it to fail.",
+      content:
+        "Are you sure you want to delete this workflow report?\nNote that if the workflow is still running, this may cause it to fail.",
       okText: "Delete",
       okButtonProps: { danger: true },
       onOk: async () => {
@@ -459,9 +467,14 @@ export default function TaskListView({
           ),
       },
       { key: "5", onClick: showArtifactsDiskUsageList, label: "Show Disk Usage of Artifacts" },
-      { key: "6", onClick: deleteWorkflowReport, label: "Delete Workflow Report"},
     ],
   };
+  if (isCurrentUserSuperUser)
+    overflowMenu.items?.push({
+      key: "6",
+      onClick: deleteWorkflowReport,
+      label: "Delete Workflow Report",
+    });
 
   type ItemType = ArrayElement<CollapseProps["items"]>;
 

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -125,7 +125,7 @@ function TaskStateTag({ taskInfo }: { taskInfo: VoxelyticsTaskInfo }) {
             (taskInfo.chunkCounts.complete +
               taskInfo.chunkCounts.failed +
               taskInfo.chunkCounts.cancelled)) *
-          (taskInfo.chunkCounts.total - taskInfo.chunkCounts.skipped) -
+            (taskInfo.chunkCounts.total - taskInfo.chunkCounts.skipped) -
           currentDuration;
         const estimatedEndTime = new Date(Date.now() + estimatedRemainingDuration);
         return (


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Start a workflow
- Delete the workflow by clicking on the workflow and then on the three dots menu selecting Delete Workflow report.
- Notice it is no longer in the list
- (Note that there is nothing in the database)

### Questions
- It is possible to delete the workflow while it is running. Should this be disabled? This causes the workflow to fail, more or less as expected. It does not seem like anything breaks.
- Since this is only for super users, should the button in the frontend be only available for super users (disabled / not shown?)

### TODOs:
- [ ] ...

### Issues:
- fixes #7973 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Removed dev-only changes like prints and application.conf edits
	- I have on logger statement in the deletion route. I think that could remain?
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added the ability to add metadata to annotations for Trees and Segments.
	- Enhanced search functionality to find unnamed segments using their default names.
	- Introduced a new button in the search popover for selecting all matching non-group results.
	- Added a summary row in the time tracking overview.
	- Unified UI terminology by replacing "Resolution" with "Magnification."
	- Support for remote OME-Zarr NGFF version 0.5 datasets.
	- Users can now delete workflow reports and workflows directly from the application.
	- Admins can view and cancel all jobs with job ownership displayed.

- **Bug Fixes**
	- Resolved issues with dataset uploads and bbox export menu.
	- Fixed automatic expansion of groups in skeleton searches and zarr streaming version corrections.
	- Ensured insufficient sharing tokens are discarded appropriately.

- **Chores**
	- Migrated nightly screenshot tests from CircleCI to GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->