### PR TITLE
Fix reading hdf5 attachments with absolute paths without scheme file://

### DIFF
--- a/unreleased_changes/8832.md
+++ b/unreleased_changes/8832.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where hdf5 attachments explicitly mentioned in the datasource-properties.json would not be readable if they have an absolute path but no `file://` prefix.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DatasetLayerAttachments.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DatasetLayerAttachments.scala
@@ -46,7 +46,11 @@ case class LayerAttachment(name: String,
       throw new Exception(
         "Trying to open non-local hdf5 file. Hdf5 files are only supported on the datastore-local file system.")
     }
-    Path.of(path)
+    if (path.getScheme == null) {
+      Path.of(path.toString)
+    } else {
+      Path.of(path)
+    }
   }
 }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/Hdf5AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/Hdf5AgglomerateService.scala
@@ -14,7 +14,7 @@ import com.scalableminds.webknossos.datastore.models.requests.DataServiceDataReq
 import com.scalableminds.webknossos.datastore.services.DataConverter
 import com.scalableminds.webknossos.datastore.storage._
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
 import java.nio.{ByteBuffer, ByteOrder, LongBuffer}
 import javax.inject.Inject
 import scala.annotation.tailrec

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/Hdf5AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/Hdf5AgglomerateService.scala
@@ -263,7 +263,7 @@ class Hdf5AgglomerateService @Inject()(config: DataStoreConfig) extends DataConv
   // Otherwise, we read configurable sized blocks from the agglomerate file and save them in a LRU cache.
   private def openAsCachedAgglomerateFile(agglomerateFileKey: AgglomerateFileKey) = {
     val cumsumPath =
-      Path.of(agglomerateFileKey.attachment.path).getParent.resolve(cumsumFileName)
+      agglomerateFileKey.attachment.localPath.getParent.resolve(cumsumFileName)
 
     val reader = openHdf5(agglomerateFileKey)
 


### PR DESCRIPTION
Fixed a bug where hdf5 attachments explicitly mentioned in the datasource-properties.json would not be readable if they have an absolute path but no `file://` prefix.

These URI/path/string/VaultPath/remoteSourceDescriptor conversions are no fun. We need to refactor this into a unified solution. https://github.com/scalableminds/webknossos/issues/8762

### Steps to test:
- In your datasource-properties.json include an hdf5 agglomerate file with an absolute path that does not have the `file://` prefix
- Try to load data with this agglomerate file active, should work.
- Using zarr in the same way should also still work

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1754469854679349

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
