### PR TITLE
Redirect rather than proxy to about page

### DIFF
--- a/MIGRATIONS.unreleased.md
+++ b/MIGRATIONS.unreleased.md
@@ -10,6 +10,7 @@ User-facing changes are documented in the [changelog](CHANGELOG.released.md).
 - Removed support for HTTP API versions 3 and 4. [#8075](https://github.com/scalableminds/webknossos/pull/8075)
 - New FossilDB version `0.1.33` (docker image `scalableminds/fossildb:master__504`) is required.
 - Datastore config options `datastore.baseFolder` and `localFolderWhitelist` to `datastore.baseDirectory` and `localDirectoryWhitelist` respectively, to avoid confusion with the dashboard folders. [#8292](https://github.com/scalableminds/webknossos/pull/8292)
+- config options `proxy.prefix` and `proxy.routes` were renamed to `aboutPageRedirect.prefix` and `aboutPageRedirect.routes` (as we no longer proxy, but redirect). [#8344](https://github.com/scalableminds/webknossos/pull/8344)
 
 ### Postgres Evolutions:
 - [124-decouple-dataset-directory-from-name](conf/evolutions/124-decouple-dataset-directory-from-name)

--- a/app/RequestHandler.scala
+++ b/app/RequestHandler.scala
@@ -1,6 +1,6 @@
 import com.scalableminds.util.mvc.{CspHeaders, ExtendedController}
 import com.typesafe.scalalogging.LazyLogging
-import controllers.{Assets, SitemapController, WkorgProxyController}
+import controllers.{Assets, SitemapController, AboutPageRedirectController}
 
 import javax.inject.Inject
 import play.api.OptionalDevContext
@@ -18,7 +18,7 @@ class RequestHandler @Inject()(webCommands: WebCommands,
                                router: Router,
                                errorHandler: HttpErrorHandler,
                                httpConfiguration: HttpConfiguration,
-                               wkorgProxyController: WkorgProxyController,
+                               aboutPageRedirectController: AboutPageRedirectController,
                                filters: HttpFilters,
                                val cspConfig: CSPConfig,
                                conf: WkConf,
@@ -55,7 +55,7 @@ class RequestHandler @Inject()(webCommands: WebCommands,
       Some(Action { Ok("").as("text/javascript") })
     } else if (request.uri == "/favicon.ico") {
       Some(Action { NotFound })
-    } else Some(wkorgProxyController.proxyPageOrMainView)
+    } else Some(aboutPageRedirectController.redirectToAboutPageOrSendMainView)
 
   private def assetWithCsp(requestHeader: RequestHeader) = Action.async { implicit request =>
     addCspHeader(asset(requestHeader))

--- a/app/controllers/AboutPageRedirectController.scala
+++ b/app/controllers/AboutPageRedirectController.scala
@@ -26,7 +26,7 @@ class AboutPageRedirectController @Inject()(conf: WkConf,
 
   def redirectToAboutPageOrSendMainView: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     if (matchesRedirectRoute(request)) {
-      Fox.successful(Redirect(conf.AboutPageRedirect.prefix + request.uri))
+      Fox.successful(Redirect(conf.AboutPageRedirect.prefix + request.uri, status = MOVED_PERMANENTLY))
     } else {
       for {
         multiUserOpt <- Fox.runOptional(request.identity)(user =>

--- a/app/controllers/AboutPageRedirectController.scala
+++ b/app/controllers/AboutPageRedirectController.scala
@@ -26,7 +26,8 @@ class AboutPageRedirectController @Inject()(conf: WkConf,
 
   def redirectToAboutPageOrSendMainView: Action[AnyContent] = sil.UserAwareAction.async { implicit request =>
     if (matchesRedirectRoute(request)) {
-      Fox.successful(Redirect(conf.AboutPageRedirect.prefix + request.uri, status = MOVED_PERMANENTLY))
+      val status = if (request.uri == "/") SEE_OTHER else MOVED_PERMANENTLY
+      Fox.successful(Redirect(conf.AboutPageRedirect.prefix + request.uri, status = status))
     } else {
       for {
         multiUserOpt <- Fox.runOptional(request.identity)(user =>

--- a/app/utils/SitemapWriter.scala
+++ b/app/utils/SitemapWriter.scala
@@ -20,7 +20,7 @@ case class SitemapURL(url: String,
 
 class SitemapWriter @Inject()(publicationDAO: PublicationDAO, wkConf: WkConf)(implicit ec: ExecutionContext)
     extends FoxImplicits {
-  private val proxyURLs = wkConf.Proxy.routes.filter(!_.contains("*")).map(SitemapURL(_))
+  private val proxyURLs = wkConf.AboutPageRedirect.routes.filter(!_.contains("*")).map(SitemapURL(_))
   private lazy val outputFactory = XMLOutputFactory.newInstance()
 
   def getSitemap(prefix: String): Fox[String] = {

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -136,9 +136,9 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
     val publicUri: Option[String] = getOptional[String]("tracingstore.publicUri")
   }
 
-  object Proxy {
-    val prefix: String = get[String]("proxy.prefix")
-    val routes: List[String] = getList[String]("proxy.routes")
+  object AboutPageRedirect {
+    val prefix: String = get[String]("aboutPageRedirect.prefix")
+    val routes: List[String] = getList[String]("aboutPageRedirect.routes")
   }
 
   object Mail {
@@ -250,7 +250,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
       Features,
       Tracingstore,
       Datastore,
-      Proxy,
+      AboutPageRedirect,
       Mail,
       Silhouette,
       Jobs,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -223,8 +223,8 @@ datastore {
   agglomerateSkeleton.maxEdges = 1000000
 }
 
-# Proxy some routes to prefix + route (only if features.isWkorgInstance, route "/" only if logged out)
-proxy {
+# Redirect some routes to prefix + route (only if features.isWkorgInstance, route "/" only if logged out)
+aboutPageRedirect {
   prefix = ""
   routes = []
 }


### PR DESCRIPTION
We decided to no longer the about page to the same domain as wk, but use a redirect to a subdomain. This PR implements the wk side of this change.

### Steps to test:
- In application.conf, set `isWkOrgInstance.true`, set `aboutPageRedirect.prefix` to the target root address, and `aboutPagePredirect.routes` to a list of test url paths (e.g. `["/test.html"]`
- visiting `localhost:9000/test.html` should redirect to `targetHost/test.html`

------
- [x] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
