### PR TITLE
Fix orga plan expiration warning

### DIFF
--- a/frontend/javascripts/admin/organization/organization_cards.tsx
+++ b/frontend/javascripts/admin/organization/organization_cards.tsx
@@ -161,56 +161,30 @@ export function PlanExceededAlert({ organization }: { organization: APIOrganizat
 }
 
 export function PlanAboutToExceedAlert({ organization }: { organization: APIOrganization }) {
-  const alerts = [];
   const activeUser = useWkSelector((state) => state.activeUser);
   const isAboutToExpire =
     dayjs.duration(dayjs(organization.paidUntil).diff(dayjs())).asWeeks() <= 6 &&
     !hasPricingPlanExpired(organization);
 
-  if (isAboutToExpire)
-    alerts.push({
-      message:
-        "Your WEBKNOSSOS plan is about to expire soon. Renew your plan now to avoid being downgraded, users being blocked, and losing access to features.",
-      actionButton: (
-        <Button
-          size="small"
-          type="primary"
-          onClick={() => UpgradePricingPlanModal.extendPricingPlan(organization)}
-        >
-          Extend Plan Now
-        </Button>
-      ),
-    });
-  else {
-    alerts.push({
-      message:
-        "Your organization is about to exceed the storage space included in your current plan. Upgrade now to avoid your account from being blocked.",
-      actionButton: (
-        <Button
-          size="small"
-          type="primary"
-          onClick={() => UpgradePricingPlanModal.upgradePricingPlan(organization)}
-        >
-          Upgrade Now
-        </Button>
-      ),
-    });
-  }
+  if (isAboutToExpire) {
+    const actionButton = (
+      <Button
+        size="small"
+        type="primary"
+        onClick={() => UpgradePricingPlanModal.extendPricingPlan(organization)}
+      >
+        Extend Plan Now
+      </Button>
+    );
 
-  return (
-    <>
-      {alerts.map((alert) => (
-        <Alert
-          key={alert.message.slice(0, 10)}
-          showIcon
-          type="warning"
-          message={alert.message}
-          action={
-            activeUser && isUserAllowedToRequestUpgrades(activeUser) ? alert.actionButton : null
-          }
-          style={{ marginBottom: 20 }}
-        />
-      ))}
-    </>
-  );
+    return (
+      <Alert
+        showIcon
+        type="warning"
+        message="Your WEBKNOSSOS plan is about to expire soon. Renew your plan now to avoid being downgraded, users being blocked, and losing access to features."
+        action={activeUser && isUserAllowedToRequestUpgrades(activeUser) ? actionButton : null}
+        style={{ marginBottom: 20 }}
+      />
+    );
+  } else return null;
 }


### PR DESCRIPTION
This PR fixes a regression of PR #8672 that would always show a warning that your orga plan is using too much storage. 

For some reason, in a previous WK build most of this code was commented out and got commented in with PR #8672 causing the regression.

<img width="1295" alt="Screenshot 2025-06-30 at 16 37 44" src="https://github.com/user-attachments/assets/d6516a5b-5798-4893-8871-aa9d86aea67e" />

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1751293404276169

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
