### PR TITLE
Fix credit system by returning balance as a string in organization routes

### DIFF
--- a/app/models/organization/OrganizationService.scala
+++ b/app/models/organization/OrganizationService.scala
@@ -68,7 +68,7 @@ class OrganizationService @Inject()(organizationDAO: OrganizationDAO,
         "includedStorageBytes" -> organization.includedStorageBytes,
         "usedStorageBytes" -> usedStorageBytes,
         "ownerName" -> ownerNameOpt,
-        "creditBalance" -> creditBalanceOpt
+        "creditBalance" -> creditBalanceOpt.map(_.toString)
       ) ++ adminOnlyInfo
   }
 


### PR DESCRIPTION
Reason for the bug: The frontend expects the returned type to be string and not a number. This is fine as the frontend does not do any credit based calculations. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Try to open the AI Analysis modal. That currently crashes on the master :/

### Issues:
- fixes bug merged in pr #8352

