### PR TITLE
When parsing datasource, allow omitting cubeLength also in wkwResolutions

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/layers/WKWDataLayers.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/layers/WKWDataLayers.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.{Format, JsError, JsResult, JsSuccess, JsValue, Json, 
 import ucar.ma2.{Array => MultiArray}
 
 case class WKWResolution(resolution: Vec3Int,
-                         cubeLength: Int,
+                         cubeLength: Option[Int] = None,
                          path: Option[String] = None,
                          credentialId: Option[String] = None) {
   def toMagLocator: MagLocator =


### PR DESCRIPTION
The field is unused anyway, since we always call toMagLocator now.

### Steps to test:
(I already tested locally)

- Test datasource-properties.json with a wkw layer and wkwResolutions like this:

```
"wkwResolutions": [
                {
                    "resolution": [
                        1,
                        1,
                        1
                    ]
                },
…
]
```

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1755077454864449

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
