### PR TITLE
Always Upload Screenshot Artifacts for Nightly Tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
           BROWSERSTACK_ACCESS_KEY : ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
       - name: Upload screenshots as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Upload screenshots as artifact
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: screenshots
           path: frontend/javascripts/test/screenshots

--- a/.github/workflows/wkorg-nightly.yaml
+++ b/.github/workflows/wkorg-nightly.yaml
@@ -33,7 +33,7 @@ jobs:
           BROWSERSTACK_ACCESS_KEY : ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
       - name: Upload screenshots as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/wkorg-nightly.yaml
+++ b/.github/workflows/wkorg-nightly.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Upload screenshots as artifact
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: screenshots
           path: frontend/javascripts/test/screenshots-wkorg

--- a/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.ts
+++ b/frontend/javascripts/test/puppeteer/dataset_rendering_helpers.ts
@@ -374,16 +374,19 @@ export function setupBeforeEachAndAfterEach() {
       browser_version: "latest",
       os: "os x",
       os_version: "mojave",
+      name: t.title, // add test name to BrowserStack session
       "browserstack.username": process.env.BROWSERSTACK_USERNAME,
       "browserstack.accessKey": process.env.BROWSERSTACK_ACCESS_KEY,
     };
-    t.context.browser = await puppeteer.connect({
+    const browser = await puppeteer.connect({
       browserWSEndpoint: `ws://cdp.browserstack.com/puppeteer?caps=${encodeURIComponent(
         JSON.stringify(caps),
       )}`,
     });
+    t.context.browser = browser;
 
     console.log(`\nRunning chrome version ${await t.context.browser.version()}\n`);
+    console.log(`\nBrowserStack Session Id ${await getBrowserstackSessionId(browser)}\n`);
     global.Headers = Headers;
     global.fetch = fetch;
     global.Request = Request;
@@ -395,6 +398,17 @@ export function setupBeforeEachAndAfterEach() {
   test.afterEach.always(async (t) => {
     await t.context.browser.close();
   });
+}
+
+async function getBrowserstackSessionId(browser: Browser) {
+  const page = await browser.newPage();
+  const response = (await page.evaluate(
+    (_) => {},
+    `browserstack_executor: ${JSON.stringify({ action: "getSessionDetails" })}`,
+  )) as unknown as string;
+
+  const sessionDetails = await JSON.parse(response);
+  return sessionDetails.hashed_id;
 }
 
 export function checkBrowserstackCredentials() {


### PR DESCRIPTION
### Changes:
- In order to better debug (failing) nightly screenshots tests, GitHub Actions should always upload screenshot artifacts.
- Added some improvements to the BrowserStack integration:
  -  added the test name to each BrowserStack session so we can more easily identify tests on their website
  - added logging of the BrowserStack session ID to our tests

### Steps to test:
- Run GA worklofw



------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced BrowserStack integration with the ability to retrieve and log the session ID during tests.
	- Test titles are now assigned to BrowserStack sessions for better tracking.

- **Bug Fixes**
	- Ensured that screenshot uploads occur regardless of test success or failure.

- **Documentation**
	- Improved console logging for better visibility of the Chrome version and BrowserStack session ID during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->