### PR TITLE
Fix permisson error in listGrouped in list datasets route

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fix performance bottleneck when deleting a lot of trees at once. [#8176](https://github.com/scalableminds/webknossos/pull/8176)
+- Fix that listing datasets with the `api/datasets` route without compression failed due to missing permissions regarding public datasets. [#8249](https://github.com/scalableminds/webknossos/pull/8249)
 - Fix a bug where changing the color of a segment via the menu in the segments tab would update the segment color of the previous segment, on which the context menu was opened. [#8225](https://github.com/scalableminds/webknossos/pull/8225)
 - Fix a bug when importing an NML with groups when only groups but no trees exist in an annotation. [#8176](https://github.com/scalableminds/webknossos/pull/8176)
 - Fix a bug where trying to delete a non-existing node (via the API, for example) would delete the whole active tree. [#8176](https://github.com/scalableminds/webknossos/pull/8176)

--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -237,7 +237,7 @@ class DatasetController @Inject()(userService: UserService,
         for {
           _ <- Fox.successful(())
           _ = logger.info(s"byOrgaTuple orga: ${byOrgaTuple._1}, datasets: ${byOrgaTuple._2}")
-          organization <- organizationDAO.findOne(byOrgaTuple._1) ?~> s"Could not find organization ${byOrgaTuple._1}"
+          organization <- organizationDAO.findOne(byOrgaTuple._1)(GlobalAccessContext) ?~> s"Could not find organization ${byOrgaTuple._1}"
           groupedByDataStore = byOrgaTuple._2.groupBy(_._dataStore).toList
           _ <- Fox.serialCombined(groupedByDataStore) { byDataStoreTuple: (String, List[Dataset]) =>
             {


### PR DESCRIPTION
This pr fixes permission errors for listing datasets without `compact=true`. The error results from the access query including all public datasets and the code that groups the datasets by organization before serialization to json requesting the organization without a global access context. This causes the code not to find organizations that are included in the list due to public DS in their organizations. This makes the code crash.
For reference: Here the DSes are retrieved (including public DS):
https://github.com/scalableminds/webknossos/blob/24e4981d7d68212b3f52ddd63cb0dcde9a570031/app/controllers/DatasetController.scala#L189-L199
And here the orga of each DS (they are grouped by orga id at this point) is accessed:
https://github.com/scalableminds/webknossos/blob/24e4981d7d68212b3f52ddd63cb0dcde9a570031/app/controllers/DatasetController.scala#L239-L241
=> This request fails if the previous ds listing includes datasets which are public and of an organization the user has no access to.

To fix this, I suggest making this request in a `GlobalAccessContext` as the previous DS listing takes care of only loading DS the user is allowed to see and the serialization of the DS does not include any sensitive information of the organization.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Well ...
- Spin up 2 organizations
- For 1 have a public dataset
- log in as a user of the other organization
- test whether the `<wk-url>/api/datasets`route works

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1732725487545929?thread_ts=1732717609.114699&cid=C5AKLAV0B

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)

