### PR TITLE
Refactor several modals to functional components

### DIFF
--- a/frontend/javascripts/dashboard/transfer_task_modal.tsx
+++ b/frontend/javascripts/dashboard/transfer_task_modal.tsx
@@ -28,6 +28,7 @@ const TransferTaskModal: React.FC<Props> = ({ isOpen, onCancel, annotationId, on
     try {
       const updatedAnnotation = await transferTask(annotationId, currentUserIdValue);
       onChange(updatedAnnotation);
+      setCurrentUserIdValue("");
     } catch (error) {
       handleGenericError(error as Error);
     }
@@ -42,14 +43,14 @@ const TransferTaskModal: React.FC<Props> = ({ isOpen, onCancel, annotationId, on
       title="Transfer a Task"
       open={isOpen}
       onCancel={onCancel}
-      footer={
-        <div>
+      footer={() => (
+        <>
           <Button type="primary" onClick={transfer} disabled={currentUserIdValue === ""}>
             Transfer
           </Button>
           <Button onClick={onCancel}>Close</Button>
-        </div>
-      }
+        </>
+      )}
     >
       <div className="control-group">
         <div className="form-group">

--- a/frontend/javascripts/viewer/view/action-bar/add_new_layout_modal.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/add_new_layout_modal.tsx
@@ -1,49 +1,36 @@
 import { Input, Modal } from "antd";
-import * as React from "react";
+import type React from "react";
+import { memo, useCallback, useState } from "react";
 
 type Props = {
   addLayout: (arg0: string) => void;
   isOpen: boolean;
   onCancel: () => void;
 };
-type State = {
-  value: string;
+
+const AddNewLayoutModal: React.FC<Props> = ({ addLayout, isOpen, onCancel }) => {
+  const [value, setValue] = useState("");
+
+  const onConfirm = useCallback(() => {
+    addLayout(value);
+    setValue("");
+  }, [addLayout, value]);
+
+  const handleChange = useCallback((evt: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(evt.target.value);
+  }, []);
+
+  return (
+    <Modal title="Add a new layout" open={isOpen} onOk={onConfirm} onCancel={onCancel}>
+      <Input
+        placeholder="Layout Name"
+        value={value}
+        onChange={handleChange}
+        autoFocus
+        onPressEnter={onConfirm}
+      />
+    </Modal>
+  );
 };
 
-class AddNewLayoutModal extends React.PureComponent<Props, State> {
-  state: State = {
-    value: "",
-  };
-  onConfirm = () => {
-    const value = this.state.value;
-    this.setState({
-      value: "",
-    });
-    this.props.addLayout(value);
-  };
-
-  render() {
-    return (
-      <Modal
-        title="Add a new layout"
-        open={this.props.isOpen}
-        onOk={this.onConfirm}
-        onCancel={this.props.onCancel}
-      >
-        <Input
-          placeholder="Layout Name"
-          value={this.state.value}
-          onChange={(evt) => {
-            this.setState({
-              value: evt.target.value,
-            });
-          }}
-          autoFocus
-          onPressEnter={this.onConfirm}
-        />
-      </Modal>
-    );
-  }
-}
-
-export default AddNewLayoutModal;
+export default memo(AddNewLayoutModal);

--- a/frontend/javascripts/viewer/view/action-bar/user_scripts_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/user_scripts_modal_view.tsx
@@ -15,140 +15,113 @@ type UserScriptsModalViewProps = {
   onOK: (...args: Array<any>) => any;
   isOpen: boolean;
 };
-type State = {
-  code: string;
-  isCodeChanged: boolean;
-  scripts: Array<Script>;
-  selectedScript: string | null | undefined;
-  isLoading: boolean;
-};
 
-class _UserScriptsModalView extends React.PureComponent<UserScriptsModalViewProps, State> {
-  state: State = {
-    code: "",
-    isCodeChanged: false,
-    scripts: [],
-    // Needs to be undefined so the placeholder is displayed in the beginning
-    selectedScript: undefined,
-    isLoading: true,
-  };
+const _UserScriptsModalView: React.FC<UserScriptsModalViewProps> = ({ onOK, isOpen }) => {
+  const [code, setCode] = React.useState("");
+  const [isCodeChanged, setIsCodeChanged] = React.useState(false);
+  const [scripts, setScripts] = React.useState<Script[]>([]);
+  const [selectedScript, setSelectedScript] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(true);
 
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  fetchData() {
+  React.useEffect(() => {
     Request.receiveJSON("/api/scripts", {
       showErrorToast: false,
     })
       .then((scripts) => {
-        this.setState({
-          isLoading: false,
-        });
+        setIsLoading(false);
 
         if (scripts.length) {
-          this.setState({
-            scripts,
-          });
+          setScripts(scripts);
         }
       })
       .catch((e) => {
         console.error(e);
-        this.setState({
-          isLoading: false,
-        });
+        setIsLoading(false);
       });
-  }
+  }, []);
 
-  handleCodeChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    this.setState({
-      code: event.target.value,
-      isCodeChanged: true,
-    });
-  };
+  const handleCodeChange = React.useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setCode(event.target.value);
+    setIsCodeChanged(true);
+  }, []);
 
-  handleScriptChange = async (scriptId: string) => {
-    const script = this.state.scripts.find((s) => s.id === scriptId);
-    if (script == null) return;
-
-    if (!this.state.isCodeChanged) {
-      this.loadScript(script);
-    } else {
-      Modal.confirm({
-        content: messages["add_script.confirm_change"],
-        onOk: () => this.loadScript(script),
-      });
-    }
-  };
-
-  loadScript = async (script: Script) => {
+  const loadScript = React.useCallback(async (script: Script) => {
     try {
-      this.setState({
-        isLoading: true,
-      });
+      setIsLoading(true);
       const content = await fetchGistContent(script.gist, script.name);
-      this.setState({
-        selectedScript: script.id,
-        code: content,
-        isCodeChanged: false,
-      });
+      setSelectedScript(script.id);
+      setCode(content);
+      setIsCodeChanged(false);
     } catch (error) {
       handleGenericError(error as Error);
     } finally {
-      this.setState({
-        isLoading: false,
-      });
+      setIsLoading(false);
     }
-  };
+  }, []);
 
-  handleClick = () => {
+  const handleScriptChange = React.useCallback(
+    async (scriptId: string) => {
+      const script = scripts.find((s) => s.id === scriptId);
+      if (script == null) return;
+
+      if (!isCodeChanged) {
+        void loadScript(script);
+      } else {
+        Modal.confirm({
+          content: messages["add_script.confirm_change"],
+          onOk: () => loadScript(script),
+        });
+      }
+    },
+    [scripts, isCodeChanged, loadScript],
+  );
+
+  const handleClick = React.useCallback(() => {
     try {
       // biome-ignore lint/security/noGlobalEval: Loads a user provided frontend API script.
-      eval(this.state.code);
+      eval(code);
       // close modal if the script executed successfully
-      return this.props.onOK();
+      return onOK();
     } catch (error) {
       console.error(error);
       return alert(error);
     }
-  };
+  }, [code, onOK]);
 
-  render() {
-    return (
-      <Modal
-        open={this.props.isOpen}
-        title="Add User Script"
-        okText="Add"
-        cancelText="Close"
-        onOk={this.handleClick}
-        onCancel={this.props.onOK}
-      >
-        <Spin spinning={this.state.isLoading}>
-          <Select
-            value={this.state.isCodeChanged ? "Modified Script" : this.state.selectedScript}
-            style={{
-              width: 200,
-              marginBottom: 10,
-            }}
-            onChange={this.handleScriptChange}
-            placeholder="Select an existing user script"
-            options={this.state.scripts.map((script) => ({
-              value: script.id,
-              label: script.name,
-            }))}
-          />
-          <TextArea
-            rows={15}
-            onChange={this.handleCodeChange}
-            value={this.state.code}
-            placeholder="Choose an existing user script from the dropdown above or add WEBKNOSSOS frontend script code here"
-          />
-        </Spin>
-      </Modal>
-    );
-  }
-}
+  return (
+    <Modal
+      open={isOpen}
+      title="Add User Script"
+      okText="Add"
+      cancelText="Close"
+      onOk={handleClick}
+      onCancel={onOK}
+    >
+      <Spin spinning={isLoading}>
+        <Select
+          value={isCodeChanged ? "Modified Script" : selectedScript}
+          style={{
+            width: 200,
+            marginBottom: 10,
+          }}
+          onChange={handleScriptChange}
+          placeholder="Select an existing user script"
+          options={scripts.map((script) => ({
+            value: script.id,
+            label: script.name,
+          }))}
+        />
+        <TextArea
+          rows={15}
+          onChange={handleCodeChange}
+          value={code}
+          placeholder="Choose an existing user script from the dropdown above or add WEBKNOSSOS frontend script code here"
+        />
+      </Spin>
+    </Modal>
+  );
+};
 
-const UserScriptsModalView = makeComponentLazy(_UserScriptsModalView);
+const UserScriptsModalView = makeComponentLazy(React.memo(_UserScriptsModalView));
 
 export default UserScriptsModalView;

--- a/frontend/javascripts/viewer/view/new_task_description_modal.tsx
+++ b/frontend/javascripts/viewer/view/new_task_description_modal.tsx
@@ -1,76 +1,62 @@
 import { Button, Modal } from "antd";
 import Markdown from "libs/markdown_adapter";
-import * as React from "react";
+import type React from "react";
+import { useCallback, useEffect, useState } from "react";
+
 type Props = {
   description: string;
   destroy: () => void;
   title: string;
 };
-type State = {
-  mayClose: boolean;
-  isOpen: boolean;
-};
-export default class NewTaskDescriptionModal extends React.Component<Props, State> {
-  timeoutId: ReturnType<typeof setTimeout> | undefined;
-  state: State = {
-    mayClose: false,
-    isOpen: true,
-  };
 
-  componentDidMount() {
-    this.timeoutId = setTimeout(
+const NewTaskDescriptionModal: React.FC<Props> = ({ description, destroy, title }) => {
+  const [mayClose, setMayClose] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(
       () => {
-        this.allowClose();
+        setMayClose(true);
       },
       process.env.NODE_ENV === "production" ? 10000 : 2000,
     );
-  }
 
-  componentWillUnmount() {
-    if (this.timeoutId != null) {
-      clearTimeout(this.timeoutId);
-    }
-  }
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, []);
 
-  allowClose() {
-    this.setState({
-      mayClose: true,
-    });
-  }
-
-  handleOk = () => {
-    if (!this.state.mayClose) {
+  const handleOk = useCallback(() => {
+    if (!mayClose) {
       return;
     }
 
-    this.setState({
-      isOpen: false,
-    });
-    this.props.destroy();
-  };
+    setIsOpen(false);
+    destroy();
+  }, [mayClose, destroy]);
 
-  render() {
-    return (
-      <Modal
-        maskClosable={false}
-        open={this.state.isOpen}
-        title={this.props.title}
-        onOk={this.handleOk}
-        onCancel={this.handleOk}
-        footer={[
-          <Button
-            key="submit"
-            type="primary"
-            loading={!this.state.mayClose}
-            onClick={this.handleOk}
-            disabled={!this.state.mayClose}
-          >
-            Ok
-          </Button>,
-        ]}
-      >
-        <Markdown>{this.props.description}</Markdown>
-      </Modal>
-    );
-  }
-}
+  return (
+    <Modal
+      maskClosable={false}
+      open={isOpen}
+      title={title}
+      onOk={handleOk}
+      onCancel={handleOk}
+      footer={[
+        <Button
+          key="submit"
+          type="primary"
+          loading={!mayClose}
+          onClick={handleOk}
+          disabled={!mayClose}
+        >
+          Ok
+        </Button>,
+      ]}
+    >
+      <Markdown>{description}</Markdown>
+    </Modal>
+  );
+};
+
+export default NewTaskDescriptionModal;

--- a/frontend/javascripts/viewer/view/recommended_configuration_modal.tsx
+++ b/frontend/javascripts/viewer/view/recommended_configuration_modal.tsx
@@ -1,9 +1,11 @@
 import { settingComments } from "admin/tasktype/recommended_configuration_view";
 import { Modal, Table } from "antd";
-import _ from "lodash";
+import { map } from "lodash";
 import messages, { settings } from "messages";
-import * as React from "react";
+import type React from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { RecommendedConfiguration } from "viewer/store";
+
 const columns = [
   {
     title: "Setting",
@@ -18,68 +20,67 @@ const columns = [
     dataIndex: "comment",
   },
 ];
+
 type Props = {
   config: RecommendedConfiguration;
   onOk: () => void;
   destroy: () => void;
 };
-type State = {
-  isOpen: boolean;
+
+const RecommendedConfigurationModal: React.FC<Props> = ({ config, onOk, destroy }) => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const hide = useCallback(() => {
+    setIsOpen(false);
+    destroy();
+  }, [destroy]);
+
+  const handleOk = useCallback(() => {
+    onOk();
+    hide();
+  }, [onOk, hide]);
+
+  const configurationEntries = useMemo(
+    () =>
+      map(config, (value, key) => {
+        const settingsKey = key as keyof RecommendedConfiguration;
+        return {
+          name: key in settings ? settings[settingsKey] : null,
+          value: value?.toString(),
+          comment: settingComments[settingsKey] || "",
+        };
+      }),
+    [config],
+  );
+
+  return (
+    <Modal
+      maskClosable={false}
+      open={isOpen}
+      title="Recommended Configuration"
+      okText="Accept"
+      cancelText="Decline"
+      onOk={handleOk}
+      onCancel={hide}
+      width={750}
+    >
+      {messages["task.recommended_configuration"]}
+      <Table
+        style={{
+          marginTop: 20,
+          maxHeight: 500,
+          overflow: "auto",
+        }}
+        columns={columns}
+        dataSource={configurationEntries}
+        size="small"
+        pagination={false}
+        scroll={{
+          x: "max-content",
+        }}
+      />
+    </Modal>
+  );
 };
-export default class RecommendedConfigurationModal extends React.Component<Props, State> {
-  state: State = {
-    isOpen: true,
-  };
 
-  handleOk = () => {
-    this.props.onOk();
-    this.hide();
-  };
-
-  hide = () => {
-    this.setState({
-      isOpen: false,
-    });
-    this.props.destroy();
-  };
-
-  render() {
-    const configurationEntries = _.map(this.props.config, (value, key) => {
-      // @ts-ignore Typescript doesn't infer that key will be of type keyof RecommendedConfiguration
-      const settingsKey: keyof RecommendedConfiguration = key;
-      return {
-        name: key in settings ? settings[settingsKey] : null,
-        value: value?.toString(),
-        comment: settingComments[settingsKey] || "",
-      };
-    });
-    return (
-      <Modal
-        maskClosable={false}
-        open={this.state.isOpen}
-        title="Recommended Configuration"
-        okText="Accept"
-        cancelText="Decline"
-        onOk={this.handleOk}
-        onCancel={this.hide}
-        width={750}
-      >
-        {messages["task.recommended_configuration"]}
-        <Table
-          style={{
-            marginTop: 20,
-            maxHeight: 500,
-            overflow: "auto",
-          }}
-          columns={columns}
-          dataSource={configurationEntries}
-          size="small"
-          pagination={false}
-          scroll={{
-            x: "max-content",
-          }}
-        />
-      </Modal>
-    );
-  }
-}
+export default RecommendedConfigurationModal;

--- a/frontend/javascripts/viewer/view/remove_tree_modal.tsx
+++ b/frontend/javascripts/viewer/view/remove_tree_modal.tsx
@@ -1,58 +1,44 @@
 import { Checkbox, Modal } from "antd";
 import type { CheckboxChangeEvent } from "antd/lib/checkbox";
 import messages from "messages";
-import React from "react";
+import type React from "react";
+import { useCallback, useState } from "react";
+import { useDispatch } from "react-redux";
 import { updateUserSettingAction } from "viewer/model/actions/settings_actions";
-import Store from "viewer/store";
 
 type Props = {
   onOk: (...args: Array<any>) => any;
   destroy?: (...args: Array<any>) => any;
 };
-type State = {
-  shouldNotWarnAgain: boolean;
-  isOpen: boolean;
+
+const TreeRemovalModal: React.FC<Props> = ({ onOk, destroy }) => {
+  const [shouldNotWarnAgain, setShouldNotWarnAgain] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
+  const dispatch = useDispatch();
+
+  const handleCheckboxChange = useCallback((event: CheckboxChangeEvent) => {
+    setShouldNotWarnAgain(event.target.checked);
+  }, []);
+
+  const hide = useCallback(() => {
+    setIsOpen(false);
+    if (destroy) destroy();
+  }, [destroy]);
+
+  const handleOk = useCallback(() => {
+    dispatch(updateUserSettingAction("hideTreeRemovalWarning", shouldNotWarnAgain));
+    onOk();
+    hide();
+  }, [shouldNotWarnAgain, onOk, hide, dispatch]);
+
+  return (
+    <Modal title={messages["tracing.delete_tree"]} onOk={handleOk} onCancel={hide} open={isOpen}>
+      <Checkbox onChange={handleCheckboxChange} checked={shouldNotWarnAgain}>
+        Do not warn me again. (Remember, accidentally deleted trees can always be restored using the
+        Undo functionality (Ctrl/Cmd + Z)).
+      </Checkbox>
+    </Modal>
+  );
 };
-export default class TreeRemovalModal extends React.Component<Props, State> {
-  state = {
-    shouldNotWarnAgain: false,
-    isOpen: true,
-  };
 
-  handleCheckboxChange = (event: CheckboxChangeEvent) => {
-    this.setState({
-      shouldNotWarnAgain: event.target.checked,
-    });
-  };
-
-  hide = () => {
-    this.setState({
-      isOpen: false,
-    });
-    if (this.props.destroy) this.props.destroy();
-  };
-
-  handleOk = () => {
-    Store.dispatch(
-      updateUserSettingAction("hideTreeRemovalWarning", this.state.shouldNotWarnAgain),
-    );
-    this.props.onOk();
-    this.hide();
-  };
-
-  render() {
-    return (
-      <Modal
-        title={messages["tracing.delete_tree"]}
-        onOk={this.handleOk}
-        onCancel={this.hide}
-        open={this.state.isOpen}
-      >
-        <Checkbox onChange={this.handleCheckboxChange} checked={this.state.shouldNotWarnAgain}>
-          Do not warn me again. (Remember, accidentally deleted trees can always be restored using
-          the Undo functionality (Ctrl/Cmd + Z)).
-        </Checkbox>
-      </Modal>
-    );
-  }
-}
+export default TreeRemovalModal;


### PR DESCRIPTION
In this PR I converted several class components to functional components using modern React hooks
- `TransferTaskModal`
- `NewTaskDescriptionModal`
- `RecommendedConfigurationModal`
- `TreeRemovalModal`
-  `AddNewLayoutModal`
- `UserScriptsModalView`


### Steps to test:
- Check that the modals are still showing
- The changes are lightweight enough to not do deep test

### Issues:
- Contributes to #8747

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
