### PR TITLE
format the credits in orga view

### DIFF
--- a/frontend/javascripts/admin/organization/organization_overview_view.tsx
+++ b/frontend/javascripts/admin/organization/organization_overview_view.tsx
@@ -2,7 +2,7 @@ import { PlusOutlined } from "@ant-design/icons";
 import { SettingsTitle } from "admin/account/helpers/settings_title";
 import { getPricingPlanStatus, getUsers, updateOrganization } from "admin/rest_api";
 import { Button, Col, Row, Spin, Tooltip, Typography } from "antd";
-import { formatCountToDataAmountUnit } from "libs/format_utils";
+import { formatCountToDataAmountUnit, formatCreditsString } from "libs/format_utils";
 import Toast from "libs/toast";
 import { useEffect, useState } from "react";
 import type { APIOrganization, APIPricingPlanStatus } from "types/api_types";
@@ -159,7 +159,7 @@ export function OrganizationOverviewView({ organization }: { organization: APIOr
     {
       key: "credits",
       title: "WEBKNOSSOS Credits",
-      value: organization.creditBalance || "N/A",
+      value: formatCreditsString(organization.creditBalance || "N/A"),
       action: buyMoreCreditsAction,
     },
   ];


### PR DESCRIPTION
This PR add formatting for the displayed credits in the organization page again. 

### Issues:
- Fixes a regression from #8679

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
