### PR TITLE
Fix UAV migration bug: look up editableMappingsInfo versions in correct list

### DIFF
--- a/tools/migration-unified-annotation-versioning/add_editable_mapping_info.py
+++ b/tools/migration-unified-annotation-versioning/add_editable_mapping_info.py
@@ -1,0 +1,36 @@
+import logging
+from utils import setup_logging, log_since
+import argparse
+from connections import connect_to_fossildb, assert_grpc_success
+import time
+import fossildbapi_pb2 as proto
+
+
+logger = logging.getLogger("migration-logs")
+
+
+def main():
+    logger.info("Hello from add_editable_mapping_info")
+    setup_logging()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fossil", type=str, help="Fossildb host and port. Example: localhost:7155", required=True)
+    parser.add_argument("--editable_mapping_info_file", type=str, help="path to binary input file to put", required=True)
+    parser.add_argument("--tracingId", type=str, help="tracingId to put the entry to", required=True)
+    parser.add_argument("--version", type=int, help="version number to put the entry to", required=True)
+    args = parser.parse_args()
+    before = time.time()
+    stub = connect_to_fossildb(args.fossil, "target")
+    with open(args.editable_mapping_info_file, 'rb') as infile:
+        bytes_to_put = infile.read()
+
+    logger.info(f"putting {len(bytes_to_put)} bytes of type {type(bytes_to_put)} at {args.tracingId} v{args.version}")
+    reply = stub.Put(proto.PutRequest(collection="editableMappingsInfo", key=args.tracingId, version=args.version, value=bytes_to_put))
+    assert_grpc_success(reply)
+    log_since(before, "Inserting one editable mapping info entry")
+
+
+
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/migration-unified-annotation-versioning/migration.py
+++ b/tools/migration-unified-annotation-versioning/migration.py
@@ -443,7 +443,6 @@ class Migration:
             logger.info(f"Migrating segment index with large batch sizes for {tracing_id} failed with {e}, retrying with small batch sizes...")
             self.migrate_all_versions_and_keys_with_prefix("volumeSegmentIndex", tracing_id, layer_version_mapping, transform_key=None, put_buffer_size=10, get_keys_page_size=1, get_keys_version_batch_size=1000)
 
-
     def migrate_editable_mapping(self, tracing_id: str, layer_version_mapping: LayerVersionMapping, mapping_id_map: MappingIdMap) -> List[int]:
         if tracing_id not in mapping_id_map:
             return []
@@ -458,9 +457,9 @@ class Migration:
         materialized_versions = self.list_versions(collection, mapping_id)
         materialized_versions_unified = []
         for materialized_version in materialized_versions:
-            value_bytes = self.get_bytes(collection, mapping_id, materialized_version)
-            if materialized_version not in layer_version_mapping[tracing_id]:
+            if materialized_version not in layer_version_mapping[mapping_id]:
                 continue
+            value_bytes = self.get_bytes(collection, mapping_id, materialized_version)
             new_version = layer_version_mapping[mapping_id][materialized_version]
             materialized_versions_unified.append(new_version)
             self.save_bytes(collection, tracing_id, new_version, value_bytes)


### PR DESCRIPTION

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
