### PR TITLE
WIP allowing rotating ortho views

### DIFF
--- a/frontend/javascripts/oxalis/controller/scene_controller.ts
+++ b/frontend/javascripts/oxalis/controller/scene_controller.ts
@@ -243,9 +243,11 @@ class SceneController {
       [OrthoViews.PLANE_YZ]: new Plane(OrthoViews.PLANE_YZ),
       [OrthoViews.PLANE_XZ]: new Plane(OrthoViews.PLANE_XZ),
     };
-    this.planes[OrthoViews.PLANE_XY].setRotation(new THREE.Euler(Math.PI, 0, 0));
-    this.planes[OrthoViews.PLANE_YZ].setRotation(new THREE.Euler(Math.PI, (1 / 2) * Math.PI, 0));
-    this.planes[OrthoViews.PLANE_XZ].setRotation(new THREE.Euler((-1 / 2) * Math.PI, 0, 0));
+    this.planes[OrthoViews.PLANE_XY].setBaseRotation(new THREE.Euler(Math.PI, 0, 0));
+    this.planes[OrthoViews.PLANE_YZ].setBaseRotation(
+      new THREE.Euler(Math.PI, (1 / 2) * Math.PI, 0),
+    );
+    this.planes[OrthoViews.PLANE_XZ].setBaseRotation(new THREE.Euler((-1 / 2) * Math.PI, 0, 0));
 
     const planeMeshes = _.values(this.planes).flatMap((plane) => plane.getMeshes());
     this.rootNode = new THREE.Group().add(
@@ -384,15 +386,17 @@ class SceneController {
       for (const planeId of OrthoViewValuesWithoutTDView) {
         if (planeId === id) {
           this.planes[planeId].setOriginalCrosshairColor();
-          this.planes[planeId].setVisible(!hidePlanes);
+          this.planes[planeId].setVisible(id === "PLANE_XY");
 
           const pos = _.clone(originalPosition);
+          //TODOM: adjust rotation of the plane
 
           const ind = Dimensions.getIndices(planeId);
           // Offset the plane so the user can see the skeletonTracing behind the plane
+          // TODO: Fix z positioning!!!
           pos[ind[2]] +=
             planeId === OrthoViews.PLANE_XY ? this.planeShift[ind[2]] : -this.planeShift[ind[2]];
-          this.planes[planeId].setPosition(pos, originalPosition);
+          // this.planes[planeId].setPosition(pos, originalPosition);
 
           this.quickSelectGeometry.adaptVisibilityForRendering(originalPosition, ind[2]);
         } else {
@@ -402,10 +406,10 @@ class SceneController {
       }
     } else {
       for (const planeId of OrthoViewValuesWithoutTDView) {
-        this.planes[planeId].setPosition(originalPosition);
+        // this.planes[planeId].setPosition(originalPosition);
         this.planes[planeId].setGrayCrosshairColor();
         this.planes[planeId].setVisible(
-          tdViewDisplayPlanes !== TDViewDisplayModeEnum.NONE,
+          planeId === "PLANE_XY" && tdViewDisplayPlanes !== TDViewDisplayModeEnum.NONE,
           this.isPlaneVisible[planeId] && tdViewDisplayPlanes === TDViewDisplayModeEnum.DATA,
         );
         this.planes[planeId].materialFactory.uniforms.is3DViewBeingRendered.value = true;
@@ -426,6 +430,7 @@ class SceneController {
       );
     }
 
+    // TODO: maybe this needs to be removed!!!
     if (!optArbitraryPlane) {
       for (const currentPlane of _.values<Plane>(this.planes)) {
         const [scaleX, scaleY] = getPlaneScalingFactor(state, flycam, currentPlane.planeID);

--- a/frontend/javascripts/oxalis/controller/scene_controller.ts
+++ b/frontend/javascripts/oxalis/controller/scene_controller.ts
@@ -70,6 +70,13 @@ THREE.Mesh.prototype.raycast = acceleratedRaycast;
 const CUBE_COLOR = 0x999999;
 const LAYER_CUBE_COLOR = 0xffff99;
 
+export const OrthoBaseRotations = {
+  [OrthoViews.PLANE_XY]: new THREE.Euler(Math.PI, 0, 0),
+  [OrthoViews.PLANE_YZ]: new THREE.Euler(Math.PI, (1 / 2) * Math.PI, 0),
+  [OrthoViews.PLANE_XZ]: new THREE.Euler((-1 / 2) * Math.PI, 0, 0),
+  [OrthoViews.TDView]: new THREE.Euler(Math.PI / 4, Math.PI / 4, Math.PI / 4),
+};
+
 const getVisibleSegmentationLayerNames = reuseInstanceOnEquality((storeState: OxalisState) =>
   getVisibleSegmentationLayers(storeState).map((l) => l.name),
 );
@@ -243,11 +250,9 @@ class SceneController {
       [OrthoViews.PLANE_YZ]: new Plane(OrthoViews.PLANE_YZ),
       [OrthoViews.PLANE_XZ]: new Plane(OrthoViews.PLANE_XZ),
     };
-    this.planes[OrthoViews.PLANE_XY].setBaseRotation(new THREE.Euler(Math.PI, 0, 0));
-    this.planes[OrthoViews.PLANE_YZ].setBaseRotation(
-      new THREE.Euler(Math.PI, (1 / 2) * Math.PI, 0),
-    );
-    this.planes[OrthoViews.PLANE_XZ].setBaseRotation(new THREE.Euler((-1 / 2) * Math.PI, 0, 0));
+    this.planes[OrthoViews.PLANE_XY].setBaseRotation(OrthoBaseRotations[OrthoViews.PLANE_XY]);
+    this.planes[OrthoViews.PLANE_YZ].setBaseRotation(OrthoBaseRotations[OrthoViews.PLANE_YZ]);
+    this.planes[OrthoViews.PLANE_XZ].setBaseRotation(OrthoBaseRotations[OrthoViews.PLANE_XZ]);
 
     const planeMeshes = _.values(this.planes).flatMap((plane) => plane.getMeshes());
     this.rootNode = new THREE.Group().add(
@@ -386,7 +391,7 @@ class SceneController {
       for (const planeId of OrthoViewValuesWithoutTDView) {
         if (planeId === id) {
           this.planes[planeId].setOriginalCrosshairColor();
-          this.planes[planeId].setVisible(id === "PLANE_XY");
+          this.planes[planeId].setVisible(!hidePlanes);
 
           const pos = _.clone(originalPosition);
           //TODOM: adjust rotation of the plane
@@ -409,7 +414,7 @@ class SceneController {
         // this.planes[planeId].setPosition(originalPosition);
         this.planes[planeId].setGrayCrosshairColor();
         this.planes[planeId].setVisible(
-          planeId === "PLANE_XY" && tdViewDisplayPlanes !== TDViewDisplayModeEnum.NONE,
+          tdViewDisplayPlanes !== TDViewDisplayModeEnum.NONE,
           this.isPlaneVisible[planeId] && tdViewDisplayPlanes === TDViewDisplayModeEnum.DATA,
         );
         this.planes[planeId].materialFactory.uniforms.is3DViewBeingRendered.value = true;

--- a/frontend/javascripts/oxalis/controller/scene_controller.ts
+++ b/frontend/javascripts/oxalis/controller/scene_controller.ts
@@ -71,7 +71,7 @@ const CUBE_COLOR = 0x999999;
 const LAYER_CUBE_COLOR = 0xffff99;
 
 export const OrthoBaseRotations = {
-  [OrthoViews.PLANE_XY]: new THREE.Euler(Math.PI, 0, 0),
+  [OrthoViews.PLANE_XY]: new THREE.Euler(0, Math.PI, 0),
   [OrthoViews.PLANE_YZ]: new THREE.Euler(Math.PI, (1 / 2) * Math.PI, 0),
   [OrthoViews.PLANE_XZ]: new THREE.Euler((-1 / 2) * Math.PI, 0, 0),
   [OrthoViews.TDView]: new THREE.Euler(Math.PI / 4, Math.PI / 4, Math.PI / 4),
@@ -393,15 +393,17 @@ class SceneController {
           this.planes[planeId].setOriginalCrosshairColor();
           this.planes[planeId].setVisible(!hidePlanes);
 
-          const pos = _.clone(originalPosition);
-          //TODOM: adjust rotation of the plane
-
           const ind = Dimensions.getIndices(planeId);
           // Offset the plane so the user can see the skeletonTracing behind the plane
-          // TODO: Fix z positioning!!!
-          pos[ind[2]] +=
+          const positionOffset: [number, number, number] = [0, 0, 0];
+          positionOffset[ind[2]] +=
             planeId === OrthoViews.PLANE_XY ? this.planeShift[ind[2]] : -this.planeShift[ind[2]];
-          // this.planes[planeId].setPosition(pos, originalPosition);
+          //TODOM: adjust rotation of the plane
+
+          this.planes[planeId].offsetForRenderingOrthoView(
+            new THREE.Vector3(...positionOffset),
+            originalPosition,
+          );
 
           this.quickSelectGeometry.adaptVisibilityForRendering(originalPosition, ind[2]);
         } else {
@@ -416,6 +418,15 @@ class SceneController {
         this.planes[planeId].setVisible(
           tdViewDisplayPlanes !== TDViewDisplayModeEnum.NONE,
           this.isPlaneVisible[planeId] && tdViewDisplayPlanes === TDViewDisplayModeEnum.DATA,
+        );
+        const ind = Dimensions.getIndices(planeId);
+        // Offset the plane so the user can see the skeletonTracing behind the plane
+        const positionOffset: [number, number, number] = [0, 0, 0];
+        positionOffset[ind[2]] +=
+          planeId === OrthoViews.PLANE_XY ? this.planeShift[ind[2]] : -this.planeShift[ind[2]];
+        this.planes[planeId].dontOffsetForRenderingTDView(
+          new THREE.Vector3(...positionOffset),
+          originalPosition,
         );
         this.planes[planeId].materialFactory.uniforms.is3DViewBeingRendered.value = true;
       }

--- a/frontend/javascripts/oxalis/geometries/plane.ts
+++ b/frontend/javascripts/oxalis/geometries/plane.ts
@@ -77,6 +77,7 @@ class Plane {
     );
     const textureMaterial = this.materialFactory.setup().getMaterial();
     this.plane = new THREE.Mesh(planeGeo, textureMaterial);
+    this.plane.name = `${this.planeID}-plane`;
     this.plane.matrixAutoUpdate = false;
     this.plane.material.side = THREE.DoubleSide;
     // create crosshair
@@ -106,6 +107,8 @@ class Plane {
       // The default renderOrder is 0. In order for the crosshairs to be shown
       // render them AFTER the plane has been rendered.
       this.crosshair[i].renderOrder = 1;
+      this.crosshair[i].name = `${this.planeID}-crosshair-${i}`;
+      this.crosshair[i].matrixAutoUpdate = false;
     }
 
     // create borders
@@ -121,6 +124,8 @@ class Plane {
       tdViewBordersGeo,
       this.getLineBasicMaterial(OrthoViewColors[this.planeID], 1),
     );
+    this.TDViewBorders.name = `${this.planeID}-TDViewBorders`;
+    this.TDViewBorders.matrixAutoUpdate = false;
   }
 
   setDisplayCrosshair = (value: boolean): void => {
@@ -198,33 +203,35 @@ class Plane {
   updateToFlycamMatrix(flycamMatrix: Matrix4x4): void {
     // TODO: Copied from ArbitraryPlane. This should be refactored to a common function maybe.
     if (this.isDirty) {
+      const meshMatrix = new THREE.Matrix4();
+      meshMatrix.set(
+        flycamMatrix[0],
+        flycamMatrix[4],
+        flycamMatrix[8],
+        flycamMatrix[12],
+        flycamMatrix[1],
+        flycamMatrix[5],
+        flycamMatrix[9],
+        flycamMatrix[13],
+        flycamMatrix[2],
+        flycamMatrix[6],
+        flycamMatrix[10],
+        flycamMatrix[14],
+        flycamMatrix[3],
+        flycamMatrix[7],
+        flycamMatrix[11],
+        flycamMatrix[15],
+      );
       const updateMesh = (mesh: THREE.Mesh | THREE.Line | null | undefined) => {
         if (!mesh) {
           return;
         }
-
-        const meshMatrix = new THREE.Matrix4();
-        meshMatrix.set(
-          flycamMatrix[0],
-          flycamMatrix[4],
-          flycamMatrix[8],
-          flycamMatrix[12],
-          flycamMatrix[1],
-          flycamMatrix[5],
-          flycamMatrix[9],
-          flycamMatrix[13],
-          flycamMatrix[2],
-          flycamMatrix[6],
-          flycamMatrix[10],
-          flycamMatrix[14],
-          flycamMatrix[3],
-          flycamMatrix[7],
-          flycamMatrix[11],
-          flycamMatrix[15],
-        );
         mesh.matrix.identity();
         mesh.matrix.multiply(meshMatrix);
         mesh.matrix.multiply(new THREE.Matrix4().makeRotationFromEuler(this.baseRotation));
+        if (this.planeID === "PLANE_XY") {
+          console.log("matrix plane", mesh.name, mesh.matrix);
+        }
         mesh.matrixWorldNeedsUpdate = true;
       };
       this.getMeshes().forEach(updateMesh);

--- a/frontend/javascripts/oxalis/geometries/plane.ts
+++ b/frontend/javascripts/oxalis/geometries/plane.ts
@@ -69,7 +69,7 @@ class Plane {
   createMeshes(): void {
     const pWidth = constants.VIEWPORT_WIDTH;
     // create plane
-    const planeGeo = new THREE.PlaneGeometry(pWidth, pWidth, PLANE_SUBDIVISION, PLANE_SUBDIVISION);
+    const planeGeo = new THREE.PlaneGeometry(pWidth, pWidth, 1, 1);
     this.materialFactory = new PlaneMaterialFactory(
       this.planeID,
       false,

--- a/frontend/javascripts/oxalis/model/bucket_data_handling/prefetch_strategy_plane.ts
+++ b/frontend/javascripts/oxalis/model/bucket_data_handling/prefetch_strategy_plane.ts
@@ -70,6 +70,8 @@ export class AbstractPrefetchStrategy {
     return buckets;
   }
 }
+
+// TODOM: in case of rotation, a PrefetchStrategyArbitrary is needed for every viewport
 export class PrefetchStrategy extends AbstractPrefetchStrategy {
   velocityRangeStart = 0;
   velocityRangeEnd = Number.POSITIVE_INFINITY;

--- a/frontend/javascripts/oxalis/model/reducers/flycam_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/flycam_reducer.ts
@@ -275,13 +275,7 @@ function FlycamReducer(state: OxalisState, action: Action): OxalisState {
     }
 
     case "SET_ROTATION": {
-      // This action should only be dispatched when *not* being in orthogonal mode,
-      // because this would lead to incorrect buckets being selected for rendering.
-      if (state.temporaryConfiguration.viewMode !== "orthogonal") {
-        return setRotationReducer(state, action.rotation);
-      }
-      // No-op
-      return state;
+      return setRotationReducer(state, action.rotation);
     }
 
     case "SET_DIRECTION": {

--- a/frontend/javascripts/oxalis/model/reducers/settings_reducer.ts
+++ b/frontend/javascripts/oxalis/model/reducers/settings_reducer.ts
@@ -183,8 +183,8 @@ function SettingsReducer(state: OxalisState, action: Action): OxalisState {
           viewMode: action.viewMode,
         });
         if (action.viewMode !== "orthogonal") {
-          return newState;
         }
+        return newState;
         // Restore rotation because it might have been changed by the user
         // in flight/oblique mode. Since this affects the matrix (which is
         // also used in orthogonal mode), the rotation needs to be reset.

--- a/frontend/javascripts/oxalis/shaders/coords.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/coords.glsl.ts
@@ -54,11 +54,8 @@ export const getWorldCoordUVW: ShaderModule = {
         // In orthogonal mode, the planes are offset in 3D space to allow skeletons to be rendered before
         // each plane. Since w (e.g., z for xy plane) is
         // the same for all texels computed in this shader, we simply use globalPosition[w] instead
-        <% if (isOrthogonal) { %>
-          getW(globalPosition)
-        <% } else { %>
-          worldCoordUVW.z / voxelSizeFactorUVW.z
-        <% } %>
+        // TODOM: if not rotated, getW can be used
+        worldCoordUVW.z / voxelSizeFactorUVW.z
       );
 
       return worldCoordUVW;

--- a/frontend/javascripts/oxalis/shaders/filtering.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/filtering.glsl.ts
@@ -79,6 +79,7 @@ export const getTrilinearColorFor: ShaderModule = {
 const getMaybeFilteredColor: ShaderModule = {
   requirements: [getColorForCoords, getBilinearColorFor, getTrilinearColorFor],
   code: `
+  // TODOM: Consider passing an argument like "isRotated" to determine whether bilinear or trilinear filtering should be used.
     vec4 getMaybeFilteredColor(
       float layerIndex,
       float d_texture_width,

--- a/frontend/javascripts/oxalis/shaders/main_data_shaders.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/main_data_shaders.glsl.ts
@@ -480,7 +480,7 @@ void main() {
   // Remember the original z position, since it can subtly diverge in the
   // following calculations due to floating point inaccuracies. This can
   // result in artifacts, such as the crosshair disappearing.
-  float originalZ = gl_Position.z;
+  /*float originalZ = gl_Position.z;
 
   // Remember, the top of the viewport has Y=1 whereas the left has X=-1.
   vec3 worldCoordTopLeft     = transDim((modelMatrix * vec4(-PLANE_WIDTH/2.,  PLANE_WIDTH/2., 0., 1.)).xyz);
@@ -590,7 +590,7 @@ void main() {
       }
     }
   }
-  <% }) %>
+  <% }) %>*/
 }
   `)({
     ...params,

--- a/frontend/javascripts/oxalis/shaders/texture_access.glsl.ts
+++ b/frontend/javascripts/oxalis/shaders/texture_access.glsl.ts
@@ -206,8 +206,8 @@ export const getColorForCoords: ShaderModule = {
 
       // To avoid rare rendering artifacts, don't use the precomputed
       // bucket address when being at the border of buckets.
-      bool beSafe = false;
-      {
+      bool beSafe = true;
+      /*{
         renderedMagIdx = outputMagIdx[globalLayerIndex];
         vec3 coords = floor(getAbsoluteCoords(worldPositionUVW, renderedMagIdx, globalLayerIndex));
         vec3 absoluteBucketPosition = div(coords, bucketWidth);
@@ -220,7 +220,7 @@ export const getColorForCoords: ShaderModule = {
           ) {
           beSafe = true;
         }
-      }
+      }*/
 
 
       if (beSafe || !supportsPrecomputedBucketAddress) {

--- a/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.tsx
+++ b/frontend/javascripts/oxalis/view/action-bar/dataset_position_view.tsx
@@ -6,7 +6,6 @@ import Toast from "libs/toast";
 import { Vector3Input } from "libs/vector_input";
 import message from "messages";
 import type { Vector3, ViewMode } from "oxalis/constants";
-import constants from "oxalis/constants";
 import { getDatasetExtentInVoxel } from "oxalis/model/accessors/dataset_accessor";
 import { getPosition, getRotation } from "oxalis/model/accessors/flycam_accessor";
 import { setPositionAction, setRotationAction } from "oxalis/model/actions/flycam_actions";
@@ -112,7 +111,6 @@ class DatasetPositionView extends PureComponent<Props> {
     }
 
     const rotation = V3.round(getRotation(this.props.flycam));
-    const isArbitraryMode = constants.MODES_ARBITRARY.includes(this.props.viewMode);
     const positionView = (
       <div
         style={{
@@ -142,7 +140,7 @@ class DatasetPositionView extends PureComponent<Props> {
           />
           <ShareButton dataset={this.props.dataset} style={iconColoringStyle} />
         </Space.Compact>
-        {isArbitraryMode ? (
+        {
           <Space.Compact
             style={{
               whiteSpace: "nowrap",
@@ -170,7 +168,7 @@ class DatasetPositionView extends PureComponent<Props> {
               allowDecimals
             />
           </Space.Compact>
-        ) : null}
+        }
       </div>
     );
     return (

--- a/frontend/javascripts/oxalis/view/arbitrary_view.ts
+++ b/frontend/javascripts/oxalis/view/arbitrary_view.ts
@@ -43,6 +43,7 @@ class ArbitraryView {
   group: THREE.Object3D;
   cameraPosition: Array<number>;
   unsubscribeFunctions: Array<() => void> = [];
+  baseRotation = new THREE.Euler(0, 0, 0);
 
   constructor() {
     this.animate = this.animateImpl.bind(this);
@@ -74,6 +75,10 @@ class ArbitraryView {
   getCameras(): OrthoViewMap<THREE.OrthographicCamera> {
     return this.cameras;
   }
+
+  setBaseRotation = (rotVec: THREE.Euler): void => {
+    this.baseRotation.copy(rotVec);
+  };
 
   start(): void {
     if (!this.isRunning) {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] fix rendering correct data in ortho viewports (avoid rendering data offset by clipping distance)
- [ ] Do not use rotation value of just activated skeleton node
  - [ ] Discuss what the actual rotation value of a newly created node should be
- [ ] Fully adapt context menu (disabled options too complex to support in current interaction if rotation is active)
- [ ] fix scalebar info when rotated 
- [ ] adapt bucket picking (reuse picker for arbitrary mode)
- [ ] adapt shader
- [ ] adapt mouse interactions
  - [x] mapping of mouse position to voxel position
  - [ ] fix skeleton tool interactions
  - [ ] fix measurement tools interactions
    - [ ] make measurement tool show accurate information (length / area calculation needs to be rotation aware)
- [ ] disable or support rendering of segmentation data in rotated viewport (how to interpolate?)
  - works for now, not sure about interpolation 
  - [ ] fix pattern rendering
- [ ] first iteration should only support skeleton tool
- [ ] put rotation value into url
- [ ] UI
  - [x] disable all tools beside skeleton & measurement once rotation is active 
  - [x] expose rotation value
  - [ ] "warn" user when angles are not axis aligned
- [ ] Consider optimizing the code by avoiding creating new threejs objects and use mjs instead 
- [ ] active tool mouse cursor is somehow broken?! 

### Issues:
- fixes [#7569](https://github.com/scalableminds/webknossos/issues/7569)

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
