### PR TITLE
Redo: Fix volume annotation tool availability on datasets with rotation transforms

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed a bug that would lock a non-existing mapping to an empty segmentation layer under certain conditions. [#8401](https://github.com/scalableminds/webknossos/pull/8401)
 - Fixed the alignment of the button that allows restricting floodfill operations to a bounding box. [#8388](https://github.com/scalableminds/webknossos/pull/8388) 
+- Fixed a bug for rotated dataset where volume tools were disabled although the dataset was rendered untransformed. [#8432](https://github.com/scalableminds/webknossos/pull/8432)
 - Fixed rare bug where saving got stuck. [#8409](https://github.com/scalableminds/webknossos/pull/8409)
 - Fixed a bug where reverting annotations could get stuck if some of its layers had been deleted in the meantime. [#8405](https://github.com/scalableminds/webknossos/pull/8405)
 - Fixed a bug where newly added remote datasets would always appear in root folder, regardless of actual selected folder. [#8425](https://github.com/scalableminds/webknossos/pull/8425)

--- a/frontend/javascripts/oxalis/model/accessors/dataset_layer_transformation_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_layer_transformation_accessor.ts
@@ -191,6 +191,10 @@ export function isLayerWithoutTransformationConfigSupport(layer: APIDataLayer | 
   );
 }
 
+function toIdentityTransformMaybe(transform: Transform | null): Transform {
+  return transform && !equalsIdentityTransform(transform) ? transform : IdentityTransform;
+}
+
 function _getTransformsForLayerOrNull(
   dataset: APIDataset,
   layer: APIDataLayer | APISkeletonLayer,
@@ -210,7 +214,7 @@ function _getTransformsForLayerOrNull(
   const layerTransforms = getOriginalTransformsForLayerOrNull(dataset, layer as APIDataLayer);
   if (nativelyRenderedLayerName == null) {
     // No layer is requested to be rendered natively. -> We can use the layer's transforms as is.
-    return layerTransforms;
+    return toIdentityTransformMaybe(layerTransforms);
   }
 
   // Apply the inverse of the layer that should be rendered natively
@@ -221,11 +225,11 @@ function _getTransformsForLayerOrNull(
   if (transformsOfNativeLayer == null) {
     // The inverse of no transforms, are no transforms. Leave the layer
     // transforms untouched.
-    return layerTransforms;
+    return toIdentityTransformMaybe(layerTransforms);
   }
 
   const inverseNativeTransforms = invertTransform(transformsOfNativeLayer);
-  return chainTransforms(layerTransforms, inverseNativeTransforms);
+  return toIdentityTransformMaybe(chainTransforms(layerTransforms, inverseNativeTransforms));
 }
 
 export const getTransformsForLayerOrNull = memoizeWithThreeKeys(_getTransformsForLayerOrNull);
@@ -239,7 +243,7 @@ export function getTransformsForLayer(
   );
 }
 
-export function isIdentityTransform(transform: Transform) {
+function equalsIdentityTransform(transform: Transform) {
   return transform.type === "affine" && _.isEqual(transform.affineMatrix, Identity4x4);
 }
 
@@ -266,7 +270,7 @@ function _getTransformsForLayerThatDoesNotSupportTransformationConfigOrNull(
     const someLayersTransformsMaybe = usableReferenceLayer
       ? getTransformsForLayerOrNull(dataset, usableReferenceLayer, nativelyRenderedLayerName)
       : null;
-    return someLayersTransformsMaybe;
+    return toIdentityTransformMaybe(someLayersTransformsMaybe);
   } else if (nativelyRenderedLayerName != null && allLayersSameRotation) {
     // If all layers have the same transformations and at least one is rendered natively, this means that all layer should be rendered natively.
     return null;
@@ -281,7 +285,7 @@ function _getTransformsForLayerThatDoesNotSupportTransformationConfigOrNull(
     return null;
   }
 
-  return invertTransform(transformsOfNativeLayer);
+  return toIdentityTransformMaybe(invertTransform(transformsOfNativeLayer));
 }
 
 export const getTransformsForLayerThatDoesNotSupportTransformationConfigOrNull = memoizeOne(

--- a/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/oxalis/view/left-border-tabs/layer_settings_tab.tsx
@@ -40,7 +40,7 @@ import {
   settingsTooltips,
 } from "messages";
 import type { Vector3 } from "oxalis/constants";
-import Constants, { ControlModeEnum, MappingStatusEnum } from "oxalis/constants";
+import Constants, { ControlModeEnum, IdentityTransform, MappingStatusEnum } from "oxalis/constants";
 import defaultState from "oxalis/default_state";
 import {
   getDefaultValueRangeOfLayer,
@@ -55,7 +55,6 @@ import {
   getTransformsForLayer,
   getTransformsForLayerOrNull,
   hasDatasetTransforms,
-  isIdentityTransform,
   isLayerWithoutTransformationConfigSupport,
 } from "oxalis/model/accessors/dataset_layer_transformation_accessor";
 import {
@@ -208,7 +207,7 @@ function TransformationIcon({ layer }: { layer: APIDataLayer | APISkeletonLayer 
   if (!showIcon) {
     return null;
   }
-  const isRenderedNatively = transform == null || isIdentityTransform(transform);
+  const isRenderedNatively = transform == null || transform === IdentityTransform;
 
   const typeToLabel = {
     affine: "an affine",


### PR DESCRIPTION
Redo PR for https://github.com/scalableminds/webknossos/pull/8432 including the fix for report: https://scm.slack.com/archives/C02H5T8Q08P/p1741624272851439

Please see my comments for details on the problem & fix

### How to test:
- Same as before
- In a normal untransformed dataset open a hybrid annotation. Check that all tools are available and not "transformation" is blocking the tools.

Other PRs description:
> This PR makes volume annotation tools properly available for datasets with rotation transforms where the dataset rotation is turned off but not the active volume layer is the selected "nativelyRenderedLayerName".
> 
> The bug: Previously, when having an annotation on a dataset with rotation transforms and deactivating rendering the DS transformed via the color layer, the volume tools were not enabled as the frontend thought that the volume layer was still rendered with transforms. This PR fixes this by letting `getTransformsForLayerOrNull` return the `IdentityTransform` object for all transformations that are equal to the identity transform. Thus, making the `===` or `!==` comparisons with the `IdentityTransform` now correct 😇.
> 
> ### URL of deployed dev instance (used for testing):
> * https://___.webknossos.xyz
> 
> ### Steps to test:
> * Open a DS with rotation transforms enabled
> * Toggle the rotation transforms on the color layer
> * When the transformations are turned off, not only the skeleton tool but all volume tools should be available.
> * Check that the transform icons are also rendered correctly (as the check was also modified in this pr)
> * Compare with master -> There the volume tools should be disabled if doing the steps above.
> 
> ### Issues:
> * fixes [Fix volume annotation tools for rotated datasets #8421](https://github.com/scalableminds/webknossos/issues/8421)
> 
> (Please delete unneeded items, merge only when none are left open)
> 
> * [x]  Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)

