### PR TITLE
Format credits on orga page

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,6 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed the alignment of the button that allows restricting floodfill operations to a bounding box. [#8388](https://github.com/scalableminds/webknossos/pull/8388) 
 - Fixed a bug for rotated dataset where volume tools were disabled although the dataset was rendered untransformed. [#8432](https://github.com/scalableminds/webknossos/pull/8432)
 - Fixed rare bug where saving got stuck. [#8409](https://github.com/scalableminds/webknossos/pull/8409)
+- Improve formatting of credits amount in organization management page [8487](https://github.com/scalableminds/webknossos/pull/8487)
 - Re-enabled jobs planned to be paid with credits for organizations without a paid plan. [#8478](https://github.com/scalableminds/webknossos/pull/8478)
 - Fixed that the dataset extent tooltip in the right details bar in the dashboard did not properly update when switching datasets. [#8477](https://github.com/scalableminds/webknossos/pull/8477)
 - Fixed some rendering bugs for float datasets that used a large dynamic range. [#8325](https://github.com/scalableminds/webknossos/pull/8325)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -32,7 +32,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed the alignment of the button that allows restricting floodfill operations to a bounding box. [#8388](https://github.com/scalableminds/webknossos/pull/8388) 
 - Fixed a bug for rotated dataset where volume tools were disabled although the dataset was rendered untransformed. [#8432](https://github.com/scalableminds/webknossos/pull/8432)
 - Fixed rare bug where saving got stuck. [#8409](https://github.com/scalableminds/webknossos/pull/8409)
-- Improve formatting of credits amount in organization management page [8487](https://github.com/scalableminds/webknossos/pull/8487)
+- Improve formatting of credits amount in organization management page [#8487](https://github.com/scalableminds/webknossos/pull/8487)
 - Re-enabled jobs planned to be paid with credits for organizations without a paid plan. [#8478](https://github.com/scalableminds/webknossos/pull/8478)
 - Fixed that the dataset extent tooltip in the right details bar in the dashboard did not properly update when switching datasets. [#8477](https://github.com/scalableminds/webknossos/pull/8477)
 - Fixed some rendering bugs for float datasets that used a large dynamic range. [#8325](https://github.com/scalableminds/webknossos/pull/8325)

--- a/frontend/javascripts/admin/organization/organization_cards.tsx
+++ b/frontend/javascripts/admin/organization/organization_cards.tsx
@@ -7,7 +7,7 @@ import {
 import { Alert, Button, Card, Col, Progress, Row, Tooltip } from "antd";
 import { formatDateInLocalTimeZone } from "components/formatted_date";
 import dayjs from "dayjs";
-import { formatCountToDataAmountUnit } from "libs/format_utils";
+import { formatCountToDataAmountUnit, formatCreditsString } from "libs/format_utils";
 import Constants from "oxalis/constants";
 import type { OxalisState } from "oxalis/store";
 import type React from "react";
@@ -311,7 +311,7 @@ export function PlanDashboardCard({
             <Row justify="center" align="middle" style={{ minHeight: 160 }}>
               <h3>
                 {organization.creditBalance != null
-                  ? organization.creditBalance
+                  ? formatCreditsString(organization.creditBalance)
                   : "No information access"}
               </h3>
             </Row>


### PR DESCRIPTION
Properly formats the amout of credits of an organization in the orga page.

### URL of deployed dev instance (used for testing):
- https://formatcreditinorgapage.webknossos.xyz

### Steps to test:
- Open the orga page. It should show 2 instead of 2.000 for credits


### Issues:
- fixes report https://scm.slack.com/archives/C5AKLAV0B/p1743506482803409

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)