### PR TITLE
Apply proper antd theming to Welcome Toast

### DIFF
--- a/frontend/javascripts/oxalis/view/novel_user_experiences/welcome_toast.tsx
+++ b/frontend/javascripts/oxalis/view/novel_user_experiences/welcome_toast.tsx
@@ -1,11 +1,12 @@
-import { Button, notification } from "antd";
+import { App, Button } from "antd";
+import type { NotificationInstance } from "antd/es/notification/interface";
 import features from "features";
 import { useEffectOnlyOnce } from "libs/react_hooks";
 import UserLocalStorage from "libs/user_local_storage";
 import type { OxalisState } from "oxalis/store";
 import { useSelector } from "react-redux";
 
-function showWelcomeToast() {
+function showWelcomeToast(notification: NotificationInstance) {
   notification.open({
     className: "webknossos-welcome-toast",
     duration: 0,
@@ -45,6 +46,8 @@ function showWelcomeToast() {
 
 export default function WelcomeToast() {
   const activeUser = useSelector((state: OxalisState) => state.activeUser);
+  const { notification } = App.useApp();
+
   useEffectOnlyOnce(() => {
     if (!features().isWkorgInstance) {
       return;
@@ -56,7 +59,7 @@ export default function WelcomeToast() {
 
     if (activeUser == null && hasSeenToast == null) {
       // Only if the user is not logged in and has never seen the toast before, we show it here.
-      showWelcomeToast();
+      showWelcomeToast(notification);
     }
 
     // Even if the toast wasn't opened above, we set the hasSeen bit, since the decision to not


### PR DESCRIPTION
Update WelcomeToast to use App notification instance for proper antd theming.

Using the static antd `notification` calls are deprecated since antd v5 and do not support React Context objects , e.g. antd's `ConfigProvider` for apply the correct theme.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open any dataset and sharing button to copy the link
- Open an icognito browser window and paste the copied url
- inspect the welcome notification. It should no use nunito as the font and have proper style for antd's button classes

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1744025883826889

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
