### PR TITLE
Perf improvement for applying MoveTreeComponent update action

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
@@ -168,15 +168,17 @@ case class MoveTreeComponentSkeletonAction(nodeIds: List[Int],
     extends SkeletonUpdateAction
     with SkeletonUpdateActionHelper {
 
+  lazy val nodeIdsSet = nodeIds.toSet
+
   // this should only move a whole component,
   // that is disjoint from the rest of the tree
   override def applyOn(tracing: SkeletonTracing): SkeletonTracing = {
     val sourceTree = treeById(tracing, sourceId)
     val targetTree = treeById(tracing, targetId)
 
-    val (movedNodes, remainingNodes) = sourceTree.nodes.partition(nodeIds contains _.id)
+    val (movedNodes, remainingNodes) = sourceTree.nodes.partition(n => nodeIdsSet.contains(n.id))
     val (movedEdges, remainingEdges) =
-      sourceTree.edges.partition(e => nodeIds.contains(e.source) && nodeIds.contains(e.target))
+      sourceTree.edges.partition(e => nodeIdsSet.contains(e.source) && nodeIdsSet.contains(e.target))
     val updatedSource = sourceTree.copy(nodes = remainingNodes, edges = remainingEdges)
     val updatedTarget =
       targetTree.copy(nodes = targetTree.nodes.concat(movedNodes), edges = targetTree.edges.concat(movedEdges))


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
