### PR TITLE
Fix appending task bbox to user bbox in annotation nml upload

### DIFF
--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -156,11 +156,11 @@ class NmlParser @Inject()(datasetDAO: DatasetDAO) extends LazyLogging with Proto
         taskBoundingBox: Option[BoundingBox] = if (sharedParsingParameters.isTaskUpload)
           parseTaskBoundingBox(parameters \ "taskBoundingBox")
         else None
-        userBoundingBoxes = parseBoundingBoxes(parameters \ "userBoundingBox")
       } yield {
+        var userBoundingBoxes = parseBoundingBoxes(parameters \ "userBoundingBox")
         if (!sharedParsingParameters.isTaskUpload) {
           parseTaskBoundingBoxAsUserBoundingBox(parameters \ "taskBoundingBox", userBoundingBoxes)
-            .map(asUserBoundingBox => userBoundingBoxes :+ asUserBoundingBox)
+            .foreach(asUserBoundingBox => userBoundingBoxes = userBoundingBoxes :+ asUserBoundingBox)
         }
         NmlParsedParameters(
           datasetIdOpt,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Upload the annotation from the slack thread in the wk dashboard. 
- The opened annotation should have 2 bboxes (one the task bbox)

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1734346665715109
- Introduced by #8075 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
