### PR TITLE
Fix flood fill tool for coarse mags

### DIFF
--- a/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/data_cube.ts
@@ -696,22 +696,27 @@ class DataCube {
               currentGlobalBucketPosition,
               V3.scale3(adjustedNeighbourVoxelXyz, currentMag),
             );
+            // When flood filling in a coarser mag, a voxel in the coarse mag is more than one voxel in mag 1
+            const voxelBoundingBoxInMag1 = new BoundingBox({
+              min: currentGlobalPosition,
+              max: V3.add(currentGlobalPosition, currentMag),
+            });
 
             if (bucketData[neighbourVoxelIndex] === sourceSegmentId) {
-              if (floodfillBoundingBox.containsPoint(currentGlobalPosition)) {
+              if (floodfillBoundingBox.intersectedWith(voxelBoundingBoxInMag1).getVolume() > 0) {
                 bucketData[neighbourVoxelIndex] = segmentId;
                 markUvwInSliceAsLabeled(neighbourVoxelUvw);
                 neighbourVoxelStackUvw.pushVoxel(neighbourVoxelUvw);
                 labeledVoxelCount++;
 
-                coveredBBoxMin[0] = Math.min(coveredBBoxMin[0], currentGlobalPosition[0]);
-                coveredBBoxMin[1] = Math.min(coveredBBoxMin[1], currentGlobalPosition[1]);
-                coveredBBoxMin[2] = Math.min(coveredBBoxMin[2], currentGlobalPosition[2]);
+                coveredBBoxMin[0] = Math.min(coveredBBoxMin[0], voxelBoundingBoxInMag1.min[0]);
+                coveredBBoxMin[1] = Math.min(coveredBBoxMin[1], voxelBoundingBoxInMag1.min[1]);
+                coveredBBoxMin[2] = Math.min(coveredBBoxMin[2], voxelBoundingBoxInMag1.min[2]);
 
                 // The maximum is exclusive which is why we add 1 to the position
-                coveredBBoxMax[0] = Math.max(coveredBBoxMax[0], currentGlobalPosition[0] + 1);
-                coveredBBoxMax[1] = Math.max(coveredBBoxMax[1], currentGlobalPosition[1] + 1);
-                coveredBBoxMax[2] = Math.max(coveredBBoxMax[2], currentGlobalPosition[2] + 1);
+                coveredBBoxMax[0] = Math.max(coveredBBoxMax[0], voxelBoundingBoxInMag1.max[0] + 1);
+                coveredBBoxMax[1] = Math.max(coveredBBoxMax[1], voxelBoundingBoxInMag1.max[1] + 1);
+                coveredBBoxMax[2] = Math.max(coveredBBoxMax[2], voxelBoundingBoxInMag1.max[2] + 1);
 
                 if (labeledVoxelCount % 1000000 === 0) {
                   console.log(`Labeled ${labeledVoxelCount} Vx. Continuing...`);

--- a/frontend/javascripts/oxalis/model/sagas/volume/floodfill_saga.tsx
+++ b/frontend/javascripts/oxalis/model/sagas/volume/floodfill_saga.tsx
@@ -41,7 +41,24 @@ export function* floodFill(): Saga<void> {
   yield* takeEvery("FLOOD_FILL", handleFloodFill);
 }
 
-function* getBoundingBoxForFloodFillWhenRestricted(position: Vector3, currentViewport: OrthoView) {
+function getMaximumBoundingBoxForFloodFill(
+  fillMode: FillMode,
+  finestSegmentationLayerMag: Vector3,
+): Vector3 {
+  const maximumBoundingBoxMag1 = Constants.FLOOD_FILL_EXTENTS[fillMode];
+  // If the finest mag of the segmentation layer is restricted, the maximum bounding box can be larger
+  const maximumBoundingBoxInFinestMag = V3.scale3(
+    maximumBoundingBoxMag1,
+    finestSegmentationLayerMag,
+  );
+  return maximumBoundingBoxInFinestMag;
+}
+
+function* getBoundingBoxForFloodFillWhenRestricted(
+  position: Vector3,
+  currentViewport: OrthoView,
+  finestSegmentationLayerMag: Vector3,
+) {
   const fillMode = yield* select((state) => state.userConfiguration.fillMode);
   const bboxes = yield* select((state) => getUserBoundingBoxesThatContainPosition(state, position));
   if (bboxes.length === 0) {
@@ -52,9 +69,12 @@ function* getBoundingBoxForFloodFillWhenRestricted(position: Vector3, currentVie
   }
   const smallestBbox = _.sortBy(bboxes, (bbox) => new BoundingBox(bbox.boundingBox).getVolume())[0];
 
-  const maximumVoxelSize =
-    Constants.FLOOD_FILL_MULTIPLIER_FOR_BBOX_RESTRICTION *
-    V3.prod(Constants.FLOOD_FILL_EXTENTS[fillMode]);
+  const maxBbox = yield* call(
+    getMaximumBoundingBoxForFloodFill,
+    fillMode,
+    finestSegmentationLayerMag,
+  );
+  const maxBboxVolume = Constants.FLOOD_FILL_MULTIPLIER_FOR_BBOX_RESTRICTION * V3.prod(maxBbox);
   const bboxObj = new BoundingBox(smallestBbox.boundingBox);
 
   const bboxVolume =
@@ -64,9 +84,9 @@ function* getBoundingBoxForFloodFillWhenRestricted(position: Vector3, currentVie
         V2.prod(
           Dimensions.getIndices(currentViewport).map((idx) => bboxObj.getSize()[idx]) as Vector2,
         );
-  if (bboxVolume > maximumVoxelSize) {
+  if (bboxVolume > maxBboxVolume) {
     return {
-      failureReason: `The bounding box that encloses the clicked position is too large. Shrink its size so that it does not contain more than ${maximumVoxelSize} voxels.`,
+      failureReason: `The bounding box that encloses the clicked position is too large, containing ${bboxVolume} voxels. Shrink its size so that it does not contain more than ${maxBboxVolume} voxels.`,
     };
   }
   return smallestBbox.boundingBox;
@@ -75,18 +95,24 @@ function* getBoundingBoxForFloodFillWhenRestricted(position: Vector3, currentVie
 function* getBoundingBoxForFloodFillWhenUnrestricted(
   position: Vector3,
   currentViewport: OrthoView,
+  finestSegmentationLayerMag: Vector3,
 ) {
   const fillMode = yield* select((state) => state.userConfiguration.fillMode);
-  const halfBoundingBoxSizeUVW = V3.scale(Constants.FLOOD_FILL_EXTENTS[fillMode], 0.5);
+  const maxBoundingBox = yield* call(
+    getMaximumBoundingBoxForFloodFill,
+    fillMode,
+    finestSegmentationLayerMag,
+  );
+  const halfBoundingBoxSize = V3.scale(maxBoundingBox, 0.5);
   const currentViewportBounding = {
-    min: V3.sub(position, halfBoundingBoxSizeUVW),
-    max: V3.add(position, halfBoundingBoxSizeUVW),
+    min: V3.sub(position, halfBoundingBoxSize),
+    max: V3.add(position, halfBoundingBoxSize),
   };
 
   if (fillMode === FillModeEnum._2D) {
     // Only use current plane
     const thirdDimension = Dimensions.thirdDimensionForPlane(currentViewport);
-    const numberOfSlices = 1;
+    const numberOfSlices = finestSegmentationLayerMag[thirdDimension];
     currentViewportBounding.min[thirdDimension] = position[thirdDimension];
     currentViewportBounding.max[thirdDimension] = position[thirdDimension] + numberOfSlices;
   }
@@ -104,14 +130,25 @@ function* getBoundingBoxForFloodFillWhenUnrestricted(
 function* getBoundingBoxForFloodFill(
   position: Vector3,
   currentViewport: OrthoView,
+  finestSegmentationLayerMag: Vector3,
 ): Saga<BoundingBoxType | { failureReason: string }> {
   const isRestrictedToBoundingBox = yield* select(
     (state) => state.userConfiguration.isFloodfillRestrictedToBoundingBox,
   );
   if (isRestrictedToBoundingBox) {
-    return yield* call(getBoundingBoxForFloodFillWhenRestricted, position, currentViewport);
+    return yield* call(
+      getBoundingBoxForFloodFillWhenRestricted,
+      position,
+      currentViewport,
+      finestSegmentationLayerMag,
+    );
   } else {
-    return yield* call(getBoundingBoxForFloodFillWhenUnrestricted, position, currentViewport);
+    return yield* call(
+      getBoundingBoxForFloodFillWhenUnrestricted,
+      position,
+      currentViewport,
+      finestSegmentationLayerMag,
+    );
   }
 }
 
@@ -172,7 +209,13 @@ function* handleFloodFill(floodFillAction: FloodFillAction): Saga<void> {
   if (!isModificationAllowed) {
     return;
   }
-  const boundingBoxForFloodFill = yield* call(getBoundingBoxForFloodFill, seedPosition, planeId);
+  const finestSegmentationLayerMag = magInfo.getFinestMag();
+  const boundingBoxForFloodFill = yield* call(
+    getBoundingBoxForFloodFill,
+    seedPosition,
+    planeId,
+    finestSegmentationLayerMag,
+  );
   if ("failureReason" in boundingBoxForFloodFill) {
     Toast.warning(boundingBoxForFloodFill.failureReason, {
       key: NO_FLOODFILL_BBOX_TOAST_KEY,


### PR DESCRIPTION
The 2D flood fill tool did not work properly when flood filling in a mag other than the finest one if the "third-dimension" coordinate was not divisible by the respective mag. This resulted in early-out flood fills only filling a single or a few voxels.
Also, this commit adjusts the flood fill maximum bounding size limits if the segmentation layer's finest mag is not 1. This allows to use the flood fill tool in coarser mags if the segmentation layer is properly mag-restricted.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- To test the fix for 2D flood fill for coarse mags
  - Create an annotation with the volume layer restricted to mag 16.
  - Zoom out to mag 16.
  - Activate the flood fill tool in 2D and relabel a segment (on master this only works if the z-position is divisible by the z-component of mag 16, otherwise a single or only a few voxels are labeled)
- To test the adjusted bbox size limit:
  - Create an annotation with the volume layer restricted to mag 16.
  - Create a bounding box of size 1280³ vx and perform a brush stroke inside.
  - Zoom out to mag 16.
  - Activate the flood fill tool in 3D, activate the bbox restriction, and try to use it to relabel the brushed segment.

### Issues:
- fixes #8366 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
