### PR TITLE
Fix screenshot tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install dependencies and wait
         run: |

--- a/.github/workflows/wkorg-nightly.yaml
+++ b/.github/workflows/wkorg-nightly.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-            node-version: 18
+            node-version: 22
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fix screenshot tests by configuring the right node version (v22+).


### Steps to test:
- See successful CI run: https://github.com/scalableminds/webknossos/actions/runs/14726355787


### Issues:
- fixes https://github.com/scalableminds/webknossos/actions/runs/14720584884/attempts/1

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
