### PR TITLE
Fix redundant newer-version-on-server toast

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -46,6 +46,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed that the brightness/contrast settings (in the histogram) could not be changed if the histogram data could not be loaded for some reason. [#8459](https://github.com/scalableminds/webknossos/pull/8459)
 - Fixed that downloading + reupload of an annotation, in which the skeleton tools were never used, actually made them unreachable. [#8466](https://github.com/scalableminds/webknossos/pull/8466)
 - Fixed a bug where task creation with volume zip as input would fail. [#8468](https://github.com/scalableminds/webknossos/pull/8468)
+- Fixed that a warning message about a newer version of an annotation was shown multiple times. [#8486](https://github.com/scalableminds/webknossos/pull/8486)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/model/sagas/save_saga.ts
+++ b/frontend/javascripts/oxalis/model/sagas/save_saga.ts
@@ -499,39 +499,37 @@ function* watchForSaveConflicts(): Saga<never> {
       annotationId,
     );
 
-    for (const tracing of tracings) {
-      // Read the tracing version again from the store, since the
-      // old reference to tracing might be outdated now due to the
-      // immutability.
-      const versionOnClient = yield* select((state) => {
-        return state.tracing.version;
-      });
+    // Read the tracing version again from the store, since the
+    // old reference to tracing might be outdated now due to the
+    // immutability.
+    const versionOnClient = yield* select((state) => {
+      return state.tracing.version;
+    });
 
-      const toastKey = `save_conflicts_warning_${tracing.tracingId}`;
-      if (versionOnServer > versionOnClient) {
-        // The latest version on the server is greater than the most-recently
-        // stored version.
+    const toastKey = "save_conflicts_warning";
+    if (versionOnServer > versionOnClient) {
+      // The latest version on the server is greater than the most-recently
+      // stored version.
 
-        const saveQueue = yield* select((state) => state.save.queue);
+      const saveQueue = yield* select((state) => state.save.queue);
 
-        let msg = "";
-        if (!allowSave) {
-          msg =
-            "A newer version of this annotation was found on the server. Reload the page to see the newest changes.";
-        } else if (saveQueue.length > 0) {
-          msg =
-            "A newer version of this annotation was found on the server. Your current changes to this annotation cannot be saved anymore.";
-        } else {
-          msg =
-            "A newer version of this annotation was found on the server. Please reload the page to see the newer version. Otherwise, changes to the annotation cannot be saved anymore.";
-        }
-        Toast.warning(msg, {
-          sticky: true,
-          key: toastKey,
-        });
+      let msg = "";
+      if (!allowSave) {
+        msg =
+          "A newer version of this annotation was found on the server. Reload the page to see the newest changes.";
+      } else if (saveQueue.length > 0) {
+        msg =
+          "A newer version of this annotation was found on the server. Your current changes to this annotation cannot be saved anymore.";
       } else {
-        Toast.close(toastKey);
+        msg =
+          "A newer version of this annotation was found on the server. Please reload the page to see the newer version. Otherwise, changes to the annotation cannot be saved anymore.";
       }
+      Toast.warning(msg, {
+        sticky: true,
+        key: toastKey,
+      });
+    } else {
+      Toast.close(toastKey);
     }
   }
 


### PR DESCRIPTION
Since #7839, there is no need to check for a newer version per tracing.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create an annotation, make it public
- open it again in an incognito window
- mutate the first tab and save
- wait for 1 minute (that's the polling interval)
- one toast should appear telling the user that a newer version is available on the server

### Issues:
- follow-up to #7839 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
 