### PR TITLE
Fix that segment stats in context menu did not show on first open

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed a rare bug where download requests would terminate without sending the whole annotation. [#8624](https://github.com/scalableminds/webknossos/pull/8624)
 - Fixed that deletion of dataset would lead to an error. [#8639](https://github.com/scalableminds/webknossos/pull/8639)
 - Fixed a bug where merging annotations with large tree IDs could lead to an error. [#8643](https://github.com/scalableminds/webknossos/pull/8643)
+- Fixed that the segment stats were sometimes not displayed in the context menu. [#8645](https://github.com/scalableminds/webknossos/pull/8645)
 
 ### Removed
 - The old "Selective Segment Visibility" feature that allowed to only see the active and the hovered segment was removed. From now on the visibility of segments can be controlled with checkboxes in the segment list and with the "Hide unlisted segments" toggle in the layer settings. [#8546](https://github.com/scalableminds/webknossos/pull/8546)

--- a/frontend/javascripts/viewer/view/context_menu.tsx
+++ b/frontend/javascripts/viewer/view/context_menu.tsx
@@ -1599,7 +1599,12 @@ function ContextMenuInner() {
     isLoadingVolumeAndBB,
     // Update segment infos when opening the context menu, in case the annotation was saved since the context menu was last opened.
     // Of course the info should also be updated when the menu is opened for another segment, or after the refresh button was pressed.
-    [contextMenuPosition, clickedSegmentOrMeshId, lastTimeSegmentInfoShouldBeFetched],
+    [
+      contextMenuPosition,
+      isSegmentIndexAvailable,
+      clickedSegmentOrMeshId,
+      lastTimeSegmentInfoShouldBeFetched,
+    ],
   );
 
   let nodeContextMenuTree: Tree | null = null;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a new volume tracing with no fallback (that we definitely have a segment index)
- brush a bit
- ensure that segments tab is NOT visible
- reload the page
- rightclick a segment -> the segment stats should show (on the master, this did not happen)

### Explanation
The information whether a segmentation layer has a segment index is loaded ad-hoc. If the segments tab is visible, this is done on mount. If not, it only happens as soon as the context menu is loaded. However, the react hook did not update when the information about the segment index changed. This is fixed now.

### Issues:
- fixes #8470

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
