### PR TITLE
Fix getBranchPoints accessor

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,7 @@ For upgrade instructions, please check the [migration guide](MIGRATIONS.released
 - Fixed the contrast of the WelcomeToast buttons. Updated `antd` to version `5.22`.[#8688](https://github.com/scalableminds/webknossos/pull/8688)
 - Fixed a race condition when starting proofreading with a split action. [#8676](https://github.com/scalableminds/webknossos/pull/8676)
 - Fixed that activating a mapping got stuck when a dataset was opened in "view" mode. [#8687](https://github.com/scalableminds/webknossos/pull/8687)
+- Fixed a regression that led to incorrect behavior when trying to jump to the last branchpoint even though no branchpoint existed. [#8695](https://github.com/scalableminds/webknossos/pull/8695)
 
 ### Removed
 

--- a/frontend/javascripts/viewer/model/accessors/skeletontracing_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/skeletontracing_accessor.ts
@@ -276,13 +276,16 @@ export function getMaxNodeId(skeletonTracing: SkeletonTracing): number | null {
   );
 }
 
-export function getBranchPoints(annotation: StoreAnnotation): IteratorObject<BranchPoint[]> | null {
+export function getBranchPoints(annotation: StoreAnnotation): BranchPoint[] | null {
   const skeletonTracing = getSkeletonTracing(annotation);
   if (skeletonTracing == null) {
     return null;
   }
 
-  return skeletonTracing.trees.values().map((tree) => tree.branchPoints);
+  return skeletonTracing.trees
+    .values()
+    .flatMap((tree) => tree.branchPoints)
+    .toArray();
 }
 
 export function getFlatTreeGroups(

--- a/frontend/javascripts/viewer/model/sagas/skeletontracing_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/skeletontracing_saga.ts
@@ -125,7 +125,7 @@ function* watchBranchPointDeletion(): Saga<void> {
 
     if (deleteBranchpointAction) {
       const hasBranchPoints = yield* select(
-        (state: WebknossosState) => (getBranchPoints(state.annotation)?.toArray() ?? []).length > 0,
+        (state: WebknossosState) => (getBranchPoints(state.annotation) ?? []).length > 0,
       );
 
       if (hasBranchPoints) {


### PR DESCRIPTION
Regression from #8626. The branchpoints need to be a flat list so that the length can be compared to 0.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a new tree with node
- press J

### Issues:
- fixes https://discuss.webknossos.org/t/absence-of-jumps-in-annotations-is-not-detected/1930/2

------
(Please delete unneeded items, merge only when none are left open)
- [x] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)