### PR TITLE
In annotation upload, always add skeleton if none is found in NML

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Compound annotations (created when viewing all annotations of a task) no longer permanently store data in the FossilDB. [#8422](https://github.com/scalableminds/webknossos/pull/8422)
 - When creating multiple tasks at once (bulk task creation), they now all need to have the same task type. [#8405](https://github.com/scalableminds/webknossos/pull/8405)
 - Improved performance when changing the layout/viewports. [#8448](https://github.com/scalableminds/webknossos/pull/8448)
+- Annotation upload will now always add a skeleton annotation layer, even if the downloaded annotation was volume-only. [#8466](https://github.com/scalableminds/webknossos/pull/8466)
 
 ### Fixed
 - Fixed a bug that would lock a non-existing mapping to an empty segmentation layer under certain conditions. [#8401](https://github.com/scalableminds/webknossos/pull/8401)
@@ -38,6 +39,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a spacing issue in the statusbar. [#8455](https://github.com/scalableminds/webknossos/pull/8455)
 - Fixed a bug where the "Create Animation" modal did not open when selecting the corresponding feature from the navbar menu. [#8444](https://github.com/scalableminds/webknossos/pull/8444)
 - Fixed that the brightness/contrast settings (in the histogram) could not be changed if the histogram data could not be loaded for some reason. [#8459](https://github.com/scalableminds/webknossos/pull/8459)
+- Fixed that downloading + reupload of an annotation, in which the skeleton tools were never used, actually made them unreachable. [#8466](https://github.com/scalableminds/webknossos/pull/8466)
 
 ### Removed
 

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -31,7 +31,7 @@ import net.liftweb.common.Empty
 import models.analytics.{AnalyticsService, DownloadAnnotationEvent, UploadAnnotationEvent}
 import models.annotation.AnnotationState._
 import models.annotation._
-import models.annotation.nml.NmlResults.{NmlParseResult, NmlParseSuccess}
+import models.annotation.nml.NmlResults.NmlParseResult
 import models.annotation.nml.{NmlResults, NmlWriter}
 import models.dataset._
 import models.organization.OrganizationDAO
@@ -114,8 +114,7 @@ class AnnotationIOController @Inject()(
           name = nameForUploaded(parseResultsFiltered.map(_.fileName))
           description = descriptionForNMLs(parseResultsFiltered.map(_.description))
           wkUrl = wkUrlsForNMLs(parseResultsFiltered.map(_.wkUrl))
-          _ <- assertNonEmpty(parseSuccesses)
-          skeletonTracings = parseSuccesses.flatMap(_.skeletonTracingOpt)
+          skeletonTracings = parseSuccesses.map(_.skeletonTracing)
           // Create a list of volume layers for each uploaded (non-skeleton-only) annotation.
           // This is what determines the merging strategy for volume layers
           volumeLayersGroupedRaw = parseSuccesses.map(_.volumeLayers).filter(_.nonEmpty)
@@ -225,9 +224,6 @@ class AnnotationIOController @Inject()(
                           AnnotationLayer.defaultSkeletonLayerName,
                           AnnotationLayerStatistics.unknown))
     }
-
-  private def assertNonEmpty(parseSuccesses: List[NmlParseSuccess]) =
-    bool2Fox(parseSuccesses.exists(p => p.skeletonTracingOpt.nonEmpty || p.volumeLayers.nonEmpty)) ?~> "nml.file.noFile"
 
   private def findDatasetForUploadedAnnotations(
       skeletonTracings: List[SkeletonTracing],

--- a/app/models/annotation/AnnotationUploadService.scala
+++ b/app/models/annotation/AnnotationUploadService.scala
@@ -55,8 +55,8 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService, nmlPar
         basePath
       )
     parserOutput.futureBox.map {
-      case Full(NmlParseSuccessWithoutFile(skeletonTracingOpt, uploadedVolumeLayers, datasetId, description, wkUrl)) =>
-        NmlParseSuccess(name, skeletonTracingOpt, uploadedVolumeLayers, datasetId, description, wkUrl)
+      case Full(NmlParseSuccessWithoutFile(skeletonTracing, uploadedVolumeLayers, datasetId, description, wkUrl)) =>
+        NmlParseSuccess(name, skeletonTracing, uploadedVolumeLayers, datasetId, description, wkUrl)
       case f: Failure => NmlParseFailure(name, formatFailureChain(f, messagesProviderOpt = Some(m)))
       case Empty      => NmlParseEmpty(name)
     }
@@ -100,13 +100,8 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService, nmlPar
 
     if (parseResults.length > 1) {
       parseResults.map {
-        case NmlParseSuccess(name, Some(skeletonTracing), uploadedVolumeLayers, datasetId, description, wkUrl) =>
-          NmlParseSuccess(name,
-                          Some(renameTrees(name, skeletonTracing)),
-                          uploadedVolumeLayers,
-                          datasetId,
-                          description,
-                          wkUrl)
+        case NmlParseSuccess(name, skeletonTracing, uploadedVolumeLayers, datasetId, description, wkUrl) =>
+          NmlParseSuccess(name, renameTrees(name, skeletonTracing), uploadedVolumeLayers, datasetId, description, wkUrl)
         case r => r
       }
     } else {
@@ -142,9 +137,9 @@ class AnnotationUploadService @Inject()(tempFileService: TempFileService, nmlPar
       volumeLayers.map(v => v.copy(tracing = wrapSegmentsInGroup(name, v.tracing)))
 
     parseResults.map {
-      case NmlParseSuccess(name, Some(skeletonTracing), uploadedVolumeLayers, datasetId, description, wkUrl) =>
+      case NmlParseSuccess(name, skeletonTracing, uploadedVolumeLayers, datasetId, description, wkUrl) =>
         NmlParseSuccess(name,
-                        Some(wrapTreesInGroup(name, skeletonTracing)),
+                        wrapTreesInGroup(name, skeletonTracing),
                         wrapVolumeLayers(name, uploadedVolumeLayers),
                         datasetId,
                         description,

--- a/app/models/annotation/nml/NmlParser.scala
+++ b/app/models/annotation/nml/NmlParser.scala
@@ -95,30 +95,25 @@ class NmlParser @Inject()(datasetDAO: DatasetDAO) extends LazyLogging with Proto
           v.name,
         )
       }
-      skeletonTracingOpt: Option[SkeletonTracing] = if (nmlParams.treesSplit.isEmpty && nmlParams.userBoundingBoxes.isEmpty)
-        None
-      else
-        Some(
-          SkeletonTracing(
-            dataset.name,
-            nmlParams.treesSplit,
-            nmlParams.timestamp,
-            nmlParams.taskBoundingBox,
-            nmlParams.activeNodeId,
-            nmlParams.editPosition,
-            nmlParams.editRotation,
-            nmlParams.zoomLevel,
-            version = 0,
-            None,
-            nmlParams.treeGroupsAfterSplit,
-            nmlParams.userBoundingBoxes,
-            Some(dataset._organization),
-            nmlParams.editPositionAdditionalCoordinates,
-            additionalAxes = nmlParams.additionalAxisProtos
-          )
-        )
+      skeletonTracing: SkeletonTracing = SkeletonTracing(
+        dataset.name,
+        nmlParams.treesSplit,
+        nmlParams.timestamp,
+        nmlParams.taskBoundingBox,
+        nmlParams.activeNodeId,
+        nmlParams.editPosition,
+        nmlParams.editRotation,
+        nmlParams.zoomLevel,
+        version = 0,
+        None,
+        nmlParams.treeGroupsAfterSplit,
+        nmlParams.userBoundingBoxes,
+        Some(dataset._organization),
+        nmlParams.editPositionAdditionalCoordinates,
+        additionalAxes = nmlParams.additionalAxisProtos
+      )
     } yield
-      NmlParseSuccessWithoutFile(skeletonTracingOpt, volumeLayers, dataset._id, nmlParams.description, nmlParams.wkUrl)
+      NmlParseSuccessWithoutFile(skeletonTracing, volumeLayers, dataset._id, nmlParams.description, nmlParams.wkUrl)
 
   private def getParametersFromNML(
       nmlInputStream: InputStream,

--- a/app/models/task/TaskCreationService.scala
+++ b/app/models/task/TaskCreationService.scala
@@ -305,11 +305,9 @@ class TaskCreationService @Inject()(annotationService: AnnotationService,
         skeletons
           .zip(volumes)
           .map {
-            case (skeletonTracingBox, volumeTracingBox) =>
-              volumeTracingBox match {
-                case Full(_) => (Failure(Messages("taskType.mismatch", "skeleton", "volume")), Empty)
-                case _       => (skeletonTracingBox, Empty)
-              }
+            case (skeletonTracingBox, _) =>
+              // drop the volume if it exists
+              (skeletonTracingBox, Empty)
           }
           .unzip)
     } else if (taskType.tracingType == TracingType.volume) {
@@ -317,11 +315,9 @@ class TaskCreationService @Inject()(annotationService: AnnotationService,
         skeletons
           .zip(volumes)
           .map {
-            case (skeletonTracingBox, volumeTracingBox) =>
-              skeletonTracingBox match {
-                case Full(_) => (Empty, Failure(Messages("taskType.mismatch", "volume", "skeleton")))
-                case _       => (Empty, volumeTracingBox.map(box => (box._1.tracing, box._2)))
-              }
+            case (_, volumeTracingBox) =>
+              // drop the skeleton if it exists
+              (Empty, volumeTracingBox.map(box => (box._1.tracing, box._2)))
           }
           .unzip)
     } else

--- a/test/backend/InstantTestSuite.scala
+++ b/test/backend/InstantTestSuite.scala
@@ -4,8 +4,6 @@ import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.JsonHelper
 import org.scalatestplus.play.PlaySpec
 
-import scala.concurrent.ExecutionContext.global
-
 class InstantTestSuite extends PlaySpec {
   val handleFoxJustification = "Handling Fox in Unit Test Context"
 

--- a/test/backend/NMLUnitTestSuite.scala
+++ b/test/backend/NMLUnitTestSuite.scala
@@ -71,8 +71,8 @@ class NMLUnitTestSuite @Inject()(nmlParser: NmlParser) extends PlaySpec {
     parsedTracing match {
       case Full(tuple) =>
         tuple match {
-          case NmlParseSuccessWithoutFile(Some(_), _, _, _, _) => true
-          case _                                               => false
+          case NmlParseSuccessWithoutFile(_, _, _, _, _) => true
+          case _                                         => false
         }
       case _ => false
     }
@@ -84,7 +84,7 @@ class NMLUnitTestSuite @Inject()(nmlParser: NmlParser) extends PlaySpec {
       writeAndParseTracing(dummyTracing) match {
         case Full(tuple) =>
           tuple match {
-            case NmlParseSuccessWithoutFile(Some(tracing), _, _, _, _) =>
+            case NmlParseSuccessWithoutFile(tracing, _, _, _, _) =>
               assert(tracing == dummyTracing)
             case _ => throw new Exception
           }
@@ -106,7 +106,7 @@ class NMLUnitTestSuite @Inject()(nmlParser: NmlParser) extends PlaySpec {
       writeAndParseTracing(dummyTracingWithOmittedIsExpandedTreeGroupProp) match {
         case Full(tuple) =>
           tuple match {
-            case NmlParseSuccessWithoutFile(Some(tracing), _, _, _, _) =>
+            case NmlParseSuccessWithoutFile(tracing, _, _, _, _) =>
               assert(tracing == dummyTracing)
             case _ => throw new Exception
           }


### PR DESCRIPTION
We decided that on annotation upload, an empty skeleton layer should always be created, see https://github.com/scalableminds/webknossos/issues/8143#issuecomment-2751144704

### URL of deployed dev instance (used for testing):
- https://uploadalwaysskeleton.webknossos.xyz

### Steps to test:
- Create hybrid, download + reupload, should still contain both layers
- Create volume-only, download + reupload, should contain both layers too
- Note that volume task creation with upload currently fails, fixed in related: https://github.com/scalableminds/webknossos/pull/8468

### Issues:
- fixes #8143 

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
