### PR TITLE
Restructure list annotations query to guide Postgres to a more efficient query plan

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where task creation with volume zip as input would fail. [#8468](https://github.com/scalableminds/webknossos/pull/8468)
 - Fixed a bug where segment statistics would sometimes be wrong in case of an on-disk segmentation fallback layer with segment index file. [#8460](https://github.com/scalableminds/webknossos/pull/8460)
 - Fixed a bug where sometimes outdated segment statistics would be displayed. [#8460](https://github.com/scalableminds/webknossos/pull/8460)
+- Fixed a bug where the annotation list would sometimes load very long if you have many annotations. [#8498](https://github.com/scalableminds/webknossos/pull/8498)
 
 ### Removed
 


### PR DESCRIPTION
It appears the new postgres version doesn’t find an efficient query plan anymore for our old WITH query. This PR restructures the query to get the LIMIT in early.

### Steps to test:
- View annotation list, should work
- Share some annotations with multiple teams
- Should be still listed correctly in annotation list view (no duplicates)
- I already tested with a postgres client that the new query is no longer slow on the large production database.

### Issues:
- fixes https://discuss.webknossos.org/t/annotations-tab-loads-forever/1915

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
