### PR TITLE
Fix concurrency bug in skeleton saving

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a bug where sometimes outdated segment statistics would be displayed. [#8460](https://github.com/scalableminds/webknossos/pull/8460)
 - Fixed a bug where the annotation list would sometimes load very long if you have many annotations. [#8498](https://github.com/scalableminds/webknossos/pull/8498)
 - Fixed a bug where outbound zarr streaming would contain a typo in the zarr header dimension_separator field. [#8510](https://github.com/scalableminds/webknossos/pull/8510)
+- Fixed a bug where sometimes large skeletons were not saved correctly, making them inaccessible on the next load. [#8513](https://github.com/scalableminds/webknossos/pull/8513)
 
 ### Removed
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -44,7 +44,7 @@ class SkeletonTracingService @Inject()(
       for {
         _ <- Fox.serialCombined(treeIdsToFlush) { treeId =>
           for {
-            treeBody <- extractTreeBody(tracing, treeId)
+            treeBody <- extractTreeBody(tracing, treeId).toFox
             _ <- skeletonTreeBodiesPutBuffer.put(f"$tracingId/$treeId", treeBody)
           } yield ()
         }


### PR DESCRIPTION
This for comprehension is Box-Flavored, which is why the Fox from `put` was not awaited properly.

This regression was introduced in #8482

In other spots this was forbidden by the compiler. I will analyse what was different here so that we can hopefully guard against this kind of subtle mistake in the future.

I checked the other existing uses of the put buffer and this is the only one that had this problem.

### URL of deployed dev instance (used for testing):
- https://fixsaveskeleton.webknossos.xyz

### Steps to test:
- Upload NML with significantly more than 100 trees (say, 300)
- Should load correctly.
- On the current master this will error

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
