### PR TITLE
Fix loading segment statistics for ND case

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -75,8 +75,14 @@ class BinaryDataService(val dataBaseDir: Path,
         requestsSelected: Seq[DataServiceDataRequest] = requests.zipWithIndex.collect {
           case (request, idx) if !indicesWhereOutsideRange.contains(idx) => request
         }
-        readInstructions = requestsSelected.map(r =>
-          DataReadInstruction(dataBaseDir, dataSourceId, dataLayer, r.cuboid.topLeft.toBucket, r.settings.version))
+        readInstructions = requestsSelected.map(
+          r =>
+            DataReadInstruction(
+              dataBaseDir,
+              dataSourceId,
+              dataLayer,
+              r.cuboid.topLeft.toBucket.copy(additionalCoordinates = r.settings.additionalCoordinates),
+              r.settings.version))
         bucketProvider = bucketProviderCache.getOrLoadAndPut((dataSourceId, dataLayer.bucketProviderCacheKey))(_ =>
           dataLayer.bucketProvider(remoteSourceDescriptorServiceOpt, dataSourceId, sharedChunkContentsCache))
         bucketBoxes <- datasetErrorLoggingService.withErrorLoggingMultiple(


### PR DESCRIPTION
This conversion from DatasServiceDataRequest to DataReadInstruction accidentally dropped the additionalCoordinates.

### Steps to test:
(I tested locally)
- In a dataset with additionalAxes, create volume annotation, brush some, hit right-click
- segment volume should have a real value, not zero
- same for bounding box, same for segment stats modal reachable in segments tab.

### Issues:
- fixes #8836

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
