### PR TITLE
Add Unidata UCAR Maven Repository

### DIFF
--- a/project/DependencyResolvers.scala
+++ b/project/DependencyResolvers.scala
@@ -2,6 +2,7 @@ import sbt._
 
 object DependencyResolvers {
   val atlassian = "Atlassian Releases" at "https://maven.atlassian.com/public/"
+  val unidataUcar = "Unidata UCAR" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"
   val sciJava = "SciJava Public" at "https://maven.scijava.org/content/repositories/public/"
   val senbox = "Senbox (for Zarr)" at "https://nexus.senbox.net/nexus/content/groups/public/"
 
@@ -10,6 +11,7 @@ object DependencyResolvers {
       Resolver.sonatypeOssRepos("snapshots") ++
       Seq(
         Resolver.typesafeRepo("releases"),
+        unidataUcar,
         sciJava,
         atlassian,
         senbox


### PR DESCRIPTION
While the SciJava maven repository is [still being rebuilt](https://forum.image.sc/t/unplanned-server-outage-for-maven-scijava-org/113683), let’s fetch the ucar-cdm dependency from the unidata.ucar.edu maven repository instead.

(Still leaving the SciJava one in, because it looks like we’re fetching jhdf5 from there, which works again already.)

### Steps to test:
- CI
