### PR TITLE
Revert "Fix Colors in Data Screenshots"

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,7 +24,6 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 ### Fixed
 - Fixed that layer bounding boxes were sometimes colored green even though this should only happen for tasks. [#8535](https://github.com/scalableminds/webknossos/pull/8535)
 - Fixed that annotations could not be opened anymore (caused by #8535). [#8599](https://github.com/scalableminds/webknossos/pull/8599)
-- Fixed wrong color space in screenshots. [#8564](https://github.com/scalableminds/webknossos/pull/8564)
 
 ### Removed
 

--- a/frontend/javascripts/oxalis/controller/segment_mesh_controller.ts
+++ b/frontend/javascripts/oxalis/controller/segment_mesh_controller.ts
@@ -401,6 +401,7 @@ export default class SegmentMeshController {
       [1, -1, -1],
       [-1, -1, -1],
     ];
+
     const directionalLights: THREE.DirectionalLight[] = [];
 
     lightPositions.forEach((pos, index) => {

--- a/frontend/javascripts/oxalis/view/rendering_utils.ts
+++ b/frontend/javascripts/oxalis/view/rendering_utils.ts
@@ -91,9 +91,7 @@ export function renderToTexture(
   renderer.setViewport(0, 0 + height, width, height);
   renderer.setScissorTest(false);
   renderer.setClearColor(clearColor === 0xffffff ? getBackgroundColor() : clearColor, 1);
-  const renderTarget = new THREE.WebGLRenderTarget(width, height, {
-    colorSpace: THREE.SRGBColorSpace,
-  });
+  const renderTarget = new THREE.WebGLRenderTarget(width, height);
   const buffer = new Uint8Array(width * height * 4);
 
   if (plane !== ArbitraryViewport) {


### PR DESCRIPTION
Reverts scalableminds/webknossos#8564

Color picking and the colors of the data viewports got broken.