### PR TITLE
In IntervalScheduler, keep Future-returning ticks overlap-free

### DIFF
--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import com.scalableminds.util.accesscontext.{AuthorizedAccessContext, GlobalAccessContext}
 import com.scalableminds.util.objectid.ObjectId
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.controllers.JobExportProperties
 import com.scalableminds.webknossos.datastore.models.UnfinishedUpload
@@ -32,6 +33,7 @@ import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.{WebknossosBearerTokenAuthenticatorService, WkSilhouetteEnvironment}
 import telemetry.SlackNotificationService
 import utils.WkConf
+import scala.concurrent.duration.DurationInt
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -184,26 +186,22 @@ class WKRemoteDataStoreController @Inject()(
     }
   }
 
-  def updateAll(name: String, key: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
-    dataStoreService.validateAccess(name, key) { dataStore =>
-      request.body.validate[List[InboxDataSource]] match {
-        case JsSuccess(dataSources, _) =>
-          for {
-            _ <- Fox.successful(
-              logger.info(s"Received dataset list from datastore '${dataStore.name}': " +
-                s"${dataSources.count(_.isUsable)} active, ${dataSources.count(!_.isUsable)} inactive datasets"))
-            existingIds <- datasetService.updateDataSources(dataStore, dataSources)(GlobalAccessContext)
-            _ <- datasetService.deactivateUnreportedDataSources(existingIds, dataStore)
-          } yield {
-            JsonOk
-          }
-
-        case e: JsError =>
-          logger.warn("Data store reported invalid json for data sources.")
-          Fox.successful(JsonBadRequest(JsError.toJson(e)))
+  def updateAll(name: String, key: String): Action[List[InboxDataSource]] =
+    Action.async(validateJson[List[InboxDataSource]]) { implicit request =>
+      dataStoreService.validateAccess(name, key) { dataStore =>
+        val dataSources = request.body
+        for {
+          before <- Instant.nowFox
+          _ = logger.info(
+            s"Received dataset list from datastore '${dataStore.name}': " +
+              s"${dataSources.count(_.isUsable)} active, ${dataSources.count(!_.isUsable)} inactive")
+          existingIds <- datasetService.updateDataSources(dataStore, dataSources)(GlobalAccessContext)
+          _ <- datasetService.deactivateUnreportedDataSources(existingIds, dataStore)
+          _ = if (Instant.since(before) > (30 seconds))
+            Instant.logSince(before, s"Updating datasources from datastore '${dataStore.name}'")
+        } yield Ok
       }
     }
-  }
 
   def updateOne(name: String, key: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
     dataStoreService.validateAccess(name, key) { dataStore =>

--- a/app/mail/MailchimpTicker.scala
+++ b/app/mail/MailchimpTicker.scala
@@ -16,7 +16,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 class MailchimpTicker @Inject()(val lifecycle: ApplicationLifecycle,
-                                val system: ActorSystem,
+                                val actorSystem: ActorSystem,
                                 multiUserDAO: MultiUserDAO,
                                 mailchimpClient: MailchimpClient)(implicit val ec: ExecutionContext)
     extends IntervalScheduler
@@ -28,13 +28,12 @@ class MailchimpTicker @Inject()(val lifecycle: ApplicationLifecycle,
 
   override protected def tickerInitialDelay: FiniteDuration = 1 hour
 
-  override protected def tick(): Unit = {
+  override protected def tick(): Fox[Unit] = {
     logger.info("Checking if any users need mailchimp tagging...")
     for {
       multiUsers: List[MultiUser] <- multiUserDAO.findAll
       _ = multiUsers.foreach(withErrorLogging(_, tagUserByActivity))
     } yield ()
-    ()
   }
 
   private def withErrorLogging(multiUser: MultiUser, block: MultiUser => Fox[Unit]): Unit =

--- a/app/models/annotation/AnnotationMutexService.scala
+++ b/app/models/annotation/AnnotationMutexService.scala
@@ -24,7 +24,7 @@ case class AnnotationMutex(annotationId: ObjectId, userId: ObjectId, expiry: Ins
 case class MutexResult(canEdit: Boolean, blockedByUser: Option[ObjectId])
 
 class AnnotationMutexService @Inject()(val lifecycle: ApplicationLifecycle,
-                                       val system: ActorSystem,
+                                       val actorSystem: ActorSystem,
                                        wkConf: WkConf,
                                        userDAO: UserDAO,
                                        userService: UserService,
@@ -34,12 +34,10 @@ class AnnotationMutexService @Inject()(val lifecycle: ApplicationLifecycle,
 
   override protected def tickerInterval: FiniteDuration = 1 hour
 
-  override protected def tick(): Unit = {
+  override protected def tick(): Fox[Unit] =
     for {
       deleteCount <- annotationMutexDAO.deleteExpired()
     } yield logger.info(s"Cleaned up $deleteCount expired annotation mutexes.")
-    ()
-  }
 
   private val defaultExpiryTime = wkConf.WebKnossos.Annotation.Mutex.expiryTime
 

--- a/app/models/job/Worker.scala
+++ b/app/models/job/Worker.scala
@@ -102,7 +102,7 @@ class WorkerLivenessService @Inject()(workerService: WorkerService,
                                       workerDAO: WorkerDAO,
                                       slackNotificationService: SlackNotificationService,
                                       val lifecycle: ApplicationLifecycle,
-                                      val system: ActorSystem)(implicit val ec: ExecutionContext)
+                                      val actorSystem: ActorSystem)(implicit val ec: ExecutionContext)
     extends IntervalScheduler
     with Formatter
     with LazyLogging {
@@ -111,13 +111,11 @@ class WorkerLivenessService @Inject()(workerService: WorkerService,
 
   override protected def tickerInterval: FiniteDuration = 1 minute
 
-  override protected def tick(): Unit = {
+  override protected def tick(): Fox[Unit] =
     for {
       workers <- workerDAO.findAll(GlobalAccessContext)
       _ = workers.foreach(reportIfLivenessChanged)
     } yield ()
-    ()
-  }
 
   private val reportedAsDead: scala.collection.mutable.Set[ObjectId] = scala.collection.mutable.Set()
 

--- a/app/models/storage/UsedStorageService.scala
+++ b/app/models/storage/UsedStorageService.scala
@@ -18,7 +18,7 @@ import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class UsedStorageService @Inject()(val system: ActorSystem,
+class UsedStorageService @Inject()(val actorSystem: ActorSystem,
                                    val lifecycle: ApplicationLifecycle,
                                    organizationDAO: OrganizationDAO,
                                    datasetService: DatasetService,
@@ -43,12 +43,14 @@ class UsedStorageService @Inject()(val system: ActorSystem,
 
   implicit private val ctx: DBAccessContext = GlobalAccessContext
 
-  override protected def tick(): Unit =
+  override protected def tick(): Fox[Unit] = {
     if (isRunning.compareAndSet(false, true)) {
       tickAsync().futureBox.onComplete { _ =>
         isRunning.set(false)
       }
     }
+    Fox.successful(())
+  }
 
   private def tickAsync(): Fox[Unit] =
     for {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/IntervalScheduler.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/IntervalScheduler.scala
@@ -1,10 +1,15 @@
 package com.scalableminds.webknossos.datastore.helpers
 
+import com.scalableminds.util.tools.Fox
+import com.typesafe.scalalogging.LazyLogging
+import net.liftweb.common.Failure
 import org.apache.pekko.actor.{ActorSystem, Cancellable}
 import play.api.inject.ApplicationLifecycle
 
+import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import com.scalableminds.util.time.Instant
 
 trait IntervalScheduler {
 
@@ -12,28 +17,48 @@ trait IntervalScheduler {
 
   protected def lifecycle: ApplicationLifecycle
 
-  protected def system: ActorSystem
+  protected def actorSystem: ActorSystem
 
-  protected def enabled: Boolean = true
+  protected def tickerEnabled: Boolean = true
 
   protected def tickerInterval: FiniteDuration
 
   protected def tickerInitialDelay: FiniteDuration = 10 seconds
 
-  protected def tick(): Unit
+  protected def tick(): Fox[_]
 
-  private var scheduled: Cancellable = _
+  private val innerTickerInterval: FiniteDuration = 100 millis
+  private val lastCompletionTimeMillis = new AtomicLong(0)
+  private val isRunning = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+  private def innerTick: Runnable = () => {
+    if (lastCompletionIsLongEnoughPast) {
+      if (isRunning.compareAndSet(false, true)) {
+        for {
+          _ <- tick().futureBox
+          _ = lastCompletionTimeMillis.set(Instant.now.epochMillis)
+          _ = isRunning.set(false)
+        } yield ()
+      }
+    }
+    ()
+  }
+
+  private def lastCompletionIsLongEnoughPast: Boolean =
+    (Instant(lastCompletionTimeMillis.get()) + tickerInterval).isPast
+
+  private var scheduled: Option[Cancellable] = None
 
   lifecycle.addStopHook(stop _)
 
-  if (enabled) {
-    scheduled = system.scheduler.scheduleWithFixedDelay(tickerInitialDelay, tickerInterval)(() => tick())
+  if (tickerEnabled) {
+    scheduled = Some(actorSystem.scheduler.scheduleWithFixedDelay(tickerInitialDelay, innerTickerInterval)(innerTick))
   }
 
   private def stop(): Future[Unit] = {
-    if (scheduled != null) {
-      scheduled.cancel()
-      scheduled = null
+    if (scheduled.isDefined) {
+      scheduled.foreach(_.cancel())
+      scheduled = None
     }
     Future.successful(())
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
@@ -44,7 +44,7 @@ class DSRemoteWebknossosClient @Inject()(
     rpc: RPC,
     config: DataStoreConfig,
     val lifecycle: ApplicationLifecycle,
-    @Named("webknossos-datastore") val system: ActorSystem
+    @Named("webknossos-datastore") val actorSystem: ActorSystem
 )(implicit val ec: ExecutionContext)
     extends RemoteWebknossosClient
     with IntervalScheduler
@@ -60,7 +60,7 @@ class DSRemoteWebknossosClient @Inject()(
 
   protected lazy val tickerInterval: FiniteDuration = config.Datastore.WebKnossos.pingInterval
 
-  def tick(): Unit = reportStatus()
+  def tick(): Fox[Unit] = reportStatus().map(_ => ())
 
   private def reportStatus(): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/status")

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -18,11 +18,10 @@ import net.liftweb.common.Box.tryo
 import net.liftweb.common._
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
-import play.libs.Scala
 
 import java.io.{File, FileWriter}
 import java.nio.file.{Files, Path, Paths}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.io.Source
 
@@ -51,14 +50,9 @@ class DataSourceService @Inject()(
 
   def tick(): Fox[Unit] =
     for {
-      /*_ <- checkInbox(verbose = inboxCheckVerboseCounter == 0)
+      _ <- checkInbox(verbose = inboxCheckVerboseCounter == 0)
       _ = inboxCheckVerboseCounter += 1
-      _ = if (inboxCheckVerboseCounter >= 10) inboxCheckVerboseCounter = 0*/
-      _ <- Fox.successful()
-      i = scala.util.Random.nextInt()
-      _ = logger.info(s"Tick! $i in ${Thread.currentThread.getId} Sleeping 10s...")
-      _ = Thread.sleep(10000)
-      _ = logger.info(s"Sleeping done for $i in ${Thread.currentThread.getId}.")
+      _ = if (inboxCheckVerboseCounter >= 10) inboxCheckVerboseCounter = 0
     } yield ()
 
   def assertDataDirWritable(organizationId: String): Fox[Unit] = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DatasetErrorLoggingService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DatasetErrorLoggingService.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 class DatasetErrorLoggingService @Inject()(
     val lifecycle: ApplicationLifecycle,
     val applicationHealthService: ApplicationHealthService,
-    @Named("webknossos-datastore") val system: ActorSystem)(implicit val ec: ExecutionContext)
+    @Named("webknossos-datastore") val actorSystem: ActorSystem)(implicit val ec: ExecutionContext)
     extends IntervalScheduler
     with Formatter
     with LazyLogging {
@@ -47,7 +47,7 @@ class DatasetErrorLoggingService @Inject()(
   def clearForDataset(organizationId: String, datasetName: String): Unit =
     recentErrors.remove((organizationId, datasetName))
 
-  override protected def tick(): Unit = recentErrors.clear()
+  override protected def tick(): Fox[Unit] = Fox.successful(recentErrors.clear())
 
   def withErrorLogging(dataSourceId: DataSourceId, label: String, resultFox: Fox[Array[Byte]]): Fox[Array[Byte]] =
     resultFox.futureBox.flatMap {


### PR DESCRIPTION
Before this PR, the tick functions returned Unit, meaning that if they started asynchronous work, the IntervalScheduler couldn’t wait for it to be completed.

Now, tick returns Fox[Unit]. The IntervalScheduler runs with an internal interval of 100ms and checks if the time since the last tick’s completion is long enough to start a new one. That means the real interval will be a little higher than the specified one, because it *includes* the time to compute the tick (plus the time until the next internal 100ms-spaced tick).

### Steps to test:
- To test this, I added a 10s sleep to one of the tick’s asynchronous bodies, and turned down the interval to 2 seconds, and added some logging. The output was like this (note that the internal ticker interval was still set to 20ms then:

```
11:51:20,304 Tick! Sleeping 10s...
11:51:30,304 Sleeping done.

11:51:32,324 Tick! Sleeping 10s...
11:51:42,324 Sleeping done.

11:51:44,344 Tick! Sleeping 10s...
11:51:54,344 Sleeping done.

11:51:56,344 Tick! Sleeping 10s...
11:52:06,344 Sleeping done.

11:52:08,344 Tick! Sleeping 10s...
11:52:18,344 Sleeping done.

11:52:20,364 Tick! Sleeping 10s...
11:52:30,364 Sleeping done.

11:52:32,393 Tick! Sleeping 10s...

```



### Issues:
- Hopefully fixes overloaded postgres when receiving datasource upgrades from the datastore. (My theory is that the next one came, after 1min, before the first one was completely ingested).

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
