### PR TITLE
Fix inital loading of mappings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Changed
 
 ### Fixed
+- Fixed a bug that would lock a non existing mapping to an empty segmentation layer under certain conditions. [#8401](https://github.com/scalableminds/webknossos/pull/8401)
 
 ### Removed
 

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -132,12 +132,9 @@ class WkConf @Inject()(configuration: Configuration, certificateValidationServic
     val publicDemoDatasetUrl: String = get[String]("features.publicDemoDatasetUrl")
     val exportTiffMaxVolumeMVx: Long = get[Long]("features.exportTiffMaxVolumeMVx")
     val exportTiffMaxEdgeLengthVx: Long = get[Long]("features.exportTiffMaxEdgeLengthVx")
-    val openIdConnectEnabled: Boolean =
-      featureOverrides.getOrElse("openIdConnectEnabled", get[Boolean]("features.openIdConnectEnabled"))
-    val editableMappingsEnabled: Boolean =
-      featureOverrides.getOrElse("editableMappingsEnabled", get[Boolean]("features.editableMappingsEnabled"))
-    val segmentAnythingEnabled: Boolean =
-      featureOverrides.getOrElse("segmentAnythingEnabled", get[Boolean]("features.segmentAnythingEnabled"))
+    val openIdConnectEnabled: Boolean = get[Boolean]("features.openIdConnectEnabled")
+    val editableMappingsEnabled: Boolean = get[Boolean]("features.editableMappingsEnabled")
+    val segmentAnythingEnabled: Boolean = get[Boolean]("features.segmentAnythingEnabled")
   }
 
   object Datastore {

--- a/frontend/javascripts/oxalis/model/actions/volumetracing_actions.ts
+++ b/frontend/javascripts/oxalis/model/actions/volumetracing_actions.ts
@@ -381,14 +381,16 @@ export const dispatchFloodfillAsync = async (
   await readyDeferred.promise();
 };
 
-export const setHasEditableMappingAction = () =>
+export const setHasEditableMappingAction = (tracingId: string) =>
   ({
     type: "SET_HAS_EDITABLE_MAPPING",
+    tracingId,
   }) as const;
 
-export const setMappingIsLockedAction = () =>
+export const setMappingIsLockedAction = (tracingId: string) =>
   ({
     type: "SET_MAPPING_IS_LOCKED",
+    tracingId,
   }) as const;
 
 export const computeQuickSelectForRectAction = (

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -277,15 +277,29 @@ export function serverVolumeToClientVolumeTracing(tracing: ServerVolumeTracing):
   return volumeTracing;
 }
 
-function VolumeTracingReducer(
-  state: OxalisState,
-  action:
-    | VolumeTracingAction
-    | SetMappingAction
-    | FinishMappingInitializationAction
-    | SetMappingEnabledAction
-    | SetMappingNameAction,
-): OxalisState {
+type VolumeTracingReducerAction =
+  | VolumeTracingAction
+  | SetMappingAction
+  | FinishMappingInitializationAction
+  | SetMappingEnabledAction
+  | SetMappingNameAction;
+
+function retrieveVolumeTracing(state: OxalisState, action: VolumeTracingReducerAction) {
+  if ("tracingId" in action && action.tracingId != null) {
+    return getVolumeTracingById(state.tracing, action.tracingId);
+  }
+  const volumeLayer = getRequestedOrVisibleSegmentationLayer(
+    state,
+    "layerName" in action ? action.layerName : null,
+  );
+
+  if (volumeLayer == null || volumeLayer.tracingId == null) {
+    return null;
+  }
+  return getVolumeTracingById(state.tracing, volumeLayer.tracingId);
+}
+
+function VolumeTracingReducer(state: OxalisState, action: VolumeTracingReducerAction): OxalisState {
   switch (action.type) {
     case "INITIALIZE_VOLUMETRACING": {
       const volumeTracing = serverVolumeToClientVolumeTracing(action.tracing);
@@ -394,13 +408,10 @@ function VolumeTracingReducer(
     return state;
   }
 
-  const volumeLayer = getRequestedOrVisibleSegmentationLayer(state, null);
-
-  if (volumeLayer == null || volumeLayer.tracingId == null) {
+  const volumeTracing = retrieveVolumeTracing(state, action);
+  if (volumeTracing == null) {
     return state;
   }
-
-  const volumeTracing = getVolumeTracingById(state.tracing, volumeLayer.tracingId);
 
   switch (action.type) {
     case "SET_ACTIVE_CELL": {

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -286,7 +286,7 @@ type VolumeTracingReducerAction =
   | SetMappingEnabledAction
   | SetMappingNameAction;
 
-function retrieveVolumeTracing(state: OxalisState, action: VolumeTracingReducerAction) {
+function getVolumeTracingFromAction(state: OxalisState, action: VolumeTracingReducerAction) {
   if ("tracingId" in action && action.tracingId != null) {
     return getVolumeTracingById(state.tracing, action.tracingId);
   }
@@ -414,7 +414,7 @@ function VolumeTracingReducer(state: OxalisState, action: VolumeTracingReducerAc
     return state;
   }
 
-  const volumeTracing = retrieveVolumeTracing(state, action);
+  const volumeTracing = getVolumeTracingFromAction(state, action);
   if (volumeTracing == null) {
     return state;
   }

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer.ts
@@ -3,8 +3,10 @@ import DiffableMap from "libs/diffable_map";
 import * as Utils from "libs/utils";
 import { ContourModeEnum } from "oxalis/constants";
 import {
+  getLayerByName,
   getMappingInfo,
   getMaximumSegmentIdForLayer,
+  getVisibleSegmentationLayer,
 } from "oxalis/model/accessors/dataset_accessor";
 import {
   getRequestedOrVisibleSegmentationLayer,
@@ -288,15 +290,19 @@ function retrieveVolumeTracing(state: OxalisState, action: VolumeTracingReducerA
   if ("tracingId" in action && action.tracingId != null) {
     return getVolumeTracingById(state.tracing, action.tracingId);
   }
-  const volumeLayer = getRequestedOrVisibleSegmentationLayer(
-    state,
-    "layerName" in action ? action.layerName : null,
-  );
+  const maybeVolumeLayer =
+    "layerName" in action && action.layerName != null
+      ? getLayerByName(state.dataset, action.layerName)
+      : getVisibleSegmentationLayer(state);
 
-  if (volumeLayer == null || volumeLayer.tracingId == null) {
+  if (
+    maybeVolumeLayer == null ||
+    !("tracingId" in maybeVolumeLayer) ||
+    maybeVolumeLayer.tracingId == null
+  ) {
     return null;
   }
-  return getVolumeTracingById(state.tracing, volumeLayer.tracingId);
+  return getVolumeTracingById(state.tracing, maybeVolumeLayer.tracingId);
 }
 
 function VolumeTracingReducer(state: OxalisState, action: VolumeTracingReducerAction): OxalisState {

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.ts
@@ -20,10 +20,7 @@ import type {
   SegmentMap,
   VolumeTracing,
 } from "oxalis/store";
-import {
-  getMaximumSegmentIdForLayer,
-  getSegmentationLayerByName,
-} from "../accessors/dataset_accessor";
+import { getMaximumSegmentIdForLayer } from "../accessors/dataset_accessor";
 import { mapGroupsToGenerator } from "../accessors/skeletontracing_accessor";
 
 export function updateVolumeTracing(
@@ -181,22 +178,6 @@ export function setMappingNameReducer(
   // not stored in the back-end for now.
   if (mappingType !== "HDF5" || !isMappingEnabled) {
     mappingName = null;
-  }
-  if (mappingName) {
-    const { agglomerates, mappings } = getSegmentationLayerByName(
-      state.dataset,
-      volumeTracing.tracingId,
-    );
-    const listToSearchIn = mappingType === "HDF5" ? agglomerates : mappings;
-    if (
-      mappingType === "HDF5" &&
-      (listToSearchIn == null || listToSearchIn.indexOf(mappingName) === -1)
-    ) {
-      console.error(
-        `Cannot set mapping ${mappingName} of type ${mappingType} for volume tracing ${volumeTracing.tracingId} because it is not included in the mapping list of the data layer: ${listToSearchIn}.`,
-      );
-      return state;
-    }
   }
 
   return updateVolumeTracing(state, volumeTracing.tracingId, {

--- a/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.ts
+++ b/frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.ts
@@ -193,7 +193,7 @@ export function setMappingNameReducer(
       (listToSearchIn == null || listToSearchIn.indexOf(mappingName) === -1)
     ) {
       console.error(
-        `Cannot set mapping ${mappingName} of type ${mappingType} for volume tracing ${volumeTracing.tracingId} because it is not included in the agglomerate list of the data layer: ${agglomerates}.`,
+        `Cannot set mapping ${mappingName} of type ${mappingType} for volume tracing ${volumeTracing.tracingId} because it is not included in the mapping list of the data layer: ${listToSearchIn}.`,
       );
       return state;
     }

--- a/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/proofread_saga.ts
@@ -273,7 +273,7 @@ function* createEditableMapping(): Saga<string> {
   const layerName = volumeTracingId;
   const baseMappingName = volumeTracing.mappingName;
   yield* put(setMappingNameAction(layerName, volumeTracingId, "HDF5"));
-  yield* put(setHasEditableMappingAction());
+  yield* put(setHasEditableMappingAction(volumeTracingId));
   // Ensure a saved state so that the mapping is locked and editable before doing the first proofreading operation.
   yield* call([Model, Model.ensureSavedState]);
   const editableMapping: ServerEditableMapping = {

--- a/frontend/javascripts/oxalis/model/sagas/saga_helpers.ts
+++ b/frontend/javascripts/oxalis/model/sagas/saga_helpers.ts
@@ -64,7 +64,7 @@ export function askUserForLockingActiveMapping(
         // See https://github.com/scalableminds/webknossos/issues/5431 for more information.
         const activeMapping = activeMappingByLayer[volumeTracing.tracingId];
         if (activeMapping.mappingName) {
-          Store.dispatch(setMappingIsLockedAction());
+          Store.dispatch(setMappingIsLockedAction(volumeTracing.tracingId));
           const message = messages["tracing.locked_mapping_confirmed"](activeMapping.mappingName);
           Toast.info(message, { timeout: 10000 });
           console.log(message);
@@ -111,7 +111,7 @@ export function* ensureMaybeActiveMappingIsLocked(
       return error as EnsureMappingIsLockedReturnType;
     }
   } else {
-    yield* put(setMappingIsLockedAction());
+    yield* put(setMappingIsLockedAction(volumeTracing.tracingId));
     return { isMappingLockedIfNeeded: true, reason: "Locked that no mapping is active." };
   }
 }

--- a/frontend/javascripts/test/sagas/volumetracing/volumetracing_saga.spec.ts
+++ b/frontend/javascripts/test/sagas/volumetracing/volumetracing_saga.spec.ts
@@ -456,7 +456,11 @@ test("ensureMaybeActiveMappingIsLocked should lock an existing mapping to the an
 test("ensureMaybeActiveMappingIsLocked should lock 'no mapping' in case no mapping is active.", (t) => {
   const saga = ensureMaybeActiveMappingIsLocked(volumeTracing);
   saga.next();
-  expectValueDeepEqual(t, saga.next({}), put(VolumeTracingActions.setMappingIsLockedAction()));
+  expectValueDeepEqual(
+    t,
+    saga.next({}),
+    put(VolumeTracingActions.setMappingIsLockedAction(volumeTracing.tracingId)),
+  );
   t.true(saga.next().done);
 });
 
@@ -467,7 +471,7 @@ test("ensureMaybeActiveMappingIsLocked should lock 'no mapping' in case a mappin
   expectValueDeepEqual(
     t,
     saga.next({ [volumeTracing.tracingId]: jsonDummyMapping }),
-    put(VolumeTracingActions.setMappingIsLockedAction()),
+    put(VolumeTracingActions.setMappingIsLockedAction(volumeTracing.tracingId)),
   );
   t.true(saga.next().done);
 });
@@ -479,7 +483,7 @@ test("ensureMaybeActiveMappingIsLocked should lock 'no mapping' in case a JSON m
   expectValueDeepEqual(
     t,
     saga.next({ [volumeTracing.tracingId]: jsonDummyMapping }),
-    put(VolumeTracingActions.setMappingIsLockedAction()),
+    put(VolumeTracingActions.setMappingIsLockedAction(volumeTracing.tracingId)),
   );
   t.true(saga.next().done);
 });


### PR DESCRIPTION
There is currently a bug in the WEBKNOSSOS frontend that leads to mappings being loaded and set for the wrong layer under certain conditions. this PR aims to fix this. Moreover, I added an "assertion" to the code lines that update the mapping name to have a check whether that mapping acutally exists. Else the update is ignored and  an error is printed to the console as this state should never have been reached by a user and to make debugging easier.  

Regarding implementation details: The cause of the bug was that the reducer was working with segmentation layer retrieved by `getRequestedOrVisibleSegmentationLayer(state, null);` which completely disregarded the `volumeTracingId` potentially part of the action that was dispatched. My PR now "honors" a potentially passed `volumeTracingId` or `layerName` in an volume update action which is handled in the reducer after line 411 (in the new version of the code). 
Moreover, in lines 185ff. in `frontend/javascripts/oxalis/model/reducers/volumetracing_reducer_helpers.ts` before changing the mapping name I added code to ensure that this mapping name exists before accepting to update it for the data layer. 

### URL of deployed dev instance (used for testing):
- https://fixinitalloadingofmappings.webknossos.xyz

### Steps to test:
- You need a dataset with a segmentation layer with an agglomerate mapping.
- View this dataset and configure the segmentation layer's agglomerate mapping as default in the default view config (can easily be done in the dataset view in the left sidebar settings)
- Open an new annotation for that dataset form the dashboard and use the extra menu with the three dots. There configure to create a new layer without the existing fallback layer. 
- On the new empty segmentation layer draw around.
- Reload the annotation: No error about an agglomerate mapping that could not be found should be shown. Moreover, in the left settings the active segmentation layer without the fallback should not look like it has a locked agglomerate mapping.


### Issues:
- fixes this bug report: https://scm.slack.com/archives/C02H5T8Q08P/p1739806596969149

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
