### PR TITLE
Add error when unauthenticated in changelog tool

### DIFF
--- a/tools/create-changelog-entry.py
+++ b/tools/create-changelog-entry.py
@@ -41,8 +41,11 @@ def get_pr_number_from_gh():
         print(
             "⚠️  GitHub CLI (`gh`) not found. You can install it from https://cli.github.com/"
         )
-    except subprocess.CalledProcessError:
-        print("⚠️  No pull request found for the current branch.")
+    except subprocess.CalledProcessError as e:
+        if "Bad credentials" in e.stderr:
+            print("⚠️  You are not authenticated with GitHub (Run 'gh auth login'). No pull request found.")
+        else:
+            print("⚠️  No pull request found for the current branch.")
     return None
 
 


### PR DESCRIPTION
I always had "No pull request found" and wanted a more useful error.