### PR TITLE
Fix typo when writing zarr header: dimension_separator

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where segment statistics would sometimes be wrong in case of an on-disk segmentation fallback layer with segment index file. [#8460](https://github.com/scalableminds/webknossos/pull/8460)
 - Fixed a bug where sometimes outdated segment statistics would be displayed. [#8460](https://github.com/scalableminds/webknossos/pull/8460)
 - Fixed a bug where the annotation list would sometimes load very long if you have many annotations. [#8498](https://github.com/scalableminds/webknossos/pull/8498)
+- Fixed a bug where outbound zarr streaming would contain a typo in the zarr header dimension_separator field. [#8510](https://github.com/scalableminds/webknossos/pull/8510)
 
 ### Removed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrHeader.scala
@@ -98,7 +98,7 @@ object ZarrHeader extends JsonImplicits {
         "compressor" -> zarrHeader.compressor,
         "filters" -> None,
         "shape" -> zarrHeader.shape,
-        "dimension_seperator" -> zarrHeader.dimension_separator
+        "dimension_separator" -> zarrHeader.dimension_separator
       )
   }
 }


### PR DESCRIPTION
It kinda still works because "." is the fallback value anyway.

### Issues:
- fixes #8508

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Needs datastore update after deployment
