### PR TITLE
Update CI to Redis 8

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       retries: 30
 
   redis:
-    image: redis:7.4
+    image: redis:8
     command:
       - redis-server
     ports:


### PR DESCRIPTION
### Steps to test:
- CI should pass

### Issues:
- upgrade Redis to latest major version
