### PR TITLE
Log unknown data type when exploring neuroglancer precomputed dataset

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/PrecomputedExplorer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/PrecomputedExplorer.scala
@@ -36,7 +36,7 @@ class PrecomputedExplorer(implicit val ec: ExecutionContext) extends RemoteLayer
       boundingBox <- BoundingBox
         .fromTopLeftAndSize(firstScale.voxel_offset.getOrElse(Array(0, 0, 0)), firstScale.size)
         .toFox
-      elementClass: ElementClass.Value <- elementClassFromPrecomputedDataType(precomputedHeader.data_type) ?~> "Unknown data type"
+      elementClass: ElementClass.Value <- elementClassFromPrecomputedDataType(precomputedHeader.data_type) ?~> s"Unknown data type ${precomputedHeader.data_type}"
       smallestResolution = firstScale.resolution
       voxelSize <- Vec3Double.fromArray(smallestResolution).toFox
       mags: List[MagLocator] <- Fox.serialCombined(precomputedHeader.scales)(


### PR DESCRIPTION
I'd say this in an optional change. Feel free to adapt or close this pr @fm3.

The reason for this PR is that the error message stating the type might be more explanatory to the user and to us. Thing might help finding such errors easier :)

### Context:
https://scm.slack.com/archives/C02H5T8Q08P/p1731058788439709

### Steps to test:
- Shouldn't be necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messaging for data type determination failures, now displaying the actual problematic data type for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->