### PR TITLE
Allow to paste position or link anywhere

### DIFF
--- a/frontend/javascripts/viewer/controller/url_manager.ts
+++ b/frontend/javascripts/viewer/controller/url_manager.ts
@@ -161,12 +161,17 @@ class UrlManager {
   }
 
   onHashChange = () => {
-    const urlState = this.parseUrlHash();
-    applyState(urlState);
+    this.updateToHash();
   };
 
-  parseUrlHash(): PartialUrlManagerState {
-    const urlHash = decodeURIComponent(location.hash.slice(1));
+  updateToHash(optionalHash?: string) {
+    const urlState = this.parseUrlHash(optionalHash);
+    applyState(urlState);
+  }
+
+  parseUrlHash(optionalHash?: string): PartialUrlManagerState {
+    // Cut off the #
+    const urlHash = decodeURIComponent(optionalHash ?? location.hash.slice(1));
 
     if (urlHash.includes("{")) {
       // The hash is in json format


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- ensure that pasting into existing fields does work as usual
- copy the current position
- move somewhere else
- ctrl-paste should jump to the copied position
- repeat the same by copying the entire url. this should also set the correct zoom etc.

### Issues:
- fixes #8634

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
