### PR TITLE
Fix changing color of active segment

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fix performance bottleneck when deleting a lot of trees at once. [#8176](https://github.com/scalableminds/webknossos/pull/8176)
+- Fix a bug where changing the color of a segment via the menu in the segments tab would update the segment color of the previous segment, on which the context menu was opened. [#8225](https://github.com/scalableminds/webknossos/pull/8225)
 - Fix a bug when importing an NML with groups when only groups but no trees exist in an annotation. [#8176](https://github.com/scalableminds/webknossos/pull/8176)
 - Fix a bug where trying to delete a non-existing node (via the API, for example) would delete the whole active tree. [#8176](https://github.com/scalableminds/webknossos/pull/8176)
 

--- a/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/segments_tab/segment_list_item.tsx
@@ -443,7 +443,7 @@ function _SegmentListItem({
         hideContextMenu,
       ),
       {
-        key: "changeSegmentColor",
+        key: `changeSegmentColor-${segment.id}`,
         label: (
           <ChangeColorMenuItemContent
             isDisabled={false}


### PR DESCRIPTION
When changing the color of multiple segments one after another, the color change was applied to the previous segment. This was due to the color-changing menu item being the only menu item that is a component that is cached by react. Therefore, the color-changing menu item always referred to the segment on which the context menu was previously rendered. By including the segment id in the color-changing menu item's key, an update for the color-changing menu item is enforced each time the segment id changes. Thus the bug should be vanished :sparkle: 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- try on master / wk org:
- Open a hybrid tracing on any dataset with an already existing volume layer
- select two segments to add them to the segments list 
- in the segment list change the color of the first segment via the context menu in the segments list. Should work
- change the color of the other segment ->  should update the color of the previous segment :woozy_face: 
- switch to this branch / dev instance
- do the exact same as before
- when changing the color for the second segment, this should update the segments color (not the previous one) -> bug should be gone

### Issues:
- fixes #8223

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now paste remote URIs from Neuroglancer without removing format prefixes.
	- Asynchronous reading of image files from the datastore for improved performance.
	- Enhanced clarity in error messages for starting jobs on external datasets.
	- Super users can now utilize larger bounding box sizes for inferral jobs.

- **Bug Fixes**
	- Resolved performance issues when deleting multiple trees.
	- Fixed color change inconsistency in segment selection.
	- Addressed NML file import issues and a critical deletion bug in the API.

- **Chores**
	- Removed Google Analytics integration from the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->