### PR TITLE
Fix meshfile fetching for view only mode

### DIFF
--- a/frontend/javascripts/viewer/model/accessors/volumetracing_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/volumetracing_accessor.ts
@@ -79,6 +79,13 @@ export function getVolumeTracingById(
   return volumeTracing;
 }
 
+export function isTracingLayerWithoutFallback(segmentationLayer: APIDataLayer): boolean {
+  const isTracingLayer = "tracingId" in segmentationLayer && segmentationLayer.tracingId != null;
+  const hasFallbackLayer =
+    "fallbackLayer" in segmentationLayer && segmentationLayer.fallbackLayer != null;
+  return isTracingLayer && !hasFallbackLayer;
+}
+
 export function getVolumeTracingLayers(dataset: APIDataset): Array<APISegmentationLayer> {
   const layers = getSegmentationLayers(dataset);
   return layers.filter((layer) => layer.tracingId != null);

--- a/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
@@ -29,6 +29,7 @@ import {
 import {
   getEditableMappingForVolumeTracingId,
   getTracingForSegmentationLayer,
+  isTracingLayerWithoutFallback,
 } from "viewer/model/accessors/volumetracing_accessor";
 import type { Action } from "viewer/model/actions/actions";
 import {
@@ -58,12 +59,8 @@ let fetchDeferredsPerLayer: Record<string, Deferred<Array<APIMeshFileInfo>, unkn
 function* maybeFetchMeshFiles(action: MaybeFetchMeshFilesAction): Saga<void> {
   const { segmentationLayer, dataset, mustRequest, autoActivate, callback } = action;
 
-  // Only an segmentation layer with an existing fallback layer can have meshfiles.
-  if (
-    !segmentationLayer ||
-    !("fallbackLayer" in segmentationLayer) ||
-    segmentationLayer.fallbackLayer == null
-  ) {
+  // Only an segmentation | tracing layer with an existing fallback layer can have meshfiles.
+  if (!segmentationLayer || isTracingLayerWithoutFallback(segmentationLayer)) {
     callback([]);
     return;
   }

--- a/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
@@ -58,7 +58,12 @@ let fetchDeferredsPerLayer: Record<string, Deferred<Array<APIMeshFileInfo>, unkn
 function* maybeFetchMeshFiles(action: MaybeFetchMeshFilesAction): Saga<void> {
   const { segmentationLayer, dataset, mustRequest, autoActivate, callback } = action;
 
-  if (!segmentationLayer) {
+  // Only an segmentation layer with an existing fallback layer can have meshfiles.
+  if (
+    !segmentationLayer ||
+    !("fallbackLayer" in segmentationLayer) ||
+    segmentationLayer.fallbackLayer == null
+  ) {
     callback([]);
     return;
   }

--- a/unreleased_changes/8726.md
+++ b/unreleased_changes/8726.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug when loading mesh files for segmentation layer without fallback data. Such layer cannot have mesh files.

--- a/unreleased_changes/8728.md
+++ b/unreleased_changes/8728.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed fetching mesh files in view only mode. Bug introduced by #8726


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a dataset with meshfile & volume layer in view only mode and load a precomputed mesh. Should work

### TODOs:
- [ ] ...

### Issues:
- fixes bug introduced by #8726 and noticed by https://scm.slack.com/archives/C02H5T8Q08P/p1751285529575259?thread_ts=1751282276.200889&cid=C02H5T8Q08P

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
