### PR TITLE
Fix integer overflow in zarr chunk index computation

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/wkw/WKWArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/wkw/WKWArray.scala
@@ -131,6 +131,6 @@ class WKWArray(vaultPath: VaultPath,
       header.datasetShape.map(fullAxisOrder.permuteIndicesArrayToWkLong),
       fullAxisOrder.permuteIndicesArrayToWk(header.shardShape),
       header.chunkShape,
-      chunkIndex.zip(header.chunkShape).map { case (i, s) => i * s }
+      chunkIndex.zip(header.chunkShape).map { case (i, s) => i.toLong * s }
     )
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
@@ -165,7 +165,7 @@ class Zarr3Array(vaultPath: VaultPath,
       header.datasetShape,
       header.outerChunkShape,
       header.chunkShape,
-      chunkIndex.zip(header.chunkShape).map { case (i, s) => i * s }
+      chunkIndex.zip(header.chunkShape).map { case (i, s) => i.toLong * s }
     )
 
   override protected def getShardedChunkPathAndRange(


### PR DESCRIPTION
Had a 1D zarr3 array with shape [2821863639] and shard shape [536870912]. This lead to an int overflow when multiplying chunkIndex with chunkShape to compute the shard index from chunk index.

### Steps to test:
- Should now be able to load full mesh from that particular dataset. (I tested locally)

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1753345422073889

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
