### PR TITLE
Fix legacy support for outdated displayName field of datasets

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where changing the color of a segment via the menu in the segments tab would update the segment color of the previous segment, on which the context menu was opened. [#8225](https://github.com/scalableminds/webknossos/pull/8225)
 - Fixed a bug where in the add remote dataset view the dataset name setting was not in sync with the datasource setting of the advanced tab making the form not submittable. [#8245](https://github.com/scalableminds/webknossos/pull/8245)
 - Fixed a bug when importing an NML with groups when only groups but no trees exist in an annotation. [#8176](https://github.com/scalableminds/webknossos/pull/8176)
+- Fix read and update dataset route for versions 8 and lower. [#8263](https://github.com/scalableminds/webknossos/pull/8263)
 - Added missing legacy support for `isValidNewName` route. [#8252](https://github.com/scalableminds/webknossos/pull/8252)
 - Fixed a bug where trying to delete a non-existing node (via the API, for example) would delete the whole active tree. [#8176](https://github.com/scalableminds/webknossos/pull/8176)
 - Fixed a bug where dataset uploads would fail if the organization directory on disk is missing. [#8230](https://github.com/scalableminds/webknossos/pull/8230)

--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -339,7 +339,7 @@ class DatasetController @Inject()(userService: UserService,
     sil.SecuredAction.async(parse.json) { implicit request =>
       withJsonBodyUsing(datasetPublicReads) {
         case (description, datasetName, legacyDatasetDisplayName, sortingKey, isPublic, tags, metadata, folderId) => {
-          val name = if (datasetName.isDefined) datasetName else legacyDatasetDisplayName
+          val name = if (legacyDatasetDisplayName.isDefined) legacyDatasetDisplayName else datasetName
           for {
             datasetIdValidated <- ObjectId.fromString(datasetId)
             dataset <- datasetDAO.findOne(datasetIdValidated) ?~> notFoundMessage(datasetIdValidated.toString) ~> NOT_FOUND

--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -72,7 +72,8 @@ class LegacyApiController @Inject()(annotationController: AnnotationController,
       for {
         dataset <- datasetDAO.findOneByNameAndOrganization(datasetName, organizationId)
         result <- datasetController.read(dataset._id.toString, sharingToken)(request)
-      } yield result
+        adaptedResult <- replaceInResult(migrateDatasetJsonToOldFormat)(result)
+      } yield adaptedResult
     }
 
   def updateDatasetV8(organizationId: String, datasetName: String): Action[JsValue] =
@@ -81,7 +82,8 @@ class LegacyApiController @Inject()(annotationController: AnnotationController,
         _ <- Fox.successful(logVersioned(request))
         dataset <- datasetDAO.findOneByNameAndOrganization(datasetName, organizationId)
         result <- datasetController.update(dataset._id.toString)(request)
-      } yield result
+        adaptedResult <- replaceInResult(migrateDatasetJsonToOldFormat)(result)
+      } yield adaptedResult
     }
 
   def updateDatasetTeamsV8(organizationId: String, datasetName: String): Action[List[ObjectId]] =
@@ -240,6 +242,19 @@ class LegacyApiController @Inject()(annotationController: AnnotationController,
     }
 
   /* private helper methods for legacy adaptation */
+
+  private def migrateDatasetJsonToOldFormat(jsResult: JsObject): Fox[JsObject] = {
+    val datasetName = (jsResult \ "name").asOpt[String]
+    val directoryName = (jsResult \ "directoryName").asOpt[String]
+    datasetName.zip(directoryName) match {
+      case Some((name, dirName)) =>
+        for {
+          dsWithOldNameField <- tryo(jsResult - "name" + ("name" -> Json.toJson(dirName))).toFox
+          dsWithOldDisplayNameField <- tryo(dsWithOldNameField - "displayName" + ("displayName" -> Json.toJson(name))).toFox
+        } yield dsWithOldDisplayNameField
+      case _ => Fox.successful(jsResult)
+    }
+  }
 
   private def addDataSetToTaskInAnnotation(jsResult: JsObject): Fox[JsObject] = {
     val taskObjectOpt = (jsResult \ "task").asOpt[JsObject]

--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -249,8 +249,8 @@ class LegacyApiController @Inject()(annotationController: AnnotationController,
     datasetName.zip(directoryName) match {
       case Some((name, dirName)) =>
         for {
-          dsWithOldNameField <- tryo(jsResult - "name" + ("name" -> Json.toJson(dirName))).toFox
-          dsWithOldDisplayNameField <- tryo(dsWithOldNameField - "displayName" + ("displayName" -> Json.toJson(name))).toFox
+          dsWithOldNameField <- tryo(jsResult - "directoryName" + ("name" -> Json.toJson(dirName))).toFox
+          dsWithOldDisplayNameField <- tryo(dsWithOldNameField + ("displayName" -> Json.toJson(name))).toFox
         } yield dsWithOldDisplayNameField
       case _ => Fox.successful(jsResult)
     }


### PR DESCRIPTION
Fixes a compatibility bug introduced in #8075. `wk.Dataset.open_remote("...").display_name = "fancy name"` did not result in any changes due to two bugs:
1. displayName was no longer part of the ds objects returned by the API, even in legacy routes.
2. When updating a dataset, the name given by the update request took precedence. This discarded all updates to the ds name done via `displayName` as "old" clients like wklibs always send the current name of the ds and the updated `displayName`. Therefore, the `displayName` should take precedence. Clients using new API version should no longer send the `displayName prop and thus renaming with them should also still work.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Test whether renaming a dataset via the web UI works
- with wklibs run the following and check if the console shows the success of the renaming:
```python
    with webknossos_context(token="<token>", url="http://localhost:9000"):
        ds = Dataset.open_remote("l4_sample_small")
        print("current ds name", ds.display_name)
        ds.display_name = "blue"
        print("name after renaming", ds.display_name)
```
- run that script on another branch again. Each print should have a name `None` as the `displayName` is not included in the json format of the dataset. This should be fixed in this pr.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1733346943571389

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
