### PR TITLE
Change long unit name in frontend from ångström to angstrom

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug during dataset upload in case the configured `datastore.baseFolder` is an absolute path. [#8098](https://github.com/scalableminds/webknossos/pull/8098) [#8103](https://github.com/scalableminds/webknossos/pull/8103)
 - Fixed bbox export menu item [#8152](https://github.com/scalableminds/webknossos/pull/8152)
 - When trying to save an annotation opened via a link including a sharing token, the token is automatically discarded in case it is insufficient for update actions but the users token is. [#8139](https://github.com/scalableminds/webknossos/pull/8139)
+- Fixed that uploading a dataset which needs a conversion failed when the angstrom unit was configured for the conversion. [#8173](https://github.com/scalableminds/webknossos/pull/8173)
 - Fixed that the skeleton search did not automatically expand groups that contained the selected tree [#8129](https://github.com/scalableminds/webknossos/pull/8129)
 - Fixed a bug that zarr streaming version 3 returned the shape of mag (1, 1, 1) / the finest mag for all mags. [#8116](https://github.com/scalableminds/webknossos/pull/8116)
 - Fixed sorting of mags in outbound zarr streaming. [#8125](https://github.com/scalableminds/webknossos/pull/8125)

--- a/frontend/javascripts/oxalis/constants.ts
+++ b/frontend/javascripts/oxalis/constants.ts
@@ -419,7 +419,7 @@ export enum UnitLong {
   Em = "exameter",
   Zm = "zettameter",
   Ym = "yottameter",
-  Å = "ångström",
+  Å = "angstrom",
   in = "inch",
   ft = "foot",
   yd = "yard",


### PR DESCRIPTION
The backend uses "angstrom", which is consistent with ngff, compare https://ngff.openmicroscopy.org/latest/#axes-md – so the frontend needs to send the same.

### URL of deployed dev instance (used for testing):
- https://angstrom.webknossos.xyz

### Steps to test:
- Attempt to upload dataset with Å as unit, should work

### Issues:
- fixes https://scm.slack.com/archives/CMBMU5684/p1730907197948829

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
