### PR TITLE
WIP faster mapped mesh loading

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSMeshController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSMeshController.scala
@@ -1,6 +1,7 @@
 package com.scalableminds.webknossos.datastore.controllers
 
 import com.google.inject.Inject
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.services._
@@ -55,6 +56,7 @@ class DSMeshController @Inject()(
         urlOrHeaderToken(token, request)) {
         for {
           _ <- Fox.successful(())
+          before = Instant.now
           mappingNameForMeshFile = meshFileService.mappingNameForMeshFile(organizationId,
                                                                           datasetDirectoryName,
                                                                           dataLayerName,
@@ -70,6 +72,7 @@ class DSMeshController @Inject()(
             omitMissing = false,
             urlOrHeaderToken(token, request)
           )
+          _ = Instant.logSince(before, "listChunks setup")
           chunkInfos <- meshFileService.listMeshChunksForSegmentsMerged(organizationId,
                                                                         datasetDirectoryName,
                                                                         dataLayerName,


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] use existing alfucache?
- [ ] cache buckets too?
- [ ] neuroglancer array seems too large to sensibly cache. Do other tricks like request sorting work?
- [ ] force sequential chunk requests?
- [ ] do the hpc file systems behave like a single spinning disk? what about block size? how about parallel access?

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
