### PR TITLE
Force rerender of dataset extent tooltip on dataset change

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed the alignment of the button that allows restricting floodfill operations to a bounding box. [#8388](https://github.com/scalableminds/webknossos/pull/8388) 
 - Fixed a bug for rotated dataset where volume tools were disabled although the dataset was rendered untransformed. [#8432](https://github.com/scalableminds/webknossos/pull/8432)
 - Fixed rare bug where saving got stuck. [#8409](https://github.com/scalableminds/webknossos/pull/8409)
+- Fixed that the dataset extent tooltip in the right details bar in the dashboard did not properly update when switching datasets. [#8477](https://github.com/scalableminds/webknossos/pull/8477)
 - Fixed some rendering bugs for float datasets that used a large dynamic range. [#8325](https://github.com/scalableminds/webknossos/pull/8325)
 - Fixed a bug where reverting annotations could get stuck if some of its layers had been deleted in the meantime. [#8405](https://github.com/scalableminds/webknossos/pull/8405)
 - When removing a segment from the segment list, a corresponding precomputed mesh was not removed automatically. [#8428](https://github.com/scalableminds/webknossos/pull/8428)

--- a/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/oxalis/view/right-border-tabs/dataset_info_tab_view.tsx
@@ -152,7 +152,12 @@ export function DatasetExtentRow({ dataset }: { dataset: APIDataset }) {
   };
 
   return (
-    <FastTooltip dynamicRenderer={renderDSExtentTooltip} placement="left" wrapper="tr">
+    <FastTooltip
+      dynamicRenderer={renderDSExtentTooltip}
+      placement="left"
+      wrapper="tr"
+      key={dataset.id}
+    >
       <td
         style={{
           paddingRight: 20,


### PR DESCRIPTION
This PR fixes a little bug where the dataset extent tooltip in the details bar in the dashboard did not properly update when switching datasets. See report: https://scm.slack.com/archives/C5AKLAV0B/p1741895918236529

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the dashboard and open the extent tooltip on different datasets. The tooltip should update now.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1741895918236529

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
