### PR TITLE
Enable custom path + credentialID for WKW mags as well

### DIFF
--- a/unreleased_changes/8725.md
+++ b/unreleased_changes/8725.md
@@ -1,0 +1,2 @@
+### Added
+- WKW datasets can now also have custom paths in their datasource-properties.json.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/layers/WKWDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/layers/WKWDataLayers.scala
@@ -9,7 +9,13 @@ import com.scalableminds.webknossos.datastore.storage.RemoteSourceDescriptorServ
 import play.api.libs.json.{Json, OFormat}
 import ucar.ma2.{Array => MultiArray}
 
-case class WKWResolution(resolution: Vec3Int, cubeLength: Int)
+case class WKWResolution(resolution: Vec3Int,
+                         cubeLength: Int,
+                         path: Option[String] = None,
+                         credentialId: Option[String] = None) {
+  def toMagLocator: MagLocator =
+    MagLocator(mag = resolution, path = path, credentialId = credentialId)
+}
 
 object WKWResolution extends MagFormatHelper {
   implicit val jsonFormat: OFormat[WKWResolution] = Json.format[WKWResolution]
@@ -26,7 +32,7 @@ trait WKWLayer extends DataLayer {
 
   def wkwResolutions: List[WKWResolution]
 
-  def mags: List[MagLocator] = wkwResolutions.map(wkwResolution => MagLocator(wkwResolution.resolution))
+  def mags: List[MagLocator] = wkwResolutions.map(_.toMagLocator)
 
   def resolutions: List[Vec3Int] = wkwResolutions.map(_.resolution)
 


### PR DESCRIPTION
The `wkwResolutions` entries in `datasource-properties.json`s can now also contain custom `path` and `credentialId`, much like with the `mags` entries for zarr,zarr3,n5,neuroP.

### Steps to test:
- Move a mag directory of a WKW dataset away from its standard location
- Edit the json, specifying the `path`.
- Reload the dataset in wk. Data should be visible
- Change the path again to where the data is not
- Reload again, data should no longer be visible
- Data in the standard location `layerName/magLiteral` e.g. `color/2-2-1` should still be shown even if no path is supplied.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1751030574372869

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
