### PR TITLE
Allow local absolute mag paths to point to same-orga datasets

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RemoteSourceDescriptorService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RemoteSourceDescriptorService.scala
@@ -55,7 +55,7 @@ class RemoteSourceDescriptorService @Inject()(dSRemoteWebknossosClient: DSRemote
     } else if (uri.getScheme == null || uri.getScheme == DataVaultService.schemeFile) {
       val localPath = Paths.get(uri.getPath)
       if (localPath.isAbsolute) {
-        if (localPath.toString.startsWith(localDatasetDir.toAbsolutePath.toString) || dataStoreConfig.Datastore.localDirectoryWhitelist
+        if (localPath.toString.startsWith(localDatasetDir.getParent.toAbsolutePath.toString) || dataStoreConfig.Datastore.localDirectoryWhitelist
               .exists(whitelistEntry => localPath.toString.startsWith(whitelistEntry)))
           uri
         else


### PR DESCRIPTION
Vx now writes out absolute paths instead of symlinking other dataset layers. This is currently rejected by wk. This PR relaxes this check.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1750927178238689?thread_ts=1750859466.889959&cid=C5AKLAV0B

------
- [x] Needs datastore update after deployment
