### PR TITLE
Fix CSS spacing for actions in Dashboard > Tasks

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where newly added remote datasets would always appear in root folder, regardless of actual selected folder. [#8425](https://github.com/scalableminds/webknossos/pull/8425)
 - Fixed a bug where the python libs functionality `wk.RemoteDataset.explore_and_add_remote` would error. [#8425](https://github.com/scalableminds/webknossos/pull/8425)
 - Fixed a bug where various UI dialogs would be dark mode even the user preferred a light theme. [#8445](https://github.com/scalableminds/webknossos/pull/8445)
+- Fixed an issue with icon spacing on the task dashboard page. [#8452](https://github.com/scalableminds/webknossos/pull/8452)
 
 ### Removed
 

--- a/frontend/javascripts/admin/statistic/time_tracking_overview.tsx
+++ b/frontend/javascripts/admin/statistic/time_tracking_overview.tsx
@@ -199,8 +199,8 @@ function TimeTrackingOverview() {
                 selectedProjectIds,
               );
             }}
+            icon={<DownloadOutlined />}
           >
-            <DownloadOutlined className="icon-margin-right" />
             Download time spans
           </LinkButton>
         );

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -375,8 +375,7 @@ function TaskListView({ initialFieldValues }: Props) {
           </div>
           {task.status.pending > 0 ? (
             <div>
-              <LinkButton onClick={_.partial(assignTaskToUser, task)}>
-                <UserAddOutlined className="icon-margin-right" />
+              <LinkButton onClick={_.partial(assignTaskToUser, task)} icon={<UserAddOutlined />}>
                 Manually Assign to User
               </LinkButton>
             </div>
@@ -397,8 +396,7 @@ function TaskListView({ initialFieldValues }: Props) {
             </div>
           ) : null}
           <div>
-            <LinkButton onClick={_.partial(deleteTask, task)}>
-              <DeleteOutlined className="icon-margin-right" />
+            <LinkButton onClick={_.partial(deleteTask, task)} icon={<DeleteOutlined />}>
               Delete
             </LinkButton>
           </div>

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
@@ -270,8 +270,7 @@ function TaskTypeListView({ initialSearchValue }: Props) {
                   Download
                 </AsyncLink>
                 <br />
-                <LinkButton onClick={_.partial(deleteTaskType, taskType)}>
-                  <DeleteOutlined className="icon-margin-right" />
+                <LinkButton onClick={_.partial(deleteTaskType, taskType)} icon={<DeleteOutlined />}>
                   Delete
                 </LinkButton>
               </span>

--- a/frontend/javascripts/admin/team/team_list_view.tsx
+++ b/frontend/javascripts/admin/team/team_list_view.tsx
@@ -176,7 +176,7 @@ function TeamListView() {
     <div className="container">
       <div className="pull-right">
         <Button
-          icon={<PlusOutlined className="icon-margin-right" />}
+          icon={<PlusOutlined />}
           style={marginRight}
           type="primary"
           onClick={() => setIsTeamCreationModalVisible(true)}
@@ -233,14 +233,13 @@ function TeamListView() {
                       setSelectedTeam(team);
                       setIsTeamEditModalVisible(true);
                     }}
+                    icon={<UserOutlined />}
                   >
-                    <UserOutlined className="icon-margin-right" />
                     Add / Remove Users
                   </LinkButton>
                 </div>
                 <div>
-                  <LinkButton onClick={_.partial(deleteTeam, team)}>
-                    <DeleteOutlined className="icon-margin-right" />
+                  <LinkButton onClick={_.partial(deleteTeam, team)} icon={<DeleteOutlined />}>
                     Delete
                   </LinkButton>
                 </div>

--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -194,8 +194,7 @@ function UserListView({ activeUser, activeOrganization }: Props) {
           <Row key={user.id} gutter={16}>
             <Col span={6}>{`${user.lastName}, ${user.firstName} (${user.email}) `}</Col>
             <Col span={4}>
-              <LinkButton onClick={() => activateUser(user)}>
-                <UserAddOutlined className="icon-margin-right" />
+              <LinkButton onClick={() => activateUser(user)} icon={<UserAddOutlined />}>
                 Activate User
               </LinkButton>
             </Col>
@@ -594,8 +593,7 @@ function UserListView({ activeUser, activeOrganization }: Props) {
             render={(__, user: APIUser) => (
               <span>
                 <Link to={`/users/${user.id}/details`}>
-                  <UserOutlined className="icon-margin-right" />
-                  Show Annotations
+                  <LinkButton icon={<UserOutlined />}>Show Annotations</LinkButton>
                 </Link>
                 <br />
                 {user.isActive ? (
@@ -605,8 +603,8 @@ function UserListView({ activeUser, activeOrganization }: Props) {
                         event.stopPropagation();
                         deactivateUser(user);
                       }}
+                      icon={<UserDeleteOutlined />}
                     >
-                      <UserDeleteOutlined className="icon-margin-right" />
                       Deactivate User
                     </LinkButton>
                   ) : null
@@ -616,8 +614,8 @@ function UserListView({ activeUser, activeOrganization }: Props) {
                       event.stopPropagation();
                       activateUser(user);
                     }}
+                    icon={<UserAddOutlined />}
                   >
-                    <UserAddOutlined className="icon-margin-right" />
                     Activate User
                   </LinkButton>
                 )}

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -232,7 +232,7 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
     );
     return task.annotation.state === "Finished" ? (
       <div>
-        <CheckCircleOutlined className="icon-margin-right"/>
+        <CheckCircleOutlined className="icon-margin-right" />
         Finished
       </div>
     ) : (

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -9,7 +9,7 @@ import {
   UserAddOutlined,
 } from "@ant-design/icons";
 import { PropTypes } from "@scalableminds/prop-types";
-import { Button, Card, Col, List, Modal, Row, Tag, Tooltip } from "antd";
+import { Button, Card, Col, List, Modal, Row, Space, Tag, Tooltip } from "antd";
 import Markdown from "libs/markdown_adapter";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -226,37 +226,25 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
         .map((team) => team.name)
         .includes(task.team);
     const label = this.props.isAdminView ? (
-      <span>
-        <EyeOutlined className="icon-margin-right" />
-        View
-      </span>
+      <LinkButton icon={<EyeOutlined />}>View</LinkButton>
     ) : (
-      <span>
-        <PlayCircleOutlined className="icon-margin-right" />
-        Open
-      </span>
+      <LinkButton icon={<PlayCircleOutlined />}>Open</LinkButton>
     );
     return task.annotation.state === "Finished" ? (
       <div>
-        <CheckCircleOutlined className="icon-margin-right" />
+        <CheckCircleOutlined className="icon-margin-right"/>
         Finished
-        <br />
       </div>
     ) : (
-      <div>
+      <Space direction="vertical" size={1}>
         <Link to={`/annotations/${annotation.id}`}>{label}</Link>
-        <br />
         {isAdmin || this.props.isAdminView ? (
-          <div>
-            <LinkButton onClick={() => this.openTransferModal(annotation.id)}>
-              <TeamOutlined className="icon-margin-right" />
-              Transfer
-            </LinkButton>
-            <br />
-          </div>
+          <LinkButton onClick={() => this.openTransferModal(annotation.id)} icon={<TeamOutlined />}>
+            Transfer
+          </LinkButton>
         ) : null}
         {isAdmin ? (
-          <div>
+          <>
             <AsyncLink
               href="#"
               onClick={() => {
@@ -267,30 +255,24 @@ class DashboardTaskListView extends React.PureComponent<Props, State> {
             >
               Download
             </AsyncLink>
-            <br />
-            <LinkButton onClick={() => this.resetTask(annotation)}>
+            <LinkButton onClick={() => this.resetTask(annotation)} icon={<RollbackOutlined />}>
               <Tooltip title={messages["task.tooltip_explain_reset"]} placement="left">
-                <RollbackOutlined className="icon-margin-right" />
                 Reset
               </Tooltip>
             </LinkButton>
-            <br />
-            <LinkButton onClick={() => this.cancelAnnotation(annotation)}>
+            <LinkButton onClick={() => this.cancelAnnotation(annotation)} icon={<DeleteOutlined />}>
               <Tooltip title={messages["task.tooltip_explain_reset_cancel"]} placement="left">
-                <DeleteOutlined className="icon-margin-right" />
                 Reset and Cancel
               </Tooltip>
             </LinkButton>
-            <br />
-          </div>
+          </>
         ) : null}
         {this.props.isAdminView ? null : (
-          <LinkButton onClick={() => this.confirmFinish(task)}>
-            <CheckCircleOutlined className="icon-margin-right" />
+          <LinkButton onClick={() => this.confirmFinish(task)} icon={<CheckCircleOutlined />}>
             Finish
           </LinkButton>
         )}
-      </div>
+      </Space>
     );
   };
 


### PR DESCRIPTION
Fixed the CSS spacing for the task actions in the Dashboard > Tasks view. The same issue is also present in some of the other list views that have a similar "Actions" column.

High-level the underlying issue has to do with several factors:
- a mix of components representing each action (`<span>`, `<ButtonLink>`, `<a>`, `<AsyncLink`) with different stylings
- A mixed use of the `<ButtonLink>` component. Sometimes the icon was passed a prop and had the default antd spacing applied. Other times, the icon was wrapped as child with it's on margin-right. (And worse case, you do both and end up with twice the right spacing :-/ )

<img width="522" alt="Screenshot 2025-03-17 at 16 02 34" src="https://github.com/user-attachments/assets/f0303ab1-87e6-41b5-91bb-34e84ebac1aa" />


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz


### Steps to test:
- Create a new task
- Go to Dashboard -> Task and request a task
- Action should neatly line up


### Issues:
- contributes to #8427

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
