### PR TITLE
Fix already upload of zarr datasets with already existing `datasource-properties.json` file

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed that listing datasets with the `api/datasets` route without compression failed due to missing permissions regarding public datasets. [#8249](https://github.com/scalableminds/webknossos/pull/8249)
+- Fixed a bug that uploading a zarr dataset with an already existing `datasource-properties.json` file failed. [#8268](https://github.com/scalableminds/webknossos/pull/8268)
 - Fixed that the frontend did not ensure a minium length for annotation layer names. Moreover, names starting with a `.` are also disallowed now. [#8244](https://github.com/scalableminds/webknossos/pull/8244)
 - Fixed a bug where in the add remote dataset view the dataset name setting was not in sync with the datasource setting of the advanced tab making the form not submittable. [#8245](https://github.com/scalableminds/webknossos/pull/8245)
 - Fix read and update dataset route for versions 8 and lower. [#8263](https://github.com/scalableminds/webknossos/pull/8263)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
@@ -354,9 +354,7 @@ class UploadService @Inject()(dataSourceRepository: DataSourceRepository,
                                      typ: UploadedDataSourceType.Value): Fox[Unit] =
     for {
       _ <- Fox.runIf(typ == UploadedDataSourceType.ZARR)(addLayerAndMagDirIfMissing(path, FILENAME_DOT_ZARRAY).toFox)
-      layers <- PathUtils.listDirectories(path, silent = true).toFox
-      _ <- bool2Fox(layers.nonEmpty) ~> s"Could not find a layer in $path"
-      explored <- exploreLocalLayerService.exploreLocal(path, dataSourceId, layers.head.getFileName.toString)
+      explored <- exploreLocalLayerService.exploreLocal(path, dataSourceId)
       _ <- exploreLocalLayerService.writeLocalDatasourceProperties(explored, path)
     } yield ()
 


### PR DESCRIPTION
This PR fixes the upload of zarr datasets which already have a `datasource-properties.json` file present. The bug originates from (I'd say) wrong prioritization during finishing a dataset upload. First, it was checked whether the uploaded DS is in zarr format and only if that failed, the backend checked if there is a `datasource-properties.json` present (meaning the dataset is already ready to be used). This PR moves the checking for a `datasource-properties.json` first position. Thus, a full dataset with an already existing `datasource-properties.json` is just assumed as already explored an no additional effored it tried to generate a `datasource-properties.json` file for the dataset. 
Previously, the backend would detect such a dataset as zarr and that it needed a `datasource-properties.json` whose contents needs to be guessed. And this is currently not supported by the zarr after upload exploration code. Thus, the uploads failed.

I hope this is the correct way of fixing this. An alternative (which I tried first before locating the wrong ordering of determining the ds format) was to fix the zarr upload exploration. But this created strange datasets -> all mags were interpreted as layers. Which lead to a wrong `datasource-properties.json` and moreover: !! @fm3 The server crashed with a heap overflow when trying to view the dataset. IMO this should never happen in case some `datasource-properties.json` is misconfigured.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- prepare a single layered zarr dataset with a `datasource-properties.json`
- zip it
- and upload it via the UI
- this should succeed. As well as viewing the data


### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1733738810435789

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
