### PR TITLE
Improve error reporting when sagas crash

### DIFF
--- a/frontend/javascripts/viewer/model/sagas/root_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/root_saga.ts
@@ -88,13 +88,16 @@ function* restartableSaga(): Saga<void> {
       call(splitBoundaryMeshSaga),
       call(toolSaga),
     ]);
-  } catch (err) {
+  } catch (err: any) {
     rootSagaCrashed = true;
     console.error("The sagas crashed because of the following error:", err);
 
     if (!process.env.IS_TESTING) {
-      // @ts-ignore
-      ErrorHandling.notify(err, {});
+      if ("message" in err) {
+        err.message = `Root saga crashed: ${err.message}`;
+      }
+      ErrorHandling.notify(err);
+
       // Hide potentially old error highlighting which mentions a retry mechanism.
       toggleErrorHighlighting(false);
       // Show error highlighting which mentions the permanent error.
@@ -103,10 +106,7 @@ function* restartableSaga(): Saga<void> {
 Internal error.
 Please reload the page to avoid losing data.
 
-${
-  JSON.stringify(err)
-  // @ts-ignore
-} ${err.stack || ""}`);
+${JSON.stringify(err)} ${err.stack || ""}`);
     }
   }
 }

--- a/frontend/javascripts/viewer/model/sagas/root_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/root_saga.ts
@@ -93,10 +93,7 @@ function* restartableSaga(): Saga<void> {
     console.error("The sagas crashed because of the following error:", err);
 
     if (!process.env.IS_TESTING) {
-      if ("message" in err) {
-        err.message = `Root saga crashed: ${err.message}`;
-      }
-      ErrorHandling.notify(err);
+      ErrorHandling.notifyWithPrefix(err, "Root saga crashed: ");
 
       // Hide potentially old error highlighting which mentions a retry mechanism.
       toggleErrorHighlighting(false);


### PR DESCRIPTION
Errors within the sagas are critical. They are reported currently, but if a simple failing network request brings down the entire sagas (most have a retry mechanism but some don't), the current error reporting only shows the failing network request (which doesn't really show the severity).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I added a `throw new Error("bla")` to the brush saga. you can see the report for it here: https://scm.airbrake.io/projects/95438/groups/4097474921126226079?tab=notice-detail
- no need to test further imo

### Issues:
- improves error reporting