### PR TITLE
Do not fetch connectome file list for volume layer without fallback

### DIFF
--- a/frontend/javascripts/viewer/view/right-border-tabs/connectome_tab/connectome_settings.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/connectome_tab/connectome_settings.tsx
@@ -7,6 +7,7 @@ import { connect } from "react-redux";
 import type { APIConnectomeFile, APIDataset, APISegmentationLayer } from "types/api_types";
 import { userSettings } from "types/schemas/user_settings.schema";
 import defaultState from "viewer/default_state";
+import { isTracingLayerWithoutFallback } from "viewer/model/accessors/volumetracing_accessor";
 import {
   updateConnectomeFileListAction,
   updateCurrentConnectomeFileAction,
@@ -67,7 +68,12 @@ class ConnectomeFilters extends React.Component<Props> {
       pendingConnectomeFileName,
     } = this.props;
     // If availableConnectomeFiles is not null, they have already been fetched
-    if (segmentationLayer == null || availableConnectomeFiles != null) return;
+    if (
+      segmentationLayer == null ||
+      isTracingLayerWithoutFallback(segmentationLayer) ||
+      availableConnectomeFiles != null
+    )
+      return;
     const connectomeFiles = await getConnectomeFilesForDatasetLayer(
       dataset.dataStore.url,
       dataset,

--- a/unreleased_changes/8768.md
+++ b/unreleased_changes/8768.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where WEBKNOSSOS would show an error toast for volume annotations that have no fallback segmentation layer.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://noconnectomesforbarevolumelayer.webknossos.xyz

### Steps to test:
- Open a volume annotation with no fallback segmentation layer
- No error toast saying “DataLayer x not found” should show

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1751993085147359?thread_ts=1751993051.004949&cid=C02H5T8Q08P

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
