### PR TITLE
Support reading Blosc-compressed data chunks with autoshuffle

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - When using the “Restore older Version” feature, there are no longer separate tabs for the different annotation layers. Only one linear annotation history is now used, and if you revert to an older version, all layers are reverted. If layers were added/deleted since then, that is also reverted. This also means that proofreading annotations can now be reverted to older versions as well. The description text of annotations is now versioned as well. [#7917](https://github.com/scalableminds/webknossos/pull/7917)
 - Added the possibility to use the "merger mode" even when the user has annotated volume data in the current layer (as long as no other mapping is active). [#8335](https://github.com/scalableminds/webknossos/pull/8335)
 - Measurement tools are now accessible when viewing datasets outside of an annotation. [#8334](https://github.com/scalableminds/webknossos/pull/8334)
+- Support reading Blosc-Compressed datasets with “autoshuffle”. [#8387](https://github.com/scalableminds/webknossos/pull/8387)
 
 ### Changed
 - Improved the scrolling behaviour of sliders: Sliders must be focused to scroll them. Additionally, parent element scrolling is prevented when using the slider. [#8321](https://github.com/scalableminds/webknossos/pull/8321) [#8321](https://github.com/scalableminds/webknossos/pull/8321)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - When using the “Restore older Version” feature, there are no longer separate tabs for the different annotation layers. Only one linear annotation history is now used, and if you revert to an older version, all layers are reverted. If layers were added/deleted since then, that is also reverted. This also means that proofreading annotations can now be reverted to older versions as well. The description text of annotations is now versioned as well. [#7917](https://github.com/scalableminds/webknossos/pull/7917)
 - Added the possibility to use the "merger mode" even when the user has annotated volume data in the current layer (as long as no other mapping is active). [#8335](https://github.com/scalableminds/webknossos/pull/8335)
 - Measurement tools are now accessible when viewing datasets outside of an annotation. [#8334](https://github.com/scalableminds/webknossos/pull/8334)
-- Support reading Blosc-Compressed datasets with “autoshuffle”. [#8387](https://github.com/scalableminds/webknossos/pull/8387)
+- Support reading Blosc-compressed datasets with the “autoshuffle” parameter. [#8387](https://github.com/scalableminds/webknossos/pull/8387)
 
 ### Changed
 - Improved the scrolling behaviour of sliders: Sliders must be focused to scroll them. Additionally, parent element scrolling is prevented when using the slider. [#8321](https://github.com/scalableminds/webknossos/pull/8321) [#8321](https://github.com/scalableminds/webknossos/pull/8321)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
@@ -198,7 +198,7 @@ object BloscCompressor {
   val defaultShuffle: Int = BYTESHUFFLE
   val keyBlocksize = "blocksize"
   val defaultBlocksize = 0
-  val supportedShuffle: List[Int] = List(NOSHUFFLE, BYTESHUFFLE, BITSHUFFLE)
+  val supportedShuffle: List[Int] = List(AUTOSHUFFLE, NOSHUFFLE, BYTESHUFFLE, BITSHUFFLE)
   val supportedCnames: List[String] = List("zstd", "blosclz", defaultCname, "lz4hc", "zlib")
   val keyTypesize = "typesize"
   val defaultTypesize = 1
@@ -241,11 +241,11 @@ class BloscCompressor(val properties: Map[String, CompressionSetting]) extends C
 
   private def validateShuffle(shuffle: Int): Int = {
     val supportedShuffleNames =
-      List("0 (NOSHUFFLE)", "1 (BYTESHUFFLE)", "2 (BITSHUFFLE)")
+      List("-1 (AUTOSHUFFLE), 0 (NOSHUFFLE)", "1 (BYTESHUFFLE)", "2 (BITSHUFFLE)")
 
     if (!BloscCompressor.supportedShuffle.contains(shuffle))
       throw new IllegalArgumentException(
-        "blosc: shuffle type not supported: '" + shuffle + "'; expected one of " + supportedShuffleNames.mkString(","))
+        f"blosc: shuffle type '$shuffle' not supported. Expected one of ${supportedShuffleNames.mkString(",")}")
     shuffle
   }
 


### PR DESCRIPTION
Turns out the error didn’t come from JBlosc, but our own implementation. @frcroth do you remember if there was a specific reason to originally reject AUTOSHUFFLE?

### URL of deployed dev instance (used for testing):
- https://autoshuffle.webknossos.xyz

### Steps to test:
- Import dataset from https://scm.slack.com/archives/C02H5T8Q08P/p1738766454436339 – should show data

### Issues:
- fixes #8381 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
