### PR TITLE
adds a placeholder to the voxel size field in upload

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -875,7 +875,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                     info="The voxel size defines the extent (for x, y, z) of one voxel in the specified unit."
                     // @ts-ignore
                     disabled={this.state.needsConversion}
-                    help="Your dataset is not yet in WKW Format. Therefore you need to define the voxel size."
+                    help="Your dataset is not yet in a WEBKNOSSOS format. Therefore, you need to define the voxel size."
                     rules={[
                       {
                         required: this.state.needsConversion,
@@ -891,6 +891,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                   >
                     <Vector3Input
                       allowDecimals
+                      placeholder="e.g. 11.23, 11.23, 28.3"
                       onChange={(voxelSizeFactor: Vector3) => {
                         if (this.formRef.current == null) return;
                         this.formRef.current.setFieldsValue({
@@ -988,17 +989,10 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                   }, "Archives cannot be mixed with other files."),
                 },
                 {
-                  validator: syncValidator(
-                    (files: FileWithPath[]) => {
-                      const fileSize = getFileSize(files);
-                      return getLeftOverStorageBytes(this.props.organization) >= fileSize;
-                    },
-                    `The selected files exceed the available storage of your organization. Please ${
-                      isActiveUserAdmin
-                        ? "use the organization management page to request more storage"
-                        : "ask your administrator to request more storage"
-                    }.`,
-                  ),
+                  validator: syncValidator((files: FileWithPath[]) => {
+                    const fileSize = getFileSize(files);
+                    return getLeftOverStorageBytes(this.props.organization) >= fileSize;
+                  }, `The selected files exceed the available storage of your organization. Please ${isActiveUserAdmin ? "use the organization management page to request more storage" : "ask your administrator to request more storage"}.`),
                 },
                 {
                   validator: syncValidator((files: FileWithPath[]) => {
@@ -1023,28 +1017,20 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
                   }, "WKW files should not be mixed with image files."),
                 },
                 {
-                  validator: syncValidator(
-                    (files: FileWithPath[]) => {
-                      const { unfinishedUploadToContinue } = this.state;
-                      if (
-                        !unfinishedUploadToContinue ||
-                        unfinishedUploadToContinue.filePaths == null
-                      ) {
-                        return true;
-                      }
-                      const filePaths = files.map((file) => file.path || "");
-                      return (
-                        unfinishedUploadToContinue.filePaths.length === filePaths.length &&
-                        _.difference(unfinishedUploadToContinue.filePaths, filePaths).length === 0
-                      );
-                    },
-                    "The selected files do not match the files of the unfinished upload. Please select the same files as before." +
-                      (unfinishedUploadToContinue?.filePaths != null
-                        ? `The file names are: ${unfinishedUploadToContinue?.filePaths?.join(
-                            ", ",
-                          )}.`
-                        : ""),
-                  ),
+                  validator: syncValidator((files: FileWithPath[]) => {
+                    const { unfinishedUploadToContinue } = this.state;
+                    if (
+                      !unfinishedUploadToContinue ||
+                      unfinishedUploadToContinue.filePaths == null
+                    ) {
+                      return true;
+                    }
+                    const filePaths = files.map((file) => file.path || "");
+                    return (
+                      unfinishedUploadToContinue.filePaths.length === filePaths.length &&
+                      _.difference(unfinishedUploadToContinue.filePaths, filePaths).length === 0
+                    );
+                  }, "The selected files do not match the files of the unfinished upload. Please select the same files as before." + (unfinishedUploadToContinue?.filePaths != null ? `The file names are: ${unfinishedUploadToContinue?.filePaths?.join(", ")}.` : "")),
                 },
               ]}
               valuePropName="fileList"


### PR DESCRIPTION
Adds a placeholder to the voxel size field in the upload form with the expected format.

<img width="828" height="538" alt="Screenshot 2025-08-26 at 14 53 24" src="https://github.com/user-attachments/assets/e76edf03-27d5-4c82-aca5-5ba548e72ade" />

- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)