### PR TITLE
Refactor action bar components to functional components using hooks

### DIFF
--- a/frontend/javascripts/viewer/view/action-bar/dataset_position_view.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/dataset_position_view.tsx
@@ -2,29 +2,20 @@ import { PushpinOutlined, ReloadOutlined } from "@ant-design/icons";
 import { Space } from "antd";
 import FastTooltip from "components/fast_tooltip";
 import { V3 } from "libs/mjs";
+import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
 import { Vector3Input } from "libs/vector_input";
 import message from "messages";
 import type React from "react";
-import { PureComponent } from "react";
-import { connect } from "react-redux";
-import type { APIDataset } from "types/api_types";
-import type { Vector3, ViewMode } from "viewer/constants";
+import type { Vector3 } from "viewer/constants";
 import constants from "viewer/constants";
 import { getDatasetExtentInVoxel } from "viewer/model/accessors/dataset_accessor";
 import { getPosition, getRotation } from "viewer/model/accessors/flycam_accessor";
 import { setPositionAction, setRotationAction } from "viewer/model/actions/flycam_actions";
-import type { Flycam, Task, WebknossosState } from "viewer/store";
 import Store from "viewer/store";
 import { ShareButton } from "viewer/view/action-bar/share_modal_view";
 import ButtonComponent from "viewer/view/components/button_component";
 
-type Props = {
-  flycam: Flycam;
-  viewMode: ViewMode;
-  dataset: APIDataset;
-  task: Task | null | undefined;
-};
 const positionIconStyle: React.CSSProperties = {
   transform: "rotate(-45deg)",
   marginRight: 0,
@@ -42,29 +33,33 @@ const positionInputErrorStyle: React.CSSProperties = {
   ...warningColors,
 };
 
-class DatasetPositionView extends PureComponent<Props> {
-  copyPositionToClipboard = async () => {
-    const position = V3.floor(getPosition(this.props.flycam)).join(", ");
+function DatasetPositionView() {
+  const flycam = useWkSelector((state) => state.flycam);
+  const viewMode = useWkSelector((state) => state.temporaryConfiguration.viewMode);
+  const dataset = useWkSelector((state) => state.dataset);
+  const task = useWkSelector((state) => state.task);
+
+  const copyPositionToClipboard = async () => {
+    const position = V3.floor(getPosition(flycam)).join(", ");
     await navigator.clipboard.writeText(position);
     Toast.success("Position copied to clipboard");
   };
 
-  copyRotationToClipboard = async () => {
-    const rotation = V3.round(getRotation(this.props.flycam)).join(", ");
+  const copyRotationToClipboard = async () => {
+    const rotation = V3.round(getRotation(flycam)).join(", ");
     await navigator.clipboard.writeText(rotation);
     Toast.success("Rotation copied to clipboard");
   };
 
-  handleChangePosition = (position: Vector3) => {
+  const handleChangePosition = (position: Vector3) => {
     Store.dispatch(setPositionAction(position));
   };
 
-  handleChangeRotation = (rotation: Vector3) => {
+  const handleChangeRotation = (rotation: Vector3) => {
     Store.dispatch(setRotationAction(rotation));
   };
 
-  isPositionOutOfBounds = (position: Vector3) => {
-    const { dataset, task } = this.props;
+  const isPositionOutOfBounds = (position: Vector3) => {
     const { min: datasetMin, max: datasetMax } = getDatasetExtentInVoxel(dataset);
 
     const isPositionOutOfBounds = (min: Vector3, max: Vector3) =>
@@ -95,100 +90,87 @@ class DatasetPositionView extends PureComponent<Props> {
     };
   };
 
-  render() {
-    const position = V3.floor(getPosition(this.props.flycam));
-    const { isOutOfDatasetBounds, isOutOfTaskBounds } = this.isPositionOutOfBounds(position);
-    const iconColoringStyle = isOutOfDatasetBounds || isOutOfTaskBounds ? iconErrorStyle : {};
-    const positionInputStyle =
-      isOutOfDatasetBounds || isOutOfTaskBounds
-        ? positionInputErrorStyle
-        : positionInputDefaultStyle;
-    let maybeErrorMessage = null;
+  const position = V3.floor(getPosition(flycam));
+  const { isOutOfDatasetBounds, isOutOfTaskBounds } = isPositionOutOfBounds(position);
+  const iconColoringStyle = isOutOfDatasetBounds || isOutOfTaskBounds ? iconErrorStyle : {};
+  const positionInputStyle =
+    isOutOfDatasetBounds || isOutOfTaskBounds ? positionInputErrorStyle : positionInputDefaultStyle;
+  let maybeErrorMessage = null;
 
-    if (isOutOfDatasetBounds) {
-      maybeErrorMessage = message["tracing.out_of_dataset_bounds"];
-    } else if (!maybeErrorMessage && isOutOfTaskBounds) {
-      maybeErrorMessage = message["tracing.out_of_task_bounds"];
-    }
+  if (isOutOfDatasetBounds) {
+    maybeErrorMessage = message["tracing.out_of_dataset_bounds"];
+  } else if (!maybeErrorMessage && isOutOfTaskBounds) {
+    maybeErrorMessage = message["tracing.out_of_task_bounds"];
+  }
 
-    const rotation = V3.round(getRotation(this.props.flycam));
-    const isArbitraryMode = constants.MODES_ARBITRARY.includes(this.props.viewMode);
-    const positionView = (
-      <div
+  const rotation = V3.round(getRotation(flycam));
+  const isArbitraryMode = constants.MODES_ARBITRARY.includes(viewMode);
+  const positionView = (
+    <div
+      style={{
+        display: "flex",
+      }}
+    >
+      <Space.Compact
         style={{
-          display: "flex",
+          whiteSpace: "nowrap",
         }}
       >
+        <FastTooltip title={message["tracing.copy_position"]} placement="bottom-start">
+          <ButtonComponent
+            onClick={copyPositionToClipboard}
+            style={{ padding: "0 10px", ...iconColoringStyle }}
+            className="hide-on-small-screen"
+          >
+            <PushpinOutlined style={positionIconStyle} />
+          </ButtonComponent>
+        </FastTooltip>
+        <Vector3Input
+          value={position}
+          onChange={handleChangePosition}
+          autoSize
+          style={positionInputStyle}
+          allowDecimals
+        />
+        <ShareButton dataset={dataset} style={iconColoringStyle} />
+      </Space.Compact>
+      {isArbitraryMode ? (
         <Space.Compact
           style={{
             whiteSpace: "nowrap",
+            marginLeft: 10,
           }}
         >
-          <FastTooltip title={message["tracing.copy_position"]} placement="bottom-start">
+          <FastTooltip title={message["tracing.copy_rotation"]} placement="bottom-start">
             <ButtonComponent
-              onClick={this.copyPositionToClipboard}
-              style={{ padding: "0 10px", ...iconColoringStyle }}
+              onClick={copyRotationToClipboard}
+              style={{
+                padding: "0 10px",
+              }}
               className="hide-on-small-screen"
             >
-              <PushpinOutlined style={positionIconStyle} />
+              <ReloadOutlined />
             </ButtonComponent>
           </FastTooltip>
           <Vector3Input
-            value={position}
-            onChange={this.handleChangePosition}
-            autoSize
-            style={positionInputStyle}
+            value={rotation}
+            onChange={handleChangeRotation}
+            style={{
+              textAlign: "center",
+              width: 120,
+            }}
             allowDecimals
           />
-          <ShareButton dataset={this.props.dataset} style={iconColoringStyle} />
         </Space.Compact>
-        {isArbitraryMode ? (
-          <Space.Compact
-            style={{
-              whiteSpace: "nowrap",
-              marginLeft: 10,
-            }}
-          >
-            <FastTooltip title={message["tracing.copy_rotation"]} placement="bottom-start">
-              <ButtonComponent
-                onClick={this.copyRotationToClipboard}
-                style={{
-                  padding: "0 10px",
-                }}
-                className="hide-on-small-screen"
-              >
-                <ReloadOutlined />
-              </ButtonComponent>
-            </FastTooltip>
-            <Vector3Input
-              value={rotation}
-              onChange={this.handleChangeRotation}
-              style={{
-                textAlign: "center",
-                width: 120,
-              }}
-              allowDecimals
-            />
-          </Space.Compact>
-        ) : null}
-      </div>
-    );
-    return (
-      <FastTooltip title={maybeErrorMessage || null} wrapper="div">
-        {positionView}
-      </FastTooltip>
-    );
-  }
+      ) : null}
+    </div>
+  );
+
+  return (
+    <FastTooltip title={maybeErrorMessage || null} wrapper="div">
+      {positionView}
+    </FastTooltip>
+  );
 }
 
-function mapStateToProps(state: WebknossosState): Props {
-  return {
-    flycam: state.flycam,
-    viewMode: state.temporaryConfiguration.viewMode,
-    dataset: state.dataset,
-    task: state.task,
-  };
-}
-
-const connector = connect(mapStateToProps);
-export default connector(DatasetPositionView);
+export default DatasetPositionView;

--- a/frontend/javascripts/viewer/view/action-bar/view_modes_view.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/view_modes_view.tsx
@@ -1,27 +1,17 @@
 import { Button, Dropdown, type MenuProps, Space } from "antd";
 import * as Utils from "libs/utils";
-import { PureComponent } from "react";
-import { connect } from "react-redux";
-import type { Dispatch } from "redux";
-import type { EmptyObject } from "types/globals";
+import { useCallback } from "react";
+
+import { useWkSelector } from "libs/react_hooks";
+import { useDispatch } from "react-redux";
 import { type ViewMode, ViewModeValues } from "viewer/constants";
 import constants from "viewer/constants";
 import {
   setFlightmodeRecordingAction,
   setViewModeAction,
 } from "viewer/model/actions/settings_actions";
-import type { AllowedMode, WebknossosState } from "viewer/store";
 import Store from "viewer/store";
 import { NARROW_BUTTON_STYLE } from "./tools/tool_helpers";
-
-type StateProps = {
-  viewMode: ViewMode;
-  allowedModes: Array<AllowedMode>;
-};
-type DispatchProps = {
-  onChangeFlightmodeRecording: (arg0: boolean) => void;
-};
-type Props = StateProps & DispatchProps;
 
 const VIEW_MODE_TO_ICON = {
   [constants.MODE_PLANE_TRACING]: <i className="fas fa-th-large" />,
@@ -31,8 +21,19 @@ const VIEW_MODE_TO_ICON = {
   ),
 };
 
-class ViewModesView extends PureComponent<Props, EmptyObject> {
-  handleChange: MenuProps["onClick"] = (args) => {
+function ViewModesView() {
+  const viewMode = useWkSelector((state) => state.temporaryConfiguration.viewMode);
+  const allowedModes = useWkSelector((state) => state.annotation.restrictions.allowedModes);
+  const dispatch = useDispatch();
+
+  const onChangeFlightmodeRecording = useCallback(
+    (value: boolean) => {
+      dispatch(setFlightmodeRecordingAction(value));
+    },
+    [dispatch],
+  );
+
+  const handleChange: MenuProps["onClick"] = (args) => {
     if (!ViewModeValues.includes(args.key as ViewMode)) {
       return;
     }
@@ -40,11 +41,8 @@ class ViewModesView extends PureComponent<Props, EmptyObject> {
     // If we switch back from any arbitrary mode we stop recording.
     // This prevents that when the user switches back to any arbitrary mode,
     // a new node is instantly created at the screen's center.
-    if (
-      constants.MODES_ARBITRARY.includes(this.props.viewMode) &&
-      mode === constants.MODE_PLANE_TRACING
-    ) {
-      this.props.onChangeFlightmodeRecording(false);
+    if (constants.MODES_ARBITRARY.includes(viewMode) && mode === constants.MODE_PLANE_TRACING) {
+      onChangeFlightmodeRecording(false);
     }
 
     Store.dispatch(setViewModeAction(mode));
@@ -52,52 +50,36 @@ class ViewModesView extends PureComponent<Props, EmptyObject> {
     args.domEvent.target.blur();
   };
 
-  isDisabled(mode: ViewMode) {
-    return !this.props.allowedModes.includes(mode);
-  }
-
-  render() {
-    const MENU_ITEMS: MenuProps["items"] = [
-      {
-        key: "1",
-        type: "group",
-        label: "Select View Mode",
-        children: ViewModeValues.map((mode) => ({
-          label: Utils.capitalize(mode),
-          key: mode,
-          disabled: this.isDisabled(mode),
-          icon: <span style={{ marginRight: 8 }}>{VIEW_MODE_TO_ICON[mode]}</span>,
-        })),
-      },
-    ];
-
-    const menuProps = {
-      items: MENU_ITEMS,
-      onClick: this.handleChange,
-    };
-
-    return (
-      <Dropdown menu={menuProps}>
-        <Button style={NARROW_BUTTON_STYLE}>
-          <Space>{VIEW_MODE_TO_ICON[this.props.viewMode]}</Space>
-        </Button>
-      </Dropdown>
-    );
-  }
-}
-
-const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
-  onChangeFlightmodeRecording(value: boolean) {
-    dispatch(setFlightmodeRecordingAction(value));
-  },
-});
-
-function mapStateToProps(state: WebknossosState): StateProps {
-  return {
-    viewMode: state.temporaryConfiguration.viewMode,
-    allowedModes: state.annotation.restrictions.allowedModes,
+  const isDisabled = (mode: ViewMode) => {
+    return !allowedModes.includes(mode);
   };
+
+  const MENU_ITEMS: MenuProps["items"] = [
+    {
+      key: "1",
+      type: "group",
+      label: "Select View Mode",
+      children: ViewModeValues.map((mode) => ({
+        label: Utils.capitalize(mode),
+        key: mode,
+        disabled: isDisabled(mode),
+        icon: <span style={{ marginRight: 8 }}>{VIEW_MODE_TO_ICON[mode]}</span>,
+      })),
+    },
+  ];
+
+  const menuProps = {
+    items: MENU_ITEMS,
+    onClick: handleChange,
+  };
+
+  return (
+    <Dropdown menu={menuProps}>
+      <Button style={NARROW_BUTTON_STYLE}>
+        <Space>{VIEW_MODE_TO_ICON[viewMode]}</Space>
+      </Button>
+    </Dropdown>
+  );
 }
 
-const connector = connect(mapStateToProps, mapDispatchToProps);
-export default connector(ViewModesView);
+export default ViewModesView;


### PR DESCRIPTION
This PR converts several class components in the action bar to React functional components.

The following components were refactored:
- DatasetPositionView
- SaveButton
- TracingActionsView
- ViewModesView

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Check that action bar components still do their job

### Issues:
- Contributes to #8747

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
