### PR TITLE
Fixes for reading attachments: fill value; hdf5 path

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetArray.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.datastore.datareaders
 import com.scalableminds.util.accesscontext.TokenContext
 import com.scalableminds.util.cache.AlfuCache
 import com.scalableminds.util.geometry.Vec3Int
-import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import com.scalableminds.util.tools.{Empty, Failure, Fox, FoxImplicits, Full}
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.models.AdditionalCoordinate
@@ -248,10 +248,15 @@ class DatasetArray(vaultPath: VaultPath,
       implicit ec: ExecutionContext,
       tc: TokenContext): Fox[MultiArray] =
     if (header.isSharded) {
+      val chunkShape = chunkShapeAtIndex(chunkIndex)
       for {
-        (shardPath, chunkRange) <- getShardedChunkPathAndRange(chunkIndex) ?~> "chunk.getShardedPathAndRange.failed"
-        chunkShape = chunkShapeAtIndex(chunkIndex)
-        multiArray <- chunkReader.read(shardPath, chunkShape, Some(chunkRange), useSkipTypingShortcut)
+        shardPathAndChunkRangeBox <- getShardedChunkPathAndRange(chunkIndex).shiftBox
+        multiArray <- shardPathAndChunkRangeBox match {
+          case Full((shardPath, chunkRange)) =>
+            chunkReader.read(shardPath, chunkShape, Some(chunkRange), useSkipTypingShortcut)
+          case Empty      => chunkReader.createFromFillValue(chunkShape, useSkipTypingShortcut)
+          case f: Failure => f.toFox
+        }
       } yield multiArray
     } else {
       val chunkPath = vaultPath / getChunkFilename(chunkIndex)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
@@ -87,7 +87,7 @@ class PrecomputedArray(vaultPath: VaultPath,
     val shardPath = shardingSpecification.getPathForShard(vaultPath, minishardInfo._1)
     for {
       _ <- Fox.fromBool(minishardInfo._2 <= Int.MaxValue) ?~> "Minishard number is too large"
-      minishardIndex <- getMinishardIndex(shardPath, minishardInfo._2.toInt) ?~> f"Could not get minishard index for chunkIndex ${chunkIndex
+      minishardIndex <- getMinishardIndex(shardPath, minishardInfo._2.toInt) ?=> f"Could not get minishard index for chunkIndex ${chunkIndex
         .mkString(",")}"
       chunkRange: NumericRange.Exclusive[Long] <- getChunkRange(chunkIdentifier, minishardIndex) ?~> s"Could not get chunk range for chunkIndex ${chunkIndex
         .mkString(",")}  with chunkIdentifier $chunkIdentifier in minishard index."

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
@@ -120,7 +120,7 @@ class Zarr3Array(vaultPath: VaultPath,
   private def readAndParseShardIndex(shardPath: VaultPath)(implicit ec: ExecutionContext,
                                                            tc: TokenContext): Fox[Array[(Long, Long)]] =
     for {
-      shardIndexRaw <- readShardIndex(shardPath) ?~> "zarr.readShardIndex.failed"
+      shardIndexRaw <- readShardIndex(shardPath) ?=> "zarr.readShardIndex.failed"
       parsed = parseShardIndex(shardIndexRaw)
     } yield parsed
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AgglomerateService.scala
@@ -98,7 +98,11 @@ class AgglomerateService @Inject()(config: DataStoreConfig,
       })
       localFallbackAttachment = LayerAttachment(
         mappingName,
-        localDatasetDir.resolve(dataLayer.name).resolve(agglomerateDir).toUri,
+        localDatasetDir
+          .resolve(dataLayer.name)
+          .resolve(agglomerateDir)
+          .resolve(mappingName + "." + hdf5AgglomerateFileExtension)
+          .toUri,
         LayerAttachmentDataformat.hdf5
       )
       selectedAttachment = registeredAttachmentNormalized.getOrElse(localFallbackAttachment)


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
