### PR TITLE
Support non-WKW layers for linking upon upload

### DIFF
--- a/unreleased_changes/8773.md
+++ b/unreleased_changes/8773.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed layer linking to support non-WKW layers.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
@@ -4,8 +4,9 @@ import com.google.inject.Inject
 import com.scalableminds.util.io.PathUtils.ensureDirectoryBox
 import com.scalableminds.util.io.{PathUtils, ZipIO}
 import com.scalableminds.util.objectid.ObjectId
-import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
-import com.scalableminds.webknossos.datastore.dataformats.layers.{WKWDataLayer, WKWSegmentationLayer}
+import com.scalableminds.util.tools.Box.tryo
+import com.scalableminds.util.tools._
+import com.scalableminds.webknossos.datastore.dataformats.layers._
 import com.scalableminds.webknossos.datastore.dataformats.wkw.WKWDataFormatHelper
 import com.scalableminds.webknossos.datastore.datareaders.n5.N5Header.FILENAME_ATTRIBUTES_JSON
 import com.scalableminds.webknossos.datastore.datareaders.n5.{N5Header, N5Metadata}
@@ -24,8 +25,6 @@ import com.scalableminds.webknossos.datastore.services.{
 }
 import com.scalableminds.webknossos.datastore.storage.DataStoreRedisStore
 import com.typesafe.scalalogging.LazyLogging
-import com.scalableminds.util.tools.Box.tryo
-import com.scalableminds.util.tools._
 import org.apache.commons.io.FileUtils
 import play.api.libs.json.{Json, OFormat, Reads}
 
@@ -507,9 +506,17 @@ class UploadService @Inject()(dataSourceRepository: DataSourceRepository,
       layer: DataLayer <- usableDataSource.getDataLayer(layerIdentifier.layerName).toFox
       newName = layerIdentifier.newLayerName.getOrElse(layerIdentifier.layerName)
       layerRenamed: DataLayer <- layer match {
-        case l: WKWSegmentationLayer => Fox.successful(l.copy(name = newName))
-        case l: WKWDataLayer         => Fox.successful(l.copy(name = newName))
-        case _                       => Fox.failure("Unknown layer type for link")
+        case l: N5DataLayer                  => Fox.successful(l.copy(name = newName))
+        case l: N5SegmentationLayer          => Fox.successful(l.copy(name = newName))
+        case l: PrecomputedDataLayer         => Fox.successful(l.copy(name = newName))
+        case l: PrecomputedSegmentationLayer => Fox.successful(l.copy(name = newName))
+        case l: Zarr3DataLayer               => Fox.successful(l.copy(name = newName))
+        case l: Zarr3SegmentationLayer       => Fox.successful(l.copy(name = newName))
+        case l: ZarrDataLayer                => Fox.successful(l.copy(name = newName))
+        case l: ZarrSegmentationLayer        => Fox.successful(l.copy(name = newName))
+        case l: WKWDataLayer                 => Fox.successful(l.copy(name = newName))
+        case l: WKWSegmentationLayer         => Fox.successful(l.copy(name = newName))
+        case _                               => Fox.failure("Unknown layer type for link")
       }
     } yield layerRenamed
   }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- Support non-WKW layers for linking upon upload

### Steps to test:
```
import webknossos as wk
import numpy as np

ds = wk.Dataset("test", (1,1,1))
ds.write_layer("raw", wk.COLOR_CATEGORY, data=np.zeros((2,2)))
ds.upload(layers_to_link=[wk.Dataset.open_remote("http://localhost:9000/datasets/l4_sample").get_layer("color")]
```
------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)