### PR TITLE
Update default security.txt for 2025

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -125,7 +125,7 @@ webKnossos {
   securityTxt {
     enabled = true
     content ="""Contact: https://github.com/scalableminds/webknossos/security/advisories/new
-Expires: 2024-07-03T10:00:00.000Z
+Expires: 2025-07-03T10:00:00.000Z
 Preferred-Languages: en,de
     """
   }


### PR DESCRIPTION
Current info is stale.

<https://www.rfc-editor.org/rfc/rfc9116#name-expires>

Should be updated regularly