### PR TITLE
Fix broken annotation view (caused by incorrect merge in #8535)

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 
 ### Fixed
 - Fixed that layer bounding boxes were sometimes colored green even though this should only happen for tasks. [#8535](https://github.com/scalableminds/webknossos/pull/8535)
+- Fixed that annotations could not be opened anymore (caused by #8535). [#8599](https://github.com/scalableminds/webknossos/pull/8599)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/controller/scene_controller.ts
+++ b/frontend/javascripts/oxalis/controller/scene_controller.ts
@@ -231,7 +231,6 @@ class SceneController {
       showCrossSections: true,
       isHighlighted: false,
     });
-    this.datasetBoundingBox.getMeshes().forEach((mesh) => this.rootNode.add(mesh));
 
     this.contour = new ContourGeometry();
     this.quickSelectGeometry = new QuickSelectGeometry();


### PR DESCRIPTION
An incorrect merge led to https://github.com/scalableminds/webknossos/commit/be4230791f58f52d794499b5f55a89711f3068d2 breaking the initialization of the scene controller.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open an annotation

### Issues:
- follow-up to be4230791f58f52d794499b5f55a89711f3068d2
- https://scm.slack.com/archives/C3RUHRXBM/p1746456892104129

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
