### PR TITLE
Don't fetch mesh files for segmentation layers without fallback layers

### DIFF
--- a/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
@@ -58,7 +58,12 @@ let fetchDeferredsPerLayer: Record<string, Deferred<Array<APIMeshFileInfo>, unkn
 function* maybeFetchMeshFiles(action: MaybeFetchMeshFilesAction): Saga<void> {
   const { segmentationLayer, dataset, mustRequest, autoActivate, callback } = action;
 
-  if (!segmentationLayer) {
+  // Only an segmentation layer with an existing fallback layer can have meshfiles.
+  if (
+    !segmentationLayer ||
+    !("fallbackLayer" in segmentationLayer) ||
+    segmentationLayer.fallbackLayer == null
+  ) {
     callback([]);
     return;
   }


### PR DESCRIPTION
The fetching of the meshes was not guarded against segmentation layer without a fallback. Only segmentation layer with fallback can have meshes.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- On master: Create a skeleton only annotaiton
- add a empty volume layer without fallback
- open segmentation tab -> watch it crash
- On this branch: Do the same
- No crash  

### Issues:
- fixes report https://scm.slack.com/archives/C02H5T8Q08P/p1751282276200889

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
