### PR TITLE
clean up spire usages

### DIFF
--- a/test/backend/Zarr3TestSuite.scala
+++ b/test/backend/Zarr3TestSuite.scala
@@ -8,7 +8,6 @@ import com.scalableminds.webknossos.datastore.datareaders.zarr3.{
 import com.scalableminds.webknossos.datastore.datareaders.zarr3.Zarr3ArrayHeader.Zarr3ArrayHeaderFormat
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
-import spire.math.Number
 
 class Zarr3TestSuite extends PlaySpec {
 
@@ -35,7 +34,7 @@ class Zarr3TestSuite extends PlaySpec {
         assert(header.shape.sameElements(Seq(64, 64, 64)))
         assert(header.data_type.left.getOrElse("notUint8") == "uint8")
         assert(header.zarr_format == 3)
-        assert(header.fill_value.getOrElse(Number(1)).intValue() == 0)
+        assert(header.fill_value == Right[String, Number](0))
         assert(header.dimension_names.get.sameElements(Seq("x", "y", "z")))
       }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataConverter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataConverter.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.datastore.services
 
 import com.scalableminds.util.tools.FoxImplicits
 import com.scalableminds.webknossos.datastore.models.datasource.ElementClass
-import spire.math.{ULong, _}
+import spire.math.{UByte, UInt, ULong, UShort}
 
 import java.nio._
 import scala.reflect.ClassTag
@@ -75,20 +75,6 @@ trait DataConverter extends FoxImplicits {
         case d: Array[Float] => d.filter(!_.isNaN).filter(_ != 0f)
       }
     }
-
-  def toBytesSpire(typed: Array[_ >: UByte with UShort with UInt with ULong with Float],
-                   elementClass: ElementClass.Value): Array[Byte] = {
-    val numBytes = ElementClass.bytesPerElement(elementClass)
-    val byteBuffer = ByteBuffer.allocate(numBytes * typed.length).order(ByteOrder.LITTLE_ENDIAN)
-    typed match {
-      case data: Array[UByte]  => data.foreach(el => byteBuffer.put(el.signed))
-      case data: Array[UShort] => data.foreach(el => byteBuffer.putChar(el.signed))
-      case data: Array[UInt]   => data.foreach(el => byteBuffer.putInt(el.signed))
-      case data: Array[ULong]  => data.foreach(el => byteBuffer.putLong(el.signed))
-      case data: Array[Float]  => data.foreach(el => byteBuffer.putFloat(el))
-    }
-    byteBuffer.array()
-  }
 
   def toBytes(typed: Array[_ >: Byte with Short with Int with Long with Float],
               elementClass: ElementClass.Value): Array[Byte] = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/AgglomerateFileCache.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/AgglomerateFileCache.scala
@@ -176,7 +176,7 @@ class BoundingBoxCache(
       val isTransformed = Array.fill(input.length)(false)
       while (offset <= readerRange._2) {
         val agglomerateIds: Array[Long] =
-          readHDF(reader, offset, spire.math.min(maxReaderRange, readerRange._2 - offset) + 1)
+          readHDF(reader, offset, Math.min(maxReaderRange, readerRange._2 - offset) + 1)
         for (i <- input.indices) {
           val inputElement = input(i)
           if (!isTransformed(i) && inputElement >= offset && inputElement < offset + maxReaderRange) {


### PR DESCRIPTION
I want to eventually get rid of the spire dependency, see #3810 

This removes a few usages where there was no specific spire functionality in use anyway (and an unused function).

### URL of deployed dev instance (used for testing):
- https://spirecleanup.webknossos.xyz

### Steps to test:
- Loading data with active agglomerate mapping should still work

### Issues:
- contributes to #3810