### PR TITLE
Allow guest users from trial orgas

### DIFF
--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -91,7 +91,7 @@ case class UserCompactInfo(
 
 class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
     extends SQLDAO[User, UsersRow, Users](sqlClient) {
-private val PricingPlansAllowingGuestsSql = q"""(${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom}, ${PricingPlan.Team_Trial}, ${PricingPlan.Power_Trial})"""
+private val PricingPlansAllowingGuestsQuery = q"""(${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom}, ${PricingPlan.Team_Trial}, ${PricingPlan.Power_Trial})"""
   protected val collection = Users
 
   protected def idColumn(x: Users): Rep[String] = x._Id

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -91,6 +91,7 @@ case class UserCompactInfo(
 
 class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
     extends SQLDAO[User, UsersRow, Users](sqlClient) {
+private val PricingPlansAllowingGuestsSql = q"""(${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom}, ${PricingPlan.Team_Trial}, ${PricingPlan.Power_Trial})"""
   protected val collection = Users
 
   protected def idColumn(x: Users): Rep[String] = x._Id
@@ -217,7 +218,7 @@ class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
               AND _organization IN (
                 SELECT _id
                 FROM webknossos.organizations
-                WHERE pricingPlan IN ('Team', 'Power', 'Custom')
+                WHERE pricingPlan IN $PricingPlansAllowingGuestsSql
               )
             ORDER BY _multiUser, created ASC
          )
@@ -403,7 +404,7 @@ class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
                       AND NOT isDeactivated
                       AND _organization IN (
                         SELECT _id FROM webknossos.organizations
-                        WHERE pricingPlan IN (${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom}, ${PricingPlan.Team_Trial}, ${PricingPlan.Power_Trial})
+                        WHERE pricingPlan IN $PricingPlansAllowingGuestsSql
                       )
                       ORDER BY created ASC
                       LIMIT 1""".as[ObjectId])

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -403,7 +403,7 @@ class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
                       AND NOT isDeactivated
                       AND _organization IN (
                         SELECT _id FROM webknossos.organizations
-                        WHERE pricingPlan IN (${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom})
+                        WHERE pricingPlan IN (${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom}, ${PricingPlan.Team_Trial}, ${PricingPlan.Power_Trial})
                       )
                       ORDER BY created ASC
                       LIMIT 1""".as[ObjectId])

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -219,7 +219,7 @@ class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
               AND _organization IN (
                 SELECT _id
                 FROM webknossos.organizations
-                WHERE pricingPlan IN $PricingPlansAllowingGuestsSql
+                WHERE pricingPlan IN $PricingPlansAllowingGuestsQuery
               )
             ORDER BY _multiUser, created ASC
          )
@@ -405,7 +405,7 @@ class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
                       AND NOT isDeactivated
                       AND _organization IN (
                         SELECT _id FROM webknossos.organizations
-                        WHERE pricingPlan IN $PricingPlansAllowingGuestsSql
+                        WHERE pricingPlan IN $PricingPlansAllowingGuestsQuery
                       )
                       ORDER BY created ASC
                       LIMIT 1""".as[ObjectId])

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -91,7 +91,8 @@ case class UserCompactInfo(
 
 class UserDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionContext)
     extends SQLDAO[User, UsersRow, Users](sqlClient) {
-private val PricingPlansAllowingGuestsQuery = q"""(${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom}, ${PricingPlan.Team_Trial}, ${PricingPlan.Power_Trial})"""
+  private val PricingPlansAllowingGuestsQuery =
+    q"""(${PricingPlan.Team}, ${PricingPlan.Power}, ${PricingPlan.Custom}, ${PricingPlan.Team_Trial}, ${PricingPlan.Power_Trial})"""
   protected val collection = Users
 
   protected def idColumn(x: Users): Rep[String] = x._Id

--- a/unreleased_changes/8772.md
+++ b/unreleased_changes/8772.md
@@ -1,0 +1,2 @@
+### Changed
+- Users of organizations with a trial pricing plan can now join other organizations as guests.


### PR DESCRIPTION
Adds orgas with a trial plan to orgas that pay for their users, meaning they can become guests in other orgas. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I suggest manually testing. But I already did this, and as it is quite the hassle, I'd say no additional testing is needed

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1752133546847139

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
