### PR TITLE
Misc fixes for toolkit UI and tool cycling

### DIFF
--- a/frontend/javascripts/viewer/model/accessors/disabled_tool_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/disabled_tool_accessor.ts
@@ -22,7 +22,7 @@ import {
 } from "viewer/model/accessors/volumetracing_accessor";
 import { AnnotationTool, type AnnotationToolId } from "./tool_accessor";
 
-type DisabledInfo = {
+export type DisabledInfo = {
   isDisabled: boolean;
   explanation: string;
 };

--- a/frontend/javascripts/viewer/model/reducers/reducer_helpers.ts
+++ b/frontend/javascripts/viewer/model/reducers/reducer_helpers.ts
@@ -7,12 +7,8 @@ import type {
   UserBoundingBoxFromServer,
 } from "types/api_types";
 import type { BoundingBoxType } from "viewer/constants";
-import type { AnnotationTool } from "viewer/model/accessors/tool_accessor";
+import type { AnnotationTool, AnnotationToolId } from "viewer/model/accessors/tool_accessor";
 import { Toolkits } from "viewer/model/accessors/tool_accessor";
-import {
-  isVolumeAnnotationDisallowedForZoom,
-  isVolumeTool,
-} from "viewer/model/accessors/volumetracing_accessor";
 import { updateKey } from "viewer/model/helpers/deep_update";
 import type { BoundingBoxObject, UserBoundingBox, UserBoundingBoxToServer } from "viewer/store";
 import type { Annotation, WebknossosState } from "viewer/store";
@@ -134,6 +130,21 @@ export function convertServerAdditionalAxesToFrontEnd(
   }));
 }
 
+export function isToolAvailable(
+  state: WebknossosState,
+  disabledToolInfo: Record<AnnotationToolId, DisabledInfo>,
+  tool: AnnotationTool,
+) {
+  const { isDisabled } = disabledToolInfo[tool.id];
+  if (isDisabled) {
+    return false;
+  }
+  if (!state.annotation.restrictions.allowUpdate) {
+    return Toolkits.READ_ONLY_TOOLS.includes(tool);
+  }
+  return true;
+}
+
 export function getNextTool(state: WebknossosState): AnnotationTool | null {
   const disabledToolInfo = getDisabledInfoForTools(state);
   const tools = Toolkits[state.userConfiguration.activeToolkit];
@@ -147,7 +158,7 @@ export function getNextTool(state: WebknossosState): AnnotationTool | null {
   ) {
     const newTool = tools[newToolIndex % tools.length];
 
-    if (!disabledToolInfo[newTool.id].isDisabled) {
+    if (isToolAvailable(state, disabledToolInfo, newTool)) {
       return newTool;
     }
   }
@@ -167,7 +178,7 @@ export function getPreviousTool(state: WebknossosState): AnnotationTool | null {
   ) {
     const newTool = tools[(tools.length + newToolIndex) % tools.length];
 
-    if (!disabledToolInfo[newTool.id].isDisabled) {
+    if (isToolAvailable(state, disabledToolInfo, newTool)) {
       return newTool;
     }
   }
@@ -179,7 +190,8 @@ export function setToolReducer(state: WebknossosState, tool: AnnotationTool) {
     return state;
   }
 
-  if (isVolumeTool(tool) && isVolumeAnnotationDisallowedForZoom(tool, state)) {
+  const disabledToolInfo = getDisabledInfoForTools(state);
+  if (!isToolAvailable(state, disabledToolInfo, tool)) {
     return state;
   }
 

--- a/frontend/javascripts/viewer/model/reducers/reducer_helpers.ts
+++ b/frontend/javascripts/viewer/model/reducers/reducer_helpers.ts
@@ -12,7 +12,7 @@ import { Toolkits } from "viewer/model/accessors/tool_accessor";
 import { updateKey } from "viewer/model/helpers/deep_update";
 import type { BoundingBoxObject, UserBoundingBox, UserBoundingBoxToServer } from "viewer/store";
 import type { Annotation, WebknossosState } from "viewer/store";
-import { getDisabledInfoForTools } from "../accessors/disabled_tool_accessor";
+import { type DisabledInfo, getDisabledInfoForTools } from "../accessors/disabled_tool_accessor";
 
 export function convertServerBoundingBoxToBoundingBox(
   boundingBox: ServerBoundingBox,

--- a/frontend/javascripts/viewer/model/reducers/ui_reducer.ts
+++ b/frontend/javascripts/viewer/model/reducers/ui_reducer.ts
@@ -8,7 +8,6 @@ import {
 } from "viewer/model/reducers/reducer_helpers";
 import { hideBrushReducer } from "viewer/model/reducers/volumetracing_reducer_helpers";
 import type { WebknossosState } from "viewer/store";
-import { Toolkits } from "../accessors/tool_accessor";
 
 function UiReducer(state: WebknossosState, action: Action): WebknossosState {
   switch (action.type) {
@@ -68,14 +67,7 @@ function UiReducer(state: WebknossosState, action: Action): WebknossosState {
     }
 
     case "SET_TOOL": {
-      if (!state.annotation.restrictions.allowUpdate) {
-        if (Toolkits.READ_ONLY_TOOLS.includes(action.tool)) {
-          return setToolReducer(state, action.tool);
-        }
-        return state;
-      }
-
-      return setToolReducer(state, action.tool);
+      return setToolReducer(hideBrushReducer(state), action.tool);
     }
 
     case "CYCLE_TOOL": {

--- a/frontend/javascripts/viewer/model/sagas/settings_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/settings_saga.ts
@@ -2,14 +2,20 @@ import { updateDatasetConfiguration, updateUserConfiguration } from "admin/rest_
 import ErrorHandling from "libs/error_handling";
 import Toast from "libs/toast";
 import messages from "messages";
-import { all, call, debounce, retry, takeEvery } from "typed-redux-saga";
-import type { UpdateUserSettingAction } from "viewer/model/actions/settings_actions";
+import { all, call, debounce, put, retry, takeEvery } from "typed-redux-saga";
+import { ControlModeEnum } from "viewer/constants";
+import {
+  type UpdateUserSettingAction,
+  updateUserSettingAction,
+} from "viewer/model/actions/settings_actions";
 import { type Saga, select, take } from "viewer/model/sagas/effect-generators";
 import {
   SETTINGS_MAX_RETRY_COUNT,
   SETTINGS_RETRY_DELAY,
 } from "viewer/model/sagas/save_saga_constants";
 import type { DatasetConfiguration, DatasetLayerConfiguration } from "viewer/store";
+import { Toolkit } from "../accessors/tool_accessor";
+import { ensureWkReady } from "./ready_sagas";
 
 function* pushUserSettingsAsync(): Saga<void> {
   const activeUser = yield* select((state) => state.activeUser);
@@ -108,6 +114,21 @@ function* showUserSettingToast(action: UpdateUserSettingAction): Saga<void> {
   }
 }
 
+function* ensureValidToolkit(): Saga<void> {
+  /*
+   * Default to the ALL_TOOLS toolkit if the annotation/dataset is read-only.
+   */
+  yield* call(ensureWkReady);
+  const isViewMode = yield* select(
+    (state) => state.temporaryConfiguration.controlMode === ControlModeEnum.VIEW,
+  );
+  const isReadOnly = yield* select((state) => !state.annotation.restrictions.allowUpdate);
+
+  if (isViewMode || isReadOnly) {
+    yield* put(updateUserSettingAction("activeToolkit", Toolkit.ALL_TOOLS));
+  }
+}
+
 export default function* watchPushSettingsAsync(): Saga<void> {
   const action = yield* take("INITIALIZE_SETTINGS");
   if (action.type !== "INITIALIZE_SETTINGS") {
@@ -123,5 +144,6 @@ export default function* watchPushSettingsAsync(): Saga<void> {
     ),
     debounce(2500, "UPDATE_LAYER_SETTING", () => pushDatasetSettingsAsync(originalDatasetSettings)),
     takeEvery("UPDATE_USER_SETTING", showUserSettingToast),
+    call(ensureValidToolkit),
   ]);
 }

--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -193,6 +193,7 @@ function ModesView() {
   const is2d = useWkSelector((state) => is2dDataset(state.dataset));
   const controlMode = useWkSelector((state) => state.temporaryConfiguration.controlMode);
   const isViewMode = controlMode === ControlModeEnum.VIEW;
+  const isReadOnly = useWkSelector((state) => !state.annotation.restrictions.allowUpdate);
 
   const isArbitrarySupported = hasSkeleton || isViewMode;
 
@@ -201,7 +202,7 @@ function ModesView() {
     <div>
       <Space.Compact>
         {isArbitrarySupported && !is2d ? <ViewModesView /> : null}
-        {isViewMode ? null : <ToolkitView />}
+        {isViewMode || isReadOnly ? null : <ToolkitView />}
       </Space.Compact>
     </div>
   );

--- a/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segment_list_item.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segment_list_item.tsx
@@ -373,6 +373,16 @@ function _MeshInfoItem(props: {
 
 const MeshInfoItem = React.memo(_MeshInfoItem);
 
+function SegmentIdAddendum({ id }: { id: number }) {
+  return (
+    <FastTooltip title="Segment ID">
+      <span className="deemphasized italic" style={{ marginLeft: 4 }}>
+        {id}
+      </span>
+    </FastTooltip>
+  );
+}
+
 function _SegmentListItem({
   segment,
   mappingInfo,
@@ -568,15 +578,6 @@ function _SegmentListItem({
     };
   };
 
-  function getSegmentIdDetails() {
-    // Only if segment.name is truthy, render additional info.
-    return segment.name ? (
-      <FastTooltip title="Segment ID">
-        <span className="deemphasized italic">{segment.id}</span>
-      </FastTooltip>
-    ) : null;
-  }
-
   const onOpenContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
 
@@ -637,8 +638,8 @@ function _SegmentListItem({
           <FastTooltip title="Open context menu (also available via right-click)">
             <EllipsisOutlined onClick={onOpenContextMenu} />
           </FastTooltip>
-          {/* Show Default Segment Name if another one is already defined*/}
-          {getSegmentIdDetails()}
+          {/* Show Segment ID if the segment has a name. Otherwise, the id will already be rendered. */}
+          {segment.name != null ? <SegmentIdAddendum id={segment.id} /> : null}
           {isCentered ? (
             <FastTooltip title="This segment is currently centered in the data viewports.">
               <i


### PR DESCRIPTION
Additionally, I added some margin to the segment id in the segment list (only relevant when a segment name exists).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open an annotation and cycle through tools in different toolkits
- open an annotation in view mode -> the toolkit switcher should not be visible. only move and measurement tools should be visible.
- this is a bit more complicated to test, but I already did this, so no need to re-test: with the old code, I activated the split toolkit. then I switched to the new code and reloaded the page --> now, the default toolkit should be active (noticable because the orange "split tool" label is not shown anymore)

### Issues:
- no issue

------
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
