### PR TITLE
Fixed CSS alignment for skeleton tab buttons 

### DIFF
--- a/frontend/javascripts/oxalis/view/right-border-tabs/trees_tab/skeleton_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/trees_tab/skeleton_tab_view.tsx
@@ -847,58 +847,56 @@ class SkeletonTabView extends React.PureComponent<Props, State> {
                 >
                   <Spin />
                 </Modal>
-                <Space.Compact className="compact-icons">
-                  <div className="compact-buttons">
-                    <AdvancedSearchPopover
-                      onSelect={this.handleSearchSelect}
-                      data={this.getTreeAndTreeGroupList(trees, treeGroups, orderAttribute)}
-                      searchKey="name"
-                      provideShortcut
-                      targetId={treeTabId}
-                      onSelectAllMatches={this.handleSelectAllMatchingTrees}
-                    >
-                      <ButtonComponent
-                        title="Open the search via CTRL + Shift + F"
-                        className="firstButton"
-                      >
-                        <SearchOutlined />
-                      </ButtonComponent>
-                    </AdvancedSearchPopover>
+                <Space.Compact className="compact-icons compact-wrap">
+                  <AdvancedSearchPopover
+                    onSelect={this.handleSearchSelect}
+                    data={this.getTreeAndTreeGroupList(trees, treeGroups, orderAttribute)}
+                    searchKey="name"
+                    provideShortcut
+                    targetId={treeTabId}
+                    onSelectAllMatches={this.handleSelectAllMatchingTrees}
+                  >
                     <ButtonComponent
-                      onClick={this.props.onCreateTree}
-                      title={isEditingDisabled ? isEditingDisabledMessage : "Create new Tree (C)"}
-                      disabled={isEditingDisabled}
+                      title="Open the search via CTRL + Shift + F"
+                      className="firstButton"
                     >
-                      <i className="fas fa-plus" />
+                      <SearchOutlined />
                     </ButtonComponent>
-                    <ButtonComponent
-                      onClick={this.handleDelete}
-                      title={isEditingDisabled ? isEditingDisabledMessage : "Delete Selected Trees"}
-                      disabled={isEditingDisabled}
-                    >
-                      <i className="far fa-trash-alt" />
+                  </AdvancedSearchPopover>
+                  <ButtonComponent
+                    onClick={this.props.onCreateTree}
+                    title={isEditingDisabled ? isEditingDisabledMessage : "Create new Tree (C)"}
+                    disabled={isEditingDisabled}
+                  >
+                    <i className="fas fa-plus" />
+                  </ButtonComponent>
+                  <ButtonComponent
+                    onClick={this.handleDelete}
+                    title={isEditingDisabled ? isEditingDisabledMessage : "Delete Selected Trees"}
+                    disabled={isEditingDisabled}
+                  >
+                    <i className="far fa-trash-alt" />
+                  </ButtonComponent>
+                  <ButtonComponent
+                    onClick={this.toggleAllTrees}
+                    title="Toggle Visibility of All Trees (1)"
+                    disabled={isEditingDisabled}
+                  >
+                    <i className="fas fa-toggle-on" />
+                  </ButtonComponent>
+                  <ButtonComponent
+                    onClick={this.toggleInactiveTrees}
+                    title="Toggle Visibility of Inactive Trees (2)"
+                    disabled={isEditingDisabled}
+                  >
+                    <i className="fas fa-toggle-off" />
+                  </ButtonComponent>
+                  <Dropdown menu={this.getActionsDropdown()} trigger={["click"]}>
+                    <ButtonComponent style={{ overflow: "clip" }} className="lastButton">
+                      More
+                      <DownOutlined />
                     </ButtonComponent>
-                    <ButtonComponent
-                      onClick={this.toggleAllTrees}
-                      title="Toggle Visibility of All Trees (1)"
-                      disabled={isEditingDisabled}
-                    >
-                      <i className="fas fa-toggle-on" />
-                    </ButtonComponent>
-                    <ButtonComponent
-                      onClick={this.toggleInactiveTrees}
-                      title="Toggle Visibility of Inactive Trees (2)"
-                      disabled={isEditingDisabled}
-                    >
-                      <i className="fas fa-toggle-off" />
-                    </ButtonComponent>
-                    <Dropdown menu={this.getActionsDropdown()} trigger={["click"]}>
-                      <ButtonComponent style={{ overflow: "clip" }} className="lastButton">
-                        More
-                        <DownOutlined />
-                      </ButtonComponent>
-                    </Dropdown>
-                  </div>
+                  </Dropdown>
                 </Space.Compact>
                 <Space.Compact className="compact-icons compact-items">
                   <ButtonComponent

--- a/frontend/stylesheets/trace_view/_right_menu.less
+++ b/frontend/stylesheets/trace_view/_right_menu.less
@@ -139,25 +139,15 @@
   }
 }
 
-.compact-buttons{
-  display: "inline-flex";
-  flex-wrap: "wrap";
+.compact-wrap {
+  // Should only be used with antd <Space.Compact>
+  flex-wrap: wrap;
 
-  button{
-    border-radius: 0px;
-    margin-inline: -1px;
+   button{
+    // Slightly shift buttons up to prevent double borders when wraping in flex containter occurs
     margin-top: -1px;
-  }
+   }
 
-  button.firstButton{
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-  }
-  
-  button.lastButton{
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-  }
 }
 
 .margin-bottom {

--- a/frontend/stylesheets/trace_view/_right_menu.less
+++ b/frontend/stylesheets/trace_view/_right_menu.less
@@ -144,7 +144,7 @@
   flex-wrap: wrap;
 
    button{
-    // Slightly shift buttons up to prevent double borders when wraping in flex containter occurs
+    // Slightly shift buttons up to prevent double borders when wrapping in flex container occurs
     margin-top: -1px;
    }
 


### PR DESCRIPTION
Fixed an issue with the buttons in the skeleton tab not lining up correctly.

<img width="451" alt="Screenshot 2025-03-17 at 14 22 59" src="https://github.com/user-attachments/assets/94f98b6b-7f52-4c26-b3ad-f20671c55df9" />

<img width="337" alt="Screenshot 2025-03-17 at 14 27 19" src="https://github.com/user-attachments/assets/b90aa2ff-749d-43c6-b252-ade2871f82c2" />


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open annotation
- Check alignment of skeleton tab buttons
- Resize right-hand side panel and verify that buttons wrap

### Issues:
- contributes to #8427 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
