### PR TITLE
Add key in volumetracing to store if volume bucket data has changed

### DIFF
--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -177,7 +177,8 @@ class AnnotationService @Inject()(
         mappingName = mappingName,
         mags = magsRestricted.map(vec3IntToProto),
         hasSegmentIndex = Some(fallbackLayer.isEmpty || fallbackLayerHasSegmentIndex),
-        additionalAxes = AdditionalAxis.toProto(additionalAxes)
+        additionalAxes = AdditionalAxis.toProto(additionalAxes),
+        volumeBucketDataHasChanged = Some(false)
       )
   }
 

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -699,7 +699,7 @@ class ExplorativeAnnotationsView extends React.PureComponent<Props, State> {
               </div>
               <div className="flex-container">
                 <div className="flex-item" style={{ flexGrow: 0 }}>
-                  {teamTags.length > 0 ? <TeamOutlined className="icon-margin-right"/> : null}
+                  {teamTags.length > 0 ? <TeamOutlined className="icon-margin-right" /> : null}
                 </div>
                 <div className="flex-item">{teamTags}</div>
               </div>

--- a/webknossos-datastore/proto/VolumeTracing.proto
+++ b/webknossos-datastore/proto/VolumeTracing.proto
@@ -48,6 +48,7 @@ message VolumeTracing {
   repeated AdditionalCoordinateProto editPositionAdditionalCoordinates = 21;
   repeated AdditionalAxisProto additionalAxes = 22; // Additional axes for which this tracing is defined
   optional bool mappingIsLocked = 23; // user may not select another mapping (e.g. because they have already mutated buckets)
+  optional bool volumeBucketDataHasChanged = 24; // The volume bucket data has been edited at least once
 }
 
 message SegmentGroup {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -210,7 +210,7 @@ class VolumeTracingService @Inject()(
           ) ?~> "failed to update segment index"
         } yield ()
       }
-    } yield volumeTracing
+    } yield volumeTracing.copy(volumeBucketDataHasChanged = Some(true))
 
   override def editableMappingTracingId(tracing: VolumeTracing, tracingId: String): Option[String] =
     if (tracing.getHasEditableMapping) Some(tracingId) else None
@@ -281,7 +281,7 @@ class VolumeTracingService @Inject()(
           } yield ()
         }))
       _ <- segmentIndexBuffer.flush()
-    } yield volumeTracing
+    } yield volumeTracing.copy(volumeBucketDataHasChanged = Some(true))
 
   private def assertMagIsValid(tracing: VolumeTracing, mag: Vec3Int): Fox[Unit] =
     if (tracing.mags.nonEmpty) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
