### PR TITLE
Data loading: save mem + cpu by re-using allocated fill-value chunks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Added
 - Added the total volume of a dataset to a tooltip in the dataset info tab. [#8229](https://github.com/scalableminds/webknossos/pull/8229)
+- Optimized performance of data loading with “fill value“ chunks. [#8271](https://github.com/scalableminds/webknossos/pull/8271)
 
 ### Changed
 - Renamed "resolution" to "magnification" in more places within the codebase, including local variables. [#8168](https://github.com/scalableminds/webknossos/pull/8168)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkReader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkReader.scala
@@ -26,11 +26,11 @@ class ChunkReader(header: DatasetHeader) {
         case Full(chunkBytes) if useSkipTypingShortcut =>
           shortcutChunkTyper.wrapAndType(chunkBytes, chunkShape).toFox ?~> "chunk.shortcutWrapAndType.failed"
         case Empty if useSkipTypingShortcut =>
-          shortcutChunkTyper.createFromFillValue(chunkShape).toFox ?~> "chunk.shortcutCreateFromFillValue.failed"
+          shortcutChunkTyper.createFromFillValueCached(chunkShape).toFox ?~> "chunk.shortcutCreateFromFillValue.failed"
         case Full(chunkBytes) =>
           chunkTyper.wrapAndType(chunkBytes, chunkShape).toFox ?~> "chunk.wrapAndType.failed"
         case Empty =>
-          chunkTyper.createFromFillValue(chunkShape).toFox ?~> "chunk.createFromFillValue.failed"
+          chunkTyper.createFromFillValueCached(chunkShape).toFox ?~> "chunk.createFromFillValue.failed"
         case f: Failure =>
           f.toFox ?~> s"Reading chunk at $path failed"
       }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkTyper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkTyper.scala
@@ -1,5 +1,8 @@
 package com.scalableminds.webknossos.datastore.datareaders
 
+import com.scalableminds.util.cache.AlfuCache
+import com.scalableminds.util.tools.Fox
+import com.scalableminds.util.tools.Fox.box2Fox
 import net.liftweb.common.Box
 import net.liftweb.common.Box.tryo
 
@@ -7,6 +10,8 @@ import java.io.ByteArrayInputStream
 import javax.imageio.stream.MemoryCacheImageInputStream
 import scala.util.Using
 import ucar.ma2.{Array => MultiArray, DataType => MADataType}
+
+import scala.concurrent.ExecutionContext
 
 object ChunkTyper {
   def createFromHeader(header: DatasetHeader): ChunkTyper = header.resolvedDataType match {
@@ -25,7 +30,14 @@ abstract class ChunkTyper {
   def ma2DataType: MADataType
   def wrapAndType(bytes: Array[Byte], chunkShape: Array[Int]): Box[MultiArray]
 
-  def createFromFillValue(chunkShape: Array[Int]): Box[MultiArray] =
+  // If large areas of the array use the fill value, the same chunk shape will be requested often.
+  // This cache implements a flyweight pattern by returning the same instance of the fill-valued array.
+  private val fillValueChunkCache: AlfuCache[String, MultiArray] = AlfuCache(maxCapacity = 1)
+
+  def createFromFillValueCached(chunkShape: Array[Int])(implicit ec: ExecutionContext): Fox[MultiArray] =
+    fillValueChunkCache.getOrLoad(chunkShape.mkString(","), _ => createFromFillValue(chunkShape).toFox)
+
+  protected def createFromFillValue(chunkShape: Array[Int]): Box[MultiArray] =
     MultiArrayUtils.createFilledArray(ma2DataType, chunkShapeOrdered(chunkShape), header.fillValueNumber)
 
   // Chunk shape in header is in C-Order (XYZ), but data may be in F-Order (ZYX), so the chunk shape
@@ -127,7 +139,7 @@ class ShortcutChunkTyper(val header: DatasetHeader) extends ChunkTyper {
     MultiArray.factory(ma2DataType, flatShape, bytes)
   }
 
-  override def createFromFillValue(chunkShape: Array[Int]): Box[MultiArray] = {
+  override protected def createFromFillValue(chunkShape: Array[Int]): Box[MultiArray] = {
     val flatShape = Array(chunkShape.product * header.bytesPerElement)
     MultiArrayUtils.createFilledArray(ma2DataType, flatShape, header.fillValueNumber)
   }


### PR DESCRIPTION
Dataset arrays can define a fill value. When chunks don’t exist in a location, a virtual chunk filled with that fill value is created and used.

This PR introduces a single-entry cache for this fill value chunk (per array/mag), so that we don’t have to create thousands of them in datasets where a lot of chunks are missing. Most datasets have a uniform chunk shape (and even those that don’t usually only have a few deviating chunks at the border), so this single-entry cache allows re-using the same allocated fill-value chunk many times.

Before this PR, a test dataset with a flat chunk shape, a large bounding box, and very sparse existing chunks would lead to so many all-black all-identical chunks being allocated after hitting “find data” that the GC was overwhelmed. Also, the allocation and GC take time so that the route took multiple minutes. Both problems are gone now.

“find data” is still not super fast in this case, but that’s somewhat expected due to the almost 4000 sampled positions and the bad chunk shape that makes many partial array copys necessary. It’s definitely better than before and uses way less memory.

### Steps to test:
- Open test dataset from https://scm.slack.com/archives/C02H5T8Q08P/p1733833450557419?thread_ts=1733738810.435789&cid=C02H5T8Q08P
- Hit “Jump to data” in the layer menu. It should fail (as there is no data in the sampled positions), but it should not crash the server or take more than two minutes.

### Issues:
- fixes #8269

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
