### PR TITLE
Pass annotationId to create animation job mesh parameters

### DIFF
--- a/frontend/javascripts/viewer/view/action-bar/create_animation_modal.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/create_animation_modal.tsx
@@ -267,6 +267,7 @@ function CreateAnimationModal(props: Props) {
           return {
             layerName: fullLayerName,
             tracingId: layer.tracingId || null,
+            annotationId: state.annotation?.annotationId || null,
             adhocMag,
             color: segmentColorRGBA,
             ...meshInfo,


### PR DESCRIPTION
When adapting the worker to use the new libs functions, this is called on an wk.RemoteAnnotation object, which can only be opened with the annotationId.

Prerequisite for https://github.com/scalableminds/voxelytics/pull/4239 (deploying the wk side first shouldn’t hurt)