### PR TITLE
Allow to delete bbox even if there is no visible segmentation layer

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where you could not create annotations for public datasets of other organizations. [#8107](https://github.com/scalableminds/webknossos/pull/8107)
 - Users without edit permissions to a dataset can no longer delete sharing tokens via the API. [#8083](https://github.com/scalableminds/webknossos/issues/8083)
 - Fixed downloading task annotations of teams you are not in, when accessing directly via URI. [#8155](https://github.com/scalableminds/webknossos/pull/8155)
+- Deleting a bounding box is now possible independently of a visible segmentation layer. [#8164](https://github.com/scalableminds/webknossos/pull/8164)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
+++ b/frontend/javascripts/oxalis/view/components/setting_input_views.tsx
@@ -554,7 +554,6 @@ class UserBoundingBoxInput extends React.PureComponent<UserBoundingBoxInputProps
       isLockedByOwner,
       isOwner,
     );
-    const isDeleteEnabled = !disabled && this.props.visibleSegmentationLayer != null;
 
     const getContextMenu = () => {
       const items: MenuProps["items"] = [
@@ -590,13 +589,13 @@ class UserBoundingBoxInput extends React.PureComponent<UserBoundingBoxInputProps
         },
         {
           key: "delete",
-          label: isDeleteEnabled ? (
+          label: !disabled ? (
             deleteButton
           ) : (
             <FastTooltip title={editingDisallowedExplanation}>{deleteButton}</FastTooltip>
           ),
           onClick: onDelete,
-          disabled: !isDeleteEnabled,
+          disabled,
         },
       ];
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open an annotation with a segmentation layer
- (add and) remove some bounding boxes, save, reload
- do the same without a visible segmentation layer
- both should work
- this should not be possible in a read-only annotation

### Issues:
- fixes https://scm.slack.com/archives/C3PBDFGC8/p1730364812238249

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified logic for the delete action in the context menu, making it easier to enable or disable based on the `disabled` state.
	- Added the ability to add metadata to annotations for Trees and Segments.
	- Introduced a summary row in the time tracking overview.
	- Enhanced slider functionality for value changes and resets.
	- Improved search functionality for unnamed segments.
	- Increased loading speed for precomputed meshes.
	- Added a button in the search popover for selecting all matching non-group results.
  
- **Bug Fixes**
	- Improved reliability of the delete option by removing unnecessary dependencies on other states.
	- Resolved issues with dataset uploads and bbox export menu item.
	- Fixed bugs related to sharing tokens and annotation downloads.

- **Documentation**
	- Minor updates to comments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->