### PR TITLE
Guard against failing agglomerate requests

### DIFF
--- a/frontend/javascripts/admin/rest_api.ts
+++ b/frontend/javascripts/admin/rest_api.ts
@@ -2047,7 +2047,7 @@ export async function getAgglomeratesForSegmentsFromTracingstore<T extends numbe
     params.set("token", token);
     return Utils.retryAsyncFunction(() => {
       counter++;
-      const brokenSuffix = counter % 2 === 1 ? "broken" : "broken2";
+      const brokenSuffix = counter % 2 === 1 || "alwaysFail" in window ? "broken" : "";
       console.log("brokenSuffix", brokenSuffix);
       return Request.receiveArraybuffer(
         `${tracingStoreUrl}/tracings/mapping/${tracingId}/agglomeratesForSegments${brokenSuffix}?${params}`,

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -1391,3 +1391,24 @@ export const ColoredLogger = {
     console.log(chalk.bgBlue(str), ...args);
   },
 };
+
+export async function retryAsyncFunction<T>(
+  fn: () => Promise<T>,
+  retryCount: number = 3, // 0 retries would only do 1 attempt
+  exponentialDelayFactor: number = 1000,
+): Promise<T> {
+  let currentAttempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (exception) {
+      if (currentAttempt === retryCount) {
+        throw exception;
+      } else {
+        console.warn("Failed to run async function due to", exception, ". Will retry now.");
+      }
+      currentAttempt++;
+      await sleep(exponentialDelayFactor * 2 ** currentAttempt);
+    }
+  }
+}

--- a/frontend/javascripts/viewer/model/sagas/volume/mapping_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/volume/mapping_saga.ts
@@ -477,24 +477,33 @@ export function* updateLocalHdf5Mapping(
     intersection: mutableRemainingEntries,
   } = fastDiffSetAndMap(segmentIds as Set<NumberLike>, previousMapping);
 
-  const newEntries =
-    editableMapping != null
-      ? yield* call(
-          getAgglomeratesForSegmentsFromTracingstore,
-          annotation.tracingStore.url,
-          editableMapping.tracingId,
-          Array.from(newSegmentIds),
-          annotation.annotationId,
-          annotation.version,
-        )
-      : yield* call(
-          getAgglomeratesForSegmentsFromDatastore,
-          dataset.dataStore.url,
-          dataset,
-          mappingLayerName,
-          mappingName,
-          Array.from(newSegmentIds),
-        );
+  let newEntries;
+  try {
+    newEntries =
+      editableMapping != null
+        ? yield* call(
+            getAgglomeratesForSegmentsFromTracingstore,
+            annotation.tracingStore.url,
+            editableMapping.tracingId,
+            Array.from(newSegmentIds),
+            annotation.annotationId,
+            annotation.version,
+          )
+        : yield* call(
+            getAgglomeratesForSegmentsFromDatastore,
+            dataset.dataStore.url,
+            dataset,
+            mappingLayerName,
+            mappingName,
+            Array.from(newSegmentIds),
+          );
+  } catch (exception) {
+    console.error("Could not load agglomerate ids for segments due to", exception);
+    Toast.error(
+      "Could not load agglomerate ids for segments. Some segments will remain hidden for now.",
+    );
+    return;
+  }
 
   // It is safe to mutate mutableRemainingEntries to compute the merged,
   // new mapping. See the definition of mutableRemainingEntries.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create an annotation for a ds with an agglomerate file
- enable a hdf5 mapping
- switch to proofreading tool
- every second request should fail (see network tab)
- the user shouldn't notice this (except for the delay)
- set  `window.alwaysFail = true` <-- every request should fail <-- the mapping saga should not crash

### Issues:
- contributes to #8715 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
