### PR TITLE
Use new WK_ORG_AUTH_TOKEN and WK_DEV_AUTH_TOKEN

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Refresh datasets
         run: |
-          curl -X POST --fail https://${{ env.SUBDOMAIN }}.webknossos.xyz/data/triggers/checkInboxBlocking?token=${{ secrets.WK_AUTH_TOKEN }}
+          curl -X POST --fail https://${{ env.SUBDOMAIN }}.webknossos.xyz/data/triggers/checkInboxBlocking?token=${{ secrets.WK_DEV_AUTH_TOKEN }}
 
       - name: Run screenshot tests
         run: |
@@ -62,7 +62,7 @@ jobs:
           yarn test-screenshot
         env:
           URL: https://${{ env.SUBDOMAIN }}.webknossos.xyz/
-          WK_AUTH_TOKEN: ${{ secrets.WK_AUTH_TOKEN }}
+          WK_AUTH_TOKEN: ${{ secrets.WK_DEV_AUTH_TOKEN }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 

--- a/.github/workflows/wkorg-nightly.yaml
+++ b/.github/workflows/wkorg-nightly.yaml
@@ -28,7 +28,7 @@ jobs:
           yarn test-wkorg-screenshot
         env:
           URL: https://webknossos.org/
-          WK_AUTH_TOKEN: ${{ secrets.WK_AUTH_TOKEN }}
+          WK_AUTH_TOKEN: ${{ secrets.WK_ORG_AUTH_TOKEN }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY : ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 


### PR DESCRIPTION
We assigned different auth tokens for the wkorg and wkdev nightly (necessary because the nightly should also reset the default view config on wkorg).

### Steps to test:
- let's run both nightlies against this branch