### PR TITLE
Dataset Settings: Refactor as React functional components

### DIFF
--- a/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
@@ -1,33 +1,23 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { deleteDatasetOnDisk, getDataset } from "admin/rest_api";
 import { Button } from "antd";
+import { useFetch } from "libs/react_helpers";
 import Toast from "libs/toast";
 import messages from "messages";
-import { useEffect, useState } from "react";
-import type { RouteComponentProps } from "react-router-dom";
-import { withRouter } from "react-router-dom";
-import type { APIDataset } from "types/api_types";
+import { useState } from "react";
+import { useHistory } from "react-router-dom";
 import { confirmAsync } from "./helper_components";
 
 type Props = {
   datasetId: string;
-  history: RouteComponentProps["history"];
 };
 
-const DatasetSettingsDeleteTab = ({ datasetId, history }: Props) => {
+const DatasetSettingsDeleteTab = ({ datasetId }: Props) => {
   const [isDeleting, setIsDeleting] = useState(false);
-  const [dataset, setDataset] = useState<APIDataset | null | undefined>(null);
   const queryClient = useQueryClient();
+  const history = useHistory();
 
-  async function fetch() {
-    const newDataset = await getDataset(datasetId);
-    setDataset(newDataset);
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies(fetch):
-  useEffect(() => {
-    fetch();
-  }, []);
+  const dataset = useFetch(() => getDataset(datasetId), null, [datasetId]);
 
   async function handleDeleteButtonClicked(): Promise<void> {
     if (!dataset) {
@@ -76,4 +66,4 @@ const DatasetSettingsDeleteTab = ({ datasetId, history }: Props) => {
   );
 };
 
-export default withRouter<RouteComponentProps & Props, any>(DatasetSettingsDeleteTab);
+export default DatasetSettingsDeleteTab;

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_sharing_tab.tsx
@@ -6,27 +6,25 @@ import { AsyncButton } from "components/async_clickables";
 import { PricingEnforcedBlur } from "components/pricing_enforcers";
 import DatasetAccessListView from "dashboard/advanced_dataset/dataset_access_list_view";
 import TeamSelectionComponent from "dashboard/dataset/team_selection_component";
+import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
 import { isUserAdminOrDatasetManager, isUserAdminOrTeamManager } from "libs/utils";
 import window from "libs/window";
 import type React from "react";
 import { useEffect, useState } from "react";
-import { connect } from "react-redux";
-import { type RouteComponentProps, withRouter } from "react-router-dom";
-import type { APIDataset, APIUser } from "types/api_types";
+import type { APIDataset } from "types/api_types";
 import { getReadableURLPart } from "viewer/model/accessors/dataset_accessor";
-import type { WebknossosState } from "viewer/store";
 import { FormItemWithInfo } from "./helper_components";
 
 type Props = {
   form: FormInstance | null;
   datasetId: string;
   dataset: APIDataset | null | undefined;
-  activeUser: APIUser | null | undefined;
 };
 
-function DatasetSettingsSharingTab({ form, datasetId, dataset, activeUser }: Props) {
+export default function DatasetSettingsSharingTab({ form, datasetId, dataset }: Props) {
   const [sharingToken, setSharingToken] = useState("");
+  const activeUser = useWkSelector((state) => state.activeUser);
   const isDatasetManagerOrAdmin = isUserAdminOrDatasetManager(activeUser);
 
   const allowedTeamsComponent = (
@@ -161,10 +159,3 @@ function DatasetSettingsSharingTab({ form, datasetId, dataset, activeUser }: Pro
     </div>
   ) : null;
 }
-
-const mapStateToProps = (state: WebknossosState) => ({
-  activeUser: state.activeUser,
-});
-
-const connector = connect(mapStateToProps);
-export default connector(withRouter<RouteComponentProps & Props, any>(DatasetSettingsSharingTab));

--- a/frontend/javascripts/dashboard/dataset/team_selection_component.tsx
+++ b/frontend/javascripts/dashboard/dataset/team_selection_component.tsx
@@ -1,12 +1,13 @@
 import { getEditableTeams, getTeams } from "admin/rest_api";
 import { Select } from "antd";
 import _ from "lodash";
-import * as React from "react";
 import type { APITeam } from "types/api_types";
+import { useEffect, useState, useCallback } from "react";
+import { useEffectOnlyOnce } from "libs/react_hooks";
 
 const { Option } = Select;
 
-type Props = {
+type TeamSelectionComponentProps = {
   value?: APITeam | Array<APITeam>;
   onChange?: (value: APITeam | Array<APITeam>) => void;
   afterFetchedTeams?: (arg0: Array<APITeam>) => void;
@@ -14,102 +15,79 @@ type Props = {
   allowNonEditableTeams?: boolean;
   disabled?: boolean;
 };
-type State = {
-  possibleTeams: Array<APITeam>;
-  selectedTeams: Array<APITeam>;
-  isFetchingData: boolean;
-};
 
-class TeamSelectionComponent extends React.PureComponent<Props, State> {
-  state: State = {
-    possibleTeams: [],
-    selectedTeams: this.props.value ? _.flatten([this.props.value]) : [],
-    isFetchingData: false,
-  };
+function TeamSelectionComponent({
+  value,
+  onChange,
+  afterFetchedTeams,
+  mode,
+  allowNonEditableTeams,
+  disabled,
+}: TeamSelectionComponentProps) {
+  const [possibleTeams, setPossibleTeams] = useState<APITeam[]>([]);
+  const [selectedTeams, setSelectedTeams] = useState<APITeam[]>(value ? _.flatten([value]) : []);
+  const [isFetchingData, setIsFetchingData] = useState(false);
 
-  componentDidMount() {
-    this.fetchData();
-  }
+  // Sync selectedTeams with value
+  useEffect(() => {
+    setSelectedTeams(value ? _.flatten([value]) : []);
+  }, [value]);
 
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.value !== this.props.value) {
-      this.setState({
-        selectedTeams: this.props.value ? _.flatten([this.props.value]) : [],
-      });
-    }
-  }
+  // Fetch teams on mount
+  useEffectOnlyOnce(() => {
+    fetchData();
+  });
 
-  async fetchData() {
-    this.setState({
-      isFetchingData: true,
-    });
+  async function fetchData() {
+    setIsFetchingData(true);
     try {
-      const possibleTeams = this.props.allowNonEditableTeams
-        ? await getTeams()
-        : await getEditableTeams();
-      this.setState({
-        possibleTeams,
-        isFetchingData: false,
-      });
-
-      if (this.props.afterFetchedTeams != null) {
-        this.props.afterFetchedTeams(possibleTeams);
+      const possibleTeams = allowNonEditableTeams ? await getTeams() : await getEditableTeams();
+      setPossibleTeams(possibleTeams);
+      setIsFetchingData(false);
+      if (afterFetchedTeams) {
+        afterFetchedTeams(possibleTeams);
       }
     } catch (_exception) {
       console.error("Could not load teams.");
     }
   }
 
-  onSelectTeams = (selectedTeamIdsOrId: string | Array<string>) => {
-    // we can't use this.props.mode because of flow
+  const getAllTeams = useCallback((): APITeam[] => {
+    return _.unionBy(possibleTeams, selectedTeams, (t) => t.id);
+  }, [possibleTeams, selectedTeams]);
+
+  const onSelectTeams = (selectedTeamIdsOrId: string | Array<string>) => {
     const selectedTeamIds = Array.isArray(selectedTeamIdsOrId)
       ? selectedTeamIdsOrId
       : [selectedTeamIdsOrId];
-    const allTeams = this.getAllTeams();
-
-    const selectedTeams = _.compact(selectedTeamIds.map((id) => allTeams.find((t) => t.id === id)));
-
-    if (this.props.onChange) {
-      this.props.onChange(Array.isArray(selectedTeamIdsOrId) ? selectedTeams : selectedTeams[0]);
+    const allTeams = getAllTeams();
+    const selected = _.compact(selectedTeamIds.map((id) => allTeams.find((t) => t.id === id)));
+    if (onChange) {
+      onChange(Array.isArray(selectedTeamIdsOrId) ? selected : selected[0]);
     }
-
-    this.setState({
-      selectedTeams,
-    });
+    setSelectedTeams(selected);
   };
 
-  getAllTeams = (): Array<APITeam> =>
-    _.unionBy(this.state.possibleTeams, this.state.selectedTeams, (t) => t.id);
-
-  render() {
-    return (
-      <Select
-        showSearch
-        mode={this.props.mode}
-        style={{
-          width: "100%",
-        }}
-        placeholder={
-          this.props.mode && this.props.mode === "multiple" ? "Select Teams" : "Select a Team"
-        }
-        optionFilterProp="children"
-        onChange={this.onSelectTeams}
-        value={this.state.selectedTeams.map((t) => t.id)}
-        filterOption
-        disabled={this.props.disabled ? this.props.disabled : false}
-        loading={this.state.isFetchingData}
-      >
-        {this.getAllTeams().map((team) => (
-          <Option
-            disabled={this.state.possibleTeams.find((t) => t.id === team.id) == null}
-            key={team.id}
-          >
-            {team.name}
-          </Option>
-        ))}
-      </Select>
-    );
-  }
+  return (
+    <Select
+      showSearch
+      mode={mode}
+      style={{ width: "100%" }}
+      placeholder={mode && mode === "multiple" ? "Select Teams" : "Select a Team"}
+      optionFilterProp="children"
+      onChange={onSelectTeams}
+      value={selectedTeams.map((t) => t.id)}
+      filterOption
+      disabled={disabled ? disabled : false}
+      loading={isFetchingData}
+    >
+      {getAllTeams().map((team) => (
+        <Option disabled={possibleTeams.find((t) => t.id === team.id) == null} key={team.id}>
+          {team.name}
+        </Option>
+      ))}
+    </Select>
+  );
 }
 
 export default TeamSelectionComponent;


### PR DESCRIPTION
In preparation of restyling this component in a similar fashion as the account and organization settings, I first refactored several datasets settings & tab components as React functional components to use modern hook APIs etc.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
