### PR TITLE
Fix legacy links

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -31,6 +31,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a Bug where the "Save view configuration as default" modal's text included undefined.  [#8514](https://github.com/scalableminds/webknossos/pull/8514)
 - Fixed the alignment of the button that allows restricting floodfill operations to a bounding box. [#8388](https://github.com/scalableminds/webknossos/pull/8388) 
 - Fixed that it was possible to trigger the find largest segment id job on layers which are not stored as segmentation layers on the server. [#8503](https://github.com/scalableminds/webknossos/pull/8503)
+- Fixed resolution of legacy links having dataset names with `-`. [#8548](https://github.com/scalableminds/webknossos/pull/8548)
 - Fixed a rare and subtle bug related to volume annotation and undo/redo. [#7506](https://github.com/scalableminds/webknossos/pull/7506)
 - Fixed a bug where segment statistics would sometimes be wrong in case of an on-disk segmentation fallback layer with segment index file. [#8460](https://github.com/scalableminds/webknossos/pull/8460)
 - Fixed a bug where sometimes outdated segment statistics would be displayed. [#8460](https://github.com/scalableminds/webknossos/pull/8460)

--- a/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/oxalis/model/accessors/dataset_accessor.ts
@@ -728,5 +728,5 @@ export function getDatasetIdOrNameFromReadableURLPart(datasetNameAndId: string) 
   const isId = /^[a-f0-9]{24}$/.test(datasetIdOrName || "");
   return isId
     ? { datasetId: datasetIdOrName, datasetName: null }
-    : { datasetId: null, datasetName: datasetIdOrName };
+    : { datasetId: null, datasetName: datasetNameAndId };
 }


### PR DESCRIPTION
This PR fixes legacy link resolution for dataset with names including `-` characters. Eg. http://localhost:9000/datasets/FluoEM_2016-05-26_FD0144-2_v2s2s/view.

Now 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Log in to wk
- open newtork tab
- open link http://localhost:9000/datasets/FluoEM_2016-05-26_FD0144-2_v2s2s/view (or on the host you are testing)
- `http://localhost:9000/api/datasets/disambiguate/FluoEM_2016-05-26_FD0144-2_v2s2s/toNew` should be called in the console; and not `http://localhost:9000/api/datasets/disambiguate/2_v2s2s/toNew`

### Issues:
- fixes report https://scm.slack.com/archives/C5AKLAV0B/p1745326314576419

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
