### PR TITLE
When determining mag realpaths, treat schemeless uris as local

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceService.scala
@@ -138,7 +138,7 @@ class DataSourceService @Inject()(
     if (isRemote) {
       MagPathInfo(dataLayer.name, mag.mag, magURI.toString, magURI.toString, hasLocalData = false)
     } else {
-      val magPath = Path.of(magURI)
+      val magPath = Path.of(magURI.getPath)
       val realPath = magPath.toRealPath()
       // Does this dataset have local data, i.e. the data that is referenced by the mag path is within the dataset directory
       val isLocal = realPath.startsWith(datasetPath.toAbsolutePath)
@@ -159,7 +159,7 @@ class DataSourceService @Inject()(
       layerPath.getFileName.toString,
       mag
     )
-    (uri, DataVaultService.isRemoteScheme(uri.getScheme))
+    (uri, uri.getScheme != null && DataVaultService.isRemoteScheme(uri.getScheme))
   }
 
   private def resolveRelativePath(basePath: Path, relativePath: Path): Path =


### PR DESCRIPTION
Path.of fails for URIs without scheme. We want to assume local files in this case.

I don’t like that this is encoded with null and we need to check this in so many places. Refactoring issue for that: https://github.com/scalableminds/webknossos/issues/8762

### Steps to test:
- In a datasource-properties.json, add a mag with a path that is absolute and inside of the organization dir.
- Dataset scanning should not report `Failed to determine real paths of mags of <ds>`. Realpaths should be set correctly in the DB.

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
