### PR TITLE
Fix docstring for registerSegment

### DIFF
--- a/frontend/javascripts/oxalis/api/api_latest.ts
+++ b/frontend/javascripts/oxalis/api/api_latest.ts
@@ -625,8 +625,9 @@ class TracingApi {
    * @example
    * api.tracing.registerSegment(
    *   3,
-   *   "volume-layer-id"
    *   [1, 2, 3],
+   *   null,             // optional
+   *   "volume-layer-id" // optional
    * );
    */
   registerSegment(


### PR DESCRIPTION
Fixes the docstring for `registerSegment` in the JS API module.