### PR TITLE
Fix accessing public datasets

### DIFF
--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -264,7 +264,7 @@ class DatasetController @Inject()(userService: UserService,
         for {
           datasetIdValidated <- ObjectId.fromString(datasetId)
           dataset <- datasetDAO.findOne(datasetIdValidated)(ctx) ?~> notFoundMessage(datasetId) ~> NOT_FOUND
-          organization <- organizationDAO.findOne(dataset._organization) ~> NOT_FOUND
+          organization <- organizationDAO.findOne(dataset._organization)(GlobalAccessContext) ~> NOT_FOUND
           _ <- Fox.runOptional(request.identity)(user =>
             datasetLastUsedTimesDAO.updateForDatasetAndUser(dataset._id, user._id))
           // Access checked above via dataset. In case of shared dataset/annotation, show datastore even if not otherwise accessible


### PR DESCRIPTION
Regression from #8075 – Public datasets could not be accessed without user credentials.

I tested locally that this helps. Looking up the organization bypassing its read access check here is fine, since we already checked that the dataset is public in the line above.