### PR TITLE
Make email footer line configurable

### DIFF
--- a/app/controllers/OrganizationController.scala
+++ b/app/controllers/OrganizationController.scala
@@ -212,7 +212,7 @@ class OrganizationController @Inject()(
         mail = if (requestedPlan == PricingPlan.Team) {
           defaultMails.upgradePricingPlanToTeamMail _
         } else {
-          defaultMails.upgradePricingPlanToTeamMail _
+          defaultMails.upgradePricingPlanToPowerMail _
         }
         _ = Mailer ! Send(mail(request.identity, userEmail))
         _ = Mailer ! Send(

--- a/app/mail/DefaultMails.scala
+++ b/app/mail/DefaultMails.scala
@@ -117,6 +117,14 @@ class DefaultMails @Inject()(conf: WkConf) {
       recipients = List(userEmail)
     )
 
+  def upgradePricingPlanToPowerMail(user: User, userEmail: String): Mail =
+    Mail(
+      from = defaultSender,
+      subject = "WEBKNOSSOS Plan Upgrade Request",
+      bodyHtml = html.mail.upgradePricingPlanToPower(user.name, additionalFooter).body,
+      recipients = List(userEmail)
+    )
+
   def upgradePricingPlanUsersMail(user: User, userEmail: String, requestedUsers: Int): Mail =
     Mail(
       from = defaultSender,

--- a/app/mail/DefaultMails.scala
+++ b/app/mail/DefaultMails.scala
@@ -47,22 +47,26 @@ class DefaultMails @Inject()(conf: WkConf) {
     )
 
   def activatedMail(name: String, recipient: String): Mail =
-    Mail(from = defaultSender,
-         subject = "WEBKNOSSOS | Account activated",
-         bodyHtml = html.mail.validateUser(name, uri).body,
-         recipients = List(recipient))
+    Mail(
+      from = defaultSender,
+      subject = "WEBKNOSSOS | Account activated",
+      bodyHtml = html.mail.validateUser(name, uri, additionalFooter).body,
+      recipients = List(recipient)
+    )
 
   def changePasswordMail(name: String, recipient: String): Mail =
-    Mail(from = defaultSender,
-         subject = "WEBKNOSSOS | Password changed",
-         bodyHtml = html.mail.passwordChanged(name, uri).body,
-         recipients = List(recipient))
+    Mail(
+      from = defaultSender,
+      subject = "WEBKNOSSOS | Password changed",
+      bodyHtml = html.mail.passwordChanged(name, uri, additionalFooter).body,
+      recipients = List(recipient)
+    )
 
   def resetPasswordMail(name: String, recipient: String, token: String): Mail =
     Mail(
       from = defaultSender,
       subject = "WEBKNOSSOS | Password Reset",
-      bodyHtml = html.mail.resetPassword(name, uri, token).body,
+      bodyHtml = html.mail.resetPassword(name, uri, token, additionalFooter).body,
       recipients = List(recipient)
     )
 
@@ -70,7 +74,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = s"WEBKNOSSOS | New Organization created on $domain",
-      bodyHtml = html.mail.notifyAdminNewOrganization(organizationName, creatorEmail, domain).body,
+      bodyHtml = html.mail.notifyAdminNewOrganization(organizationName, creatorEmail, domain, additionalFooter).body,
       recipients = List(newOrganizationMailingList)
     )
 
@@ -83,7 +87,8 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = s"$senderName invited you to join their WEBKNOSSOS organization at $host",
-      bodyHtml = html.mail.invite(senderName, organizationName, inviteTokenValue, uri, autoVerify).body,
+      bodyHtml =
+        html.mail.invite(senderName, organizationName, inviteTokenValue, uri, autoVerify, additionalFooter).body,
       recipients = List(recipient)
     )
   }
@@ -92,7 +97,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Help requested // Feedback provided",
-      bodyHtml = html.mail.help(user.name, organizationName, message, currentUrl).body,
+      bodyHtml = html.mail.help(user.name, organizationName, message, currentUrl, additionalFooter).body,
       recipients = List("hello@webknossos.org", userEmail)
     )
 
@@ -100,7 +105,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "WEBKNOSSOS Plan Extension Request",
-      bodyHtml = html.mail.extendPricingPlan(user.name).body,
+      bodyHtml = html.mail.extendPricingPlan(user.name, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -108,7 +113,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "WEBKNOSSOS Plan Upgrade Request",
-      bodyHtml = html.mail.upgradePricingPlanToTeam(user.name).body,
+      bodyHtml = html.mail.upgradePricingPlanToTeam(user.name, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -116,7 +121,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Request to upgrade WEBKNOSSOS users",
-      bodyHtml = html.mail.upgradePricingPlanUsers(user.name, requestedUsers).body,
+      bodyHtml = html.mail.upgradePricingPlanUsers(user.name, requestedUsers, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -124,7 +129,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Request to upgrade WEBKNOSSOS storage",
-      bodyHtml = html.mail.upgradePricingPlanStorage(user.name, requestedStorage).body,
+      bodyHtml = html.mail.upgradePricingPlanStorage(user.name, requestedStorage, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -135,7 +140,8 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Request to upgrade WEBKNOSSOS plan",
-      bodyHtml = html.mail.upgradePricingPlanRequest(user.name, userEmail, organizationName, messageBody).body,
+      bodyHtml =
+        html.mail.upgradePricingPlanRequest(user.name, userEmail, organizationName, messageBody, additionalFooter).body,
       recipients = List("hello@webknossos.org")
     )
 
@@ -148,7 +154,9 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = s"$jobTitle is ready",
-      bodyHtml = html.mail.jobSuccessfulGeneric(user.name, datasetName, jobLink, jobTitle, jobDescription).body,
+      bodyHtml = html.mail
+        .jobSuccessfulGeneric(user.name, datasetName, jobLink, jobTitle, jobDescription, additionalFooter)
+        .body,
       recipients = List(userEmail)
     )
 
@@ -156,7 +164,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Your dataset is ready",
-      bodyHtml = html.mail.jobSuccessfulUploadConvert(user.name, datasetName, jobLink).body,
+      bodyHtml = html.mail.jobSuccessfulUploadConvert(user.name, datasetName, jobLink, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -168,7 +176,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = s"Your $jobTitle is ready",
-      bodyHtml = html.mail.jobSuccessfulSegmentation(user.name, datasetName, jobLink, jobTitle).body,
+      bodyHtml = html.mail.jobSuccessfulSegmentation(user.name, datasetName, jobLink, jobTitle, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -176,7 +184,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Oops. Your WEBKNOSSOS job failed",
-      bodyHtml = html.mail.jobFailedGeneric(user.name, datasetName, jobTitle).body,
+      bodyHtml = html.mail.jobFailedGeneric(user.name, datasetName, jobTitle, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -184,7 +192,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Oops. Your dataset upload & conversion failed",
-      bodyHtml = html.mail.jobFailedUploadConvert(user.name, datasetName).body,
+      bodyHtml = html.mail.jobFailedUploadConvert(user.name, datasetName, additionalFooter).body,
       recipients = List(userEmail)
     )
 
@@ -195,7 +203,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Verify Your Email at WEBKNOSSOS",
-      bodyHtml = html.mail.verifyEmail(user.name, key, linkExpiry).body,
+      bodyHtml = html.mail.verifyEmail(user.name, key, linkExpiry, additionalFooter).body,
       recipients = List(userEmail)
     )
   }

--- a/app/mail/DefaultMails.scala
+++ b/app/mail/DefaultMails.scala
@@ -14,6 +14,7 @@ class DefaultMails @Inject()(conf: WkConf) {
   private val uri = conf.Http.uri
   private val defaultSender = conf.Mail.defaultSender
   private val newOrganizationMailingList = conf.WebKnossos.newOrganizationMailingList
+  private val additionalFooter = conf.Mail.additionalFooter
 
   def registerAdminNotifierMail(name: String,
                                 email: String,
@@ -24,7 +25,7 @@ class DefaultMails @Inject()(conf: WkConf) {
       from = defaultSender,
       subject =
         s"WEBKNOSSOS | A new user ($name, $email) registered on $uri for ${organization.name} (${organization._id})",
-      bodyHtml = html.mail.notifyAdminNewUser(name, uri, autoActivate).body,
+      bodyHtml = html.mail.notifyAdminNewUser(name, uri, autoActivate, additionalFooter).body,
       recipients = List(recipient)
     )
 
@@ -32,7 +33,8 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = s"WEBKNOSSOS | Time limit reached. ${user.abbreviatedName} in $projectName",
-      bodyHtml = html.mail.notifyAdminTimeLimit(user.name, projectName, taskId, annotationId, uri).body,
+      bodyHtml =
+        html.mail.notifyAdminTimeLimit(user.name, projectName, taskId, annotationId, uri, additionalFooter).body,
       recipients = List(projectOwner)
     )
 
@@ -40,7 +42,7 @@ class DefaultMails @Inject()(conf: WkConf) {
     Mail(
       from = defaultSender,
       subject = "Welcome to WEBKNOSSOS",
-      bodyHtml = html.mail.newUser(name, enableAutoVerify).body,
+      bodyHtml = html.mail.newUser(name, enableAutoVerify, additionalFooter).body,
       recipients = List(recipient)
     )
 

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -154,6 +154,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
     }
 
     val defaultSender: String = get[String]("mail.defaultSender")
+    def additionalFooter: String = get[String]("mail.additionalFooter")
 
     object Mailchimp {
       val host: String = get[String]("mail.mailchimp.host")

--- a/app/views/mail/emailBaseTemplate.scala.html
+++ b/app/views/mail/emailBaseTemplate.scala.html
@@ -1,4 +1,4 @@
-@(additionalFooter:String = "")(content:Html)
+@(additionalFooter: String)(content:Html)
 <html>
 
 <body>

--- a/app/views/mail/emailBaseTemplate.scala.html
+++ b/app/views/mail/emailBaseTemplate.scala.html
@@ -1,4 +1,4 @@
-@()(content:Html)
+@(additionalFooter:String = "")(content:Html)
 <html>
 
 <body>
@@ -46,8 +46,7 @@
       cancel your account at any time.
     </p>
     <p style="color: #888; font-size: 0.6rem;">
-      <a href="https://webknossos.org" style="color: #888;">webknossos.org</a> is a service by
-      <a href="https://scalableminds.com">scalable minds</a> &bull; <a href="mailto:hello@@webknossos.org" style="color: #888;">hello@@webknossos.org</a>
+      @Html(additionalFooter)
     </p>
     <div style="height: 60px;">&nbsp;</div>
   </div>

--- a/app/views/mail/extendPricingPlan.scala.html
+++ b/app/views/mail/extendPricingPlan.scala.html
@@ -1,6 +1,6 @@
-@( name: String)
+@( name: String, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name}</p>
 <p>Thank you for requesting to extend your current WEBKNOSSOS plan. Our sales team will be in contact with
   you shortly with a formal offer.</p>

--- a/app/views/mail/help.scala.html
+++ b/app/views/mail/help.scala.html
@@ -1,6 +1,6 @@
-@( name: String, organizationName: String, message: String, currentUrl: String)
+@( name: String, organizationName: String, message: String, currentUrl: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi WEBKNOSSOS team</p>
 <p>I have a question or feedback for you:</p>
 <p>

--- a/app/views/mail/invite.scala.html
+++ b/app/views/mail/invite.scala.html
@@ -1,6 +1,6 @@
-@(senderName: String, organizationName: String, inviteTokenValue: String, uri: String, autoVerify: Boolean )
+@(senderName: String, organizationName: String, inviteTokenValue: String, uri: String, autoVerify: Boolean, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 
   <p>Hello,</p>
 

--- a/app/views/mail/jobFailedGeneric.scala.html
+++ b/app/views/mail/jobFailedGeneric.scala.html
@@ -1,11 +1,11 @@
-@(name: String, datasetName: String, jobTitle: String)
+@(name: String, datasetName: String, jobTitle: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name},</p>
 
 <p>
   oops, something unexpected went wrong when working on your WEBKNOSSOS @{jobTitle} job for the <i>@{datasetName}</i> dataset.
-  This should not have happened and we are sorry about the inconvenience. Our engineers will investigate and fix the problem as soon as possible. 
+  This should not have happened and we are sorry about the inconvenience. Our engineers will investigate and fix the problem as soon as possible.
 </p>
 <p>
 Feel free to contact us via email for assistance or please try again later.
@@ -16,7 +16,7 @@ Feel free to contact us via email for assistance or please try again later.
 <div style="text-align: center;">
   <img src="https://static.webknossos.org/mails/email-drawing-failed-job.png"
     srcset="https://static.webknossos.org/mails/email-drawing-failed-job.svg"
-    alt="A person dismayed about an unsuccessful WEBKNOSSOS job" 
+    alt="A person dismayed about an unsuccessful WEBKNOSSOS job"
     style="width: 460px; height: 258px; margin-top: 10px; margin-bottom: 20px" />
 </div>
 

--- a/app/views/mail/jobFailedUploadConvert.scala.html
+++ b/app/views/mail/jobFailedUploadConvert.scala.html
@@ -1,10 +1,10 @@
-@(name: String, datasetName: String)
+@(name: String, datasetName: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name},</p>
 
 <p>
-  oops, unfortunately WEBKNOSSOS could not upload and convert your dataset <i>@{datasetName}</i> automatically. 
+  oops, unfortunately WEBKNOSSOS could not upload and convert your dataset <i>@{datasetName}</i> automatically.
   This should not have happened and we are sorry about the inconvenience. Our engineers will investigate and fix the
   problem as soon as possible.
 </p>

--- a/app/views/mail/jobSuccessfulGeneric.scala.html
+++ b/app/views/mail/jobSuccessfulGeneric.scala.html
@@ -1,9 +1,9 @@
-@(name: String, datasetName: String, jobLink: String, jobTitle: String, jobDescription: String)
+@(name: String, datasetName: String, jobLink: String, jobTitle: String, jobDescription: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name},</p>
 
-<p>We wanted to let you know that WEBKNOSSOS has finished your background job for the dataset <i>@{datasetName}</i>. 
+<p>We wanted to let you know that WEBKNOSSOS has finished your background job for the dataset <i>@{datasetName}</i>.
 <p>@{jobDescription}</p>
 
 <div style="text-align: center;">
@@ -28,9 +28,9 @@
 <p>With best regards,<br />the WEBKNOSSOS team</p>
 
 <div style="text-align: center;">
-  <img src="https://static.webknossos.org/mails/email-drawing-successful-job.png" 
-    srcset="https://static.webknossos.org/mails/email-drawing-successful-job.svg" 
-    alt="A person celebrating a successful WEBKNOSSOS job" 
+  <img src="https://static.webknossos.org/mails/email-drawing-successful-job.png"
+    srcset="https://static.webknossos.org/mails/email-drawing-successful-job.svg"
+    alt="A person celebrating a successful WEBKNOSSOS job"
     style="width: 460px; height: 307px; margin-top: 10px; margin-bottom: 20px;"/>
 </div>
 }

--- a/app/views/mail/jobSuccessfulSegmentation.scala.html
+++ b/app/views/mail/jobSuccessfulSegmentation.scala.html
@@ -1,11 +1,11 @@
-@(name: String, datasetName: String, jobLink: String, jobTitle: String)
+@(name: String, datasetName: String, jobLink: String, jobTitle: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name},</p>
 
 <p>
-  Your @{jobTitle} is ready for exploration. 
-  WEBKNOSSOS successfully applied our machine learning models on the specific subset of the <i>@{datasetName}</i> dataset. 
+  Your @{jobTitle} is ready for exploration.
+  WEBKNOSSOS successfully applied our machine learning models on the specific subset of the <i>@{datasetName}</i> dataset.
   Click the button below to open the dataset or find it amongst your other dataset in the WEBKNOSSOS dashboard.
 </p>
 
@@ -41,7 +41,7 @@
   Do you want to make corrections to the automated segmentation? Use the easy-to-use, built-in <a href="https://docs.webknossos.org/webknossos/proofreading/tools.html">proof-reading tools in WEBKNOSSOS</a> (requires Power plan).
 </p>
 <div style="text-align: center; margin-bottom: 20px;">
-  <img src="https://static.webknossos.org/mails/email-proofreading-preview.600.jpg" 
+  <img src="https://static.webknossos.org/mails/email-proofreading-preview.600.jpg"
     alt="A preview of the proofreading tools for a segmentation of a WEBKNOSSOS dataset"
     style="width: 600px; height: 300px;" />
 </div>

--- a/app/views/mail/jobSuccessfulUploadConvert.scala.html
+++ b/app/views/mail/jobSuccessfulUploadConvert.scala.html
@@ -1,11 +1,11 @@
-@(name: String, datasetName: String, jobLink: String)
+@(name: String, datasetName: String, jobLink: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name},</p>
 
 <p>
-  Your dataset @{datasetName} is ready for exploration. 
-  WEBKNOSSOS has successfully uploaded and converted the dataset. 
+  Your dataset @{datasetName} is ready for exploration.
+  WEBKNOSSOS has successfully uploaded and converted the dataset.
   Click the button below to open the dataset or find it amongst your other datasets in the WEBKNOSSOS dashboard.
 </p>
 
@@ -33,13 +33,13 @@
 </p>
 <div style="text-align: center; margin-top: 10px; margin-bottom: 6px;">
   <img src="https://static.webknossos.org/mails/email-alignment-preview.600.jpg"
-    alt="A preview of the alignment services for a WEBKNOSSOS dataset" 
+    alt="A preview of the alignment services for a WEBKNOSSOS dataset"
     style="width: 300px; height: 150px;" />
 </div>
 
 <div style="text-align: center; margin-bottom: 20px;">
   <img src="https://static.webknossos.org/mails/email-segmentation-preview.600.jpg"
-    alt="A preview of a full, automated segmentation of a WEBKNOSSOS dataset" 
+    alt="A preview of a full, automated segmentation of a WEBKNOSSOS dataset"
     style="width: 300px; height: 150px;" />
 </div>
 

--- a/app/views/mail/newUser.scala.html
+++ b/app/views/mail/newUser.scala.html
@@ -1,6 +1,6 @@
-@(name: String, enableAutoVerify: Boolean )
+@(name: String, enableAutoVerify: Boolean, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 
   <p>Hi @name,</p>
 

--- a/app/views/mail/notifyAdminNewOrganization.scala.html
+++ b/app/views/mail/notifyAdminNewOrganization.scala.html
@@ -1,6 +1,6 @@
-@( organizationName: String, creatorMail: String, domain: String )
+@( organizationName: String, creatorMail: String, domain: String, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
   <p>Hi,</p>
 
   <p>

--- a/app/views/mail/notifyAdminNewUser.scala.html
+++ b/app/views/mail/notifyAdminNewUser.scala.html
@@ -1,6 +1,6 @@
-@( username: String, uri: String, autoActivate: Boolean )
+@( username: String, uri: String, autoActivate: Boolean, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
   <p>Hi,</p>
 
   <p>A new user - @username - just registered a WEBKNOSSOS account for your <a href="@uri">organization.</a></p>

--- a/app/views/mail/notifyAdminTimeLimit.scala.html
+++ b/app/views/mail/notifyAdminTimeLimit.scala.html
@@ -1,8 +1,8 @@
-@(userName: String, projectName: String, taskId: String, annotationId: String, uri: String)
+@(userName: String, projectName: String, taskId: String, annotationId: String, uri: String, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
   <p>Hi,</p>
-  
+
   <p>
     We noticed a user reached the time limit for a project:
   </p>
@@ -13,7 +13,7 @@
       <li>Project: @{projectName}</li>
       <li>Task: @{taskId}</li>
     </ul>
-    
+
   </p>
   <p>For more information visit <a href="@{uri}/annotations/Task/@{annotationId}">@{uri}/annotations/Task/@{annotationId}</a></p>
 

--- a/app/views/mail/passwordChanged.scala.html
+++ b/app/views/mail/passwordChanged.scala.html
@@ -1,12 +1,12 @@
-@( name: String, uri: String )
+@( name: String, uri: String, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
   <p>Hi @name,</p>
 
   <p>
     The password for your WEBKNOSSOS account on <a href="@{uri}">@uri</a> has successfully been changed.
   </p>
-  
+
   <p>
     If you did not initiate this change, please contact your administrator immediately.
   </p>

--- a/app/views/mail/resetPassword.scala.html
+++ b/app/views/mail/resetPassword.scala.html
@@ -1,6 +1,6 @@
-@( name: String, uri: String, token: String)
+@( name: String, uri: String, token: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
   <p>Hi @name,</p>
   <p>
     You received this mail because you requested to change your password.

--- a/app/views/mail/upgradePricingPlanRequest.scala.html
+++ b/app/views/mail/upgradePricingPlanRequest.scala.html
@@ -1,6 +1,6 @@
-@(name: String, email: String, organizationName: String, messageBody: String)
+@(name: String, email: String, organizationName: String, messageBody: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi WEBKNOSSOS sales team</p>
 <p>There is a new request to upgrade a WEBKNOSSOS organization with additional plan/features.</p>
 <p>User: @{name} (<a href="mailto:@{email}">@{email}</a>)</p>

--- a/app/views/mail/upgradePricingPlanStorage.scala.html
+++ b/app/views/mail/upgradePricingPlanStorage.scala.html
@@ -1,9 +1,9 @@
-@(name: String, requestedStorage: Int)
+@(name: String, requestedStorage: Int, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name}</p>
 <p>Thank you for requesting to upgrade your WEBKNOSSOS plan with more storage. Our sales team will be in contact with you shortly with a formal offer.</p>
-  
+
 <p>Requested additional storage: @{requestedStorage}TB</p>
 
 <p>With best regards,<br />the WEBKNOSSOS team</p>

--- a/app/views/mail/upgradePricingPlanToPower.scala.html
+++ b/app/views/mail/upgradePricingPlanToPower.scala.html
@@ -1,6 +1,6 @@
-@( name: String)
+@( name: String, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name}</p>
 <p>Thank you for requesting an upgrade to a WEBKNOSSOS Power plan. Our sales team will be in contact with
   you shortly with a formal offer.</p>

--- a/app/views/mail/upgradePricingPlanToTeam.scala.html
+++ b/app/views/mail/upgradePricingPlanToTeam.scala.html
@@ -1,6 +1,6 @@
-@( name: String)
+@( name: String, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name}</p>
 <p>Thank you for requesting an upgrade to a WEBKNOSSOS Team plan. Our sales team will be in contact with
   you shortly with a formal offer.</p>

--- a/app/views/mail/upgradePricingPlanUsers.scala.html
+++ b/app/views/mail/upgradePricingPlanUsers.scala.html
@@ -1,6 +1,6 @@
-@( name: String, requestedUsers: Int)
+@( name: String, requestedUsers: Int, additionalFooter: String)
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
 <p>Hi @{name}</p>
 <p>Thank you for requesting to upgrade your WEBKNOSSOS plan with more users. Our sales team will be in contact with
   you shortly with a formal offer.</p>

--- a/app/views/mail/validateUser.scala.html
+++ b/app/views/mail/validateUser.scala.html
@@ -1,6 +1,6 @@
-@( name: String, uri: String )
+@( name: String, uri: String, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
   <p>Hi @name,</p>
 
   <p>

--- a/app/views/mail/verifyEmail.scala.html
+++ b/app/views/mail/verifyEmail.scala.html
@@ -1,6 +1,6 @@
-@( name: String, url: String, linkExpiry: String )
+@( name: String, url: String, linkExpiry: String, additionalFooter: String )
 
-@emailBaseTemplate() {
+@emailBaseTemplate(additionalFooter) {
   <p>Hi @name,</p>
 
   <p>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -241,7 +241,7 @@ mail {
     pass = ""
   }
   defaultSender = "WEBKNOSSOS <no-reply@webknossos.org>"
-  additionalFooter = ""
+  additionalFooter = "" # Additional line added to the email footer. HTML can be used here, won’t be escaped but inserted directly.
   mailchimp {
     host = ""
     listId = ""

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -231,7 +231,7 @@ proxy {
 
 # Send emails to users and admins
 mail {
-  logToStdout = false # To protect privacy, always set to false in production
+  logToStdout = true # To protect privacy, always set to false in production
   smtp {
     host = ""
     port = 465
@@ -241,6 +241,7 @@ mail {
     pass = ""
   }
   defaultSender = "WEBKNOSSOS <no-reply@webknossos.org>"
+  additionalFooter = additionalFooter = """<a href="https://webknossos.org" style="color: #888;">webknossos.org</a> is a service by <a href="https://scalableminds.com">scalable minds</a> &bull; <a href="mailto:hello@webknossos.org" style="color: #888;">hello@webknossos.org</a>"""
   mailchimp {
     host = ""
     listId = ""

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -231,7 +231,7 @@ proxy {
 
 # Send emails to users and admins
 mail {
-  logToStdout = true # To protect privacy, always set to false in production
+  logToStdout = false # To protect privacy, always set to false in production
   smtp {
     host = ""
     port = 465
@@ -241,7 +241,7 @@ mail {
     pass = ""
   }
   defaultSender = "WEBKNOSSOS <no-reply@webknossos.org>"
-  additionalFooter = additionalFooter = """<a href="https://webknossos.org" style="color: #888;">webknossos.org</a> is a service by <a href="https://scalableminds.com">scalable minds</a> &bull; <a href="mailto:hello@webknossos.org" style="color: #888;">hello@webknossos.org</a>"""
+  additionalFooter = ""
   mailchimp {
     host = ""
     listId = ""


### PR DESCRIPTION
New config option `mail.additionalFooter` to supply a html line for the email template.

The old behavior can be restored with `mail.additionalFooter = """<a href="https://webknossos.org" style="color: #888;">webknossos.org</a> is a service by <a href="https://scalableminds.com">scalable minds</a> &bull; <a href="mailto:hello@webknossos.org" style="color: #888;">hello@webknossos.org</a>"""`

### Steps to test:
- Insert content to `mail.additionalFooter`, set `mail.logToStdout = true`, register new user, see backend logging for full email content.

### Issues:
- fixes #8291
