### PR TITLE
Add link to avatar dropdown to link to email change view

### DIFF
--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -617,6 +617,10 @@ function LoggedInAvatar({
               type: "divider",
             },
             {
+              key: "changeEmail",
+              label: <Link to="/auth/changeEmail">Change Email</Link>,
+            },
+            {
               key: "account",
               label: <Link to="/account">Account Settings</Link>,
             },

--- a/unreleased_changes/8806.md
+++ b/unreleased_changes/8806.md
@@ -1,0 +1,2 @@
+### Fixed
+- The view to change ones email address is now available in the top right dropdown menu of the navbar.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open the avatar dropdown in the navbar. Should link to the change email view

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1753718354858849?thread_ts=1752504188.608299&cid=C5AKLAV0B

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
