### PR TITLE
Switch CI to ubuntu 22.04 for now to match docker image

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   frontend-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
         run: yarn test-verbose
 
   backend-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
 
 
   build-test-e2e-deploy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We had problems because the CI’s Ubuntu 24.04 installed newer version of libdraco, which was then incompatible with what was installed in the dockerfile.

Switching the CI to 22.04 for now to unblock current master.

We can later have a look at how to go to the more recent 24.04 for everything.

I tested that this change resolves the issue, [compare slack discussion](https://scm.slack.com/archives/C3RUHRXBM/p1744615912571029?thread_ts=1744320379.538729&cid=C3RUHRXBM)