### PR TITLE
Add stdint include to bucketscanner to fix build system compatibility

### DIFF
--- a/webknossos-jni/src/bucketScanner.cpp
+++ b/webknossos-jni/src/bucketScanner.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <unordered_set>
+#include <stdint.h>
 
 uint64_t segmentIdAtIndex(jbyte *bucketBytes, size_t index, const int bytesPerElement, const bool isSigned) {
     jbyte *currentPos = bucketBytes + (index * bytesPerElement);


### PR DESCRIPTION
For me `uint64_t` was available without this include, but that may have been system specific. This include should really be added when using `uint64_t`.