### PR TITLE
Revert "Fix volume annotation tool availability on datasets with rotation transforms"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,6 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug that would lock a non-existing mapping to an empty segmentation layer under certain conditions. [#8401](https://github.com/scalableminds/webknossos/pull/8401)
 - Fixed the alignment of the button that allows restricting floodfill operations to a bounding box. [#8388](https://github.com/scalableminds/webknossos/pull/8388) 
-- Fixed a bug for rotated dataset where volume tools were disabled although the dataset was rendered untransformed. [#8432](https://github.com/scalableminds/webknossos/pull/8432)
 - Fixed rare bug where saving got stuck. [#8409](https://github.com/scalableminds/webknossos/pull/8409)
 - Fixed a bug where reverting annotations could get stuck if some of its layers had been deleted in the meantime. [#8405](https://github.com/scalableminds/webknossos/pull/8405)
 - Fixed a bug where newly added remote datasets would always appear in root folder, regardless of actual selected folder. [#8425](https://github.com/scalableminds/webknossos/pull/8425)

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -40,7 +40,7 @@ import {
   settingsTooltips,
 } from "messages";
 import type { Vector3 } from "oxalis/constants";
-import Constants, { ControlModeEnum, IdentityTransform, MappingStatusEnum } from "oxalis/constants";
+import Constants, { ControlModeEnum, MappingStatusEnum } from "oxalis/constants";
 import defaultState from "oxalis/default_state";
 import {
   getDefaultValueRangeOfLayer,
@@ -55,6 +55,7 @@ import {
   getTransformsForLayer,
   getTransformsForLayerOrNull,
   hasDatasetTransforms,
+  isIdentityTransform,
   isLayerWithoutTransformationConfigSupport,
 } from "oxalis/model/accessors/dataset_layer_transformation_accessor";
 import {
@@ -207,7 +208,7 @@ function TransformationIcon({ layer }: { layer: APIDataLayer | APISkeletonLayer 
   if (!showIcon) {
     return null;
   }
-  const isRenderedNatively = transform == null || transform === IdentityTransform;
+  const isRenderedNatively = transform == null || isIdentityTransform(transform);
 
   const typeToLabel = {
     affine: "an affine",


### PR DESCRIPTION
Reverts scalableminds/webknossos#8432 as this seems to have introduced a bug. Needs further investigation. 
See: https://scm.slack.com/archives/C02H5T8Q08P/p1741624272851439