### PR TITLE
Refactor components to use functional components and hooks

### DIFF
--- a/frontend/javascripts/viewer/view/components/button_component.tsx
+++ b/frontend/javascripts/viewer/view/components/button_component.tsx
@@ -1,7 +1,7 @@
 import { Button, type ButtonProps } from "antd";
 import FastTooltip, { type FastTooltipPlacement } from "components/fast_tooltip";
 import _ from "lodash";
-import * as React from "react";
+import type React from "react";
 
 type ButtonComponentProps = ButtonProps & {
   faIcon?: string;
@@ -12,53 +12,50 @@ type ButtonComponentProps = ButtonProps & {
  * after it was clicked.
  */
 
-class ButtonComponent extends React.PureComponent<ButtonComponentProps> {
-  static defaultProps: ButtonComponentProps = {
-    onClick: _.noop,
+function ButtonComponent(props: ButtonComponentProps) {
+  const {
+    children,
+    faIcon,
+    title,
+    tooltipPlacement,
+    onClick = _.noop,
+    onTouchEnd,
+    ...restProps
+  } = props;
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.currentTarget.blur();
+    onClick(e);
   };
 
-  handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    // For antd buttons e.target seems to be the span with the button description, whereas
-    // e.currentTarget is the actual button
+  const handleTouchEnd = (e: React.TouchEvent<HTMLButtonElement>) => {
     e.currentTarget.blur();
-
-    if (this.props.onClick) {
-      this.props.onClick(e);
+    if (onTouchEnd) {
+      onTouchEnd(e);
     }
   };
 
-  handleTouchEnd = (e: React.TouchEvent<HTMLButtonElement>) => {
-    e.currentTarget.blur();
-
-    if (this.props.onTouchEnd) {
-      this.props.onTouchEnd(e);
-    }
-  };
-
-  render() {
-    const { children, faIcon, title, tooltipPlacement, ...restProps } = this.props;
-    const iconEl = faIcon != null && !this.props.loading ? <i className={faIcon} /> : null;
-    const button =
-      // Differentiate via children != null, since antd uses a different styling for buttons
-      // with a single icon child (.ant-btn-icon-only will be assigned)
-      children != null ? (
-        <Button {...restProps} onClick={this.handleClick} onTouchEnd={this.handleTouchEnd}>
-          {iconEl}
-          {children}
-        </Button>
-      ) : (
-        <Button {...restProps} onClick={this.handleClick} onTouchEnd={this.handleTouchEnd}>
-          {iconEl}
-        </Button>
-      );
-    return title != null ? (
-      <FastTooltip title={title} placement={tooltipPlacement}>
-        {button}
-      </FastTooltip>
+  const iconEl = faIcon != null && !props.loading ? <i className={faIcon} /> : null;
+  const button =
+    // Differentiate via children != null, since antd uses a different styling for buttons
+    // with a single icon child (.ant-btn-icon-only will be assigned)
+    children != null ? (
+      <Button {...restProps} onClick={handleClick} onTouchEnd={handleTouchEnd}>
+        {iconEl}
+        {children}
+      </Button>
     ) : (
-      button
+      <Button {...restProps} onClick={handleClick} onTouchEnd={handleTouchEnd}>
+        {iconEl}
+      </Button>
     );
-  }
+  return title != null ? (
+    <FastTooltip title={title} placement={tooltipPlacement}>
+      {button}
+    </FastTooltip>
+  ) : (
+    button
+  );
 }
 
 export function ToggleButton(props: { active: boolean } & ButtonComponentProps) {

--- a/frontend/javascripts/viewer/view/components/checkbox_component.tsx
+++ b/frontend/javascripts/viewer/view/components/checkbox_component.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from "antd";
 import _ from "lodash";
-import * as React from "react";
+import type React from "react";
 type CheckboxComponentProp = {
   onClick?: (...args: Array<any>) => any;
 };
@@ -9,25 +9,17 @@ type CheckboxComponentProp = {
  * after it was clicked.
  */
 
-class CheckboxComponent extends React.PureComponent<CheckboxComponentProp> {
-  static defaultProps: CheckboxComponentProp = {
-    onClick: _.noop,
-  };
+function CheckboxComponent(props: CheckboxComponentProp) {
+  const { onClick = _.noop, ...restProps } = props;
 
-  handleClick = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  const handleClick: React.MouseEventHandler<HTMLElement> = (e) => {
     // For antd checkboxs e.target seems to be the span with the checkbox description, whereas
     // e.currentTarget is the actual checkbox
     e.currentTarget.blur();
-
-    if (this.props.onClick) {
-      this.props.onClick(e);
-    }
+    onClick(e);
   };
 
-  render() {
-    // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: React.SyntheticEvent<HTMLInputElement>) ... Remove this comment to see the full error message
-    return <Checkbox {...this.props} onClick={this.handleClick} />;
-  }
+  return <Checkbox {...restProps} onClick={handleClick} />;
 }
 
 export default CheckboxComponent;

--- a/frontend/javascripts/viewer/view/components/editable_text_icon.tsx
+++ b/frontend/javascripts/viewer/view/components/editable_text_icon.tsx
@@ -1,5 +1,5 @@
 import { Button, Input } from "antd";
-import React from "react";
+import React, { useState } from "react";
 
 type Props = {
   icon: React.ReactElement;
@@ -7,73 +7,54 @@ type Props = {
   onChange: (value: string, event: React.SyntheticEvent<HTMLInputElement>) => void;
 };
 
-type State = {
-  isEditing: boolean;
-  value: string;
-};
+function EditableTextIcon(props: Props) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState("");
 
-class EditableTextIcon extends React.PureComponent<Props, State> {
-  state = {
-    isEditing: false,
-    value: "",
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
   };
 
-  handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({
-      value: event.target.value,
-    });
-  };
-
-  handleInputSubmit = (event: React.SyntheticEvent<HTMLInputElement>) => {
-    const { value } = this.state;
-
+  const handleInputSubmit = (event: React.FormEvent<HTMLInputElement>) => {
     if (value !== "") {
-      this.props.onChange(this.state.value, event);
+      props.onChange(value, event);
     }
 
-    this.setState({
-      isEditing: false,
-      value: "",
-    });
+    setIsEditing(false);
+    setValue("");
   };
 
-  render() {
-    if (this.state.isEditing) {
-      return (
-        <Input
-          value={this.state.value}
-          onChange={this.handleInputChange}
-          onPressEnter={this.handleInputSubmit}
-          onBlur={this.handleInputSubmit}
-          style={{
-            width: 75,
-          }}
-          size="small"
-          autoFocus
-        />
-      );
-    }
-
+  if (isEditing) {
     return (
-      <Button
-        size="small"
-        icon={this.props.icon}
+      <Input
+        value={value}
+        onChange={handleInputChange}
+        onPressEnter={handleInputSubmit}
+        onBlur={handleInputSubmit}
         style={{
-          height: 22,
-          width: this.props.label ? "initial" : 22,
-          fontSize: "12px",
-          color: "#7c7c7c",
+          width: 75,
         }}
-        onClick={() =>
-          this.setState({
-            isEditing: true,
-          })
-        }
-      >
-        {this.props.label ? <span style={{ marginLeft: 0 }}>{this.props.label}</span> : null}
-      </Button>
+        size="small"
+        autoFocus
+      />
     );
   }
+
+  return (
+    <Button
+      size="small"
+      icon={props.icon}
+      style={{
+        height: 22,
+        width: props.label ? "initial" : 22,
+        fontSize: "12px",
+        color: "#7c7c7c",
+      }}
+      onClick={() => setIsEditing(true)}
+    >
+      {props.label ? <span style={{ marginLeft: 0 }}>{props.label}</span> : null}
+    </Button>
+  );
 }
 
 export default EditableTextIcon;

--- a/frontend/javascripts/viewer/view/components/editable_text_label.tsx
+++ b/frontend/javascripts/viewer/view/components/editable_text_label.tsx
@@ -32,96 +32,65 @@ export type EditableTextLabelProp = {
   onRenameStart?: (() => void) | undefined;
   onRenameEnd?: (() => void) | undefined;
 };
-type State = {
-  isEditing: boolean;
-  value: string;
-};
+function EditableTextLabel(props: EditableTextLabelProp) {
+  const {
+    value: propValue,
+    onChange,
+    rules = [],
+    rows = 1,
+    markdown,
+    label,
+    margin,
+    onClick,
+    disableEditing,
+    hideEditIcon,
+    onContextMenu,
+    width,
+    iconClassName,
+    isInvalid = false,
+    trimValue = false,
+    onRenameStart,
+    onRenameEnd,
+  } = props;
 
-class EditableTextLabel extends React.PureComponent<EditableTextLabelProp, State> {
-  static defaultProps = {
-    rows: 1,
-    isInvalid: false,
-    trimValue: false,
-    rules: [],
-  };
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [value, setValue] = React.useState(propValue);
 
-  state: State = {
-    isEditing: false,
-    value: "",
-  };
+  React.useEffect(() => {
+    setValue(propValue);
+  }, [propValue]);
 
-  componentDidMount() {
-    this.setState({
-      value: this.props.value,
-    });
-  }
-
-  componentDidUpdate(prevProps: EditableTextLabelProp) {
-    if (prevProps.value !== this.props.value) {
-      this.setState({
-        value: this.props.value,
-      });
-    }
-  }
-
-  handleInputChangeFromEvent = (
+  const handleInputChangeFromEvent = (
     event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => {
-    this.setState({
-      value: event.target.value,
-    });
+    setValue(event.target.value);
   };
 
-  handleInputChange = (newValue: string) => {
-    this.setState({
-      value: newValue,
-    });
+  const handleInputChange = (newValue: string) => {
+    setValue(newValue);
   };
 
-  handleOnChange = () => {
-    const validateAndUpdateValue = () => {
-      if (this.validateFields()) {
-        this.props.onChange(this.state.value);
-        this.setState({
-          isEditing: false,
-        });
-        if (this.props.onRenameEnd) {
-          this.props.onRenameEnd();
-        }
-      }
-    };
-    if (this.props.trimValue) {
-      this.setState(
-        (prevState) => ({ value: prevState.value.trim() }),
-        // afterwards validate
-        validateAndUpdateValue,
-      );
-    } else {
-      validateAndUpdateValue();
-    }
-  };
-
-  validateFields() {
-    if (!this.props.rules) {
+  const validateFields = () => {
+    if (!rules) {
       return true;
     }
-    const allRulesValid = this.props.rules.every((rule) => {
+    const allRulesValid = rules.every((rule) => {
       if (rule.type === "email") {
         const re =
-          /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-        const isValid = re.test(this.state.value);
+          /^(([^<>()[\\]\\.,;:\s@"]+(\.[^<>()[\\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+        const isValid = re.test(value);
         if (!isValid) {
           Toast.error(rule.message);
           return false;
         }
       } else if (rule.validator != null) {
-        const validationResult = rule.validator(this.state.value);
+        const validationResult = rule.validator(value);
         if (!validationResult.isValid) {
           Toast.error(validationResult.message);
           return false;
         }
       } else if (rule.min != null) {
-        if (this.state.value.length < rule.min) {
+        if (value.length < rule.min) {
           Toast.error(`Length must at least be ${rule.min}.`);
           return false;
         }
@@ -129,101 +98,114 @@ class EditableTextLabel extends React.PureComponent<EditableTextLabelProp, State
       return true;
     });
     return allRulesValid;
-  }
+  };
 
-  onRename = (evt: React.MouseEvent) => {
-    if (this.props.disableEditing) {
-      return;
-    }
-    evt.stopPropagation();
-    this.setState({
-      isEditing: true,
-    });
-    if (this.props.onRenameStart) {
-      this.props.onRenameStart();
+  const handleOnChange = () => {
+    const validateAndUpdateValue = () => {
+      if (validateFields()) {
+        onChange(value);
+        setIsEditing(false);
+        if (onRenameEnd) {
+          onRenameEnd();
+        }
+      }
+    };
+    if (trimValue) {
+      setValue((prevValue) => prevValue.trim());
+      // afterwards validate
+      validateAndUpdateValue();
+    } else {
+      validateAndUpdateValue();
     }
   };
 
-  render() {
-    const iconStyle = {
-      cursor: "pointer",
-      marginLeft: 5,
-    };
-    const margin = this.props.margin != null ? this.props.margin : "0 10px";
-    const inputComponentProps: InputProps = {
-      value: this.state.value,
-      onChange: this.handleInputChangeFromEvent,
-      onPressEnter: this.handleOnChange,
-      style: {
-        width: this.props.width != null ? this.props.width : "calc(100% - 24px)",
-        margin,
-      },
-      size: "small",
-      autoFocus: true,
-    };
-    const isInvalidStyleMaybe = this.props.isInvalid ? { color: "var(--ant-color-error)" } : {};
+  const onRename = (evt: React.MouseEvent) => {
+    if (disableEditing) {
+      return;
+    }
+    evt.stopPropagation();
+    setIsEditing(true);
+    if (onRenameStart) {
+      onRenameStart();
+    }
+  };
 
-    if (this.state.isEditing) {
-      return this.props.rows === 1 ? (
-        <Space.Compact block>
-          <Input {...inputComponentProps} onBlur={() => this.handleOnChange()} />
-          <FastTooltip key="save" title={`Save ${this.props.label}`} placement="bottom">
-            <CheckOutlined
-              style={iconStyle}
-              onClick={(evt) => {
-                evt.stopPropagation();
-                this.handleOnChange();
+  const iconStyle = {
+    cursor: "pointer",
+    marginLeft: 5,
+  };
+  const currentMargin = margin != null ? margin : "0 10px";
+  const inputComponentProps: InputProps = {
+    value: value,
+    onChange: handleInputChangeFromEvent,
+    onPressEnter: handleOnChange,
+    style: {
+      width: width != null ? width : "calc(100% - 24px)",
+      margin: currentMargin,
+    },
+    size: "small",
+    autoFocus: true,
+  };
+  const isInvalidStyleMaybe = isInvalid ? { color: "var(--ant-color-error)" } : {};
+
+  if (isEditing) {
+    return rows === 1 ? (
+      <Space.Compact block>
+        <Input {...inputComponentProps} onBlur={() => handleOnChange()} />
+        <FastTooltip key="save" title={`Save ${label}`} placement="bottom">
+          <CheckOutlined
+            style={iconStyle}
+            onClick={(evt) => {
+              evt.stopPropagation();
+              handleOnChange();
+            }}
+          />
+        </FastTooltip>
+      </Space.Compact>
+    ) : (
+      <MarkdownModal
+        source={value}
+        isOpen={isEditing}
+        onChange={handleInputChange}
+        onOk={handleOnChange}
+        label={label}
+      />
+    );
+  } else {
+    return (
+      <div
+        style={{
+          margin: currentMargin,
+          display: "inline-flex",
+          alignItems: "center",
+        }}
+        className={onClick != null ? "clickable-text" : undefined}
+        onClick={onClick}
+        onDoubleClick={onRename}
+        onContextMenu={onContextMenu}
+      >
+        {markdown ? (
+          <span style={isInvalidStyleMaybe}>
+            <Markdown className="flex-item">{value}</Markdown>
+          </span>
+        ) : (
+          <span style={isInvalidStyleMaybe}>{value}</span>
+        )}
+        {disableEditing || hideEditIcon ? null : (
+          <FastTooltip key="edit" title={`Edit ${label}`} placement="bottom">
+            <EditOutlined
+              className={iconClassName + " " + (markdown ? "flex-item" : "")}
+              style={{
+                ...iconStyle,
+                display: "inline",
+                whiteSpace: "nowrap",
               }}
+              onClick={onRename}
             />
           </FastTooltip>
-        </Space.Compact>
-      ) : (
-        <MarkdownModal
-          source={this.state.value}
-          isOpen={this.state.isEditing}
-          onChange={this.handleInputChange}
-          onOk={this.handleOnChange}
-          label={this.props.label}
-        />
-      );
-    } else {
-      return (
-        <div
-          style={{
-            margin,
-            display: "inline-flex",
-            alignItems: "center",
-          }}
-          className={this.props.onClick != null ? "clickable-text" : undefined}
-          onClick={this.props.onClick}
-          onDoubleClick={this.onRename}
-          onContextMenu={this.props.onContextMenu}
-        >
-          {this.props.markdown ? (
-            <span style={isInvalidStyleMaybe}>
-              <Markdown className="flex-item">{this.props.value}</Markdown>
-            </span>
-          ) : (
-            <span style={isInvalidStyleMaybe}>{this.props.value}</span>
-          )}
-          {this.props.disableEditing || this.props.hideEditIcon ? null : (
-            <FastTooltip key="edit" title={`Edit ${this.props.label}`} placement="bottom">
-              <EditOutlined
-                className={
-                  this.props.iconClassName + " " + (this.props.markdown ? "flex-item" : "")
-                }
-                style={{
-                  ...iconStyle,
-                  display: "inline",
-                  whiteSpace: "nowrap",
-                }}
-                onClick={this.onRename}
-              />
-            </FastTooltip>
-          )}
-        </div>
-      );
-    }
+        )}
+      </div>
+    );
   }
 }
 

--- a/frontend/javascripts/viewer/view/components/input_component.tsx
+++ b/frontend/javascripts/viewer/view/components/input_component.tsx
@@ -1,11 +1,8 @@
 import { Input, type InputProps, type InputRef } from "antd";
 import FastTooltip from "components/fast_tooltip";
 import _ from "lodash";
-import * as React from "react";
-
-type InputComponentState = {
-  currentValue: React.InputHTMLAttributes<HTMLInputElement>["value"] | bigint;
-};
+import type React from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /*
  * A lightweight wrapper around <Input> which:
@@ -18,120 +15,93 @@ type InputComponentState = {
  *   while it's focused (mainly necessary when mutating the value on arrow-keypresses)
  */
 
-class InputComponent extends React.PureComponent<InputProps, InputComponentState> {
-  inputRef = React.createRef<InputRef>();
-  static defaultProps: InputProps = {
-    onChange: _.noop,
-    placeholder: "",
-    value: "",
-    style: {},
-  };
+function InputComponent(props: InputProps) {
+  const {
+    title,
+    style,
+    onChange = _.noop,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    value = "",
+    ...inputProps
+  } = props;
+  const inputRef = useRef<InputRef>(null);
+  const [currentValue, setCurrentValue] = useState(value);
 
-  state = {
-    currentValue: this.props.value,
-  };
+  useEffect(() => {
+    setCurrentValue(value);
+  }, [value]);
 
-  getSnapshotBeforeUpdate(
-    _prevProps: InputProps,
-    _prevState: InputComponentState,
-  ): [number | null, number | null] {
-    // Remember the selection within the input before updating it.
-    try {
-      return [
-        // @ts-ignore
-        this.inputRef?.current?.input.selectionStart,
-        // @ts-ignore
-        this.inputRef?.current?.input.selectionEnd,
-      ];
-    } catch {
-      return [null, null];
+  // This effect handles cursor position/selection when the input value changes
+  // while the input is focused.
+  useLayoutEffect(() => {
+    if (inputRef.current && document.activeElement === inputRef.current.input) {
+      // Store current selection
+      const selectionStart = inputRef.current.input?.selectionStart;
+      const selectionEnd = inputRef.current.input?.selectionEnd;
+
+      // Restore selection after re-render
+      if (selectionStart !== null && selectionEnd !== null) {
+        inputRef.current.input?.setSelectionRange(selectionStart, selectionEnd);
+      }
     }
-  }
+  }, [currentValue]); // Re-run when currentValue changes
 
-  componentDidUpdate(
-    prevProps: InputProps,
-    _prevState: InputComponentState,
-    snapshot: [number | null, number | null],
-  ) {
-    if (prevProps.value !== this.props.value) {
-      this.setState({
-        currentValue: this.props.value,
-      });
-    }
-
-    if (this.inputRef.current && document.activeElement !== this.inputRef.current.input) {
-      // Don't mutate the selection if the element is not active. Otherwise,
-      // the on-screen keyboard opens on iOS when moving through the dataset.
-      return;
-    }
-
-    // Restore the remembered selection when necessary
-    try {
-      // @ts-ignore
-      this.inputRef.current.input.selectionStart = snapshot[0];
-      // @ts-ignore
-      this.inputRef.current.input.selectionEnd = snapshot[1];
-    } catch {}
-  }
-
-  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({
-      currentValue: e.target.value,
-    });
-    if (this.props.onChange) {
-      this.props.onChange(e);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentValue(e.target.value);
+    if (onChange) {
+      onChange(e);
     }
   };
 
-  handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (this.props.onFocus) {
-      this.props.onFocus(e);
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (onFocus) {
+      onFocus(e);
     }
   };
 
-  handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (this.props.onBlur) {
-      this.props.onBlur(e);
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (onBlur) {
+      onBlur(e);
     }
   };
 
-  blurYourself = () => (document.activeElement as HTMLElement | null)?.blur();
+  const blurYourself = () => (document.activeElement as HTMLElement | null)?.blur();
 
-  blurOnEscape = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const blurOnEscape = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Escape") {
       event.preventDefault();
-      this.blurYourself();
+      blurYourself();
     }
-    if (this.props.onKeyDown) {
-      return this.props.onKeyDown(event);
+    if (onKeyDown) {
+      return onKeyDown(event);
     }
   };
 
-  render() {
-    const { title, style, ...inputProps } = this.props;
-    const input = (
-      <Input
-        ref={this.inputRef}
-        {...inputProps}
-        // Only pass the style to the input if no tooltip container is used.
-        // Otherwise, the tooltip container will get the style.
-        style={title == null ? style : undefined}
-        onChange={this.handleChange}
-        onFocus={this.handleFocus}
-        onBlur={this.handleBlur}
-        value={this.state.currentValue}
-        onKeyDown={this.blurOnEscape}
-      />
-    );
+  const input = (
+    <Input
+      ref={inputRef}
+      {...inputProps}
+      // Only pass the style to the input if no tooltip container is used.
+      // Otherwise, the tooltip container will get the style.
+      style={title == null ? style : undefined}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      value={currentValue}
+      onKeyDown={blurOnEscape}
+      placeholder={placeholder}
+    />
+  );
 
-    return title != null ? (
-      <FastTooltip style={style} title={title}>
-        {input}
-      </FastTooltip>
-    ) : (
-      input
-    );
-  }
+  return title != null ? (
+    <FastTooltip style={style} title={title}>
+      {input}
+    </FastTooltip>
+  ) : (
+    input
+  );
 }
 
 export default InputComponent;


### PR DESCRIPTION
Converted several more React class-based components to functional components. Mostly from `/frontend/javascripts/viewer/view/components`.

- ButtonComponent, 
- CheckboxComponent
- EditableTextIcon
- EditableTextLabel
- InputComponent 

### Issues:
- Contributes to https://github.com/scalableminds/webknossos/issues/8747

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
