### PR TITLE
Fix editable mapping updater’s putBuffer

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBPutBuffer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBPutBuffer.scala
@@ -22,10 +22,11 @@ class FossilDBPutBuffer(fossilDBClient: FossilDBClient, version: Option[Long] = 
         versionToPut <- version
           .orElse(this.version)
           .toFox ?~> "FossilDBPutBuffer put without version (needs to be passed to put or to buffer)"
-      } buffer.put((key, versionToPut), value)
-      if (isFull) {
-        flush()
-      } else Fox.successful(())
+        _ = buffer.put((key, versionToPut), value)
+      } yield
+        if (isFull) {
+          flush()
+        } else Fox.successful(())
     }
 
   private def isFull = this.synchronized { size >= maxElements }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBPutBuffer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBPutBuffer.scala
@@ -23,10 +23,10 @@ class FossilDBPutBuffer(fossilDBClient: FossilDBClient, version: Option[Long] = 
           .orElse(this.version)
           .toFox ?~> "FossilDBPutBuffer put without version (needs to be passed to put or to buffer)"
         _ = buffer.put((key, versionToPut), value)
-      } yield
-        if (isFull) {
+        result <- if (isFull) {
           flush()
         } else Fox.successful(())
+      } yield result
     }
 
   private def isFull = this.synchronized { size >= maxElements }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingUpdater.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingUpdater.scala
@@ -65,8 +65,10 @@ class EditableMappingUpdater(
     } yield updatedEditableMappingInfo
 
   def flushBuffersToFossil()(implicit ec: ExecutionContext): Fox[Unit] = {
-    val segmentToAgglomeratePutBuffer = new FossilDBPutBuffer(tracingDataStore.editableMappingsSegmentToAgglomerate)
-    val agglomerateToGraphPutBuffer = new FossilDBPutBuffer(tracingDataStore.editableMappingsAgglomerateToGraph)
+    val segmentToAgglomeratePutBuffer =
+      new FossilDBPutBuffer(tracingDataStore.editableMappingsSegmentToAgglomerate, version = Some(newVersion))
+    val agglomerateToGraphPutBuffer =
+      new FossilDBPutBuffer(tracingDataStore.editableMappingsAgglomerateToGraph, version = Some(newVersion))
     for {
       _ <- Fox.serialCombined(segmentToAgglomerateBuffer.keys.toList)(key =>
         flushSegmentToAgglomerateChunk(key, segmentToAgglomeratePutBuffer))


### PR DESCRIPTION
Fix for regression introduced in https://github.com/scalableminds/webknossos/pull/8482
(The version wasn’t set, and the assertion that was supposed to prevent that did not propagate because the for/yield structure was incomplete)

### Steps to test:
- With proofreading tool, do some splits + merges, page reload, result should be there.