### PR TITLE
Allow to specify mask during inference when using a custom workflow

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,6 +44,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that reloading the data of a volume annotation layer did not work properly. [#8298](https://github.com/scalableminds/webknossos/pull/8298)
 - Removed the magnification slider for the TIFF export within the download modal if only one magnification is available for the selected layer. [#8297](https://github.com/scalableminds/webknossos/pull/8297)
 - Fixed regression in styling of segment and skeleton tree tab. [#8307](https://github.com/scalableminds/webknossos/pull/8307)
+- Fixed the template for neuron inferral using a custom workflow. [#8312](https://github.com/scalableminds/webknossos/pull/8312)
 
 ### Removed
 - Removed support for HTTP API versions 3 and 4. [#8075](https://github.com/scalableminds/webknossos/pull/8075)

--- a/frontend/javascripts/oxalis/view/action-bar/default-predict-workflow-template.ts
+++ b/frontend/javascripts/oxalis/view/action-bar/default-predict-workflow-template.ts
@@ -8,7 +8,17 @@ export default `predict:
     model: TO_BE_SET_BY_WORKER
   config:
     name: predict
-    datasource_config: TO_BE_SET_BY_WORKER
+    datasource_config:
+      name: TO_BE_SET_BY_WORKER
+      type: "wkw"
+      scale: TO_BE_SET_BY_WORKER
+      data_dir: "/"
+      path: TO_BE_SET_BY_WORKER
+      color_name: TO_BE_SET_BY_WORKER
+      wkw_resolution: TO_BE_SET_BY_WORKER
+      bounding_box:
+        topleft: TO_BE_SET_BY_WORKER
+        size: TO_BE_SET_BY_WORKER
     # your additional config keys here
 
 # your additional tasks here
@@ -20,6 +30,7 @@ publish_dataset_meshes:
   config:
     name: TO_BE_SET_BY_WORKER
     public_directory: TO_BE_SET_BY_WORKER
+    datastore_url: TO_BE_SET_BY_WORKER
     use_symlinks: False
     move_dataset_symlink_artifact: True
     keep_symlinks_to: TO_BE_SET_BY_WORKER`;


### PR DESCRIPTION
See https://github.com/scalableminds/voxelytics/pull/3872 for context. (Needs to be deployed together)

Also the template was currently incomplete due to https://github.com/scalableminds/voxelytics/pull/3800 which I fixed by adding the `datastore_url` to the template (/cc @MatthisCl).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I tested this
- Can be tested using a local worker (voxelytics branch `use-mask-from-annotation`) by adding a mask config to the template (under the `datasource_config` key) when doing neuron inferral using a custom workflow (create an annotation with some brush strokes first and copy the annotation link):
```
        mask:
          url: <annotation_url>
          segmentation_name: Volume
          mag: [1, 1, 1]
```

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
