### PR TITLE
Allow permanent dataset layer rotation in dataset settings

### DIFF
--- a/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
@@ -22,6 +22,7 @@ import {
   FormItemWithInfo,
   RetryingErrorBoundary,
   jsonEditStyle,
+  AxisRotationSettingForLayer,
 } from "dashboard/dataset/helper_components";
 import { startFindLargestSegmentIdJob } from "admin/admin_rest_api";
 import { jsonStringify, parseMaybe } from "libs/utils";
@@ -391,8 +392,10 @@ function SimpleLayerForm({
               {
                 validator: syncValidator(
                   (value: string) =>
-                    dataLayers.filter((someLayer: APIDataLayer) => someLayer.name === value)
-                      .length <= 1,
+                    (dataLayers &&
+                      dataLayers.filter((someLayer: APIDataLayer) => someLayer.name === value)
+                        .length <= 1) ||
+                    dataLayers == null,
                   "Layer names must be unique.",
                 ),
               },
@@ -613,6 +616,12 @@ function SimpleLayerForm({
               )}
             </div>
           ) : null}
+          <Row gutter={32}>
+            <Col span={12}>
+              Permanent dataset rotation:
+              <AxisRotationSettingForLayer form={form} index={index} />
+            </Col>
+          </Row>
         </Col>
       </Row>
     </div>

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -199,6 +199,7 @@ class DatasetSettingsView extends React.PureComponent<PropsWithFormAndRouter, St
         this.props.datasetId,
       );
       enforceValidatedDatasetViewConfiguration(datasetDefaultConfiguration, dataset, true);
+      // TODOM: extract x, y, z rotation from datasetDefaultConfiguration
       form.setFieldsValue({
         defaultConfiguration: datasetDefaultConfiguration,
         defaultConfigurationLayersJson: JSON.stringify(

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_viewconfig_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_viewconfig_tab.tsx
@@ -329,66 +329,6 @@ export default function DatasetSettingsViewConfigTab(props: {
           />
         </Col>
       </Row>
-      <Row gutter={32}>
-        <Col span={12}>
-          Permanent dataset rotation:
-          <Row gutter={24}>
-            <Col span={16}>
-              <FormItemWithInfo
-                name={["xAxisRotation"]}
-                label="X Axis Rotation"
-                info="Change the datasets rotation around the x-axis."
-                colon={false}
-              >
-                <Slider min={0} max={100} step={1} />
-              </FormItemWithInfo>
-            </Col>
-            <Col span={8} style={{ marginRight: -12 }}>
-              <FormItem
-                name={["defaultConfiguration", "segmentationPatternOpacity"]}
-                colon={false}
-                label=" "
-              >
-                <InputNumber min={0} max={100} step={1} precision={0} />
-              </FormItem>
-            </Col>
-          </Row>
-          <Row gutter={24}>
-            <Col span={16}>
-              <FormItemWithInfo
-                name={["yAxisRotation"]}
-                label="Y Axis Rotation"
-                info="Change the datasets rotation around the y-axis."
-                colon={false}
-              >
-                <Slider min={0} max={100} step={1} />
-              </FormItemWithInfo>
-            </Col>
-            <Col span={8} style={{ marginRight: -12 }}>
-              <FormItem name={["yAxisRotation"]} colon={false} label=" ">
-                <InputNumber min={0} max={100} step={1} precision={0} />
-              </FormItem>
-            </Col>
-          </Row>{" "}
-          <Row gutter={24}>
-            <Col span={16}>
-              <FormItemWithInfo
-                name={["zAxisRotation"]}
-                label="Z Axis Rotation"
-                info="Change the datasets rotation around the z-axis."
-                colon={false}
-              >
-                <Slider min={0} max={100} step={1} />
-              </FormItemWithInfo>
-            </Col>
-            <Col span={8} style={{ marginRight: -12 }}>
-              <FormItem name={["zAxisRotation"]} colon={false} label=" ">
-                <InputNumber min={0} max={100} step={1} precision={0} />
-              </FormItem>
-            </Col>
-          </Row>
-        </Col>
-      </Row>
     </div>
   );
 }

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_viewconfig_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_viewconfig_tab.tsx
@@ -30,7 +30,6 @@ import ColorLayerOrderingTable from "./color_layer_ordering_component";
 import type { APIDatasetId } from "types/api_flow_types";
 import { getAgglomeratesForDatasetLayer, getMappingsForDatasetLayer } from "admin/admin_rest_api";
 import { Slider } from "components/slider";
-
 const FormItem = Form.Item;
 
 export default function DatasetSettingsViewConfigTab(props: {
@@ -223,8 +222,8 @@ export default function DatasetSettingsViewConfigTab(props: {
         <Col span={6}>
           <FormItemWithInfo
             name={["defaultConfiguration", "rotation"]}
-            label="Rotation"
-            info="The default rotation that will be used in oblique and arbitrary view mode."
+            label="Rotation - Arbitrary View Modes"
+            info="The default rotation that will be used in oblique and flight view mode."
           >
             <Vector3Input />
           </FormItemWithInfo>
@@ -328,6 +327,66 @@ export default function DatasetSettingsViewConfigTab(props: {
               x: "max-content",
             }}
           />
+        </Col>
+      </Row>
+      <Row gutter={32}>
+        <Col span={12}>
+          Permanent dataset rotation:
+          <Row gutter={24}>
+            <Col span={16}>
+              <FormItemWithInfo
+                name={["xAxisRotation"]}
+                label="X Axis Rotation"
+                info="Change the datasets rotation around the x-axis."
+                colon={false}
+              >
+                <Slider min={0} max={100} step={1} />
+              </FormItemWithInfo>
+            </Col>
+            <Col span={8} style={{ marginRight: -12 }}>
+              <FormItem
+                name={["defaultConfiguration", "segmentationPatternOpacity"]}
+                colon={false}
+                label=" "
+              >
+                <InputNumber min={0} max={100} step={1} precision={0} />
+              </FormItem>
+            </Col>
+          </Row>
+          <Row gutter={24}>
+            <Col span={16}>
+              <FormItemWithInfo
+                name={["yAxisRotation"]}
+                label="Y Axis Rotation"
+                info="Change the datasets rotation around the y-axis."
+                colon={false}
+              >
+                <Slider min={0} max={100} step={1} />
+              </FormItemWithInfo>
+            </Col>
+            <Col span={8} style={{ marginRight: -12 }}>
+              <FormItem name={["yAxisRotation"]} colon={false} label=" ">
+                <InputNumber min={0} max={100} step={1} precision={0} />
+              </FormItem>
+            </Col>
+          </Row>{" "}
+          <Row gutter={24}>
+            <Col span={16}>
+              <FormItemWithInfo
+                name={["zAxisRotation"]}
+                label="Z Axis Rotation"
+                info="Change the datasets rotation around the z-axis."
+                colon={false}
+              >
+                <Slider min={0} max={100} step={1} />
+              </FormItemWithInfo>
+            </Col>
+            <Col span={8} style={{ marginRight: -12 }}>
+              <FormItem name={["zAxisRotation"]} colon={false} label=" ">
+                <InputNumber min={0} max={100} step={1} precision={0} />
+              </FormItem>
+            </Col>
+          </Row>
         </Col>
       </Row>
     </div>

--- a/frontend/javascripts/dashboard/dataset/helper_components.tsx
+++ b/frontend/javascripts/dashboard/dataset/helper_components.tsx
@@ -1,10 +1,29 @@
-import { Alert, Form, Tooltip, Modal } from "antd";
+import {
+  Alert,
+  Form,
+  Tooltip,
+  Modal,
+  Col,
+  InputNumber,
+  Row,
+  Slider,
+  Typography,
+  type FormInstance,
+} from "antd";
 import type { FieldError } from "rc-field-form/es/interface";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import * as React from "react";
 import _ from "lodash";
 import type { NamePath } from "antd/lib/form/interface";
 import type { FormItemProps, Rule } from "antd/lib/form";
+import type { CoordinateTransformation } from "types/api_flow_types";
+import type { NestedMatrix4 } from "oxalis/constants";
+import * as THREE from "three";
+import { nestedToFlatMatrix } from "oxalis/model/helpers/transformation_helpers";
+import { useCallback } from "react";
+import { flatToNestedMatrix } from "oxalis/model/accessors/dataset_accessor";
+
+const { Text } = Typography;
 
 const FormItem = Form.Item;
 
@@ -126,4 +145,126 @@ export const hasFormError = (formErrors: FieldError[], key: string): boolean => 
     errorObj.name[0] === key ? errorObj.errors.length : 0,
   );
   return _.sum(errorsForKey) > 0;
+};
+
+type AxisRotationFormItemProps = {
+  form: FormInstance | undefined;
+  index: number;
+  axis: "x" | "y" | "z";
+};
+
+const IDENTITY_MATRIX = [
+  [1, 0, 0, 0],
+  [0, 1, 0, 0],
+  [0, 0, 1, 0],
+  [0, 0, 0, 1],
+] as NestedMatrix4;
+
+export const AxisRotationFormItem: React.FC<AxisRotationFormItemProps> = ({
+  form,
+  index,
+  axis,
+}: AxisRotationFormItemProps) => {
+  const coordinateTransformations: CoordinateTransformation[] = form?.getFieldValue([
+    "dataSource",
+    "dataLayers",
+    index,
+    "coordinateTransformations",
+  ]);
+  const firstTransformation = coordinateTransformations?.[0];
+  const deriveRotationFromMatrix = useCallback(
+    (transformation: CoordinateTransformation | undefined) => {
+      if (transformation && transformation.type !== "affine") {
+        return;
+      }
+      const matrix = transformation ? transformation.matrix : IDENTITY_MATRIX;
+      const rotation = new THREE.Quaternion();
+      const affineTransformationMatrix = new THREE.Matrix4();
+      affineTransformationMatrix.fromArray(nestedToFlatMatrix(matrix));
+      affineTransformationMatrix.decompose(new THREE.Vector3(), rotation, new THREE.Vector3());
+      const euler = new THREE.Euler().setFromQuaternion(rotation);
+      return euler[axis] * (180 / Math.PI);
+    },
+    [axis],
+  );
+  const matrixWithUpdatedRotation = useCallback(
+    (rotation: number): CoordinateTransformation => {
+      const matrix: NestedMatrix4 =
+        firstTransformation && firstTransformation.type === "affine" && firstTransformation?.matrix
+          ? firstTransformation.matrix
+          : IDENTITY_MATRIX;
+      const newMatrix = new THREE.Matrix4().fromArray(nestedToFlatMatrix(matrix));
+      const translation = new THREE.Vector3();
+      const scale = new THREE.Vector3();
+      const quaternion = new THREE.Quaternion();
+      newMatrix.decompose(translation, quaternion, scale);
+      const euler = new THREE.Euler().setFromQuaternion(quaternion);
+      euler[axis] = rotation * (Math.PI / 180);
+      quaternion.setFromEuler(euler);
+      newMatrix.compose(translation, quaternion, scale);
+      const newMatrixArray = newMatrix.toArray();
+      return { type: "affine", matrix: flatToNestedMatrix(newMatrixArray) };
+    },
+    [firstTransformation, axis],
+  );
+  if (coordinateTransformations && coordinateTransformations.length > 1) {
+    return (
+      <Text type="secondary">
+        Setting a layers rotation is only supported for a single affine transformation. This layer
+        has multiple transformations.
+      </Text>
+    );
+  }
+  if (firstTransformation && firstTransformation.type !== "affine") {
+    return (
+      <Text type="secondary">
+        Setting a layers rotation is only supported for affine transformations. This layer is
+        transformed via thin plate splines.
+      </Text>
+    );
+  }
+  return (
+    <Row gutter={24}>
+      <Col span={16}>
+        <FormItemWithInfo
+          name={["dataSource", "dataLayers", index, "coordinateTransformations", 0]}
+          label={`${axis.toUpperCase()} Axis Rotation`}
+          info={`Change the datasets rotation around the ${axis}-axis.`}
+          colon={false}
+          getValueProps={(value) => ({ value: deriveRotationFromMatrix(value) })}
+          normalize={(value) => matrixWithUpdatedRotation(value)}
+        >
+          <Slider min={0} max={360} step={90} />
+        </FormItemWithInfo>
+      </Col>
+      <Col span={8} style={{ marginRight: -12 }}>
+        <FormItem
+          name={["dataSource", "dataLayers", index, "coordinateTransformations", 0]}
+          colon={false}
+          label=" "
+          getValueProps={(value) => ({ value: deriveRotationFromMatrix(value) })}
+          normalize={(value) => matrixWithUpdatedRotation(value)}
+        >
+          <InputNumber min={0} max={360} step={90} precision={0} />
+        </FormItem>
+      </Col>
+    </Row>
+  );
+};
+
+type AxisRotationSettingForLayerProps = {
+  form: FormInstance | undefined;
+  index: number;
+};
+export const AxisRotationSettingForLayer: React.FC<AxisRotationSettingForLayerProps> = ({
+  form,
+  index,
+}: AxisRotationSettingForLayerProps) => {
+  return (
+    <div>
+      <AxisRotationFormItem form={form} index={index} axis="x" />
+      <AxisRotationFormItem form={form} index={index} axis="y" />
+      <AxisRotationFormItem form={form} index={index} axis="z" />
+    </div>
+  );
 };

--- a/frontend/javascripts/oxalis/constants.ts
+++ b/frontend/javascripts/oxalis/constants.ts
@@ -15,6 +15,8 @@ export type Vector4 = [number, number, number, number];
 export type Vector5 = [number, number, number, number, number];
 export type Vector6 = [number, number, number, number, number, number];
 
+export type NestedMatrix4 = [Vector4, Vector4, Vector4, Vector4];
+
 // For 3D data BucketAddress = x, y, z, mag
 // For higher dimensional data, BucketAddress = x, y, z, mag, [{name: "t", value: t}, ...]
 export type BucketAddress =

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -22,6 +22,7 @@ import ErrorHandling from "libs/error_handling";
 import {
   IdentityTransform,
   LongUnitToShortUnitMap,
+  type NestedMatrix4,
   type Vector3,
   type Vector4,
   type ViewMode,
@@ -867,7 +868,7 @@ export const hasDatasetTransforms = memoizeOne((dataset: APIDataset) => {
   return layers.some((layer) => _getOriginalTransformsForLayerOrNull(dataset, layer) != null);
 });
 
-export function flatToNestedMatrix(matrix: Matrix4x4): [Vector4, Vector4, Vector4, Vector4] {
+export function flatToNestedMatrix(matrix: Matrix4x4): NestedMatrix4 {
   return [
     matrix.slice(0, 4) as Vector4,
     matrix.slice(4, 8) as Vector4,

--- a/frontend/javascripts/oxalis/model/helpers/transformation_helpers.ts
+++ b/frontend/javascripts/oxalis/model/helpers/transformation_helpers.ts
@@ -2,9 +2,9 @@ import { estimateAffineMatrix4x4 } from "libs/estimate_affine";
 import { M4x4 } from "libs/mjs";
 import TPS3D from "libs/thin_plate_spline";
 import type { Matrix4x4 } from "mjs";
-import type { Vector3, Vector4 } from "oxalis/constants";
+import type { Vector3, NestedMatrix4 } from "oxalis/constants";
 
-export function nestedToFlatMatrix(matrix: [Vector4, Vector4, Vector4, Vector4]): Matrix4x4 {
+export function nestedToFlatMatrix(matrix: NestedMatrix4): Matrix4x4 {
   return [...matrix[0], ...matrix[1], ...matrix[2], ...matrix[3]];
 }
 
@@ -26,9 +26,7 @@ export type Transform =
       scaledTps: TPS3D;
     };
 
-export function createAffineTransformFromMatrix(
-  nestedMatrix: [Vector4, Vector4, Vector4, Vector4],
-): Transform {
+export function createAffineTransformFromMatrix(nestedMatrix: NestedMatrix4): Transform {
   const affineMatrix = nestedToFlatMatrix(nestedMatrix);
   return { type: "affine", affineMatrix, affineMatrixInv: M4x4.inverse(affineMatrix) };
 }

--- a/frontend/javascripts/types/api_flow_types.ts
+++ b/frontend/javascripts/types/api_flow_types.ts
@@ -19,9 +19,9 @@ import type {
   Point3,
   ColorObject,
   LOG_LEVELS,
-  Vector4,
   TreeType,
   UnitLong,
+  NestedMatrix4,
 } from "oxalis/constants";
 import type { PricingPlanEnum } from "admin/organization/pricing_plan_utils";
 import type { EmptyObject } from "./globals";
@@ -63,7 +63,7 @@ export type ServerAdditionalAxis = {
 export type CoordinateTransformation =
   | {
       type: "affine";
-      matrix: [Vector4, Vector4, Vector4, Vector4];
+      matrix: NestedMatrix4;
     }
   | {
       type: "thin_plate_spline";


### PR DESCRIPTION
This PR adds new settings to the dataset settings for each layer. A interface (still in design process) enables the user to set a affine transformation matrix by letting the user define angles for each axis around which the dataset should be rotated.


- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs / Problems:
- [ ] Design a visualization of the result. For some first ideas look at the issue [#7334](https://github.com/scalableminds/webknossos/issues/7334)
- [ ] The rotation should be done around the center of the dataset. For this, a translation by the dataset center is needed
- [ ] The interface works by defining Euler angles. The problem is that Euler angles are not deterministic / there are multiple ways to express a certain rotation with different Euler angle values. See: https://stackoverflow.com/questions/32235395/does-euler-angles-quaternion-euler-angles-always-result-in-an-equivalent-r
  - This makes it hard to update the settings correctly ->  a 180 degree rotation around y is equivalent to 180 on x and 180 on z axis :/
  - A solution for this is needed as the interface currently is pretty quirky.
- [ ] 

### Issues:
- fixes [#7334](https://github.com/scalableminds/webknossos/issues/7334)

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
