### PR TITLE
Fix: Use forwardRef for scrollable virtualized tree

### DIFF
--- a/frontend/javascripts/oxalis/view/right-border-tabs/scrollable_virtualized_tree.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/scrollable_virtualized_tree.tsx
@@ -1,7 +1,7 @@
 import { Tree as AntdTree, type TreeProps } from "antd";
 import type { BasicDataNode } from "antd/es/tree";
 import { throttle } from "lodash";
-import { useCallback, useRef } from "react";
+import { forwardRef, useCallback, useRef } from "react";
 import type RcTree from "rc-tree";
 
 const MIN_SCROLL_SPEED = 30;
@@ -10,8 +10,10 @@ const MIN_SCROLL_AREA_HEIGHT = 60;
 const SCROLL_AREA_RATIO = 10; // 1/10th of the container height
 const THROTTLE_TIME = 25;
 
-function ScrollableVirtualizedTree<T extends BasicDataNode>(
-  props: TreeProps<T> & { ref: React.RefObject<RcTree> },
+// React.forwardRef does not support generic types, so we need to define the type of the ref separately.
+function ScrollableVirtualizedTreeInner<T extends BasicDataNode>(
+  props: TreeProps<T>,
+  ref: React.Ref<RcTree>,
 ) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   // biome-ignore lint/correctness/useExhaustiveDependencies: biome is not smart enough to notice that the function needs to be re-created when wrapperRef changes.
@@ -56,9 +58,15 @@ function ScrollableVirtualizedTree<T extends BasicDataNode>(
 
   return (
     <div ref={wrapperRef}>
-      <AntdTree {...props} onDragOver={onDragOver} />
+      <AntdTree {...props} onDragOver={onDragOver} ref={ref} />
     </div>
   );
 }
+
+const ScrollableVirtualizedTree = forwardRef(ScrollableVirtualizedTreeInner) as <
+  T extends BasicDataNode,
+>(
+  props: TreeProps<T> & { ref?: React.Ref<RcTree> },
+) => ReturnType<typeof ScrollableVirtualizedTreeInner>;
 
 export default ScrollableVirtualizedTree;

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1904,7 +1904,7 @@ class SegmentsView extends React.Component<Props, State> {
                                 overflow: "hidden",
                               }}
                             >
-                              <ScrollableVirtualizedTree<SegmentHierarchyNode>
+                              <ScrollableVirtualizedTree
                                 allowDrop={this.allowDrop}
                                 onDrop={this.onDrop}
                                 onSelect={this.onSelectTreeItem}


### PR DESCRIPTION
The newly deployed scrollable fix added a wrapper for the antd tree implementation. The wrapper is functional component which needs to be wrapped in a `forwardRef` as it received a ref which should be forwarded to the antd tree component. The `forwardRef` was missing and is now added in this pr. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- On master in local dev open a tracing with some skeletons and let the skeleton tab render by viewing it. The console should show an error something like: 
```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `AutoSizer`. Error Component Stack
...
```
- Check out this branch and do the same. The error should disappear / not be printed.


### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1731403785293789
- follow up fix for #8162

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
