### PR TITLE
Fix click targets in dataset table

### DIFF
--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -661,7 +661,7 @@ class DatasetTable extends React.PureComponent<Props, State> {
               },
               onClick: (event) => {
                 // @ts-expect-error
-                if (event.target?.tagName !== "TD") {
+                if (event.target?.tagName !== "TD" && event.target?.tagName !== "DIV") {
                   // Don't (de)select when another element within the row was clicked
                   // (e.g., a link). Otherwise, clicking such elements would cause two actions
                   // (e.g., the link action and a (de)selection).


### PR DESCRIPTION
Fixes the click targets in the dataset table for selecting datasets.

![2025-03-17 11 13 40](https://github.com/user-attachments/assets/0aab673c-e8da-4d40-a9d3-207f494d4df5)

- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)