### PR TITLE
When jobsEnabled=False, send empty jobsSupportedByAvailableWorkers list

### DIFF
--- a/app/models/dataset/DataStore.scala
+++ b/app/models/dataset/DataStore.scala
@@ -72,7 +72,8 @@ class DataStoreService @Inject()(dataStoreDAO: DataStoreDAO, jobService: JobServ
         "name" -> dataStore.name,
         "url" -> dataStore.publicUrl,
         "allowsUpload" -> dataStore.allowsUpload,
-        "jobsSupportedByAvailableWorkers" -> Json.toJson(jobsSupportedByAvailableWorkers),
+        "jobsSupportedByAvailableWorkers" -> Json.toJson(
+          if (conf.Features.jobsEnabled) jobsSupportedByAvailableWorkers else List.empty),
         "jobsEnabled" -> jobsEnabled
       )
 


### PR DESCRIPTION
Making the situation for frontend job checks simpler.

### Steps to test:
- `yarn enable-jobs`
- check that dataset json includes jobsSupportedByAvailableWorkers list
- in application.conf, set features.jobsEnabled=false
- now the list sent to the frontend should be empty

### Issues:
- fixes #8306
