### PR TITLE
routes log_path to loki

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Renamed `frontend/javascripts/oxalis` to `frontend/javascripts/viewer`. [#8601](https://github.com/scalableminds/webknossos/pull/8601)
 - When loading data from a data layer that has data stored beyond the bounding box specified in the datasource-properties.json, data outside of the bounding box is now zeroed. (the layer is “clipped”). [#8551](https://github.com/scalableminds/webknossos/pull/8551)
 - Updated to Typescript from version `5.5` to `5.8`. [#8613](https://github.com/scalableminds/webknossos/pull/8613)
+- Updated Voxelytics log streaming to also include the `log_path` attribute. [#8615](https://github.com/scalableminds/webknossos/pull/8615)
 
 ### Fixed
 - Fixed that layer bounding boxes were sometimes colored green even though this should only happen for tasks. [#8535](https://github.com/scalableminds/webknossos/pull/8535)

--- a/app/models/voxelytics/LokiClient.scala
+++ b/app/models/voxelytics/LokiClient.scala
@@ -220,7 +220,8 @@ class LokiClient @Inject()(wkConf: WkConf, rpc: RPC, val actorSystem: ActorSyste
                         "thread_name" -> (entry \ "vx" \ "thread_name").as[String],
                         "vx_version" -> (entry \ "vx" \ "version").as[String],
                         "user" -> (entry \ "vx" \ "user").as[String],
-                        "pgid" -> (entry \ "vx" \ "process_group_id").as[Long].toString
+                        "pgid" -> (entry \ "vx" \ "process_group_id").as[Long].toString,
+                        "log_path" -> (entry \ "vx" \ "log_path").as[String]
                       ))
                   ).toFox
                 } yield


### PR DESCRIPTION
Passes `log_path` through to loki. This is useful, because it contains the job id in the filename.

### URL of deployed dev instance (used for testing):
- https://vxlogpath.webknossos.xyz

### Steps to test:
- [Grafana dashboard](https://grafana.scm.io/explore?schemaVersion=1&panes=%7B%220tm%22:%7B%22datasource%22:%22tQAQUboVz%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bvx_run_name%3D%5C%22dummy.2025-05-12_21-41-24%5C%22%7D%20%7C%3D%20%60%60%20%7C%20json%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22tQAQUboVz%22%7D,%22editorMode%22:%22builder%22,%22direction%22:%22forward%22%7D%5D,%22range%22:%7B%22from%22:%221746914400000%22,%22to%22:%221747173599000%22%7D%7D%7D&orgId=1)

------
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)