### PR TITLE
Limit annotation update transactions to 1M actions

### DIFF
--- a/unreleased_changes/8866.md
+++ b/unreleased_changes/8866.md
@@ -1,0 +1,2 @@
+### Changed
+- Added protection against server outages by limiting the number of update actions in an annotation update transaction to 1000000.


### PR DESCRIPTION
Allocating the string for the serialized json caused an OutOfMemoryError for huge transactions.

1M actions is already a bit much anyway. We should rather create actions that edit multiple things.

### Steps to test:
- Lower the limit to e.g. 10
- Brush some, should create >10 updateBucket actions
- hit save, should be rejected


### Issues:
- workaround for #8788 