### PR TITLE
Fix typo in mesh computation error message

### DIFF
--- a/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segments_view_helper.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segments_view_helper.tsx
@@ -113,7 +113,7 @@ export function withMappingActivationConfirmation(
   const recommendationStr =
     editableMapping == null
       ? ""
-      : "This is because the current mapping was locked while editing it with the proofreading tool. Consider changing the active mapping instead.";
+      : "This is because the current mapping was locked while editing it with the proofreading tool. Consider changing the active mesh file instead.";
 
   const confirmMappingActivation: MenuClickEventHandler = (menuClickEvent) => {
     confirm({


### PR DESCRIPTION
The full message used to be: `The currently active mesh file was computed for the mapping "agglomerate_view_30" which is not active. The mapping cannot be activated when clicking OK. This is because the current mapping was locked while editing it with the proofreading tool. Consider changing the active mapping instead.`

The last sentence is wrong. The mapping is locked and cannot be changed (as stated earlier in the message). However, the mesh file can be changed.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- No need to test

### Issues:
- Noticed this via an internal support request
