### PR TITLE
WIP Replace ava with vitest for frontend unit testing

### DIFF
--- a/frontend/javascripts/test/helpers/apiHelpers.ts
+++ b/frontend/javascripts/test/helpers/apiHelpers.ts
@@ -122,7 +122,7 @@ wkstoreAdapter = {
 mockRequire("oxalis/model/bucket_data_handling/wkstore_adapter", wkstoreAdapter);
 
 // Do not reRequire the model here as this would create a separate instance
-const Model = require("oxalis/model").default;
+import Model from "oxalis/model";
 
 const OxalisApi = mockRequire.reRequire("oxalis/api/api_loader").default;
 const TOKEN = "secure-token";
@@ -144,10 +144,10 @@ const modelData = {
   },
 };
 
-const { default: Store, startSagas } = require("oxalis/store");
-const rootSaga = require("oxalis/model/sagas/root_saga").default;
-const { setStore, setModel } = require("oxalis/singletons");
-const { setupApi } = require("oxalis/api/internal_api");
+import { default as Store, startSagas } from "oxalis/store";
+import rootSaga from "oxalis/model/sagas/root_saga";
+import { setStore, setModel } from "oxalis/singletons";
+import { setupApi } from "oxalis/api/internal_api";
 const { setActiveOrganizationAction } = mockRequire.reRequire(
   "oxalis/model/actions/organization_actions",
 );

--- a/frontend/javascripts/test/libs/async_fifo_resolver.spec.ts
+++ b/frontend/javascripts/test/libs/async_fifo_resolver.spec.ts
@@ -1,5 +1,5 @@
 import { sleep } from "libs/utils";
-import test from "ava";
+import { describe, it, expect } from "vitest";
 import { AsyncFifoResolver } from "libs/async/async_fifo_resolver";
 
 const createSubmitterFnWithProtocol = () => {
@@ -17,92 +17,86 @@ const createSubmitterFnWithProtocol = () => {
   return { submitter, resolver, protocol };
 };
 
-test("AsyncFifoResolver: Test simplest case", async (t) => {
-  t.plan(2);
+describe("AsyncFifoResolver", () => {
+  it("Test simplest case", async () => {
+    const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
+    submitter(1, 10);
+    submitter(2, 10);
 
-  const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
-  submitter(1, 10);
-  submitter(2, 10);
+    // Wait until everything is done
+    await resolver.orderedWaitFor(Promise.resolve());
 
-  // Wait until everything is done
-  await resolver.orderedWaitFor(Promise.resolve());
+    expect(protocol).toEqual([
+      "started-1",
+      "started-2",
+      "sleep-finished-1",
+      "finished-1",
+      "sleep-finished-2",
+      "finished-2",
+    ]);
+    expect(resolver.queue.length).toBe(0);
+  });
 
-  t.deepEqual(protocol, [
-    "started-1",
-    "started-2",
-    "sleep-finished-1",
-    "finished-1",
-    "sleep-finished-2",
-    "finished-2",
-  ]);
-  t.is(resolver.queue.length, 0);
-});
+  it("Test out-of-order sleeps should still finish in order", async () => {
+    const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
+    submitter(1, 50);
+    submitter(2, 10);
 
-test("AsyncFifoResolver: Test out-of-order sleeps should still finish in order", async (t) => {
-  t.plan(2);
+    // Wait until everything is done
+    await resolver.orderedWaitFor(Promise.resolve());
 
-  const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
-  submitter(1, 50);
-  submitter(2, 10);
+    expect(protocol).toEqual([
+      "started-1",
+      "started-2",
+      "sleep-finished-2",
+      "sleep-finished-1",
+      "finished-1",
+      "finished-2",
+    ]);
+    expect(resolver.queue.length).toBe(0);
+  });
 
-  // Wait until everything is done
-  await resolver.orderedWaitFor(Promise.resolve());
+  it("New submits shouldn't block old ones", async () => {
+    const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
+    // The first submitter should finish through and should not be blocked
+    // by the second one.
+    submitter(1, 50);
+    submitter(2, 1000);
 
-  t.deepEqual(protocol, [
-    "started-1",
-    "started-2",
-    "sleep-finished-2",
-    "sleep-finished-1",
-    "finished-1",
-    "finished-2",
-  ]);
-  t.is(resolver.queue.length, 0);
-});
+    await sleep(50);
 
-test("AsyncFifoResolver: New submits shouldn't block old ones.", async (t) => {
-  t.plan(2);
+    expect(protocol).toEqual(["started-1", "started-2", "sleep-finished-1", "finished-1"]);
+    expect(resolver.queue.length).toBe(1);
+  });
 
-  const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
-  // The first submitter should finish through and should not be blocked
-  // by the second one.
-  submitter(1, 50);
-  submitter(2, 1000);
+  it("Trimming of queue should work despite race condition potential", async () => {
+    const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
 
-  await sleep(50);
+    submitter(1, 100);
+    const promise = submitter(2, 100);
+    expect(resolver.queue.length).toBe(2);
+    submitter(3, 1000);
 
-  t.deepEqual(protocol, ["started-1", "started-2", "sleep-finished-1", "finished-1"]);
-  t.is(resolver.queue.length, 1);
-});
+    await promise;
+    submitter(4, 1);
 
-test("AsyncFifoResolver: Trimming of queue should work despite race condition potential.", async (t) => {
-  t.plan(3);
+    // Wait until everything is done
+    await resolver.orderedWaitFor(Promise.resolve());
 
-  const { submitter, resolver, protocol } = createSubmitterFnWithProtocol();
-
-  submitter(1, 100);
-  const promise = submitter(2, 100);
-  t.is(resolver.queue.length, 2);
-  submitter(3, 1000);
-
-  await promise;
-  submitter(4, 1);
-
-  // Wait until everything is done
-  await resolver.orderedWaitFor(Promise.resolve());
-
-  t.deepEqual(protocol, [
-    "started-1",
-    "started-2",
-    "started-3",
-    "sleep-finished-1",
-    "finished-1",
-    "sleep-finished-2",
-    "finished-2",
-    "started-4",
-    "sleep-finished-4",
-    "sleep-finished-3",
-    "finished-3",
-    "finished-4",
-  ]);
-  t.is(resolver.queue.length, 0);
+    expect(protocol).toEqual([
+      "started-1",
+      "started-2",
+      "started-3",
+      "sleep-finished-1",
+      "finished-1",
+      "sleep-finished-2",
+      "finished-2",
+      "started-4",
+      "sleep-finished-4",
+      "sleep-finished-3",
+      "finished-3",
+      "finished-4",
+    ]);
+    expect(resolver.queue.length).toBe(0);
+  });
 });

--- a/frontend/javascripts/test/libs/chainReducer.spec.ts
+++ b/frontend/javascripts/test/libs/chainReducer.spec.ts
@@ -1,5 +1,5 @@
 import ChainReducer from "test/helpers/chainReducer";
-import test from "ava";
+import { describe, it, expect } from "vitest";
 
 function IncrementReducer(state: number): number {
   return state + 1;
@@ -9,30 +9,34 @@ function SumReducer(state: number, action: number): number {
   return state + action;
 }
 
-test("ChainReducer should return the initial state if no reducers are called", (t) => {
-  const state = {};
-  const newState = ChainReducer(state).unpack();
-  t.is(newState, state);
-});
-test("ChainReducer should be called the correct number of timer", (t) => {
-  const state = 0;
-  const newState = ChainReducer(state)
-    .apply(IncrementReducer, null)
-    .apply(IncrementReducer, null)
-    .apply(IncrementReducer, null)
-    .apply(IncrementReducer, null)
-    .unpack();
-  t.is(newState, 4);
-});
-test("ChainReducer should call the reducer with the correct action", (t) => {
-  const state = 1;
-  const newState = ChainReducer(state)
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(state: number, action: number) ... Remove this comment to see the full error message
-    .apply(SumReducer, 2)
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(state: number, action: number) ... Remove this comment to see the full error message
-    .apply(SumReducer, 3)
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(state: number, action: number) ... Remove this comment to see the full error message
-    .apply(SumReducer, 4)
-    .unpack();
-  t.is(newState, 10);
+describe("ChainReducer", () => {
+  it("should return the initial state if no reducers are called", () => {
+    const state = {};
+    const newState = ChainReducer(state).unpack();
+    expect(newState).toBe(state);
+  });
+
+  it("should be called the correct number of times", () => {
+    const state = 0;
+    const newState = ChainReducer(state)
+      .apply(IncrementReducer, null)
+      .apply(IncrementReducer, null)
+      .apply(IncrementReducer, null)
+      .apply(IncrementReducer, null)
+      .unpack();
+    expect(newState).toBe(4);
+  });
+
+  it("should call the reducer with the correct action", () => {
+    const state = 1;
+    const newState = ChainReducer(state)
+      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(state: number, action: number) ... Remove this comment to see the full error message
+      .apply(SumReducer, 2)
+      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(state: number, action: number) ... Remove this comment to see the full error message
+      .apply(SumReducer, 3)
+      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '(state: number, action: number) ... Remove this comment to see the full error message
+      .apply(SumReducer, 4)
+      .unpack();
+    expect(newState).toBe(10);
+  });
 });

--- a/frontend/javascripts/test/libs/deferred.spec.ts
+++ b/frontend/javascripts/test/libs/deferred.spec.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import Deferred from "libs/async/deferred";
 import runAsync from "test/helpers/run-async";
-import test from "ava";
+import { describe, it, expect } from "vitest";
 
 function makeGetState(promise) {
   let resolved = false;
@@ -26,43 +26,44 @@ function makeGetState(promise) {
   };
 }
 
-test("Deferred should initialize an unresolved Promise", (t) => {
-  t.plan(2);
-  const deferred = new Deferred();
-  const getState = makeGetState(deferred.promise());
-  return runAsync([
-    () => {
-      const { resolved, rejected } = getState();
-      t.is(resolved, false);
-      t.is(rejected, false);
-    },
-  ]);
-});
-test("Deferred should resolve the Promise", (t) => {
-  t.plan(3);
-  const deferred = new Deferred();
-  const getState = makeGetState(deferred.promise());
-  deferred.resolve(123);
-  return runAsync([
-    () => {
-      const { resolved, rejected, result } = getState();
-      t.is(resolved, true);
-      t.is(rejected, false);
-      t.is(result, 123);
-    },
-  ]);
-});
-test("Deferred should reject the Promise", (t) => {
-  t.plan(3);
-  const deferred = new Deferred();
-  const getState = makeGetState(deferred.promise());
-  deferred.reject(123);
-  return runAsync([
-    () => {
-      const { resolved, rejected, result } = getState();
-      t.is(resolved, false);
-      t.is(rejected, true);
-      t.is(result, 123);
-    },
-  ]);
+describe("Deferred", () => {
+  it("should initialize an unresolved Promise", () => {
+    const deferred = new Deferred();
+    const getState = makeGetState(deferred.promise());
+    return runAsync([
+      () => {
+        const { resolved, rejected } = getState();
+        expect(resolved).toBe(false);
+        expect(rejected).toBe(false);
+      },
+    ]);
+  });
+
+  it("should resolve the Promise", () => {
+    const deferred = new Deferred();
+    const getState = makeGetState(deferred.promise());
+    deferred.resolve(123);
+    return runAsync([
+      () => {
+        const { resolved, rejected, result } = getState();
+        expect(resolved).toBe(true);
+        expect(rejected).toBe(false);
+        expect(result).toBe(123);
+      },
+    ]);
+  });
+
+  it("should reject the Promise", () => {
+    const deferred = new Deferred();
+    const getState = makeGetState(deferred.promise());
+    deferred.reject(123);
+    return runAsync([
+      () => {
+        const { resolved, rejected, result } = getState();
+        expect(resolved).toBe(false);
+        expect(rejected).toBe(true);
+        expect(result).toBe(123);
+      },
+    ]);
+  });
 });

--- a/frontend/javascripts/test/libs/diffable_map.spec.ts
+++ b/frontend/javascripts/test/libs/diffable_map.spec.ts
@@ -1,182 +1,192 @@
 import _ from "lodash";
 import DiffableMap, { diffDiffableMaps } from "libs/diffable_map";
-import test from "ava";
+import { describe, it, expect } from "vitest";
 
 function sort(arr: Array<number>) {
   return arr.sort((a, b) => a - b);
 }
 
-test("DiffableMap should be empty", (t) => {
-  const emptyMap = new DiffableMap<number, number>();
-  t.is(emptyMap.size(), 0);
-  t.false(emptyMap.has(1));
-  t.throws(() => emptyMap.getOrThrow(1));
-});
-test("DiffableMap should behave immutable on set/delete operations", (t) => {
-  const emptyMap = new DiffableMap();
-  const map1 = emptyMap.set(1, 1);
-  t.is(emptyMap.size(), 0);
-  t.false(emptyMap.has(1));
-  t.is(map1.size(), 1);
-  t.true(map1.has(1));
-  t.is(map1.getOrThrow(1), 1);
-  const map2 = map1.set(1, 2);
-  t.is(map1.getOrThrow(1), 1);
-  t.is(map2.getOrThrow(1), 2);
-  const map3 = map2.delete(1);
-  t.is(map2.getOrThrow(1), 2);
-  t.false(map3.has(1));
-});
-test("DiffableMap should be clonable and mutable on clone/mutableSet", (t) => {
-  const map1 = new DiffableMap().set(1, 1);
-  const map2 = map1.clone();
-  map2.mutableSet(1, 2);
-  map2.mutableSet(2, 2);
-  t.is(map2.getOrThrow(1), 2);
-  t.is(map2.getOrThrow(2), 2);
-  t.is(map1.getOrThrow(1), 1);
-  t.false(map1.has(2));
-  // Id should be the same since the internal structures look the same
-  t.is(map1.getId(), map2.getId());
-  t.is(map1.entryCount + 1, map2.entryCount);
-  t.is(map1.itemsPerBatch, map2.itemsPerBatch);
-});
-test("DiffableMap should be instantiable with Array<[key, value]>", (t) => {
-  const map = new DiffableMap([
-    [1, 2],
-    [3, 4],
-  ]);
-  t.is(map.getOrThrow(1), 2);
-  t.is(map.getOrThrow(3), 4);
-  t.is(map.size(), 2);
-});
-test("DiffableMap should work properly when it handles more items than the batch size", (t) => {
-  const emptyMap = new DiffableMap([], 10);
-  let currentMap = emptyMap;
-
-  // Fill with [i, 2*i] values
-  for (let i = 0; i < 100; i++) {
-    currentMap = currentMap.set(i, 2 * i);
-  }
-
-  // Check for [i, 2*i] values
-  for (let i = 0; i < 100; i++) {
-    t.is(currentMap.getOrThrow(i), 2 * i);
-  }
-
-  t.is(emptyMap.size(), 0);
-
-  // Remove each 10th key
-  for (let i = 0; i < 100; i++) {
-    if (i % 10 === 0) {
-      currentMap = currentMap.delete(i);
-    }
-  }
-
-  // Check that each 10th key was removed
-  for (let i = 0; i < 100; i++) {
-    if (i % 10 === 0) {
-      t.false(currentMap.has(i));
-    } else {
-      t.is(currentMap.getOrThrow(i), 2 * i);
-    }
-  }
-});
-test("diffDiffableMaps should return an empty diff for equal DiffableMaps", (t) => {
-  const emptyDiff = {
-    changed: [],
-    onlyA: [],
-    onlyB: [],
-  };
-  const emptyMap1 = new DiffableMap();
-  const emptyMap2 = new DiffableMap();
-  const emptyMap3 = emptyMap1.clone();
-  t.deepEqual(diffDiffableMaps(emptyMap1, emptyMap2), emptyDiff);
-  t.deepEqual(diffDiffableMaps(emptyMap2, emptyMap1), emptyDiff);
-  t.deepEqual(diffDiffableMaps(emptyMap1, emptyMap3), emptyDiff);
-  t.deepEqual(diffDiffableMaps(emptyMap2, emptyMap3), emptyDiff);
-});
-test("diffDiffableMaps should diff DiffableMaps which are based on each other", (t) => {
-  const peter = {};
-  const bob = {};
-  const andrew = {};
-  const map1 = new DiffableMap<number, any>([
-    [1, peter],
-    [2, bob],
-  ]);
-  const map2 = map1.set(3, andrew);
-  t.deepEqual(diffDiffableMaps(map1, map2), {
-    changed: [],
-    onlyA: [],
-    onlyB: [3],
+describe("DiffableMap", () => {
+  it("should be empty", () => {
+    const emptyMap = new DiffableMap<number, number>();
+    expect(emptyMap.size()).toBe(0);
+    expect(emptyMap.has(1)).toBe(false);
+    expect(() => emptyMap.getOrThrow(1)).toThrow();
   });
-});
-test("diffDiffableMaps should diff large DiffableMaps which are based on each other", (t) => {
-  const objects = [];
 
-  for (let i = 0; i < 105; i++) {
-    objects.push({});
-  }
-
-  // Load the first 100 objects into map1
-  const map1 = new DiffableMap<number, any>(
-    objects.slice(0, 100).map((obj, index) => [index, obj]),
-    10,
-  );
-  let map2 = map1;
-
-  // Delete even keys from map2
-  for (const key of map1.keys()) {
-    if (key % 2 === 0) {
-      map2 = map2.delete(key);
-    }
-  }
-
-  // Add the last five objects to map2
-  objects.slice(-5).forEach((obj, idx) => {
-    map2 = map2.set(idx + 100, obj);
+  it("should behave immutable on set/delete operations", () => {
+    const emptyMap = new DiffableMap();
+    const map1 = emptyMap.set(1, 1);
+    expect(emptyMap.size()).toBe(0);
+    expect(emptyMap.has(1)).toBe(false);
+    expect(map1.size()).toBe(1);
+    expect(map1.has(1)).toBe(true);
+    expect(map1.getOrThrow(1)).toBe(1);
+    const map2 = map1.set(1, 2);
+    expect(map1.getOrThrow(1)).toBe(1);
+    expect(map2.getOrThrow(1)).toBe(2);
+    const map3 = map2.delete(1);
+    expect(map2.getOrThrow(1)).toBe(2);
+    expect(map3.has(1)).toBe(false);
   });
-  // Overwrite the 50th key
-  map2 = map2.set(51, null);
-  const diff = diffDiffableMaps(map1, map2);
-  const expectedDiff = {
-    changed: [51],
-    onlyA: _.range(100).filter((idx) => idx % 2 === 0),
-    onlyB: _.range(100, 105),
-  };
-  t.deepEqual(sort(diff.changed), expectedDiff.changed);
-  t.deepEqual(sort(diff.onlyA), expectedDiff.onlyA);
-  t.deepEqual(sort(diff.onlyB), expectedDiff.onlyB);
-});
-test("diffDiffableMaps should diff large DiffableMaps which are not based on each other (independent)", (t) => {
-  const objects = [];
 
-  for (let i = 0; i < 105; i++) {
-    objects.push({});
-  }
+  it("should be clonable and mutable on clone/mutableSet", () => {
+    const map1 = new DiffableMap().set(1, 1);
+    const map2 = map1.clone();
+    map2.mutableSet(1, 2);
+    map2.mutableSet(2, 2);
+    expect(map2.getOrThrow(1)).toBe(2);
+    expect(map2.getOrThrow(2)).toBe(2);
+    expect(map1.getOrThrow(1)).toBe(1);
+    expect(map1.has(2)).toBe(false);
+    // Id should be the same since the internal structures look the same
+    expect(map1.getId()).toBe(map2.getId());
+    expect(map1.entryCount + 1).toBe(map2.entryCount);
+    expect(map1.itemsPerBatch).toBe(map2.itemsPerBatch);
+  });
 
-  // Load the first, uneven 100 objects into map1 and add a 111th key
-  const map1 = new DiffableMap<number, any>(
-    // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{}[][]' is not assignable to par... Remove this comment to see the full error message
-    objects
-      .slice(0, 100)
-      .map((obj, index) => [index, obj])
-      // @ts-expect-error ts-migrate(2362) FIXME: The left-hand side of an arithmetic operation must... Remove this comment to see the full error message
-      .filter(([idx]) => idx % 2 === 1),
-    10,
-  ).set(110, {});
-  // Load the first 105 objects into map2 and overwrite the 52th key
-  const map2 = new DiffableMap<number, any>(
-    objects.slice(0, 105).map((obj, index) => [index, obj]),
-    10,
-  ).set(51, null);
-  const diff = diffDiffableMaps(map1, map2);
-  const expectedDiff = {
-    changed: [51],
-    onlyA: [110],
-    onlyB: _.range(0, 105).filter((idx) => idx % 2 === 0 || idx > 100),
-  };
-  t.deepEqual(sort(diff.changed), expectedDiff.changed);
-  t.deepEqual(sort(diff.onlyA), expectedDiff.onlyA);
-  t.deepEqual(sort(diff.onlyB), expectedDiff.onlyB);
+  it("should be instantiable with Array<[key, value]>", () => {
+    const map = new DiffableMap([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(map.getOrThrow(1)).toBe(2);
+    expect(map.getOrThrow(3)).toBe(4);
+    expect(map.size()).toBe(2);
+  });
+
+  it("should work properly when it handles more items than the batch size", () => {
+    const emptyMap = new DiffableMap([], 10);
+    let currentMap = emptyMap;
+
+    // Fill with [i, 2*i] values
+    for (let i = 0; i < 100; i++) {
+      currentMap = currentMap.set(i, 2 * i);
+    }
+
+    // Check for [i, 2*i] values
+    for (let i = 0; i < 100; i++) {
+      expect(currentMap.getOrThrow(i)).toBe(2 * i);
+    }
+
+    expect(emptyMap.size()).toBe(0);
+
+    // Remove each 10th key
+    for (let i = 0; i < 100; i++) {
+      if (i % 10 === 0) {
+        currentMap = currentMap.delete(i);
+      }
+    }
+
+    // Check that each 10th key was removed
+    for (let i = 0; i < 100; i++) {
+      if (i % 10 === 0) {
+        expect(currentMap.has(i)).toBe(false);
+      } else {
+        expect(currentMap.getOrThrow(i)).toBe(2 * i);
+      }
+    }
+  });
+
+  it("diffDiffableMaps should return an empty diff for equal DiffableMaps", () => {
+    const emptyDiff = {
+      changed: [],
+      onlyA: [],
+      onlyB: [],
+    };
+    const emptyMap1 = new DiffableMap();
+    const emptyMap2 = new DiffableMap();
+    const emptyMap3 = emptyMap1.clone();
+    expect(diffDiffableMaps(emptyMap1, emptyMap2)).toEqual(emptyDiff);
+    expect(diffDiffableMaps(emptyMap2, emptyMap1)).toEqual(emptyDiff);
+    expect(diffDiffableMaps(emptyMap1, emptyMap3)).toEqual(emptyDiff);
+    expect(diffDiffableMaps(emptyMap2, emptyMap3)).toEqual(emptyDiff);
+  });
+
+  it("diffDiffableMaps should diff DiffableMaps which are based on each other", () => {
+    const peter = {};
+    const bob = {};
+    const andrew = {};
+    const map1 = new DiffableMap<number, any>([
+      [1, peter],
+      [2, bob],
+    ]);
+    const map2 = map1.set(3, andrew);
+    expect(diffDiffableMaps(map1, map2)).toEqual({
+      changed: [],
+      onlyA: [],
+      onlyB: [3],
+    });
+  });
+
+  it("diffDiffableMaps should diff large DiffableMaps which are based on each other", () => {
+    const objects = [];
+
+    for (let i = 0; i < 105; i++) {
+      objects.push({});
+    }
+
+    // Load the first 100 objects into map1
+    const map1 = new DiffableMap<number, any>(
+      objects.slice(0, 100).map((obj, index) => [index, obj]),
+      10,
+    );
+    let map2 = map1;
+
+    // Delete even keys from map2
+    for (const key of map1.keys()) {
+      if (key % 2 === 0) {
+        map2 = map2.delete(key);
+      }
+    }
+
+    // Add the last five objects to map2
+    objects.slice(-5).forEach((obj, idx) => {
+      map2 = map2.set(idx + 100, obj);
+    });
+    // Overwrite the 50th key
+    map2 = map2.set(51, null);
+    const diff = diffDiffableMaps(map1, map2);
+    const expectedDiff = {
+      changed: [51],
+      onlyA: _.range(100).filter((idx) => idx % 2 === 0),
+      onlyB: _.range(100, 105),
+    };
+    expect(sort(diff.changed)).toEqual(expectedDiff.changed);
+    expect(sort(diff.onlyA)).toEqual(expectedDiff.onlyA);
+    expect(sort(diff.onlyB)).toEqual(expectedDiff.onlyB);
+  });
+
+  it("diffDiffableMaps should diff large DiffableMaps which are not based on each other (independent)", () => {
+    const objects = [];
+
+    for (let i = 0; i < 105; i++) {
+      objects.push({});
+    }
+
+    // Load the first, uneven 100 objects into map1 and add a 111th key
+    const map1 = new DiffableMap<number, any>(
+      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{}[][]' is not assignable to par... Remove this comment to see the full error message
+      objects
+        .slice(0, 100)
+        .map((obj, index) => [index, obj])
+        // @ts-expect-error ts-migrate(2362) FIXME: The left-hand side of an arithmetic operation must... Remove this comment to see the full error message
+        .filter(([idx]) => idx % 2 === 1),
+      10,
+    ).set(110, {});
+    // Load the first 105 objects into map2 and overwrite the 52th key
+    const map2 = new DiffableMap<number, any>(
+      objects.slice(0, 105).map((obj, index) => [index, obj]),
+      10,
+    ).set(51, null);
+    const diff = diffDiffableMaps(map1, map2);
+    const expectedDiff = {
+      changed: [51],
+      onlyA: [110],
+      onlyB: _.range(0, 105).filter((idx) => idx % 2 === 0 || idx > 100),
+    };
+    expect(sort(diff.changed)).toEqual(expectedDiff.changed);
+    expect(sort(diff.onlyA)).toEqual(expectedDiff.onlyA);
+    expect(sort(diff.onlyB)).toEqual(expectedDiff.onlyB);
+  });
 });

--- a/frontend/javascripts/test/libs/estimate_affine.spec.ts
+++ b/frontend/javascripts/test/libs/estimate_affine.spec.ts
@@ -1,66 +1,68 @@
-import "test/mocks/lz4";
-import test from "ava";
+import "../mocks/lz4";
+import { describe, it, expect } from "vitest";
 import type { Vector3 } from "oxalis/constants";
 import Matrix from "ml-matrix";
 import estimateAffine, { estimateAffineMatrix4x4 } from "libs/estimate_affine";
 import { almostEqual, getPointsC555 } from "./transform_spec_helpers";
 import { M4x4 } from "libs/mjs";
 
-test("Estimate affine projection", (t) => {
-  const [sourcePoints, targetPoints] = getPointsC555();
-  const affineMatrix = estimateAffine(sourcePoints, targetPoints);
+describe("Estimate Affine", () => {
+  it("Estimate affine projection", () => {
+    const [sourcePoints, targetPoints] = getPointsC555();
+    const affineMatrix = estimateAffine(sourcePoints, targetPoints);
 
-  const transform = (x: number, y: number, z: number) => {
-    const vec = new Matrix([[x, y, z, 1]]).transpose();
-    const transformed = affineMatrix.mmul(vec);
-    return transformed.to1DArray() as Vector3;
-  };
+    const transform = (x: number, y: number, z: number) => {
+      const vec = new Matrix([[x, y, z, 1]]).transpose();
+      const transformed = affineMatrix.mmul(vec);
+      return transformed.to1DArray() as Vector3;
+    };
 
-  almostEqual(
-    t,
-    [568.1202797015036, 528.013612246682, 1622.1124501555569],
-    transform(570.3021, 404.5549, 502.22482),
-    5,
-  );
-  almostEqual(
-    t,
-    [1574.679455809381, 1607.1773268624395, 1791.5425120096843],
-    transform(500, 501, 502),
-    5,
-  );
-});
+    almostEqual(
+      expect,
+      [568.1202797015036, 528.013612246682, 1622.1124501555569],
+      transform(570.3021, 404.5549, 502.22482),
+      5,
+    );
+    almostEqual(
+      expect,
+      [1574.679455809381, 1607.1773268624395, 1791.5425120096843],
+      transform(500, 501, 502),
+      5,
+    );
+  });
 
-test("Estimate affine projection should make sense with M4x4 as well as Matrix", async (t) => {
-  // This transform essentially computes:
-  // coord := coord * 2 + 10
-  const source = [
-    [0, 0, 0],
-    [10, 10, 10],
-    [10, 10, 0],
-    [5, 10, 15],
-  ] as Vector3[];
-  const target = [
-    [10, 10, 10],
-    [30, 30, 30],
-    [30, 30, 10],
-    [20, 30, 40],
-  ] as Vector3[];
-  const aff1 = estimateAffineMatrix4x4(source, target);
-  const aff2 = estimateAffine(source, target);
+  it("Estimate affine projection should make sense with M4x4 as well as Matrix", async () => {
+    // This transform essentially computes:
+    // coord := coord * 2 + 10
+    const source = [
+      [0, 0, 0],
+      [10, 10, 10],
+      [10, 10, 0],
+      [5, 10, 15],
+    ] as Vector3[];
+    const target = [
+      [10, 10, 10],
+      [30, 30, 30],
+      [30, 30, 10],
+      [20, 30, 40],
+    ] as Vector3[];
+    const aff1 = estimateAffineMatrix4x4(source, target);
+    const aff2 = estimateAffine(source, target);
 
-  const transform = (pos: Vector3) => M4x4.transformVectorsAffine(M4x4.transpose(aff1), [pos])[0];
-  const transform2 = ([x, y, z]: Vector3) => {
-    const vec = new Matrix([[x, y, z, 1]]).transpose();
-    const transformed = aff2.mmul(vec);
-    return transformed.to1DArray().slice(0, 3) as Vector3;
-  };
+    const transform = (pos: Vector3) => M4x4.transformVectorsAffine(M4x4.transpose(aff1), [pos])[0];
+    const transform2 = ([x, y, z]: Vector3) => {
+      const vec = new Matrix([[x, y, z, 1]]).transpose();
+      const transformed = aff2.mmul(vec);
+      return transformed.to1DArray().slice(0, 3) as Vector3;
+    };
 
-  const epsilon = 0.001;
-  almostEqual(t, transform([0, 0, 0]), [10, 10, 10], epsilon);
-  almostEqual(t, transform([3, 7, 8]), [16, 24, 26], epsilon);
-  almostEqual(t, transform([34, 28, 9]), [78, 66, 28], epsilon);
+    const epsilon = 0.001;
+    almostEqual(expect, transform([0, 0, 0]), [10, 10, 10], epsilon);
+    almostEqual(expect, transform([3, 7, 8]), [16, 24, 26], epsilon);
+    almostEqual(expect, transform([34, 28, 9]), [78, 66, 28], epsilon);
 
-  almostEqual(t, transform2([0, 0, 0]), [10, 10, 10], epsilon);
-  almostEqual(t, transform2([3, 7, 8]), [16, 24, 26], epsilon);
-  almostEqual(t, transform2([34, 28, 9]), [78, 66, 28], epsilon);
+    almostEqual(expect, transform2([0, 0, 0]), [10, 10, 10], epsilon);
+    almostEqual(expect, transform2([3, 7, 8]), [16, 24, 26], epsilon);
+    almostEqual(expect, transform2([34, 28, 9]), [78, 66, 28], epsilon);
+  });
 });

--- a/frontend/javascripts/test/libs/format_utils.spec.ts
+++ b/frontend/javascripts/test/libs/format_utils.spec.ts
@@ -1,111 +1,113 @@
-import test from "ava";
+import { describe, it, expect } from "vitest";
 import { UnitShort, Unicode } from "oxalis/constants";
 import { formatNumberToArea, formatNumberToLength, formatNumberToVolume } from "libs/format_utils";
 
 const { ThinSpace } = Unicode;
 
-test("Format number to length with cm", (t) => {
-  t.is(`0.0${ThinSpace}cm`, formatNumberToLength(0, UnitShort.cm));
-  t.is(`0.1${ThinSpace}cm`, formatNumberToLength(0.1, UnitShort.cm, 1, true));
-  t.is(`1.0${ThinSpace}cm`, formatNumberToLength(10, UnitShort.mm));
-  t.is(`4.8${ThinSpace}cm`, formatNumberToLength(48, UnitShort.mm));
-  t.is(`1.6${ThinSpace}cm`, formatNumberToLength(16000, UnitShort.µm));
-  t.is(`1.2${ThinSpace}cm`, formatNumberToLength(0.012, UnitShort.m));
-});
+describe("Format Utils", () => {
+  it("Format number to length with cm", () => {
+    expect(`0.0${ThinSpace}cm`).toBe(formatNumberToLength(0, UnitShort.cm));
+    expect(`0.1${ThinSpace}cm`).toBe(formatNumberToLength(0.1, UnitShort.cm, 1, true));
+    expect(`1.0${ThinSpace}cm`).toBe(formatNumberToLength(10, UnitShort.mm));
+    expect(`4.8${ThinSpace}cm`).toBe(formatNumberToLength(48, UnitShort.mm));
+    expect(`1.6${ThinSpace}cm`).toBe(formatNumberToLength(16000, UnitShort.µm));
+    expect(`1.2${ThinSpace}cm`).toBe(formatNumberToLength(0.012, UnitShort.m));
+  });
 
-test("Format number to area with cm", (t) => {
-  t.is(`0.0${ThinSpace}cm²`, formatNumberToArea(0, UnitShort.cm));
-  t.is(`10.0${ThinSpace}mm²`, formatNumberToArea(0.1, UnitShort.cm));
-  t.is(`10.0${ThinSpace}mm²`, formatNumberToArea(10, UnitShort.mm));
-  t.is(`1.0${ThinSpace}cm²`, formatNumberToArea(100, UnitShort.mm));
-  t.is(`48.0${ThinSpace}mm²`, formatNumberToArea(48, UnitShort.mm));
-  t.is(`16.0${ThinSpace}cm²`, formatNumberToArea(1600000000, UnitShort.µm));
-  t.is(`1.2${ThinSpace}cm²`, formatNumberToArea(0.00012, UnitShort.m));
-});
+  it("Format number to area with cm", () => {
+    expect(`0.0${ThinSpace}cm²`).toBe(formatNumberToArea(0, UnitShort.cm));
+    expect(`10.0${ThinSpace}mm²`).toBe(formatNumberToArea(0.1, UnitShort.cm));
+    expect(`10.0${ThinSpace}mm²`).toBe(formatNumberToArea(10, UnitShort.mm));
+    expect(`1.0${ThinSpace}cm²`).toBe(formatNumberToArea(100, UnitShort.mm));
+    expect(`48.0${ThinSpace}mm²`).toBe(formatNumberToArea(48, UnitShort.mm));
+    expect(`16.0${ThinSpace}cm²`).toBe(formatNumberToArea(1600000000, UnitShort.µm));
+    expect(`1.2${ThinSpace}cm²`).toBe(formatNumberToArea(0.00012, UnitShort.m));
+  });
 
-test("Format number to volume with cm", (t) => {
-  t.is(`0.0${ThinSpace}cm³`, formatNumberToVolume(0, UnitShort.cm));
-  t.is(`100.0${ThinSpace}mm³`, formatNumberToVolume(0.1, UnitShort.cm));
-  t.is(`100.0${ThinSpace}mm³`, formatNumberToVolume(100, UnitShort.mm));
-  t.is(`1.0${ThinSpace}cm³`, formatNumberToVolume(1000, UnitShort.mm));
-  t.is(`4.8${ThinSpace}cm³`, formatNumberToVolume(4800, UnitShort.mm));
-  t.is(`16.0${ThinSpace}cm³`, formatNumberToVolume(16e12, UnitShort.µm));
-  t.is(`120.0${ThinSpace}cm³`, formatNumberToVolume(0.00012, UnitShort.m));
-});
+  it("Format number to volume with cm", () => {
+    expect(`0.0${ThinSpace}cm³`).toBe(formatNumberToVolume(0, UnitShort.cm));
+    expect(`100.0${ThinSpace}mm³`).toBe(formatNumberToVolume(0.1, UnitShort.cm));
+    expect(`100.0${ThinSpace}mm³`).toBe(formatNumberToVolume(100, UnitShort.mm));
+    expect(`1.0${ThinSpace}cm³`).toBe(formatNumberToVolume(1000, UnitShort.mm));
+    expect(`4.8${ThinSpace}cm³`).toBe(formatNumberToVolume(4800, UnitShort.mm));
+    expect(`16.0${ThinSpace}cm³`).toBe(formatNumberToVolume(16e12, UnitShort.µm));
+    expect(`120.0${ThinSpace}cm³`).toBe(formatNumberToVolume(0.00012, UnitShort.m));
+  });
 
-test("Format conversion in length", (t) => {
-  t.is(`1.2${ThinSpace}pm`, formatNumberToLength(0.0012, UnitShort.nm));
-  t.is(`12.0${ThinSpace}fm`, formatNumberToLength(0.000012, UnitShort.nm));
-  t.is(`1.2${ThinSpace}mm`, formatNumberToLength(1.2e6, UnitShort.nm));
-  t.is(`12.0${ThinSpace}nm`, formatNumberToLength(12, UnitShort.nm));
-  t.is(`10.0${ThinSpace}fm`, formatNumberToLength(1e-5, UnitShort.nm));
-  t.is(`0.0${ThinSpace}ym`, formatNumberToLength(1e-17, UnitShort.nm));
-  t.is(`1.2${ThinSpace}Mm`, formatNumberToLength(1234e12, UnitShort.nm));
-  t.is(`1234.0${ThinSpace}Ym`, formatNumberToLength(1234e33, UnitShort.nm));
-});
+  it("Format conversion in length", () => {
+    expect(`1.2${ThinSpace}pm`).toBe(formatNumberToLength(0.0012, UnitShort.nm));
+    expect(`12.0${ThinSpace}fm`).toBe(formatNumberToLength(0.000012, UnitShort.nm));
+    expect(`1.2${ThinSpace}mm`).toBe(formatNumberToLength(1.2e6, UnitShort.nm));
+    expect(`12.0${ThinSpace}nm`).toBe(formatNumberToLength(12, UnitShort.nm));
+    expect(`10.0${ThinSpace}fm`).toBe(formatNumberToLength(1e-5, UnitShort.nm));
+    expect(`0.0${ThinSpace}ym`).toBe(formatNumberToLength(1e-17, UnitShort.nm));
+    expect(`1.2${ThinSpace}Mm`).toBe(formatNumberToLength(1234e12, UnitShort.nm));
+    expect(`1234.0${ThinSpace}Ym`).toBe(formatNumberToLength(1234e33, UnitShort.nm));
+  });
 
-test("Format number to area", (t) => {
-  t.is(`100000.0${ThinSpace}fm²`, formatNumberToArea(1e-7, UnitShort.nm));
-  t.is(`0.0${ThinSpace}ym²`, formatNumberToArea(1e-33, UnitShort.nm));
-  t.is(`12.0${ThinSpace}cm²`, formatNumberToArea(0.0012, UnitShort.m));
-  t.is(`12.0${ThinSpace}mm²`, formatNumberToArea(0.000012, UnitShort.m));
-  t.is(`1.0${ThinSpace}km²`, formatNumberToArea(1e6, UnitShort.m));
-  t.is(`12.0${ThinSpace}m²`, formatNumberToArea(12, UnitShort.m));
-  t.is(`10.0${ThinSpace}mm²`, formatNumberToArea(1e-5, UnitShort.m));
-  t.is(`10.0${ThinSpace}nm²`, formatNumberToArea(1e-17, UnitShort.m));
-  t.is(`1234.0${ThinSpace}Mm²`, formatNumberToArea(1234e12, UnitShort.m));
-  t.is(`1.2${ThinSpace}Em²`, formatNumberToArea(1234e33, UnitShort.m));
-});
+  it("Format number to area", () => {
+    expect(`100000.0${ThinSpace}fm²`).toBe(formatNumberToArea(1e-7, UnitShort.nm));
+    expect(`0.0${ThinSpace}ym²`).toBe(formatNumberToArea(1e-33, UnitShort.nm));
+    expect(`12.0${ThinSpace}cm²`).toBe(formatNumberToArea(0.0012, UnitShort.m));
+    expect(`12.0${ThinSpace}mm²`).toBe(formatNumberToArea(0.000012, UnitShort.m));
+    expect(`1.0${ThinSpace}km²`).toBe(formatNumberToArea(1e6, UnitShort.m));
+    expect(`12.0${ThinSpace}m²`).toBe(formatNumberToArea(12, UnitShort.m));
+    expect(`10.0${ThinSpace}mm²`).toBe(formatNumberToArea(1e-5, UnitShort.m));
+    expect(`10.0${ThinSpace}nm²`).toBe(formatNumberToArea(1e-17, UnitShort.m));
+    expect(`1234.0${ThinSpace}Mm²`).toBe(formatNumberToArea(1234e12, UnitShort.m));
+    expect(`1.2${ThinSpace}Em²`).toBe(formatNumberToArea(1234e33, UnitShort.m));
+  });
 
-test("Format number to volume", (t) => {
-  t.is(`100000000.0${ThinSpace}pm³`, formatNumberToVolume(1e-1, UnitShort.nm));
-  t.is(`1000.0${ThinSpace}zm³`, formatNumberToVolume(1e-33, UnitShort.nm));
-  t.is(`1200.0${ThinSpace}cm³`, formatNumberToVolume(0.0012, UnitShort.m));
-  t.is(`12.0${ThinSpace}cm³`, formatNumberToVolume(0.000012, UnitShort.m));
-  t.is(`1000000.0${ThinSpace}m³`, formatNumberToVolume(1e6, UnitShort.m));
-  t.is(`12.0${ThinSpace}m³`, formatNumberToVolume(12, UnitShort.m));
-  t.is(`10.0${ThinSpace}cm³`, formatNumberToVolume(1e-5, UnitShort.m));
-  t.is(`10.0${ThinSpace}µm³`, formatNumberToVolume(1e-17, UnitShort.m));
-  t.is(`1234000.0${ThinSpace}km³`, formatNumberToVolume(1234e12, UnitShort.m));
-  t.is(`1.2${ThinSpace}Tm³`, formatNumberToVolume(1234e33, UnitShort.m));
-});
+  it("Format number to volume", () => {
+    expect(`100000000.0${ThinSpace}pm³`).toBe(formatNumberToVolume(1e-1, UnitShort.nm));
+    expect(`1000.0${ThinSpace}zm³`).toBe(formatNumberToVolume(1e-33, UnitShort.nm));
+    expect(`1200.0${ThinSpace}cm³`).toBe(formatNumberToVolume(0.0012, UnitShort.m));
+    expect(`12.0${ThinSpace}cm³`).toBe(formatNumberToVolume(0.000012, UnitShort.m));
+    expect(`1000000.0${ThinSpace}m³`).toBe(formatNumberToVolume(1e6, UnitShort.m));
+    expect(`12.0${ThinSpace}m³`).toBe(formatNumberToVolume(12, UnitShort.m));
+    expect(`10.0${ThinSpace}cm³`).toBe(formatNumberToVolume(1e-5, UnitShort.m));
+    expect(`10.0${ThinSpace}µm³`).toBe(formatNumberToVolume(1e-17, UnitShort.m));
+    expect(`1234000.0${ThinSpace}km³`).toBe(formatNumberToVolume(1234e12, UnitShort.m));
+    expect(`1.2${ThinSpace}Tm³`).toBe(formatNumberToVolume(1234e33, UnitShort.m));
+  });
 
-test("Test uncommon number formats", (t) => {
-  t.is(`1.0${ThinSpace}m`, formatNumberToLength(10, UnitShort.dm, 2));
-  t.is(`5500.0${ThinSpace}cm³`, formatNumberToVolume(5.5, UnitShort.dm, 2));
-  t.is(`1.0${ThinSpace}km`, formatNumberToLength(10, UnitShort.hm, 2));
-  t.is(`550.0${ThinSpace}m`, formatNumberToLength(5.5, UnitShort.hm, 2));
-  t.is(`1.0${ThinSpace}nm`, formatNumberToLength(10, UnitShort.Å, 2));
-  t.is(`55000.0${ThinSpace}pm²`, formatNumberToArea(5.5, UnitShort.Å, 2));
-  t.is(`25.4${ThinSpace}cm`, formatNumberToLength(10, UnitShort.in, 2));
-  t.is(`13.97${ThinSpace}cm`, formatNumberToLength(5.5, UnitShort.in, 2));
-  t.is(`3.05${ThinSpace}m`, formatNumberToLength(10, UnitShort.ft, 2));
-  t.is(`1.68${ThinSpace}m`, formatNumberToLength(5.5, UnitShort.ft, 2));
-  t.is(`9.14${ThinSpace}m`, formatNumberToLength(10, UnitShort.yd, 2));
-  t.is(`5.03${ThinSpace}m`, formatNumberToLength(5.5, UnitShort.yd, 2));
-  t.is(`16.09${ThinSpace}km`, formatNumberToLength(10, UnitShort.mi, 2));
-  t.is(`8.85${ThinSpace}km`, formatNumberToLength(5.5, UnitShort.mi, 2));
-  t.is(`308.57${ThinSpace}Pm`, formatNumberToLength(10, UnitShort.pc, 2));
-  t.is(`169.71${ThinSpace}Pm`, formatNumberToLength(5.5, UnitShort.pc, 2));
-});
+  it("Test uncommon number formats", () => {
+    expect(`1.0${ThinSpace}m`).toBe(formatNumberToLength(10, UnitShort.dm, 2));
+    expect(`5500.0${ThinSpace}cm³`).toBe(formatNumberToVolume(5.5, UnitShort.dm, 2));
+    expect(`1.0${ThinSpace}km`).toBe(formatNumberToLength(10, UnitShort.hm, 2));
+    expect(`550.0${ThinSpace}m`).toBe(formatNumberToLength(5.5, UnitShort.hm, 2));
+    expect(`1.0${ThinSpace}nm`).toBe(formatNumberToLength(10, UnitShort.Å, 2));
+    expect(`55000.0${ThinSpace}pm²`).toBe(formatNumberToArea(5.5, UnitShort.Å, 2));
+    expect(`25.4${ThinSpace}cm`).toBe(formatNumberToLength(10, UnitShort.in, 2));
+    expect(`13.97${ThinSpace}cm`).toBe(formatNumberToLength(5.5, UnitShort.in, 2));
+    expect(`3.05${ThinSpace}m`).toBe(formatNumberToLength(10, UnitShort.ft, 2));
+    expect(`1.68${ThinSpace}m`).toBe(formatNumberToLength(5.5, UnitShort.ft, 2));
+    expect(`9.14${ThinSpace}m`).toBe(formatNumberToLength(10, UnitShort.yd, 2));
+    expect(`5.03${ThinSpace}m`).toBe(formatNumberToLength(5.5, UnitShort.yd, 2));
+    expect(`16.09${ThinSpace}km`).toBe(formatNumberToLength(10, UnitShort.mi, 2));
+    expect(`8.85${ThinSpace}km`).toBe(formatNumberToLength(5.5, UnitShort.mi, 2));
+    expect(`308.57${ThinSpace}Pm`).toBe(formatNumberToLength(10, UnitShort.pc, 2));
+    expect(`169.71${ThinSpace}Pm`).toBe(formatNumberToLength(5.5, UnitShort.pc, 2));
+  });
 
-test("Test precision in formatting numbers", (t) => {
-  t.is(`1.2${ThinSpace}cm`, formatNumberToLength(1.23456789, UnitShort.cm));
-  t.is(`1.23${ThinSpace}cm`, formatNumberToLength(1.23456789, UnitShort.cm, 2));
-  t.is(`1.235${ThinSpace}cm²`, formatNumberToArea(1.23456789, UnitShort.cm, 3));
-  t.is(`1.2346${ThinSpace}cm²`, formatNumberToArea(1.23456789, UnitShort.cm, 4));
-  t.is(`1.23457${ThinSpace}cm³`, formatNumberToVolume(1.23456789, UnitShort.cm, 5));
-  t.is(`1.234568${ThinSpace}cm³`, formatNumberToVolume(1.23456789, UnitShort.cm, 6));
-});
+  it("Test precision in formatting numbers", () => {
+    expect(`1.2${ThinSpace}cm`).toBe(formatNumberToLength(1.23456789, UnitShort.cm));
+    expect(`1.23${ThinSpace}cm`).toBe(formatNumberToLength(1.23456789, UnitShort.cm, 2));
+    expect(`1.235${ThinSpace}cm²`).toBe(formatNumberToArea(1.23456789, UnitShort.cm, 3));
+    expect(`1.2346${ThinSpace}cm²`).toBe(formatNumberToArea(1.23456789, UnitShort.cm, 4));
+    expect(`1.23457${ThinSpace}cm³`).toBe(formatNumberToVolume(1.23456789, UnitShort.cm, 5));
+    expect(`1.234568${ThinSpace}cm³`).toBe(formatNumberToVolume(1.23456789, UnitShort.cm, 6));
+  });
 
-test("Test preferShorterDecimals in formatting numbers", (t) => {
-  t.is(`0.1${ThinSpace}m`, formatNumberToLength(0.1, UnitShort.m, 1, true));
-  t.is(`1.2${ThinSpace}cm`, formatNumberToLength(1.23456789, UnitShort.cm, 1, true));
-  t.is(`0.3${ThinSpace}m`, formatNumberToLength(0.35, UnitShort.m, 1, true));
-});
+  it("Test preferShorterDecimals in formatting numbers", () => {
+    expect(`0.1${ThinSpace}m`).toBe(formatNumberToLength(0.1, UnitShort.m, 1, true));
+    expect(`1.2${ThinSpace}cm`).toBe(formatNumberToLength(1.23456789, UnitShort.cm, 1, true));
+    expect(`0.3${ThinSpace}m`).toBe(formatNumberToLength(0.35, UnitShort.m, 1, true));
+  });
 
-test("Test formatting cuts off trailing zeros", (t) => {
-  t.is(`10.0${ThinSpace}cm`, formatNumberToLength(0.1, UnitShort.m, 3));
-  t.is(`12.0${ThinSpace}cm`, formatNumberToLength(0.12, UnitShort.m, 3));
-  t.is(`0.001${ThinSpace}km`, formatNumberToLength(1, UnitShort.m, 3, true));
+  it("Test formatting cuts off trailing zeros", () => {
+    expect(`10.0${ThinSpace}cm`).toBe(formatNumberToLength(0.1, UnitShort.m, 3));
+    expect(`12.0${ThinSpace}cm`).toBe(formatNumberToLength(0.12, UnitShort.m, 3));
+    expect(`0.001${ThinSpace}km`).toBe(formatNumberToLength(1, UnitShort.m, 3, true));
+  });
 });

--- a/frontend/javascripts/test/libs/latest_task_executor.spec.ts
+++ b/frontend/javascripts/test/libs/latest_task_executor.spec.ts
@@ -1,67 +1,62 @@
 import Deferred from "libs/async/deferred";
-import test from "ava";
+import { describe, it, expect } from "vitest";
 import LatestTaskExecutor, { SKIPPED_TASK_REASON } from "libs/async/latest_task_executor";
 
-test("LatestTaskExecutor: One task", async (t) => {
-  const executor = new LatestTaskExecutor();
-  const deferred1 = new Deferred();
-  const scheduledPromise = executor.schedule(() => deferred1.promise());
-  deferred1.resolve(true);
-  await scheduledPromise.then((result) => {
-    t.true(result);
+describe("LatestTaskExecutor", () => {
+  it("One task", async () => {
+    const executor = new LatestTaskExecutor();
+    const deferred1 = new Deferred();
+    const scheduledPromise = executor.schedule(() => deferred1.promise());
+    deferred1.resolve(true);
+    const result = await scheduledPromise;
+    expect(result).toBe(true);
   });
-});
-test("LatestTaskExecutor: two successive tasks", async (t) => {
-  const executor = new LatestTaskExecutor();
-  const deferred1 = new Deferred();
-  const deferred2 = new Deferred();
-  const scheduledPromise1 = executor.schedule(() => deferred1.promise());
-  deferred1.resolve(1);
-  const scheduledPromise2 = executor.schedule(() => deferred2.promise());
-  deferred2.resolve(2);
-  await scheduledPromise1.then((result) => {
-    t.is(result, 1);
+
+  it("two successive tasks", async () => {
+    const executor = new LatestTaskExecutor();
+    const deferred1 = new Deferred();
+    const deferred2 = new Deferred();
+    const scheduledPromise1 = executor.schedule(() => deferred1.promise());
+    deferred1.resolve(1);
+    const scheduledPromise2 = executor.schedule(() => deferred2.promise());
+    deferred2.resolve(2);
+    const result1 = await scheduledPromise1;
+    expect(result1).toBe(1);
+    const result2 = await scheduledPromise2;
+    expect(result2).toBe(2);
   });
-  await scheduledPromise2.then((result) => {
-    t.is(result, 2);
+
+  it("two interleaving tasks", async () => {
+    const executor = new LatestTaskExecutor();
+    const deferred1 = new Deferred();
+    const deferred2 = new Deferred();
+    const scheduledPromise1 = executor.schedule(() => deferred1.promise());
+    const scheduledPromise2 = executor.schedule(() => deferred2.promise());
+    deferred1.resolve(1);
+    deferred2.resolve(2);
+    const result1 = await scheduledPromise1;
+    expect(result1).toBe(1);
+    const result2 = await scheduledPromise2;
+    expect(result2).toBe(2);
   });
-});
-test("LatestTaskExecutor: two interleaving tasks", async (t) => {
-  const executor = new LatestTaskExecutor();
-  const deferred1 = new Deferred();
-  const deferred2 = new Deferred();
-  const scheduledPromise1 = executor.schedule(() => deferred1.promise());
-  const scheduledPromise2 = executor.schedule(() => deferred2.promise());
-  deferred1.resolve(1);
-  deferred2.resolve(2);
-  await scheduledPromise1.then((result) => {
-    t.is(result, 1);
-  });
-  await scheduledPromise2.then((result) => {
-    t.is(result, 2);
-  });
-});
-test("LatestTaskExecutor: three interleaving tasks", async (t) => {
-  const executor = new LatestTaskExecutor<number>();
-  const deferred1 = new Deferred();
-  const deferred2 = new Deferred();
-  const deferred3 = new Deferred();
-  // @ts-expect-error ts-migrate(2322) FIXME: Type 'Promise<unknown>' is not assignable to type ... Remove this comment to see the full error message
-  const scheduledPromise1 = executor.schedule(() => deferred1.promise());
-  // @ts-expect-error ts-migrate(2322) FIXME: Type 'Promise<unknown>' is not assignable to type ... Remove this comment to see the full error message
-  const scheduledPromise2 = executor.schedule(() => deferred2.promise());
-  // @ts-expect-error ts-migrate(2322) FIXME: Type 'Promise<unknown>' is not assignable to type ... Remove this comment to see the full error message
-  const scheduledPromise3 = executor.schedule(() => deferred3.promise());
-  deferred1.resolve(1);
-  deferred2.resolve(2);
-  deferred3.resolve(3);
-  await scheduledPromise1.then((result) => {
-    t.is(result, 1);
-  });
-  t.throwsAsync(scheduledPromise2, {
-    message: SKIPPED_TASK_REASON,
-  });
-  await scheduledPromise3.then((result) => {
-    t.is(result, 3);
+
+  it("three interleaving tasks", async () => {
+    const executor = new LatestTaskExecutor<number>();
+    const deferred1 = new Deferred<number, unknown>();
+    const deferred2 = new Deferred<number, unknown>();
+    const deferred3 = new Deferred<number, unknown>();
+    const scheduledPromise1 = executor.schedule(() => deferred1.promise());
+    const scheduledPromise2 = executor.schedule(() => deferred2.promise());
+    const scheduledPromise3 = executor.schedule(() => deferred3.promise());
+    deferred1.resolve(1);
+    deferred2.resolve(2);
+    deferred3.resolve(3);
+    const result1 = await scheduledPromise1;
+    expect(result1).toBe(1);
+    
+    await expect(scheduledPromise2).rejects.toThrowError(SKIPPED_TASK_REASON);
+    
+    const result3 = await scheduledPromise3;
+    expect(result3).toBe(3);
   });
 });

--- a/frontend/javascripts/test/libs/multi_key_map.spec.ts
+++ b/frontend/javascripts/test/libs/multi_key_map.spec.ts
@@ -1,61 +1,63 @@
-import test from "ava";
+import { describe, it, expect } from "vitest";
 import MultiKeyMap from "libs/multi_key_map";
 
-test("MultiKeyMap: basic set/get", (t) => {
-  const map = new MultiKeyMap();
+describe("MultiKeyMap", () => {
+  it("basic set/get", () => {
+    const map = new MultiKeyMap();
 
-  const obj1 = {};
-  const obj2 = {};
-  const obj3 = {};
-  const obj4 = {};
+    const obj1 = {};
+    const obj2 = {};
+    const obj3 = {};
+    const obj4 = {};
 
-  const key1 = [obj1, obj2, obj3, obj4];
-  // The key is another object which has a different identity
-  // than key1. However, the used objects are the same
-  // which is why the key should behave equivalently.
-  const key1Equalivent = [obj1, obj2, obj3, obj4];
+    const key1 = [obj1, obj2, obj3, obj4];
+    // The key is another object which has a different identity
+    // than key1. However, the used objects are the same
+    // which is why the key should behave equivalently.
+    const key1Equalivent = [obj1, obj2, obj3, obj4];
 
-  const key2 = [obj2, obj1, obj3, obj4];
+    const key2 = [obj2, obj1, obj3, obj4];
 
-  // Set/get with key1 and key1Equalivent
-  map.set(key1, "test");
-  t.is(map.get(key1), "test");
-  t.is(map.get(key1Equalivent), "test");
+    // Set/get with key1 and key1Equalivent
+    map.set(key1, "test");
+    expect(map.get(key1)).toBe("test");
+    expect(map.get(key1Equalivent)).toBe("test");
 
-  // Set/get with key2
-  map.set(key2, "test2");
-  t.is(map.get(key2), "test2");
+    // Set/get with key2
+    map.set(key2, "test2");
+    expect(map.get(key2)).toBe("test2");
 
-  // Set/get with key1 and key1Equalivent
-  map.set(key1, "test");
-  t.is(map.get(key1), "test");
-  t.is(map.get(key1Equalivent), "test");
-});
+    // Set/get with key1 and key1Equalivent
+    map.set(key1, "test");
+    expect(map.get(key1)).toBe("test");
+    expect(map.get(key1Equalivent)).toBe("test");
+  });
 
-test("MultiKeyMap: get non-existent key", (t) => {
-  const map = new MultiKeyMap();
+  it("get non-existent key", () => {
+    const map = new MultiKeyMap();
 
-  const obj1 = {};
-  const obj2 = {};
-  const obj3 = {};
-  const obj4 = {};
+    const obj1 = {};
+    const obj2 = {};
+    const obj3 = {};
+    const obj4 = {};
 
-  const key1 = [obj1, obj2, obj3, obj4];
-  t.is(map.get(key1), undefined);
-});
+    const key1 = [obj1, obj2, obj3, obj4];
+    expect(map.get(key1)).toBe(undefined);
+  });
 
-test("MultiKeyMap: override", (t) => {
-  const map = new MultiKeyMap();
+  it("override", () => {
+    const map = new MultiKeyMap();
 
-  const obj1 = {};
-  const obj2 = {};
-  const obj3 = {};
-  const obj4 = {};
+    const obj1 = {};
+    const obj2 = {};
+    const obj3 = {};
+    const obj4 = {};
 
-  const key1 = [obj1, obj2, obj3, obj4];
-  const key1Equalivent = [obj1, obj2, obj3, obj4];
-  map.set(key1, "test");
-  t.is(map.get(key1), "test");
-  map.set(key1Equalivent, "test2");
-  t.is(map.get(key1), "test2");
+    const key1 = [obj1, obj2, obj3, obj4];
+    const key1Equalivent = [obj1, obj2, obj3, obj4];
+    map.set(key1, "test");
+    expect(map.get(key1)).toBe("test");
+    map.set(key1Equalivent, "test2");
+    expect(map.get(key1)).toBe("test2");
+  });
 });

--- a/frontend/javascripts/test/libs/nml.spec.ts
+++ b/frontend/javascripts/test/libs/nml.spec.ts
@@ -7,26 +7,25 @@ import defaultState from "oxalis/default_state";
 import DiffableMap from "libs/diffable_map";
 import EdgeCollection from "oxalis/model/edge_collection";
 import { findGroup } from "oxalis/view/right-border-tabs/trees_tab/tree_hierarchy_view_helpers";
-import mock from "mock-require";
-import test, { type ExecutionContext } from "ava";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TreeTypeEnum } from "oxalis/constants";
-import type * as OriginalSkeletonTracingActions from "oxalis/model/actions/skeletontracing_actions";
-import type * as OriginalNmlHelpers from "oxalis/model/helpers/nml_helpers";
-import type OriginalSkeletonTracingReducer from "oxalis/model/reducers/skeletontracing_reducer";
+import {addTreesAndGroupsAction} from "oxalis/model/actions/skeletontracing_actions";
+import { serializeToNml, getNmlName, parseNml } from "oxalis/model/helpers/nml_helpers";
+import SkeletonTracingReducer from "oxalis/model/reducers/skeletontracing_reducer";
 import { enforceSkeletonTracing } from "oxalis/model/accessors/skeletontracing_accessor";
 import { annotation as TASK_ANNOTATION } from "../fixtures/tasktracing_server_objects";
 import { buildInfo as BUILD_INFO } from "../fixtures/build_info";
 
 const TIMESTAMP = 123456789;
-const { serializeToNml, getNmlName, parseNml }: typeof OriginalNmlHelpers = mock.reRequire(
-  "oxalis/model/helpers/nml_helpers",
-);
-const SkeletonTracingReducer: typeof OriginalSkeletonTracingReducer = mock.reRequire(
-  "oxalis/model/reducers/skeletontracing_reducer",
-).default;
-const SkeletonTracingActions: typeof OriginalSkeletonTracingActions = mock.reRequire(
-  "oxalis/model/actions/skeletontracing_actions",
-);
+// const { serializeToNml, getNmlName, parseNml }: typeof OriginalNmlHelpers = mock.reRequire(
+//   "oxalis/model/helpers/nml_helpers",
+// );
+// const SkeletonTracingReducer: typeof OriginalSkeletonTracingReducer = mock.reRequire(
+//   "oxalis/model/reducers/skeletontracing_reducer",
+// ).default;
+// const SkeletonTracingActions: typeof OriginalSkeletonTracingActions = mock.reRequire(
+//   "oxalis/model/actions/skeletontracing_actions",
+// );
 
 const createDummyNode = (id: number): Node => ({
   bitDepth: 8,
@@ -193,7 +192,6 @@ const initialState: OxalisState = _.extend({}, defaultState, {
 });
 
 async function testThatParserThrowsWithState(
-  t: ExecutionContext<any>,
   invalidState: OxalisState,
   key: string,
 ) {
@@ -205,697 +203,709 @@ async function testThatParserThrowsWithState(
     BUILD_INFO,
     false,
   );
-  await throwsAsyncParseError(t, () => parseNml(nmlWithInvalidContent), key);
+  await throwsAsyncParseError(() => parseNml(nmlWithInvalidContent), key);
 }
 
-async function throwsAsyncParseError(t: ExecutionContext<any>, fn: () => void, key: string) {
+async function throwsAsyncParseError(fn: () => void, key: string) {
   try {
     await fn();
-    t.fail(`Test did not throw, calling the function with the following key: ${key}`);
+    expect.fail(`Test did not throw, calling the function with the following key: ${key}`);
   } catch (e) {
     if (e instanceof Error && e.name === "NmlParseError") {
-      t.true(true);
+      expect(true).toBe(true);
     } else {
       throw e;
     }
   }
 }
 
-test.before("Mock Date.now", async () => {
-  // This only mocks Date.now, but leaves the constructor intact
-  sinon.stub(Date, "now").returns(TIMESTAMP);
-});
-test.after("Reset mocks", async () => {
-  // @ts-ignore
-  Date.now.restore();
-});
-test("NML serializing and parsing should yield the same state", async (t) => {
-  const serializedNml = serializeToNml(
-    initialState,
-    initialState.tracing,
-    enforceSkeletonTracing(initialState.tracing),
-    BUILD_INFO,
-    false,
-  );
-  const { trees, treeGroups } = await parseNml(serializedNml);
-  t.deepEqual(initialSkeletonTracing.trees, trees);
-  t.deepEqual(initialSkeletonTracing.treeGroups, treeGroups);
-});
-test("NML serializing and parsing should yield the same state even when using special characters", async (t) => {
-  const state = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            comments: {
-              $push: [
-                {
-                  nodeId: 1,
-                  content: "Hello\"a'b<c>d&e\"f'g<h>i&j",
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
+describe("NML", () => {
+  beforeAll(async () => {
+    // This only mocks Date.now, but leaves the constructor intact
+    sinon.stub(Date, "now").returns(TIMESTAMP);
   });
-  const serializedNml = serializeToNml(
-    state,
-    state.tracing,
-    enforceSkeletonTracing(state.tracing),
-    BUILD_INFO,
-    false,
-  );
-  const { trees, treeGroups } = await parseNml(serializedNml);
-  const skeletonTracing = enforceSkeletonTracing(state.tracing);
-  t.deepEqual(skeletonTracing.trees, trees);
-  t.deepEqual(skeletonTracing.treeGroups, treeGroups);
-});
-test("NML serializing and parsing should yield the same state even when using multiline attributes", async (t) => {
-  const state = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            comments: {
-              $push: [
-                {
-                  nodeId: 1,
-                  content: "Hello\nfrom\nthe\nother\nside.",
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
+  
+  afterAll(async () => {
+    // @ts-ignore
+    Date.now.restore();
   });
-  const serializedNml = serializeToNml(
-    state,
-    state.tracing,
-    enforceSkeletonTracing(state.tracing),
-    BUILD_INFO,
-    false,
-  );
-  const { trees, treeGroups } = await parseNml(serializedNml);
-  const skeletonTracing = enforceSkeletonTracing(state.tracing);
-  t.deepEqual(skeletonTracing.trees, trees);
-  t.deepEqual(skeletonTracing.treeGroups, treeGroups);
-});
-test("NML serializing and parsing should yield the same state even when additional coordinates exist", async (t) => {
-  const existingNodeMap = initialState.tracing.skeleton?.trees[1].nodes;
-  if (existingNodeMap == null) {
-    throw new Error("Unexpected null value.");
-  }
-  const existingNode = existingNodeMap.getOrThrow(1);
-  const newNodeMap = existingNodeMap.set(1, {
-    ...existingNode,
-    additionalCoordinates: [{ name: "t", value: 123 }],
-  });
-  const state = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            nodes: {
-              $set: newNodeMap,
-            },
-          },
-        },
-      },
-    },
-  });
-  const serializedNml = serializeToNml(
-    state,
-    state.tracing,
-    enforceSkeletonTracing(state.tracing),
-    BUILD_INFO,
-    false,
-  );
-  const { trees, treeGroups } = await parseNml(serializedNml);
-  const skeletonTracing = enforceSkeletonTracing(state.tracing);
-  t.deepEqual(skeletonTracing.trees, trees);
-  t.deepEqual(skeletonTracing.treeGroups, treeGroups);
-});
-test("NML Serializer should only serialize visible trees", async (t) => {
-  const state = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            isVisible: {
-              $set: false,
-            },
-          },
-        },
-      },
-    },
-  });
-  const serializedNml = serializeToNml(
-    state,
-    state.tracing,
-    enforceSkeletonTracing(state.tracing),
-    BUILD_INFO,
-    false,
-  );
-  const { trees } = await parseNml(serializedNml);
-  const skeletonTracing = enforceSkeletonTracing(state.tracing);
-  // Tree 1 should not be exported as it is not visible
-  delete skeletonTracing.trees["1"];
-  t.deepEqual(Object.keys(skeletonTracing.trees), Object.keys(trees));
-  t.deepEqual(skeletonTracing.trees, trees);
-});
-test("NML Serializer should only serialize groups with visible trees", async (t) => {
-  const state = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            isVisible: {
-              $set: false,
-            },
-          },
-        },
-      },
-    },
-  });
-  const serializedNml = serializeToNml(
-    state,
-    state.tracing,
-    enforceSkeletonTracing(state.tracing),
-    BUILD_INFO,
-    false,
-  );
-  const { treeGroups } = await parseNml(serializedNml);
-  const skeletonTracing = enforceSkeletonTracing(state.tracing);
-  // Group 1 (and group 3 and 4 which are children of group 1) should not be exported as they do not contain a visible tree
-  const expectedTreeGroups = skeletonTracing.treeGroups.filter((group) => group.groupId !== 1);
-  t.deepEqual(expectedTreeGroups, treeGroups);
-});
-test("NML serializer should produce correct NMLs", (t) => {
-  const serializedNml = serializeToNml(
-    initialState,
-    initialState.tracing,
-    enforceSkeletonTracing(initialState.tracing),
-    BUILD_INFO,
-    false,
-  );
-  t.snapshot(serializedNml);
-});
-test("NML serializer should produce correct NMLs with additional coordinates", (t) => {
-  let adaptedState = update(initialState, {
-    tracing: {
-      skeleton: {
-        additionalAxes: {
-          $set: [{ name: "t", bounds: [0, 100], index: 0 }],
-        },
-      },
-    },
+  
+  it("serializing and parsing should yield the same state", async () => {
+    const serializedNml = serializeToNml(
+      initialState,
+      initialState.tracing,
+      enforceSkeletonTracing(initialState.tracing),
+      BUILD_INFO,
+      false,
+    );
+    const { trees, treeGroups } = await parseNml(serializedNml);
+    expect(initialSkeletonTracing.trees).toEqual(trees);
+    expect(initialSkeletonTracing.treeGroups).toEqual(treeGroups);
   });
 
-  const existingNodeMap = adaptedState.tracing.skeleton?.trees[1].nodes;
-  if (existingNodeMap == null) {
-    throw new Error("Unexpected null value.");
-  }
-  const existingNode = existingNodeMap.getOrThrow(1);
-  const newNodeMap = existingNodeMap.set(1, {
-    ...existingNode,
-    additionalCoordinates: [{ name: "t", value: 123 }],
-  });
-  adaptedState = update(adaptedState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            nodes: {
-              $set: newNodeMap,
+  it("serializing and parsing should yield the same state even when using special characters", async () => {
+    const state = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              comments: {
+                $push: [
+                  {
+                    nodeId: 1,
+                    content: "Hello\"a'b<c>d&e\"f'g<h>i&j",
+                  },
+                ],
+              },
             },
           },
         },
       },
-    },
+    });
+    const serializedNml = serializeToNml(
+      state,
+      state.tracing,
+      enforceSkeletonTracing(state.tracing),
+      BUILD_INFO,
+      false,
+    );
+    const { trees, treeGroups } = await parseNml(serializedNml);
+    const skeletonTracing = enforceSkeletonTracing(state.tracing);
+    expect(skeletonTracing.trees).toEqual(trees);
+    expect(skeletonTracing.treeGroups).toEqual(treeGroups);
   });
 
-  const serializedNml = serializeToNml(
-    adaptedState,
-    adaptedState.tracing,
-    enforceSkeletonTracing(adaptedState.tracing),
-    BUILD_INFO,
-    false,
-  );
-  t.snapshot(serializedNml);
-});
-
-test("NML serializer should produce correct NMLs with metadata for trees", async (t) => {
-  const properties = [
-    {
-      key: "key of string",
-      stringValue: "string value",
-    },
-    {
-      key: "key of true",
-      boolValue: true,
-    },
-    {
-      key: "key of false",
-      boolValue: false,
-    },
-    {
-      key: "key of number",
-      numberValue: 1234,
-    },
-    {
-      key: "key of string list",
-      stringListValue: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
-    },
-  ];
-  const state = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            metadata: {
-              $set: properties,
+  it("serializing and parsing should yield the same state even when using multiline attributes", async () => {
+    const state = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              comments: {
+                $push: [
+                  {
+                    nodeId: 1,
+                    content: "Hello\nfrom\nthe\nother\nside.",
+                  },
+                ],
+              },
             },
           },
         },
       },
-    },
+    });
+    const serializedNml = serializeToNml(
+      state,
+      state.tracing,
+      enforceSkeletonTracing(state.tracing),
+      BUILD_INFO,
+      false,
+    );
+    const { trees, treeGroups } = await parseNml(serializedNml);
+    const skeletonTracing = enforceSkeletonTracing(state.tracing);
+    expect(skeletonTracing.trees).toEqual(trees);
+    expect(skeletonTracing.treeGroups).toEqual(treeGroups);
   });
-  const serializedNml = serializeToNml(
-    state,
-    state.tracing,
-    enforceSkeletonTracing(state.tracing),
-    BUILD_INFO,
-    false,
-  );
 
-  t.true(
-    serializedNml.includes('<metadataEntry key="key of string" stringValue="string value" />'),
-  );
+  it("serializing and parsing should yield the same state even when additional coordinates exist", async () => {
+    const existingNodeMap = initialState.tracing.skeleton?.trees[1].nodes;
+    if (existingNodeMap == null) {
+      throw new Error("Unexpected null value.");
+    }
+    const existingNode = existingNodeMap.getOrThrow(1);
+    const newNodeMap = existingNodeMap.set(1, {
+      ...existingNode,
+      additionalCoordinates: [{ name: "t", value: 123 }],
+    });
+    const state = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              nodes: {
+                $set: newNodeMap,
+              },
+            },
+          },
+        },
+      },
+    });
+    const serializedNml = serializeToNml(
+      state,
+      state.tracing,
+      enforceSkeletonTracing(state.tracing),
+      BUILD_INFO,
+      false,
+    );
+    const { trees, treeGroups } = await parseNml(serializedNml);
+    const skeletonTracing = enforceSkeletonTracing(state.tracing);
+    expect(skeletonTracing.trees).toEqual(trees);
+    expect(skeletonTracing.treeGroups).toEqual(treeGroups);
+  });
 
-  t.true(serializedNml.includes('<metadataEntry key="key of true" boolValue="true" />'));
-  t.true(serializedNml.includes('<metadataEntry key="key of false" boolValue="false" />'));
-  t.true(serializedNml.includes('<metadataEntry key="key of number" numberValue="1234" />'));
-  t.true(
-    serializedNml.includes(
+  it("NML Serializer should only serialize visible trees", async () => {
+    const state = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              isVisible: {
+                $set: false,
+              },
+            },
+          },
+        },
+      },
+    });
+    const serializedNml = serializeToNml(
+      state,
+      state.tracing,
+      enforceSkeletonTracing(state.tracing),
+      BUILD_INFO,
+      false,
+    );
+    const { trees } = await parseNml(serializedNml);
+    const skeletonTracing = enforceSkeletonTracing(state.tracing);
+    // Tree 1 should not be exported as it is not visible
+    delete skeletonTracing.trees["1"];
+    expect(Object.keys(skeletonTracing.trees)).toEqual(Object.keys(trees));
+    expect(skeletonTracing.trees).toEqual(trees);
+  });
+
+  it("NML Serializer should only serialize groups with visible trees", async () => {
+    const state = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              isVisible: {
+                $set: false,
+              },
+            },
+          },
+        },
+      },
+    });
+    const serializedNml = serializeToNml(
+      state,
+      state.tracing,
+      enforceSkeletonTracing(state.tracing),
+      BUILD_INFO,
+      false,
+    );
+    const { treeGroups } = await parseNml(serializedNml);
+    const skeletonTracing = enforceSkeletonTracing(state.tracing);
+    // Group 1 (and group 3 and 4 which are children of group 1) should not be exported as they do not contain a visible tree
+    const expectedTreeGroups = skeletonTracing.treeGroups.filter((group) => group.groupId !== 1);
+    expect(expectedTreeGroups).toEqual(treeGroups);
+  });
+
+  it("NML serializer should produce correct NMLs", () => {
+    const serializedNml = serializeToNml(
+      initialState,
+      initialState.tracing,
+      enforceSkeletonTracing(initialState.tracing),
+      BUILD_INFO,
+      false,
+    );
+    expect(serializedNml).toMatchSnapshot();
+  });
+
+  it("NML serializer should produce correct NMLs with additional coordinates", () => {
+    let adaptedState = update(initialState, {
+      tracing: {
+        skeleton: {
+          additionalAxes: {
+            $set: [{ name: "t", bounds: [0, 100], index: 0 }],
+          },
+        },
+      },
+    });
+
+    const existingNodeMap = adaptedState.tracing.skeleton?.trees[1].nodes;
+    if (existingNodeMap == null) {
+      throw new Error("Unexpected null value.");
+    }
+    const existingNode = existingNodeMap.getOrThrow(1);
+    const newNodeMap = existingNodeMap.set(1, {
+      ...existingNode,
+      additionalCoordinates: [{ name: "t", value: 123 }],
+    });
+    adaptedState = update(adaptedState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              nodes: {
+                $set: newNodeMap,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const serializedNml = serializeToNml(
+      adaptedState,
+      adaptedState.tracing,
+      enforceSkeletonTracing(adaptedState.tracing),
+      BUILD_INFO,
+      false,
+    );
+    expect(serializedNml).toMatchSnapshot();
+  });
+
+  it("NML serializer should produce correct NMLs with metadata for trees", async () => {
+    const properties = [
+      {
+        key: "key of string",
+        stringValue: "string value",
+      },
+      {
+        key: "key of true",
+        boolValue: true,
+      },
+      {
+        key: "key of false",
+        boolValue: false,
+      },
+      {
+        key: "key of number",
+        numberValue: 1234,
+      },
+      {
+        key: "key of string list",
+        stringListValue: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
+      },
+    ];
+    const state = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              metadata: {
+                $set: properties,
+              },
+            },
+          },
+        },
+      },
+    });
+    const serializedNml = serializeToNml(
+      state,
+      state.tracing,
+      enforceSkeletonTracing(state.tracing),
+      BUILD_INFO,
+      false,
+    );
+
+    expect(serializedNml).toContain('<metadataEntry key="key of string" stringValue="string value" />');
+
+    expect(serializedNml).toContain('<metadataEntry key="key of true" boolValue="true" />');
+    expect(serializedNml).toContain('<metadataEntry key="key of false" boolValue="false" />');
+    expect(serializedNml).toContain('<metadataEntry key="key of number" numberValue="1234" />');
+    expect(serializedNml).toContain(
       '<metadataEntry key="key of string list" stringListValue-0="1" stringListValue-1="2" stringListValue-2="3" stringListValue-3="4" stringListValue-4="5" stringListValue-5="6" stringListValue-6="7" stringListValue-7="8" stringListValue-8="9" stringListValue-9="10" stringListValue-10="11" />',
-    ),
-  );
+    );
 
-  const { trees } = await parseNml(serializedNml);
-  if (state.tracing.skeleton == null) {
-    throw new Error("Unexpected null for skeleton");
-  }
-  t.deepEqual(state.tracing.skeleton.trees[1], trees[1]);
-});
+    const { trees } = await parseNml(serializedNml);
+    if (state.tracing.skeleton == null) {
+      throw new Error("Unexpected null for skeleton");
+    }
+    expect(state.tracing.skeleton.trees[1]).toEqual(trees[1]);
+  });
 
-test("NML serializer should escape special characters and multilines", (t) => {
-  const state = update(initialState, {
-    tracing: {
-      description: {
-        $set: "Multiline dataset\ndescription\nwith special &'<>\" chars.",
-      },
-      skeleton: {
-        trees: {
-          "1": {
-            comments: {
-              $push: [
-                {
-                  nodeId: 1,
-                  content: "Hello\"a'b<c>d&e\"f'g<h>i&j\nwith\nnew\nlines",
-                },
-              ],
+  it("NML serializer should escape special characters and multilines", () => {
+    const state = update(initialState, {
+      tracing: {
+        description: {
+          $set: "Multiline dataset\ndescription\nwith special &'<>\" chars.",
+        },
+        skeleton: {
+          trees: {
+            "1": {
+              comments: {
+                $push: [
+                  {
+                    nodeId: 1,
+                    content: "Hello\"a'b<c>d&e\"f'g<h>i&j\nwith\nnew\nlines",
+                  },
+                ],
+              },
             },
           },
         },
       },
-    },
+    });
+    const serializedNml = serializeToNml(
+      state,
+      state.tracing,
+      enforceSkeletonTracing(state.tracing),
+      BUILD_INFO,
+      false,
+    );
+    // Explicitly check for the encoded characters
+    expect(
+      serializedNml.indexOf(
+        "Hello&quot;a&apos;b&lt;c&gt;d&amp;e&quot;f&apos;g&lt;h&gt;i&amp;j&#xa;with&#xa;new&#xa;lines",
+      ) > -1,
+    ).toBe(true);
+    expect(serializedNml).toMatchSnapshot();
   });
-  const serializedNml = serializeToNml(
-    state,
-    state.tracing,
-    enforceSkeletonTracing(state.tracing),
-    BUILD_INFO,
-    false,
-  );
-  // Explicitly check for the encoded characters
-  t.true(
-    serializedNml.indexOf(
-      "Hello&quot;a&apos;b&lt;c&gt;d&amp;e&quot;f&apos;g&lt;h&gt;i&amp;j&#xa;with&#xa;new&#xa;lines",
-    ) > -1,
-  );
-  t.snapshot(serializedNml);
-});
-test("Serialized nml should be correctly named", async (t) => {
-  t.is(getNmlName(initialState), "Test Dataset__5b1fd1cb97000027049c67ec____tionId.nml");
 
-  const stateWithoutTask = { ...initialState, task: null };
+  it("Serialized nml should be correctly named", async () => {
+    expect(getNmlName(initialState)).toBe("Test Dataset__5b1fd1cb97000027049c67ec____tionId.nml");
 
-  t.is(getNmlName(stateWithoutTask), "Test Dataset__explorational____tionId.nml");
-});
-test("NML Parser should throw errors for invalid nmls", async (t) => {
-  const invalidCommentState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "2": {
-            comments: {
-              $set: [
-                {
-                  content: "test",
-                  nodeId: 99,
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-  });
-  const invalidBranchPointState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "2": {
-            branchPoints: {
-              $set: [
-                {
-                  timestamp: 0,
-                  nodeId: 99,
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-  });
-  const invalidEdgeState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "2": {
-            edges: {
-              $set: EdgeCollection.loadFromArray([
-                {
-                  source: 99,
-                  target: 5,
-                },
-              ]),
-            },
-          },
-        },
-      },
-    },
-  });
-  const invalidSelfEdgeState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "2": {
-            edges: {
-              $set: EdgeCollection.loadFromArray([
-                {
-                  source: 4,
-                  target: 5,
-                },
-                {
-                  source: 5,
-                  target: 6,
-                },
-                {
-                  source: 6,
-                  target: 6,
-                },
-              ]),
-            },
-          },
-        },
-      },
-    },
-  });
-  const duplicateEdgeState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "2": {
-            edges: {
-              $set: EdgeCollection.loadFromArray([
-                {
-                  source: 4,
-                  target: 5,
-                },
-                {
-                  source: 4,
-                  target: 5,
-                },
-                {
-                  source: 5,
-                  target: 6,
-                },
-              ]),
-            },
-          },
-        },
-      },
-    },
-  });
-  const duplicateNodeState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            nodes: {
-              $set: new DiffableMap([
-                [0, createDummyNode(0)],
-                [1, createDummyNode(1)],
-                [2, createDummyNode(2)],
-                [4, createDummyNode(4)],
-                [7, createDummyNode(7)],
-              ]),
-            },
-          },
-          "2": {
-            nodes: {
-              $set: new DiffableMap([
-                [4, createDummyNode(4)],
-                [5, createDummyNode(5)],
-                [6, createDummyNode(6)],
-              ]),
-            },
-          },
-        },
-      },
-    },
-  });
-  const duplicateTreeState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "2": {
-            treeId: {
-              $set: 1,
-            },
-          },
-        },
-      },
-    },
-  });
-  const missingGroupIdState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "2": {
-            groupId: {
-              $set: 9999,
-            },
-          },
-        },
-      },
-    },
-  });
-  const duplicateGroupIdState = update(initialState, {
-    tracing: {
-      skeleton: {
-        treeGroups: {
-          $push: [
-            {
-              groupId: 3,
-              name: "Group",
-              children: [],
-            },
-          ],
-        },
-      },
-    },
-  });
-  await testThatParserThrowsWithState(t, invalidCommentState, "invalidComment");
-  await testThatParserThrowsWithState(t, invalidBranchPointState, "invalidBranchPoint");
-  await testThatParserThrowsWithState(t, invalidEdgeState, "invalidEdge");
-  await testThatParserThrowsWithState(t, invalidSelfEdgeState, "invalidSelfEdge");
-  await testThatParserThrowsWithState(t, duplicateEdgeState, "duplicateEdge");
-  await testThatParserThrowsWithState(t, duplicateNodeState, "duplicateNode");
-  await testThatParserThrowsWithState(t, duplicateTreeState, "duplicateTree");
-  await testThatParserThrowsWithState(t, missingGroupIdState, "missingGroupId");
-  await testThatParserThrowsWithState(t, duplicateGroupIdState, "duplicateGroupId");
-});
-test("addTreesAndGroups reducer should assign new node and tree ids", (t) => {
-  const action = SkeletonTracingActions.addTreesAndGroupsAction(
-    _.cloneDeep(initialSkeletonTracing.trees),
-    [],
-  );
-  const newState = SkeletonTracingReducer(initialState, action);
-  t.not(newState, initialState);
-  const newSkeletonTracing = enforceSkeletonTracing(newState.tracing);
-  // This should be unchanged / sanity check
-  t.is(newState.tracing.name, initialState.tracing.name);
-  t.is(newSkeletonTracing.activeTreeId, initialSkeletonTracing.activeTreeId);
-  // New node and tree ids should have been assigned
-  t.is(_.size(newSkeletonTracing.trees), 4);
-  t.is(newSkeletonTracing.trees[3].treeId, 3);
-  t.is(newSkeletonTracing.trees[4].treeId, 4);
-  t.is(newSkeletonTracing.trees[3].nodes.size(), 4);
-  t.is(newSkeletonTracing.trees[3].nodes.getOrThrow(8).id, 8);
-  t.is(newSkeletonTracing.trees[3].nodes.getOrThrow(9).id, 9);
-  t.is(newSkeletonTracing.trees[4].nodes.size(), 3);
-  t.is(newSkeletonTracing.trees[4].nodes.getOrThrow(12).id, 12);
+    const stateWithoutTask = { ...initialState, task: null };
 
-  const getSortedEdges = (edges: EdgeCollection) => _.sortBy(edges.asArray(), "source");
-
-  // And node ids in edges, branchpoints and comments should have been replaced
-  t.deepEqual(getSortedEdges(newSkeletonTracing.trees[3].edges), [
-    {
-      source: 8,
-      target: 9,
-    },
-    {
-      source: 9,
-      target: 11,
-    },
-    {
-      source: 10,
-      target: 9,
-    },
-  ]);
-  t.deepEqual(newSkeletonTracing.trees[3].branchPoints, [
-    {
-      nodeId: 9,
-      timestamp: 0,
-    },
-    {
-      nodeId: 11,
-      timestamp: 0,
-    },
-  ]);
-  t.deepEqual(newSkeletonTracing.trees[3].comments, [
-    {
-      content: "comment",
-      nodeId: 8,
-    },
-  ]);
-  t.deepEqual(getSortedEdges(newSkeletonTracing.trees[4].edges), [
-    {
-      source: 12,
-      target: 13,
-    },
-    {
-      source: 13,
-      target: 14,
-    },
-  ]);
-  // The cachedMaxNodeId should be correct afterwards as well
-  t.is(newSkeletonTracing.cachedMaxNodeId, 14);
-});
-test("addTreesAndGroups reducer should assign new group ids", (t) => {
-  const action = SkeletonTracingActions.addTreesAndGroupsAction(
-    _.cloneDeep(initialSkeletonTracing.trees),
-    _.cloneDeep(initialSkeletonTracing.treeGroups),
-  );
-  const newState = SkeletonTracingReducer(initialState, action);
-  t.not(newState, initialState);
-  const newSkeletonTracing = enforceSkeletonTracing(newState.tracing);
-  // This should be unchanged / sanity check
-  t.is(newState.tracing.name, initialState.tracing.name);
-  t.is(newSkeletonTracing.activeTreeId, initialSkeletonTracing.activeTreeId);
-  // New node and tree ids should have been assigned
-  t.is(_.size(newSkeletonTracing.treeGroups), 4);
-  t.not(newSkeletonTracing.treeGroups[2].groupId, newSkeletonTracing.treeGroups[0].groupId);
-  t.not(newSkeletonTracing.treeGroups[3].groupId, newSkeletonTracing.treeGroups[1].groupId);
-  t.is(newSkeletonTracing.trees[3].groupId, 5);
-  t.is(newSkeletonTracing.trees[4].groupId, newSkeletonTracing.treeGroups[3].groupId);
-});
-test("addTreesAndGroups reducer should replace nodeId references in comments when changing nodeIds", (t) => {
-  const commentWithoutValidReferences =
-    "Reference to non-existing id #42 and position reference #(4,5,6)";
-
-  const newTrees = _.cloneDeep(initialSkeletonTracing.trees);
-
-  newTrees[1].comments.push({
-    nodeId: 1,
-    content: "Reference to existing id in another tree #4",
+    expect(getNmlName(stateWithoutTask)).toBe("Test Dataset__explorational____tionId.nml");
   });
-  newTrees[1].comments.push({
-    nodeId: 2,
-    content: commentWithoutValidReferences,
-  });
-  const action = SkeletonTracingActions.addTreesAndGroupsAction(newTrees, []);
-  const newState = SkeletonTracingReducer(initialState, action);
-  const newSkeletonTracing = enforceSkeletonTracing(newState.tracing);
-  // Comments should have been rewritten if appropriate
-  t.is(_.size(newSkeletonTracing.trees), 4);
-  t.is(newSkeletonTracing.trees[3].comments.length, 3);
-  t.is(
-    newSkeletonTracing.trees[3].comments[1].content,
-    "Reference to existing id in another tree #12",
-  );
-  t.is(newSkeletonTracing.trees[3].comments[2].content, commentWithoutValidReferences);
-});
-test("NML Parser should split up disconnected trees", async (t) => {
-  const disconnectedTreeState = update(initialState, {
-    tracing: {
-      skeleton: {
-        trees: {
-          "1": {
-            edges: {
-              $set: EdgeCollection.loadFromArray([
-                {
-                  source: 0,
-                  target: 1,
-                },
-              ]),
+
+  it("NML Parser should throw errors for invalid nmls", async () => {
+    const invalidCommentState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "2": {
+              comments: {
+                $set: [
+                  {
+                    content: "test",
+                    nodeId: 99,
+                  },
+                ],
+              },
             },
           },
         },
       },
-    },
+    });
+    const invalidBranchPointState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "2": {
+              branchPoints: {
+                $set: [
+                  {
+                    timestamp: 0,
+                    nodeId: 99,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    const invalidEdgeState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "2": {
+              edges: {
+                $set: EdgeCollection.loadFromArray([
+                  {
+                    source: 99,
+                    target: 5,
+                  },
+                ]),
+              },
+            },
+          },
+        },
+      },
+    });
+    const invalidSelfEdgeState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "2": {
+              edges: {
+                $set: EdgeCollection.loadFromArray([
+                  {
+                    source: 4,
+                    target: 5,
+                  },
+                  {
+                    source: 5,
+                    target: 6,
+                  },
+                  {
+                    source: 6,
+                    target: 6,
+                  },
+                ]),
+              },
+            },
+          },
+        },
+      },
+    });
+    const duplicateEdgeState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "2": {
+              edges: {
+                $set: EdgeCollection.loadFromArray([
+                  {
+                    source: 4,
+                    target: 5,
+                  },
+                  {
+                    source: 4,
+                    target: 5,
+                  },
+                  {
+                    source: 5,
+                    target: 6,
+                  },
+                ]),
+              },
+            },
+          },
+        },
+      },
+    });
+    const duplicateNodeState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              nodes: {
+                $set: new DiffableMap([
+                  [0, createDummyNode(0)],
+                  [1, createDummyNode(1)],
+                  [2, createDummyNode(2)],
+                  [4, createDummyNode(4)],
+                  [7, createDummyNode(7)],
+                ]),
+              },
+            },
+            "2": {
+              nodes: {
+                $set: new DiffableMap([
+                  [4, createDummyNode(4)],
+                  [5, createDummyNode(5)],
+                  [6, createDummyNode(6)],
+                ]),
+              },
+            },
+          },
+        },
+      },
+    });
+    const duplicateTreeState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "2": {
+              treeId: {
+                $set: 1,
+              },
+            },
+          },
+        },
+      },
+    });
+    const missingGroupIdState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "2": {
+              groupId: {
+                $set: 9999,
+              },
+            },
+          },
+        },
+      },
+    });
+    const duplicateGroupIdState = update(initialState, {
+      tracing: {
+        skeleton: {
+          treeGroups: {
+            $push: [
+              {
+                groupId: 3,
+                name: "Group",
+                children: [],
+              },
+            ],
+          },
+        },
+      },
+    });
+    await testThatParserThrowsWithState(invalidCommentState, "invalidComment");
+    await testThatParserThrowsWithState(invalidBranchPointState, "invalidBranchPoint");
+    await testThatParserThrowsWithState(invalidEdgeState, "invalidEdge");
+    await testThatParserThrowsWithState(invalidSelfEdgeState, "invalidSelfEdge");
+    await testThatParserThrowsWithState(duplicateEdgeState, "duplicateEdge");
+    await testThatParserThrowsWithState(duplicateNodeState, "duplicateNode");
+    await testThatParserThrowsWithState(duplicateTreeState, "duplicateTree");
+    await testThatParserThrowsWithState(missingGroupIdState, "missingGroupId");
+    await testThatParserThrowsWithState(duplicateGroupIdState, "duplicateGroupId");
   });
-  const nmlWithDisconnectedTree = serializeToNml(
-    disconnectedTreeState,
-    disconnectedTreeState.tracing,
-    enforceSkeletonTracing(disconnectedTreeState.tracing),
-    BUILD_INFO,
-    false,
-  );
-  const { trees: parsedTrees, treeGroups: parsedTreeGroups } =
-    await parseNml(nmlWithDisconnectedTree);
-  // Check that the tree was split up into its three components
-  t.is(_.size(parsedTrees), 4);
-  t.true(parsedTrees[3].nodes.has(0));
-  t.true(parsedTrees[3].nodes.has(1));
-  t.false(parsedTrees[3].nodes.has(2));
-  t.false(parsedTrees[3].nodes.has(7));
-  t.is(_.size(parsedTrees[3].branchPoints), 1);
-  t.is(_.size(parsedTrees[3].comments), 1);
-  t.true(parsedTrees[4].nodes.has(2));
-  t.true(parsedTrees[5].nodes.has(7));
-  t.is(_.size(parsedTrees[5].branchPoints), 1);
-  // Check that the split up trees were wrapped in a group
-  // which was inserted into the original tree's group
-  const parentGroup = findGroup(parsedTreeGroups, 3);
-  if (parentGroup == null)
-    throw Error("Assertion Error: Serialized group is missing after parsing.");
-  t.is(_.size(parentGroup.children), 1);
-  t.is(parentGroup.children[0].name, "TestTree-0");
+
+  it("addTreesAndGroups reducer should assign new node and tree ids", () => {
+    const action = addTreesAndGroupsAction(
+      _.cloneDeep(initialSkeletonTracing.trees),
+      [],
+    );
+    const newState = SkeletonTracingReducer(initialState, action);
+    expect(newState).not.toBe(initialState);
+    const newSkeletonTracing = enforceSkeletonTracing(newState.tracing);
+    // This should be unchanged / sanity check
+    expect(newState.tracing.name).toBe(initialState.tracing.name);
+    expect(newSkeletonTracing.activeTreeId).toBe(initialSkeletonTracing.activeTreeId);
+    // New node and tree ids should have been assigned
+    expect(_.size(newSkeletonTracing.trees)).toBe(4);
+    expect(newSkeletonTracing.trees[3].treeId).toBe(3);
+    expect(newSkeletonTracing.trees[4].treeId).toBe(4);
+    expect(newSkeletonTracing.trees[3].nodes.size()).toBe(4);
+    expect(newSkeletonTracing.trees[3].nodes.getOrThrow(8).id).toBe(8);
+    expect(newSkeletonTracing.trees[3].nodes.getOrThrow(9).id).toBe(9);
+    expect(newSkeletonTracing.trees[4].nodes.size()).toBe(3);
+    expect(newSkeletonTracing.trees[4].nodes.getOrThrow(12).id).toBe(12);
+
+    const getSortedEdges = (edges: EdgeCollection) => _.sortBy(edges.asArray(), "source");
+
+    // And node ids in edges, branchpoints and comments should have been replaced
+    expect(getSortedEdges(newSkeletonTracing.trees[3].edges)).toEqual([
+      {
+        source: 8,
+        target: 9,
+      },
+      {
+        source: 9,
+        target: 11,
+      },
+      {
+        source: 10,
+        target: 9,
+      },
+    ]);
+    expect(newSkeletonTracing.trees[3].branchPoints).toEqual([
+      {
+        nodeId: 9,
+        timestamp: 0,
+      },
+      {
+        nodeId: 11,
+        timestamp: 0,
+      },
+    ]);
+    expect(newSkeletonTracing.trees[3].comments).toEqual([
+      {
+        content: "comment",
+        nodeId: 8,
+      },
+    ]);
+    expect(getSortedEdges(newSkeletonTracing.trees[4].edges)).toEqual([
+      {
+        source: 12,
+        target: 13,
+      },
+      {
+        source: 13,
+        target: 14,
+      },
+    ]);
+    // The cachedMaxNodeId should be correct afterwards as well
+    expect(newSkeletonTracing.cachedMaxNodeId).toBe(14);
+  });
+
+  it("addTreesAndGroups reducer should assign new group ids", () => {
+    const action = addTreesAndGroupsAction(
+      _.cloneDeep(initialSkeletonTracing.trees),
+      _.cloneDeep(initialSkeletonTracing.treeGroups),
+    );
+    const newState = SkeletonTracingReducer(initialState, action);
+    expect(newState).not.toBe(initialState);
+    const newSkeletonTracing = enforceSkeletonTracing(newState.tracing);
+    // This should be unchanged / sanity check
+    expect(newState.tracing.name).toBe(initialState.tracing.name);
+    expect(newSkeletonTracing.activeTreeId).toBe(initialSkeletonTracing.activeTreeId);
+    // New node and tree ids should have been assigned
+    expect(_.size(newSkeletonTracing.treeGroups)).toBe(4);
+    expect(newSkeletonTracing.treeGroups[2].groupId).not.toBe(newSkeletonTracing.treeGroups[0].groupId);
+    expect(newSkeletonTracing.treeGroups[3].groupId).not.toBe(newSkeletonTracing.treeGroups[1].groupId);
+    expect(newSkeletonTracing.trees[3].groupId).toBe(5);
+    expect(newSkeletonTracing.trees[4].groupId).toBe(newSkeletonTracing.treeGroups[3].groupId);
+  });
+
+  it("addTreesAndGroups reducer should replace nodeId references in comments when changing nodeIds", () => {
+    const commentWithoutValidReferences =
+      "Reference to non-existing id #42 and position reference #(4,5,6)";
+
+    const newTrees = _.cloneDeep(initialSkeletonTracing.trees);
+
+    newTrees[1].comments.push({
+      nodeId: 1,
+      content: "Reference to existing id in another tree #4",
+    });
+    newTrees[1].comments.push({
+      nodeId: 2,
+      content: commentWithoutValidReferences,
+    });
+    const action = addTreesAndGroupsAction(newTrees, []);
+    const newState = SkeletonTracingReducer(initialState, action);
+    const newSkeletonTracing = enforceSkeletonTracing(newState.tracing);
+    // Comments should have been rewritten if appropriate
+    expect(_.size(newSkeletonTracing.trees)).toBe(4);
+    expect(newSkeletonTracing.trees[3].comments.length).toBe(3);
+    expect(
+      newSkeletonTracing.trees[3].comments[1].content,
+    ).toBe("Reference to existing id in another tree #12");
+    expect(newSkeletonTracing.trees[3].comments[2].content).toBe(commentWithoutValidReferences);
+  });
+
+  it("NML Parser should split up disconnected trees", async () => {
+    const disconnectedTreeState = update(initialState, {
+      tracing: {
+        skeleton: {
+          trees: {
+            "1": {
+              edges: {
+                $set: EdgeCollection.loadFromArray([
+                  {
+                    source: 0,
+                    target: 1,
+                  },
+                ]),
+              },
+            },
+          },
+        },
+      },
+    });
+    const nmlWithDisconnectedTree = serializeToNml(
+      disconnectedTreeState,
+      disconnectedTreeState.tracing,
+      enforceSkeletonTracing(disconnectedTreeState.tracing),
+      BUILD_INFO,
+      false,
+    );
+    const { trees: parsedTrees, treeGroups: parsedTreeGroups } =
+      await parseNml(nmlWithDisconnectedTree);
+    // Check that the tree was split up into its three components
+    expect(_.size(parsedTrees)).toBe(4);
+    expect(parsedTrees[3].nodes.has(0)).toBe(true);
+    expect(parsedTrees[3].nodes.has(1)).toBe(true);
+    expect(parsedTrees[3].nodes.has(2)).toBe(false);
+    expect(parsedTrees[3].nodes.has(7)).toBe(false);
+    expect(_.size(parsedTrees[3].branchPoints)).toBe(1);
+    expect(_.size(parsedTrees[3].comments)).toBe(1);
+    expect(parsedTrees[4].nodes.has(2)).toBe(true);
+    expect(parsedTrees[5].nodes.has(7)).toBe(true);
+    expect(_.size(parsedTrees[5].branchPoints)).toBe(1);
+    // Check that the split up trees were wrapped in a group
+    // which was inserted into the original tree's group
+    const parentGroup = findGroup(parsedTreeGroups, 3);
+    if (parentGroup == null)
+      throw Error("Assertion Error: Serialized group is missing after parsing.");
+    expect(_.size(parentGroup.children)).toBe(1);
+    expect(parentGroup.children[0].name).toBe("TestTree-0");
+  });
 });

--- a/frontend/javascripts/test/libs/schema.spec.ts
+++ b/frontend/javascripts/test/libs/schema.spec.ts
@@ -1,12 +1,15 @@
-import test from "ava";
+import { describe, it, expect } from "vitest";
 import { getDefaultRecommendedConfiguration } from "admin/tasktype/recommended_configuration_view";
 import { validateUserSettingsJSON } from "types/validation";
 import { __setFeatures } from "features";
-test("The default recommended task type settings should be valid according to the schema", async (t) => {
-  // Set empty features
-  __setFeatures({});
 
-  validateUserSettingsJSON({}, JSON.stringify(getDefaultRecommendedConfiguration()))
-    .then(() => t.pass())
-    .catch(() => t.fail());
+describe("Schema", () => {
+  it("The default recommended task type settings should be valid according to the schema", async () => {
+    // Set empty features
+    __setFeatures({});
+
+    await validateUserSettingsJSON({}, JSON.stringify(getDefaultRecommendedConfiguration()))
+      .then(() => expect(true).toBe(true))
+      .catch(() => expect.fail("Schema validation failed"));
+  });
 });

--- a/frontend/javascripts/test/libs/task_pool.spec.ts
+++ b/frontend/javascripts/test/libs/task_pool.spec.ts
@@ -2,32 +2,33 @@ import { call, type Saga } from "oxalis/model/sagas/effect-generators";
 import { runSaga } from "redux-saga";
 import processTaskWithPool from "libs/async/task_pool";
 import * as Utils from "libs/utils";
-import test from "ava";
+import { describe, it, expect } from "vitest";
 
 /*eslint func-names: ["warn", "always", { "generators": "never" }]*/
 type Tasks = Array<() => Saga<void>>;
-test.serial("processTaskWithPool should run a simple task", async (t) => {
-  t.plan(1);
-  const protocol: number[] = [];
-  const tasks: Tasks = [
-    function* () {
-      yield* call(Utils.sleep, 100);
-      protocol.push(1);
-    },
-  ];
-  await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
-  t.is(protocol.length, 1);
-});
-test.serial("processTaskWithPool should deal with an empty task array", async (t) => {
-  t.plan(1);
-  const tasks: Tasks = [];
-  await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
-  t.pass();
-});
-test.serial(
-  "processTaskWithPool should deal with a failing task while the other tasks are still executed",
-  async (t) => {
-    t.plan(1);
+
+describe("Task Pool", () => {
+
+  it("should run a simple task", async () => {
+    const protocol: number[] = [];
+    const tasks: Tasks = [
+      function* () {
+        yield* call(Utils.sleep, 100);
+        protocol.push(1);
+      },
+    ];
+    await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
+    expect(protocol.length).toBe(1);
+  });
+
+  it("should deal with an empty task array", async () => {
+    const tasks: Tasks = [];
+    await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
+    // If we've reached here without errors, the test passes
+    expect(true).toBe(true);
+  });
+
+  it("should deal with a failing task while the other tasks are still executed", async () => {
     const protocol: number[] = [];
     const tasks: Tasks = [
       function* () {
@@ -42,71 +43,71 @@ test.serial(
 
     try {
       await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
-      t.fail("processTaskWithPool should fail");
+      expect.fail("processTaskWithPool should fail");
     } catch (_exception) {
-      t.deepEqual(protocol, [1]);
+      expect(protocol).toEqual([1]);
     }
-  },
-);
-test.serial("processTaskWithPool should run tasks sequentially", async (t) => {
-  t.plan(1);
-  const protocol: number[] = [];
-  const tasks: Tasks = [
-    function* () {
-      yield* call(Utils.sleep, 300);
-      protocol.push(1);
-    },
-    function* () {
-      yield* call(Utils.sleep, 200);
-      protocol.push(2);
-    },
-    function* () {
-      yield* call(Utils.sleep, 100);
-      protocol.push(3);
-    },
-  ];
-  await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
-  t.deepEqual(protocol, [1, 2, 3]);
-});
-test.serial("processTaskWithPool should run tasks in a sliding window manner", async (t) => {
-  t.plan(1);
-  const protocol: number[] = [];
-  const tasks: Tasks = [
-    function* () {
-      yield* call(Utils.sleep, 10);
-      protocol.push(2);
-    },
-    function* () {
-      protocol.push(1);
-      yield* call(Utils.sleep, 500);
-      protocol.push(4);
-    },
-    function* () {
-      yield* call(Utils.sleep, 10);
-      protocol.push(3);
-    },
-  ];
-  await runSaga({}, processTaskWithPool, tasks, 2).toPromise();
-  t.deepEqual(protocol, [1, 2, 3, 4]);
-});
-test.serial("processTaskWithPool should cope with too large pool size", async (t) => {
-  t.plan(1);
-  const protocol: number[] = [];
-  const tasks: Tasks = [
-    function* () {
-      yield* call(Utils.sleep, 10);
-      protocol.push(2);
-    },
-    function* () {
-      protocol.push(1);
-      yield* call(Utils.sleep, 500);
-      protocol.push(4);
-    },
-    function* () {
-      yield* call(Utils.sleep, 100);
-      protocol.push(3);
-    },
-  ];
-  await runSaga({}, processTaskWithPool, tasks, 10).toPromise();
-  t.deepEqual(protocol, [1, 2, 3, 4]);
+  });
+
+  it("should run tasks sequentially", async () => {
+    const protocol: number[] = [];
+    const tasks: Tasks = [
+      function* () {
+        yield* call(Utils.sleep, 300);
+        protocol.push(1);
+      },
+      function* () {
+        yield* call(Utils.sleep, 200);
+        protocol.push(2);
+      },
+      function* () {
+        yield* call(Utils.sleep, 100);
+        protocol.push(3);
+      },
+    ];
+    await runSaga({}, processTaskWithPool, tasks, 1).toPromise();
+    expect(protocol).toEqual([1, 2, 3]);
+  });
+
+  it("should run tasks in a sliding window manner", async () => {
+    const protocol: number[] = [];
+    const tasks: Tasks = [
+      function* () {
+        yield* call(Utils.sleep, 10);
+        protocol.push(2);
+      },
+      function* () {
+        protocol.push(1);
+        yield* call(Utils.sleep, 500);
+        protocol.push(4);
+      },
+      function* () {
+        yield* call(Utils.sleep, 10);
+        protocol.push(3);
+      },
+    ];
+    await runSaga({}, processTaskWithPool, tasks, 2).toPromise();
+    expect(protocol).toEqual([1, 2, 3, 4]);
+  });
+
+  it("should cope with too large pool size", async () => {
+    const protocol: number[] = [];
+    const tasks: Tasks = [
+      function* () {
+        yield* call(Utils.sleep, 10);
+        protocol.push(2);
+      },
+      function* () {
+        protocol.push(1);
+        yield* call(Utils.sleep, 500);
+        protocol.push(4);
+      },
+      function* () {
+        yield* call(Utils.sleep, 100);
+        protocol.push(3);
+      },
+    ];
+    await runSaga({}, processTaskWithPool, tasks, 10).toPromise();
+    expect(protocol).toEqual([1, 2, 3, 4]);
+  });
 });

--- a/frontend/javascripts/test/libs/thin_plate_spline.spec.ts
+++ b/frontend/javascripts/test/libs/thin_plate_spline.spec.ts
@@ -1,43 +1,45 @@
-import "test/mocks/lz4";
-import test from "ava";
+import "../mocks/lz4";
+import { describe, it, expect } from "vitest";
 import TPS3D from "libs/thin_plate_spline";
 import { almostEqual, getPointsC555 } from "./transform_spec_helpers";
 import { V3 } from "libs/mjs";
 import type { Vector3 } from "oxalis/constants";
 
-test("Basic TPS calculation", async (t) => {
-  const [sourcePoints, targetPoints] = getPointsC555();
+describe("Thin Plate Spline", () => {
+  it("Basic TPS calculation", async () => {
+    const [sourcePoints, targetPoints] = getPointsC555();
 
-  const tps = new TPS3D(sourcePoints, targetPoints, [1, 1, 1]);
+    const tps = new TPS3D(sourcePoints, targetPoints, [1, 1, 1]);
 
-  almostEqual(
-    t,
-    [568.1202797015036, 528.013612246682, 1622.1124501555569],
-    tps.transform(570.3021, 404.5549, 502.22482),
-  );
+    almostEqual(
+      expect,
+      [568.1202797015036, 528.013612246682, 1622.1124501555569],
+      tps.transform(570.3021, 404.5549, 502.22482),
+    );
 
-  almostEqual(
-    t,
-    [1574.679455809381, 1607.1773268624395, 1791.5425120096843],
-    tps.transform(500, 501, 502),
-  );
-});
+    almostEqual(
+      expect,
+      [1574.679455809381, 1607.1773268624395, 1791.5425120096843],
+      tps.transform(500, 501, 502),
+    );
+  });
 
-test("TPS calculation with scale", async (t) => {
-  const [sourcePoints, targetPoints] = getPointsC555();
-  const scale = [11, 12, 13] as Vector3;
-  const tps = new TPS3D(sourcePoints, targetPoints, scale);
-  const s = (el: Vector3) => V3.scale3(el, scale);
+  it("TPS calculation with scale", async () => {
+    const [sourcePoints, targetPoints] = getPointsC555();
+    const scale = [11, 12, 13] as Vector3;
+    const tps = new TPS3D(sourcePoints, targetPoints, scale);
+    const s = (el: Vector3) => V3.scale3(el, scale);
 
-  almostEqual(
-    t,
-    s([202.37820938461536, 656.9199393846154, 3268.6702726153844]),
-    tps.transform(...s([542.191067465668, 386.53899285892635, 370.4734697627965])),
-  );
+    almostEqual(
+      expect,
+      s([202.37820938461536, 656.9199393846154, 3268.6702726153844]),
+      tps.transform(...s([542.191067465668, 386.53899285892635, 370.4734697627965])),
+    );
 
-  almostEqual(
-    t,
-    s([1508.3328498461537, 1977.8310726153848, 185.3605911476923]),
-    tps.transform(...s([482.1100102621723, 492.8521135830212, 633.5717351310861])),
-  );
+    almostEqual(
+      expect,
+      s([1508.3328498461537, 1977.8310726153848, 185.3605911476923]),
+      tps.transform(...s([482.1100102621723, 492.8521135830212, 633.5717351310861])),
+    );
+  });
 });

--- a/frontend/javascripts/test/libs/transform_spec_helpers.ts
+++ b/frontend/javascripts/test/libs/transform_spec_helpers.ts
@@ -1,24 +1,19 @@
-import type { ExecutionContext } from "ava";
+import type { ExpectStatic } from "vitest";
 import type { Vector3 } from "oxalis/constants";
 
 export function almostEqual(
-  t: ExecutionContext,
+  expect: ExpectStatic,
   vec1: Vector3,
   vec2: Vector3,
   threshold: number = 1,
 ) {
-  t.true(
-    Math.abs(vec1[0] - vec2[0]) < threshold,
-    `Values are not similar enough: diff_x=${vec1[0] - vec2[0]}`,
-  );
-  t.true(
-    Math.abs(vec1[1] - vec2[1]) < threshold,
-    `Values are not similar enough: diff_y=${vec1[1] - vec2[1]}`,
-  );
-  t.true(
-    Math.abs(vec1[2] - vec2[2]) < threshold,
-    `Values are not similar enough: diff_z=${vec1[2] - vec2[2]}`,
-  );
+  const diffX = Math.abs(vec1[0] - vec2[0]);
+  const diffY = Math.abs(vec1[1] - vec2[1]);
+  const diffZ = Math.abs(vec1[2] - vec2[2]);
+
+  expect(diffX).toBeLessThan(threshold);
+  expect(diffY).toBeLessThan(threshold);
+  expect(diffZ).toBeLessThan(threshold);
 }
 
 export function getPointsC555() {

--- a/frontend/javascripts/test/libs/utils.spec.ts
+++ b/frontend/javascripts/test/libs/utils.spec.ts
@@ -1,204 +1,210 @@
 import * as Utils from "libs/utils";
-import test from "ava";
+import { describe, it, expect } from "vitest";
 
-test("filterWithSearchQueryAND: simple case", (t) => {
-  const collection = [
-    {
-      prop: "match",
-    },
-    {
-      prop: "a MATCH!",
-    },
-    {
-      prop: "no m_tch",
-    },
-  ];
-  const matchedElements = Utils.filterWithSearchQueryAND(collection, ["prop"], "match");
-  t.is(matchedElements.length, 2);
-  t.deepEqual(matchedElements, collection.slice(0, 2));
-});
-test("filterWithSearchQueryAND: complex case", (t) => {
-  const collection = [
-    {
-      prop: "match",
-      prop2: "",
-    },
-    {
-      prop: "no m_tch!",
-      prop2: "no m_tch",
-    },
-    {
-      prop: "some match",
-      prop2: "a keyword",
-    },
-  ];
-  const matchedElements = Utils.filterWithSearchQueryAND(
-    collection,
-    ["prop", (el) => el.prop2],
-    "match keyword",
-  );
-  t.is(matchedElements.length, 1);
-  t.deepEqual(matchedElements, [collection[2]]);
-});
-test("filterWithSearchQueryAND: deep case different data types", (t) => {
-  const collection = [
-    {
-      prop: {
-        prop2: 7,
+describe("Utils", () => {
+  it("filterWithSearchQueryAND: simple case", () => {
+    const collection = [
+      {
+        prop: "match",
       },
-    },
-    {
-      prop: {
-        prop2: false,
+      {
+        prop: "a MATCH!",
       },
-    },
-    {
-      prop: {
-        prop2: null,
+      {
+        prop: "no m_tch",
       },
-    },
-    {
-      prop: {
-        prop2: undefined,
-      },
-    },
-    {
-      prop: {
+    ];
+    const matchedElements = Utils.filterWithSearchQueryAND(collection, ["prop"], "match");
+    expect(matchedElements.length).toBe(2);
+    expect(matchedElements).toEqual(collection.slice(0, 2));
+  });
+
+  it("filterWithSearchQueryAND: complex case", () => {
+    const collection = [
+      {
+        prop: "match",
         prop2: "",
       },
-    },
-    {
-      prop: {
+      {
+        prop: "no m_tch!",
         prop2: "no m_tch",
       },
-    },
-    {
-      prop: {
+      {
+        prop: "some match",
         prop2: "a keyword",
       },
-    },
-  ];
-  const matchedElements = Utils.filterWithSearchQueryAND(collection, ["prop"], "a key");
-  t.is(matchedElements.length, 1);
-  t.deepEqual(matchedElements, [collection[6]]);
-});
-test("chunkIntoTimeWindows 1/2", async (t) => {
-  const chunk1 = [
-    {
-      time: 10 * 60 * 1000,
-      id: "element1",
-    },
-  ];
-  const chunk2 = [
-    {
-      time: 15 * 60 * 1000,
-      id: "element2",
-    },
-    {
-      time: 16 * 60 * 1000,
-      id: "element3",
-    },
-    {
-      time: 18 * 60 * 1000,
-      id: "element4",
-    },
-  ];
-  const collection = [...chunk1, ...chunk2];
-  const chunks = Utils.chunkIntoTimeWindows(collection, (el) => el.time, 4);
-  t.is(chunks.length, 2);
-  t.deepEqual(chunks, [chunk1, chunk2]);
-});
-test("chunkIntoTimeWindows 2/2", async (t) => {
-  const chunk1 = [
-    {
-      time: 0 * 60 * 1000,
-      id: "element1",
-    },
-  ];
-  const chunk2 = [
-    {
-      time: 10 * 60 * 1000,
-      id: "element2",
-    },
-    {
-      time: 10 * 60 * 1000,
-      id: "element3",
-    },
-    {
-      time: 18 * 60 * 1000,
-      id: "element4",
-    },
-  ];
-  const chunk3 = [
-    {
-      time: 127 * 60 * 1000,
-      id: "element5",
-    },
-    {
-      time: 134 * 60 * 1000,
-      id: "element6",
-    },
-    {
-      time: 135 * 60 * 1000,
-      id: "element7",
-    },
-  ];
-  const collection = [...chunk1, ...chunk2, ...chunk3];
-  const chunks = Utils.chunkIntoTimeWindows(collection, (el) => el.time, 9);
-  t.is(chunks.length, 3);
-  t.deepEqual(chunks, [chunk1, chunk2, chunk3]);
-});
+    ];
+    const matchedElements = Utils.filterWithSearchQueryAND(
+      collection,
+      ["prop", (el) => el.prop2],
+      "match keyword",
+    );
+    expect(matchedElements.length).toBe(1);
+    expect(matchedElements).toEqual([collection[2]]);
+  });
 
-test("chunkDynamically (I)", (t) => {
-  const elements = [5, 7, 10, 234, 10];
-  const batches = Utils.chunkDynamically(elements, 10, (el) => el);
-  t.deepEqual(batches, [[5, 7], [10, 234], [10]]);
-});
+  it("filterWithSearchQueryAND: deep case different data types", () => {
+    const collection = [
+      {
+        prop: {
+          prop2: 7,
+        },
+      },
+      {
+        prop: {
+          prop2: false,
+        },
+      },
+      {
+        prop: {
+          prop2: null,
+        },
+      },
+      {
+        prop: {
+          prop2: undefined,
+        },
+      },
+      {
+        prop: {
+          prop2: "",
+        },
+      },
+      {
+        prop: {
+          prop2: "no m_tch",
+        },
+      },
+      {
+        prop: {
+          prop2: "a keyword",
+        },
+      },
+    ];
+    const matchedElements = Utils.filterWithSearchQueryAND(collection, ["prop"], "a key");
+    expect(matchedElements.length).toBe(1);
+    expect(matchedElements).toEqual([collection[6]]);
+  });
 
-test("chunkDynamically (II)", (t) => {
-  const elements = [5, 7, 10, 234, 10];
-  const batches = Utils.chunkDynamically(elements, 100, (el) => el);
-  t.deepEqual(batches, [[5, 7, 10, 234], [10]]);
-});
+  it("chunkIntoTimeWindows 1/2", async () => {
+    const chunk1 = [
+      {
+        time: 10 * 60 * 1000,
+        id: "element1",
+      },
+    ];
+    const chunk2 = [
+      {
+        time: 15 * 60 * 1000,
+        id: "element2",
+      },
+      {
+        time: 16 * 60 * 1000,
+        id: "element3",
+      },
+      {
+        time: 18 * 60 * 1000,
+        id: "element4",
+      },
+    ];
+    const collection = [...chunk1, ...chunk2];
+    const chunks = Utils.chunkIntoTimeWindows(collection, (el) => el.time, 4);
+    expect(chunks.length).toBe(2);
+    expect(chunks).toEqual([chunk1, chunk2]);
+  });
 
-test("chunkDynamically (III)", (t) => {
-  const elements = [5, 7, 10, 234, 10];
-  const batches = Utils.chunkDynamically(elements, 1000, (el) => el);
-  t.deepEqual(batches, [[5, 7, 10, 234, 10]]);
-});
+  it("chunkIntoTimeWindows 2/2", async () => {
+    const chunk1 = [
+      {
+        time: 0 * 60 * 1000,
+        id: "element1",
+      },
+    ];
+    const chunk2 = [
+      {
+        time: 10 * 60 * 1000,
+        id: "element2",
+      },
+      {
+        time: 10 * 60 * 1000,
+        id: "element3",
+      },
+      {
+        time: 18 * 60 * 1000,
+        id: "element4",
+      },
+    ];
+    const chunk3 = [
+      {
+        time: 127 * 60 * 1000,
+        id: "element5",
+      },
+      {
+        time: 134 * 60 * 1000,
+        id: "element6",
+      },
+      {
+        time: 135 * 60 * 1000,
+        id: "element7",
+      },
+    ];
+    const collection = [...chunk1, ...chunk2, ...chunk3];
+    const chunks = Utils.chunkIntoTimeWindows(collection, (el) => el.time, 9);
+    expect(chunks.length).toBe(3);
+    expect(chunks).toEqual([chunk1, chunk2, chunk3]);
+  });
 
-test("chunkDynamically (IV)", (t) => {
-  const elements = [5, 7, 10, 234, 10];
-  const batches = Utils.chunkDynamically(elements, 1, (el) => el);
-  t.deepEqual(batches, [[5], [7], [10], [234], [10]]);
-});
+  it("chunkDynamically (I)", () => {
+    const elements = [5, 7, 10, 234, 10];
+    const batches = Utils.chunkDynamically(elements, 10, (el) => el);
+    expect(batches).toEqual([[5, 7], [10, 234], [10]]);
+  });
 
-test("computeHash", (t) => {
-  const hash1 = Utils.computeHash(
-    "https://webknossos.org/datasets/demo_orga/demo_ds/view#2816,4352,1792,0,1.3",
-  );
-  const hash2 = Utils.computeHash(
-    "https://webknossos.org/datasets/demo_orga/demo_ds/view#2816,4352,1792,0,1.4",
-  );
-  const hash3 = Utils.computeHash(
-    "https://randomdomain.org/datasets/demo_orga/demo_ds/view#2816,4352,1792,0,1.3",
-  );
-  t.not(hash1, hash2);
-  t.not(hash1, hash3);
-  t.not(hash2, hash3);
-});
+  it("chunkDynamically (II)", () => {
+    const elements = [5, 7, 10, 234, 10];
+    const batches = Utils.chunkDynamically(elements, 100, (el) => el);
+    expect(batches).toEqual([[5, 7, 10, 234], [10]]);
+  });
 
-test("encodeBase62", (t) => {
-  const encoded = Utils.encodeToBase62(0);
-  t.is(encoded, "0");
-  const encoded2 = Utils.encodeToBase62(123);
-  t.is(encoded2, "1z");
-  const encoded3 = Utils.encodeToBase62(123456);
-  t.is(encoded3, "W7E");
-  const encoded4 = Utils.encodeToBase62(-1);
-  t.is(encoded4, "z");
-  const encoded5 = Utils.encodeToBase62(-2);
-  t.is(encoded5, "y");
-  const encoded6 = Utils.encodeToBase62(-123456);
-  t.is(encoded6, "Tsm");
+  it("chunkDynamically (III)", () => {
+    const elements = [5, 7, 10, 234, 10];
+    const batches = Utils.chunkDynamically(elements, 1000, (el) => el);
+    expect(batches).toEqual([[5, 7, 10, 234, 10]]);
+  });
+
+  it("chunkDynamically (IV)", () => {
+    const elements = [5, 7, 10, 234, 10];
+    const batches = Utils.chunkDynamically(elements, 1, (el) => el);
+    expect(batches).toEqual([[5], [7], [10], [234], [10]]);
+  });
+
+  it("computeHash", () => {
+    const hash1 = Utils.computeHash(
+      "https://webknossos.org/datasets/demo_orga/demo_ds/view#2816,4352,1792,0,1.3",
+    );
+    const hash2 = Utils.computeHash(
+      "https://webknossos.org/datasets/demo_orga/demo_ds/view#2816,4352,1792,0,1.4",
+    );
+    const hash3 = Utils.computeHash(
+      "https://randomdomain.org/datasets/demo_orga/demo_ds/view#2816,4352,1792,0,1.3",
+    );
+    expect(hash1).not.toBe(hash2);
+    expect(hash1).not.toBe(hash3);
+    expect(hash2).not.toBe(hash3);
+  });
+
+  it("encodeBase62", () => {
+    const encoded = Utils.encodeToBase62(0);
+    expect(encoded).toBe("0");
+    const encoded2 = Utils.encodeToBase62(123);
+    expect(encoded2).toBe("1z");
+    const encoded3 = Utils.encodeToBase62(123456);
+    expect(encoded3).toBe("W7E");
+    const encoded4 = Utils.encodeToBase62(-1);
+    expect(encoded4).toBe("z");
+    const encoded5 = Utils.encodeToBase62(-2);
+    expect(encoded5).toBe("y");
+    const encoded6 = Utils.encodeToBase62(-123456);
+    expect(encoded6).toBe("Tsm");
+  });
 });

--- a/frontend/javascripts/test/model/model_resolutions.spec.ts
+++ b/frontend/javascripts/test/model/model_resolutions.spec.ts
@@ -1,134 +1,141 @@
-import "test/mocks/lz4";
-import test from "ava";
+import { describe, it, expect, vi } from "vitest";
+import * as lz4 from "lz4-wasm-nodejs";
+vi.mock("lz4-wasm-nodejs", { spy: true });
 import { getMagnificationUnion } from "oxalis/model/accessors/dataset_accessor";
 import type { Vector3 } from "oxalis/constants";
 import type { APIDataset } from "types/api_flow_types";
 import { convertToDenseMag } from "oxalis/model/helpers/mag_info";
 
-test("Simple convertToDenseMag", (t) => {
-  const denseMags = convertToDenseMag([
-    [2, 2, 1],
-    [4, 4, 2],
-  ]);
-  t.deepEqual(denseMags, [
-    [1, 1, 1],
-    [2, 2, 1],
-    [4, 4, 2],
-  ]);
-});
-test("Complex convertToDenseMag", (t) => {
-  const dataset = {
-    dataSource: {
-      dataLayers: [
-        {
-          resolutions: [
-            [16, 16, 2],
-            [2, 2, 1],
-            [4, 4, 1],
-            [8, 8, 1],
-            [32, 32, 4],
-          ] as Vector3[],
-        },
-        {
-          resolutions: [[32, 32, 4]] as Vector3[],
-        },
-      ],
-    },
-  };
 
-  const expectedMags = {
-    "0": [
+describe("Model resolutions", () => {
+  it("Simple convertToDenseMag", () => {
+    const denseMags = convertToDenseMag([
+      [2, 2, 1],
+      [4, 4, 2],
+    ]);
+    expect(denseMags).toEqual([
       [1, 1, 1],
       [2, 2, 1],
-      [4, 4, 1],
-      [8, 8, 1],
-      [16, 16, 2],
-      [32, 32, 4],
-    ] as Vector3[],
-    "1": [
-      [1, 1, 1],
-      [2, 2, 2],
-      [4, 4, 4],
-      [8, 8, 4],
-      [16, 16, 4],
-      [32, 32, 4],
-    ] as Vector3[],
-  };
+      [4, 4, 2],
+    ]);
+  });
 
-  const densify = (layer: { resolutions: Vector3[] }) => convertToDenseMag(layer.resolutions);
+  it("Complex convertToDenseMag", () => {
+    const dataset = {
+      dataSource: {
+        dataLayers: [
+          {
+            resolutions: [
+              [16, 16, 2],
+              [2, 2, 1],
+              [4, 4, 1],
+              [8, 8, 1],
+              [32, 32, 4],
+            ] as Vector3[],
+          },
+          {
+            resolutions: [[32, 32, 4]] as Vector3[],
+          },
+        ],
+      },
+    };
 
-  t.deepEqual(densify(dataset.dataSource.dataLayers[0]), expectedMags[0]);
-  t.deepEqual(densify(dataset.dataSource.dataLayers[1]), expectedMags[1]);
-});
-test("Test empty getMagUnion", (t) => {
-  const dataset = {
-    dataSource: {
-      dataLayers: [],
-    },
-  } as any as APIDataset;
-  const expectedMags: Array<Vector3[]> = [];
-  const union = getMagnificationUnion(dataset);
-  t.deepEqual(union, expectedMags);
-});
-test("Test getMagUnion", (t) => {
-  const dataset = {
-    dataSource: {
-      dataLayers: [
-        {
-          resolutions: [
-            [4, 4, 1],
-            [8, 8, 1],
-            [16, 16, 2],
-            [32, 32, 4],
-          ],
-        },
-        {
-          resolutions: [
-            [2, 2, 1],
-            [8, 8, 1],
-            [32, 32, 4],
-          ],
-        },
+    const expectedMags = {
+      "0": [
+        [1, 1, 1],
+        [2, 2, 1],
+        [4, 4, 1],
+        [8, 8, 1],
+        [16, 16, 2],
+        [32, 32, 4],
+      ] as Vector3[],
+      "1": [
+        [1, 1, 1],
+        [2, 2, 2],
+        [4, 4, 4],
+        [8, 8, 4],
+        [16, 16, 4],
+        [32, 32, 4],
+      ] as Vector3[],
+    };
+
+    const densify = (layer: { resolutions: Vector3[] }) => convertToDenseMag(layer.resolutions);
+
+    expect(densify(dataset.dataSource.dataLayers[0])).toEqual(expectedMags[0]);
+    expect(densify(dataset.dataSource.dataLayers[1])).toEqual(expectedMags[1]);
+  });
+
+  it("Test empty getMagUnion", () => {
+    const dataset = {
+      dataSource: {
+        dataLayers: [],
+      },
+    } as any as APIDataset;
+    const expectedMags: Array<Vector3[]> = [];
+    const union = getMagnificationUnion(dataset);
+    expect(union).toEqual(expectedMags);
+  });
+
+  it("Test getMagUnion", () => {
+    const dataset = {
+      dataSource: {
+        dataLayers: [
+          {
+            resolutions: [
+              [4, 4, 1],
+              [8, 8, 1],
+              [16, 16, 2],
+              [32, 32, 4],
+            ],
+          },
+          {
+            resolutions: [
+              [2, 2, 1],
+              [8, 8, 1],
+              [32, 32, 4],
+            ],
+          },
+        ],
+      },
+    } as any as APIDataset;
+    const expectedMags = [[[2, 2, 1]], [[4, 4, 1]], [[8, 8, 1]], [[16, 16, 2]], [[32, 32, 4]]];
+    const union = getMagnificationUnion(dataset);
+    expect(union).toEqual(expectedMags);
+  });
+
+  it("Test getMagUnion with mixed mags", () => {
+    const dataset = {
+      dataSource: {
+        dataLayers: [
+          {
+            resolutions: [
+              [4, 4, 1],
+              [8, 8, 1],
+              [16, 16, 2],
+              [32, 32, 4],
+            ],
+          },
+          {
+            resolutions: [
+              [2, 2, 1],
+              [8, 8, 2],
+              [32, 32, 4],
+            ],
+          },
+        ],
+      },
+    } as any as APIDataset;
+    const expectedMags = [
+      [[2, 2, 1]],
+      [[4, 4, 1]],
+      [
+        [8, 8, 1],
+        [8, 8, 2],
       ],
-    },
-  } as any as APIDataset;
-  const expectedMags = [[[2, 2, 1]], [[4, 4, 1]], [[8, 8, 1]], [[16, 16, 2]], [[32, 32, 4]]];
-  const union = getMagnificationUnion(dataset);
-  t.deepEqual(union, expectedMags);
-});
-
-test("Test getMagUnion with mixed mags", (t) => {
-  const dataset = {
-    dataSource: {
-      dataLayers: [
-        {
-          resolutions: [
-            [4, 4, 1],
-            [8, 8, 1],
-            [16, 16, 2],
-            [32, 32, 4],
-          ],
-        },
-        {
-          resolutions: [
-            [2, 2, 1],
-            [8, 8, 2],
-            [32, 32, 4],
-          ],
-        },
-      ],
-    },
-  } as any as APIDataset;
-  const expectedMags = [
-    [[2, 2, 1]],
-    [[4, 4, 1]],
-    [
-      [8, 8, 1],
-      [8, 8, 2],
-    ],
-    [[16, 16, 2]],
-    [[32, 32, 4]],
-  ];
-  const union = getMagnificationUnion(dataset);
-  t.deepEqual(union, expectedMags);
+      [[16, 16, 2]],
+      [[32, 32, 4]],
+    ];
+    const union = getMagnificationUnion(dataset);
+    expect(union).toEqual(expectedMags);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "css-loader": "^6.5.1",
     "dependency-cruiser": "^16.10.0",
     "documentation": "^14.0.2",
-    "domexception": "^2.0.1",
     "dpdm": "^3.14.0",
     "esbuild": "^0.25",
     "espree": "^3.5.4",
@@ -69,6 +68,8 @@
     "ts-loader": "^9.4.1",
     "typescript": "^5.5.0",
     "typescript-coverage-report": "^0.8.0",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.9",
     "webpack": "^5.74.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.2"
@@ -86,7 +87,7 @@
     "listening": "lsof -i:5005,7155,9000,9001,9002",
     "kill-listeners": "kill -9 $(lsof -t -i:5005,7155,9000,9001,9002)",
     "rm-fossil-lock": "rm fossildb/data/LOCK",
-    "test": "tools/test.sh test --timeout=30s",
+    "test": "tools/test.sh test",
     "test-changed": "tools/test.sh test-changed --timeout=30s",
     "test-verbose": "xvfb-run -s '-ac -screen 0 1280x1024x24' tools/test.sh test --timeout=60s --verbose",
     "test-backend": "sbt \"testOnly backend.*\"",
@@ -224,10 +225,17 @@
     },
     "require": [
       "./frontend/javascripts/test/_ava_polyfill_provider.ts",
-      "./frontend/javascripts/test/_force-exit.mjs"
+      "./frontend/javascripts/test/_force-exit.ts"
     ],
     "snapshotDir": "frontend/javascripts/test/snapshots",
-    "concurrency": 8
+    "concurrency": 8,
+    "extensions": {
+      "ts": "module",
+      "tsx": "module"
+    },
+    "nodeArguments": [
+      "--trace-warnings"
+    ]
   },
   "c8": {
     "exclude": [
@@ -236,5 +244,6 @@
     ],
     "reporter": "lcov"
   },
-  "packageManager": "yarn@4.4.1"
+  "packageManager": "yarn@4.4.1",
+  "type": "module"
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+  plugins: [tsconfigPaths()]
+}); 


### PR DESCRIPTION
At the moment we have a a complicated and somewhat outdated stack for frontend testing:

1. Convert all TS files to JS with `esbuild` 
  - output is CommonJS modules for compatiblity with `nodejs` while the whole codebase already uses ES modules
  - import mocking with `mockRequire` is also commonJS and very confusing
2. Run all unit tests in `nodejs` with `ava` framework

This workflow for testing TS, ESM and React code in node is configured very differently from the regular browser builds and is not very well supported out-of-the-box by either `ava` or the other tools.

`vitest` is very modern, works out-of-the-box with our current frontend setup without any additional configs. n this PR I migrated the frontend unit tests to `vitest` in an effort to rid ourselves of `ava´ and many `esbuild` configs. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- CI tests should be enough

### TODOs:
- [ ] Update all remaining unit tests
- [ ] Follow up issue: Convert all e2e tests to vitest

### Issues:
- Contributes to #8454

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
