### PR TITLE
Fix nml upload with only ds name in nml by using user's orga as fallback

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -105,10 +105,12 @@ class AnnotationIOController @Inject()(
           request.body.dataParts("createGroupForEachFile").headOption.contains("true")
         val overwritingDatasetId: Option[String] =
           request.body.dataParts.get("datasetId").flatMap(_.headOption)
+        val userOrganizationId = request.identity._organization
         val attachedFiles = request.body.files.map(f => (f.ref.path.toFile, f.filename))
         for {
-          parsedFiles <- annotationUploadService
-            .extractFromFiles(attachedFiles, SharedParsingParameters(useZipName = true, overwritingDatasetId))
+          parsedFiles <- annotationUploadService.extractFromFiles(
+            attachedFiles,
+            SharedParsingParameters(useZipName = true, overwritingDatasetId, userOrganizationId))
           parsedFilesWrapped = annotationUploadService.wrapOrPrefixGroups(parsedFiles.parseResults,
                                                                           shouldCreateGroupForEachFile)
           parseResultsFiltered: List[NmlParseResult] = parsedFilesWrapped.filter(_.succeeded)

--- a/app/models/annotation/AnnotationUploadService.scala
+++ b/app/models/annotation/AnnotationUploadService.scala
@@ -27,6 +27,7 @@ case class UploadedVolumeLayer(tracing: VolumeTracing, dataZipLocation: String, 
 
 case class SharedParsingParameters(useZipName: Boolean,
                                    overwritingDatasetId: Option[String] = None,
+                                   userOrganizationId: String,
                                    isTaskUpload: Boolean = false)
 
 class AnnotationUploadService @Inject()(tempFileService: TempFileService, nmlParser: NmlParser) extends LazyLogging {
@@ -53,8 +54,7 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService, nmlPar
       nmlParser.parse(
         name,
         inputStream,
-        sharedParsingParameters.overwritingDatasetId,
-        sharedParsingParameters.isTaskUpload,
+        sharedParsingParameters,
         basePath
       )
     parserOutput.futureBox.map {

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -24,7 +24,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.ColorGenerator
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating.TreeType
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.{MultiComponentTreeSplitter, TreeValidator}
 import com.typesafe.scalalogging.LazyLogging
-import models.annotation.UploadedVolumeLayer
+import models.annotation.{SharedParsingParameters, UploadedVolumeLayer}
 import models.dataset.DatasetDAO
 import net.liftweb.common.Box._
 import net.liftweb.common.{Box, Empty, Failure, Full}
@@ -48,13 +48,12 @@ class NmlParser @Inject()(datasetDAO: DatasetDAO) extends LazyLogging with Proto
 
   def parse(name: String,
             nmlInputStream: InputStream,
-            overwritingDatasetId: Option[String],
-            isTaskUpload: Boolean,
+            sharedParsingParameters: SharedParsingParameters,
             basePath: Option[String] = None)(implicit m: MessagesProvider,
                                              ec: ExecutionContext,
                                              ctx: DBAccessContext): Fox[NmlParseSuccessWithoutFile] =
     for {
-      nmlParsedParameters <- getParametersFromNML(nmlInputStream, name, overwritingDatasetId, isTaskUpload).toFox
+      nmlParsedParameters <- getParametersFromNML(nmlInputStream, name, sharedParsingParameters).toFox
       parsedResult <- nmlParametersToResult(nmlParsedParameters, basePath)
     } yield parsedResult
 
@@ -121,10 +120,10 @@ class NmlParser @Inject()(datasetDAO: DatasetDAO) extends LazyLogging with Proto
     } yield
       NmlParseSuccessWithoutFile(skeletonTracingOpt, volumeLayers, dataset._id, nmlParams.description, nmlParams.wkUrl)
 
-  private def getParametersFromNML(nmlInputStream: InputStream,
-                                   name: String,
-                                   overwritingDatasetId: Option[String],
-                                   isTaskUpload: Boolean)(implicit m: MessagesProvider): Box[NmlParsedParameters] =
+  private def getParametersFromNML(
+      nmlInputStream: InputStream,
+      name: String,
+      sharedParsingParameters: SharedParsingParameters)(implicit m: MessagesProvider): Box[NmlParsedParameters] =
     try {
       val nmlData = XML.load(nmlInputStream)
       for {
@@ -143,9 +142,10 @@ class NmlParser @Inject()(datasetDAO: DatasetDAO) extends LazyLogging with Proto
         _ <- TreeValidator.validateTrees(treesSplit, treeGroupsAfterSplit, branchPoints, comments)
         additionalAxisProtos <- parseAdditionalAxes(parameters \ "additionalAxes")
         datasetName = parseDatasetName(parameters \ "experiment")
-        datasetIdOpt = if (overwritingDatasetId.isDefined) overwritingDatasetId
+        datasetIdOpt = if (sharedParsingParameters.overwritingDatasetId.isDefined)
+          sharedParsingParameters.overwritingDatasetId
         else parseDatasetId(parameters \ "experiment")
-        organizationId = parseOrganizationId(parameters \ "experiment")
+        organizationId = parseOrganizationId(parameters \ "experiment", sharedParsingParameters.userOrganizationId)
         description = parseDescription(parameters \ "experiment")
         wkUrl = parseWkUrl(parameters \ "experiment")
         activeNodeId = parseActiveNode(parameters \ "activeNode")
@@ -153,11 +153,12 @@ class NmlParser @Inject()(datasetDAO: DatasetDAO) extends LazyLogging with Proto
           .getOrElse((SkeletonTracingDefaults.editPosition, Seq()))
         editRotation = parseEditRotation(parameters \ "editRotation").getOrElse(SkeletonTracingDefaults.editRotation)
         zoomLevel = parseZoomLevel(parameters \ "zoomLevel").getOrElse(SkeletonTracingDefaults.zoomLevel)
-        taskBoundingBox: Option[BoundingBox] = if (isTaskUpload) parseTaskBoundingBox(parameters \ "taskBoundingBox")
+        taskBoundingBox: Option[BoundingBox] = if (sharedParsingParameters.isTaskUpload)
+          parseTaskBoundingBox(parameters \ "taskBoundingBox")
         else None
         userBoundingBoxes = parseBoundingBoxes(parameters \ "userBoundingBox")
       } yield {
-        if (!isTaskUpload) {
+        if (!sharedParsingParameters.isTaskUpload) {
           parseTaskBoundingBoxAsUserBoundingBox(parameters \ "taskBoundingBox", userBoundingBoxes)
             .map(asUserBoundingBox => userBoundingBoxes :+ asUserBoundingBox)
         }
@@ -379,8 +380,10 @@ class NmlParser @Inject()(datasetDAO: DatasetDAO) extends LazyLogging with Proto
   private def parseWkUrl(nodes: NodeSeq): Option[String] =
     nodes.headOption.map(node => getSingleAttribute(node, "wkUrl"))
 
-  private def parseOrganizationId(nodes: NodeSeq): String =
-    nodes.headOption.map(node => getSingleAttribute(node, "organization")).getOrElse("")
+  private def parseOrganizationId(nodes: NodeSeq, fallbackOrganization: String): String =
+    nodes.headOption
+      .map(node => getSingleAttributeOpt(node, "organization").getOrElse(fallbackOrganization))
+      .getOrElse(fallbackOrganization)
 
   private def parseActiveNode(nodes: NodeSeq): Option[Int] =
     nodes.headOption.flatMap(node => getSingleAttribute(node, "id").toIntOpt)


### PR DESCRIPTION
This PR fixes uploading an nml with only setting a dataset name in the nml and not passing the optional `datasetId` to the route. Wklibs currently behaves like this. And therefore this should be fixed.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
-Just drop this nml in the dashboard. This sends the upload without a `datasetId`. The upload should succeed
[test_annotation.zip](https://github.com/user-attachments/files/18129451/test_annotation.zip)

### Issues:
- No issue or so exists for this.

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
