### PR TITLE
In exploreAndAdd, use name as directoryName

### DIFF
--- a/app/models/dataset/explore/WKExploreRemoteLayerService.scala
+++ b/app/models/dataset/explore/WKExploreRemoteLayerService.scala
@@ -114,7 +114,7 @@ class WKExploreRemoteLayerService @Inject()(credentialService: CredentialService
       organizationId = user._organization
       _ <- datasetService.assertValidDatasetName(datasetName)
       _ <- datasetService.createVirtualDataset(
-        dataSource.id.directoryName,
+        datasetName,
         organizationId,
         dataStore,
         dataSource,


### PR DESCRIPTION
directoryName of freshly explored DataSources is always emptystring, which will be rejected.
the name will be validated, so I think this is acceptable.

Down the line, directoryName should become optional and just be None for fully virtual datasets.