### PR TITLE
Only use d/f switching / dynamic space direction for d/f

### DIFF
--- a/frontend/javascripts/test/reducers/flycam_reducer.spec.ts
+++ b/frontend/javascripts/test/reducers/flycam_reducer.spec.ts
@@ -163,9 +163,18 @@ describe("Flycam", () => {
     let newState = FlycamReducer(initialState, FlycamActions.setDirectionAction([0, 0, -2]));
     newState = FlycamReducer(
       newState,
-      FlycamActions.moveFlycamOrthoAction([2, 0, 2], OrthoViews.PLANE_XY),
+      FlycamActions.moveFlycamOrthoAction([2, 0, 2], OrthoViews.PLANE_XY, true),
     );
     equalWithEpsilon(getPosition(newState.flycam), [2, 0, -2]);
+  });
+
+  it("should move not in ortho mode with dynamicSpaceDirection if action does not explicity say so", () => {
+    let newState = FlycamReducer(initialState, FlycamActions.setDirectionAction([0, 0, -2]));
+    newState = FlycamReducer(
+      newState,
+      FlycamActions.moveFlycamOrthoAction([2, 0, 2], OrthoViews.PLANE_XY),
+    );
+    equalWithEpsilon(getPosition(newState.flycam), [2, 0, 2]);
   });
 
   it("should move by plane in ortho mode (1/3)", () => {
@@ -202,9 +211,18 @@ describe("Flycam", () => {
     let newState = FlycamReducer(initialState, FlycamActions.setDirectionAction([0, 0, -2]));
     newState = FlycamReducer(
       newState,
-      FlycamActions.movePlaneFlycamOrthoAction([0, 0, 2], OrthoViews.PLANE_XY, true),
+      FlycamActions.movePlaneFlycamOrthoAction([0, 0, 2], OrthoViews.PLANE_XY, true, true),
     );
     equalWithEpsilon(getPosition(newState.flycam), [0, 0, -2]);
+  });
+
+  it("should not move by plane in ortho mode with dynamicSpaceDirection if action does not explicity say so", () => {
+    let newState = FlycamReducer(initialState, FlycamActions.setDirectionAction([0, 0, -2]));
+    newState = FlycamReducer(
+      newState,
+      FlycamActions.movePlaneFlycamOrthoAction([0, 0, 2], OrthoViews.PLANE_XY, true),
+    );
+    equalWithEpsilon(getPosition(newState.flycam), [0, 0, 2]);
   });
 
   it("should not change additional coordinates value when layers don't have any", () => {

--- a/frontend/javascripts/viewer/controller/combinations/move_handlers.ts
+++ b/frontend/javascripts/viewer/controller/combinations/move_handlers.ts
@@ -36,7 +36,11 @@ export const moveU = (deltaU: number): void => {
 export const moveV = (deltaV: number): void => {
   movePlane([0, deltaV, 0]);
 };
-export const moveW = (deltaW: number, oneSlide: boolean): void => {
+export const moveW = (
+  deltaW: number,
+  oneSlide: boolean,
+  useDynamicSpaceDirection: boolean,
+): void => {
   const state = Store.getState();
   if (is2dDataset(state.dataset)) {
     return;
@@ -58,10 +62,13 @@ export const moveW = (deltaW: number, oneSlide: boolean): void => {
       moveFlycamOrthoAction(
         Dimensions.transDim([0, 0, Math.sign(deltaW) * Math.max(1, wStep)], activeViewport),
         activeViewport,
+        useDynamicSpaceDirection,
       ),
     );
   } else {
-    Store.dispatch(movePlaneFlycamOrthoAction([0, 0, deltaW], activeViewport, false));
+    Store.dispatch(
+      movePlaneFlycamOrthoAction([0, 0, deltaW], activeViewport, false, useDynamicSpaceDirection),
+    );
   }
 };
 export function moveWhenAltIsPressed(delta: Point2, position: Point2, _id: any, event: MouseEvent) {

--- a/frontend/javascripts/viewer/controller/combinations/move_handlers.ts
+++ b/frontend/javascripts/viewer/controller/combinations/move_handlers.ts
@@ -39,7 +39,7 @@ export const moveV = (deltaV: number): void => {
 export const moveW = (
   deltaW: number,
   oneSlide: boolean,
-  useDynamicSpaceDirection: boolean,
+  useDynamicSpaceDirection: boolean = false,
 ): void => {
   const state = Store.getState();
   if (is2dDataset(state.dataset)) {

--- a/frontend/javascripts/viewer/controller/viewmodes/plane_controller.tsx
+++ b/frontend/javascripts/viewer/controller/viewmodes/plane_controller.tsx
@@ -220,11 +220,18 @@ class BoundingBoxKeybindings {
   }
 }
 
-function createDelayAwareMoveHandler(multiplier: number) {
+function createDelayAwareMoveHandler(
+  multiplier: number,
+  useDynamicSpaceDirection: boolean = false,
+) {
   // The multiplier can be used for inverting the direction as well as for
   // speeding up the movement as it's done for shift+f, for example.
   const fn = (timeFactor: number, first: boolean) =>
-    MoveHandlers.moveW(getMoveOffset(Store.getState(), timeFactor) * multiplier, first);
+    MoveHandlers.moveW(
+      getMoveOffset(Store.getState(), timeFactor) * multiplier,
+      first,
+      useDynamicSpaceDirection,
+    );
 
   fn.customAdditionalDelayFn = () => {
     // Depending on the float fraction of the current position, we want to
@@ -251,7 +258,7 @@ function createDelayAwareMoveHandler(multiplier: number) {
     const voxelPerSecond =
       state.userConfiguration.moveValue / state.dataset.dataSource.scale.factor[thirdDim];
 
-    if (state.userConfiguration.dynamicSpaceDirection) {
+    if (state.userConfiguration.dynamicSpaceDirection && useDynamicSpaceDirection) {
       // Change direction of the value connected to space, based on the last direction
       direction *= state.flycam.spaceDirectionOrtho[thirdDim];
     }
@@ -441,15 +448,15 @@ class PlaneController extends React.PureComponent<Props> {
         // KeyboardJS is sensitive to ordering (complex combos first)
         "shift + i": () => VolumeHandlers.changeBrushSizeIfBrushIsActiveBy(-1),
         "shift + o": () => VolumeHandlers.changeBrushSizeIfBrushIsActiveBy(1),
-        "shift + f": createDelayAwareMoveHandler(5),
-        "shift + d": createDelayAwareMoveHandler(-5),
+        "shift + f": createDelayAwareMoveHandler(5, true),
+        "shift + d": createDelayAwareMoveHandler(-5, true),
         "shift + space": createDelayAwareMoveHandler(-1),
         "ctrl + space": createDelayAwareMoveHandler(-1),
         enter: () => Store.dispatch(enterAction()),
         esc: () => Store.dispatch(escapeAction()),
         space: createDelayAwareMoveHandler(1),
-        f: createDelayAwareMoveHandler(1),
-        d: createDelayAwareMoveHandler(-1),
+        f: createDelayAwareMoveHandler(1, true),
+        d: createDelayAwareMoveHandler(-1, true),
         // Zoom in/out
         i: () => MoveHandlers.zoom(1, false),
         o: () => MoveHandlers.zoom(-1, false),

--- a/frontend/javascripts/viewer/model/actions/flycam_actions.ts
+++ b/frontend/javascripts/viewer/model/actions/flycam_actions.ts
@@ -101,23 +101,30 @@ export const setDirectionAction = (direction: Vector3) =>
     direction,
   }) as const;
 
-export const moveFlycamOrthoAction = (vector: Vector3, planeId: OrthoView | null | undefined) =>
+export const moveFlycamOrthoAction = (
+  vector: Vector3,
+  planeId: OrthoView | null | undefined,
+  useDynamicSpaceDirection: boolean = false,
+) =>
   ({
     type: "MOVE_FLYCAM_ORTHO",
     vector,
     planeId,
+    useDynamicSpaceDirection,
   }) as const;
 
 export const movePlaneFlycamOrthoAction = (
   vector: Vector3,
   planeId: OrthoView,
   increaseSpeedWithZoom: boolean = true,
+  useDynamicSpaceDirection: boolean = false,
 ) =>
   ({
     type: "MOVE_PLANE_FLYCAM_ORTHO",
     vector,
     planeId,
     increaseSpeedWithZoom,
+    useDynamicSpaceDirection,
   }) as const;
 
 export const moveFlycamAction = (vector: Vector3) =>

--- a/frontend/javascripts/viewer/model/reducers/flycam_reducer.ts
+++ b/frontend/javascripts/viewer/model/reducers/flycam_reducer.ts
@@ -336,7 +336,11 @@ function FlycamReducer(state: WebknossosState, action: Action): WebknossosState 
         .toArray();
 
       // if planeID is given, use it to manipulate z
-      if (planeId != null && state.userConfiguration.dynamicSpaceDirection) {
+      if (
+        planeId != null &&
+        state.userConfiguration.dynamicSpaceDirection &&
+        action.useDynamicSpaceDirection
+      ) {
         // change direction of the value connected to space, based on the last direction
         deltaInWorldV3 = V3.multiply(deltaInWorldV3, state.flycam.spaceDirectionOrtho);
       }
@@ -363,8 +367,12 @@ function FlycamReducer(state: WebknossosState, action: Action): WebknossosState 
           scaleFactor,
         );
 
-        if (planeId != null && state.userConfiguration.dynamicSpaceDirection) {
-          // change direction of the value connected to space, based on the last direction
+        if (
+          planeId != null &&
+          state.userConfiguration.dynamicSpaceDirection &&
+          action.useDynamicSpaceDirection
+        ) {
+          // Change direction of the value connected to space, based on the last direction
           deltaInWorldZoomed = V3.multiply(deltaInWorldZoomed, state.flycam.spaceDirectionOrtho);
         }
 

--- a/unreleased_changes/8786.md
+++ b/unreleased_changes/8786.md
@@ -1,2 +1,2 @@
 ### Changed
-- Change that the d/f switching setting no longer affects movements other than moving via the d/f keyboard shortcuts.
+- Changed that the d/f switching setting no longer affects movements other than moving via the d/f keyboard shortcuts.

--- a/unreleased_changes/8786.md
+++ b/unreleased_changes/8786.md
@@ -1,0 +1,2 @@
+### Changed
+- Change that the d/f switching setting no longer affects movements other than moving via the d/f keyboard shortcuts.


### PR DESCRIPTION
The d/f switching / dynamic space direction got wonky since rotating the viewports is allowed (see #8614). It impacted the moving via alt+mouse to move in wrong directions. Therefore, this PR disables the dynamic space direction to be only used / applied when using the acutal d/f short cuts. The other possibilities should not be affected by d/f switching anymore.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- do the same on master as well as on this branch
- Open an annotation.
- Brush in z layer X
- Brush in z layer x-5 or so (should be smaller than before, to cause the "flipping")
- Turn on d/f switching in the left settings drawer
- move via alt + mouse. On master this should not move as expected. On this branch, this should be fixed


### Issues:
- verbally reported bug

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
