### PR TITLE
In agglomerate mesh loading, skip missing segments

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/MeshFileUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/MeshFileUtils.scala
@@ -1,6 +1,8 @@
 package com.scalableminds.webknossos.datastore.services.mesh
 
-trait MeshFileUtils {
+import com.typesafe.scalalogging.LazyLogging
+
+trait MeshFileUtils extends LazyLogging {
 
   protected val keyBucketOffsets = "bucket_offsets"
   protected val keyBuckets = "buckets"


### PR DESCRIPTION
In the hdf5 variant there was already a flatMap there, dropping non-full boxes. Let’s do the same in zarr case.

### Steps to test:
- Load a an agglomerate mesh where you know a segment is not present in the meshfile
- Should still load

### Issues:
- fixes #8763

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
