### PR TITLE
Use mapping from viewconfig when generating thumbnail

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Admins can now see and cancel all jobs. The owner of the job is shown in the job list. [#8112](https://github.com/scalableminds/webknossos/pull/8112)
 - Migrated nightly screenshot tests from CircleCI to GitHub actions. [#8134](https://github.com/scalableminds/webknossos/pull/8134)
 - Migrated nightly screenshot tests for wk.org from CircleCI to GitHub actions. [#8135](https://github.com/scalableminds/webknossos/pull/8135)
+- Thumbnails for datasets now use the selected mapping from the view configuration if available. [#8157](https://github.com/scalableminds/webknossos/pull/8157)
 
 ### Fixed
 - Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098) [#8103](https://github.com/scalableminds/webknossos/pull/8103)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Check http://localhost:9000/api/datasets/sample_organization/test-agglomerate-file/layers/segmentation/thumbnail?w=200&h=200
- In the test-agglomerate-file dataset set the mapping to agglomerate_view_70
- Save the view config
- Check http://localhost:9000/api/datasets/sample_organization/test-agglomerate-file/layers/segmentation/thumbnail?w=200&h=200 again (hard refresh)

### Issues:
- fixes #6305

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced annotation capabilities with the ability to add metadata to Trees and Segments.
	- Summary row added to the time tracking overview for better task management.
	- Improved slider functionality for easier value adjustments and resets.
	- Enhanced search functionality to find unnamed segments by their full default name.
	- Thumbnails for datasets now utilize selected mapping from view configuration.

- **Bug Fixes**
	- Resolved issues with dataset uploads, bbox export menu, and sharing tokens.
	- Fixed automatic expansion of groups in skeleton searches and zarr streaming bugs.

- **Improvements**
	- Increased loading speeds for precomputed meshes.
	- Admins can now view and cancel all jobs with ownership displayed in the job list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->