### PR TITLE
Fix broken node selection in 3d viewport when continuous drawing is enabled

### DIFF
--- a/frontend/javascripts/viewer/controller/td_controller.tsx
+++ b/frontend/javascripts/viewer/controller/td_controller.tsx
@@ -77,6 +77,7 @@ function getTDViewMouseControlsSkeleton(planeView: PlaneView): Record<string, an
             event.ctrlKey || event.metaKey,
             OrthoViews.TDView,
             isTouch,
+            false,
           ),
   };
 }

--- a/unreleased_changes/8769.md
+++ b/unreleased_changes/8769.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed broken node selection in 3d viewport when continuous drawing was enabled in skeleton tool.


### PR DESCRIPTION
Fix broken node selection in 3d viewport when continuous drawing is enabled in skeleton tool

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- enable skeleton tool and the "pen" mode (continuous drawing)
- create nodes
- select them in the 3d viewport

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1751972807910599

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
