### PR TITLE
Avoid SQL error in case of duplicate mag in datasource-properties

### DIFF
--- a/app/models/dataset/Dataset.scala
+++ b/app/models/dataset/Dataset.scala
@@ -723,7 +723,7 @@ class DatasetMagsDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionConte
   def updateMags(datasetId: ObjectId, dataLayersOpt: Option[List[DataLayer]]): Fox[Unit] = {
     val clearQuery = q"DELETE FROM webknossos.dataset_mags WHERE _dataset = $datasetId".asUpdate
     val insertQueries = dataLayersOpt.getOrElse(List.empty).flatMap { layer: DataLayer =>
-      layer.resolutions.map { mag: Vec3Int =>
+      layer.resolutions.distinct.map { mag: Vec3Int =>
         {
           q"""INSERT INTO webknossos.dataset_mags(_dataset, dataLayerName, mag)
                 VALUES($datasetId, ${layer.name}, $mag)""".asUpdate


### PR DESCRIPTION
### Steps to test:
- Edit a datasource-properties.json to contain a duplicate mag
- Reload that dataset from the dashboard
- Backend logging should not show SQL error
- Viewing + Annotating on the dataset should (continue to) work with a nice distinct mag list.

### Issues:
- fixes https://github.com/scalableminds/webknossos/issues/8338

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
