### PR TITLE
use blosc-java instead of jblosc

### DIFF
--- a/.github/Dockerfile.datastore
+++ b/.github/Dockerfile.datastore
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21-jammy
 
 RUN apt-get update \
-  && apt-get -y install libblosc1 libbrotli1 libdraco4 \
+  && apt-get -y install libbrotli1 libdraco4 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /webknossos-datastore \

--- a/.github/Dockerfile.tracingstore
+++ b/.github/Dockerfile.tracingstore
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21-jammy
 
 RUN apt-get update \
-  && apt-get -y install libblosc1 libbrotli1 libdraco4 \
+  && apt-get -y install libbrotli1 libdraco4 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /webknossos-tracingstore \

--- a/.github/Dockerfile.webknossos
+++ b/.github/Dockerfile.webknossos
@@ -2,7 +2,7 @@ FROM eclipse-temurin:21-jammy
 ARG VERSION_NODE="22.x"
 
 RUN curl -sL "https://deb.nodesource.com/setup_${VERSION_NODE}" | bash - \
-  && apt-get -y install libblosc1 libbrotli1 postgresql-client libdraco4 git nodejs \
+  && apt-get -y install libbrotli1 postgresql-client libdraco4 git nodejs \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /webknossos

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -91,7 +91,7 @@ jobs:
         run: yarn install --immutable
 
       - name: "Install System Dependencies"
-        run: sudo apt-get update && sudo apt-get install -y libdraco-dev libblosc1
+        run: sudo apt-get update && sudo apt-get install -y libdraco-dev
 
       - name: Assert unique evolution numbers
         run: tools/postgres/dbtool.js assert-unique-evolution-numbers
@@ -151,7 +151,7 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: "Install System Dependencies"
-        run: sudo apt-get update && sudo apt-get install -y libdraco-dev libblosc1
+        run: sudo apt-get update && sudo apt-get install -y libdraco-dev
 
       - name: "Custom environment variables (Pull Request)"
         if: ${{ github.event_name == 'pull_request' }}

--- a/DEV_INSTALL.md
+++ b/DEV_INSTALL.md
@@ -7,7 +7,6 @@
 * [sbt](https://www.scala-sbt.org/)
 * [PostgreSQL 10+](https://www.postgresql.org/)
 * [Redis 5+](https://redis.io/)
-* [Blosc](https://github.com/Blosc/c-blosc)
 * [Brotli](https://github.com/google/brotli)
 * [Draco](https://github.com/google/draco)
 * [node.js 22+](https://nodejs.org/)
@@ -25,7 +24,7 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Install git, node.js, postgres, sbt, gfind, gsed, draco
-brew install openjdk draco openssl git node postgresql sbt findutils coreutils gnu-sed redis c-blosc brotli wget
+brew install openjdk draco openssl git node postgresql sbt findutils coreutils gnu-sed redis brotli wget
 
 # Set env variables for openjdk and openssl
 # You probably want to add these lines manually to avoid conflicts in your zshrc
@@ -59,7 +58,7 @@ Note: On arm64-based Macs (e.g. M1), you need to run WEBKNOSSOS in an x86_64 env
 
 ```bash
 sudo apt update
-sudo apt install -y curl ca-certificates wget git postgresql postgresql-client unzip zip redis-server build-essential libblosc1 libbrotli1 libdraco-dev cmake
+sudo apt install -y curl ca-certificates wget git postgresql postgresql-client unzip zip redis-server build-essential libbrotli1 libdraco-dev cmake
 
 # Install nvm, node 22
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,8 +58,8 @@ object Dependencies {
     "software.amazon.awssdk" % "s3" % "2.32.24",
     // Google cloud storage client. import com.google.cloud.storage, import com.google.auth.oauth2
     "com.google.cloud" % "google-cloud-storage" % "2.55.0",
-    // Blosc compression. import org.blosc
-    "org.lasersonlab" % "jblosc" % "1.0.1",
+    // Blosc compression. import dev.zarr.bloscjava
+    "com.scalableminds" % "blosc-java" % "0.1-1.21.4",
     // Zstd compression. import org.apache.commons.compress
     "org.apache.commons" % "commons-compress" % "1.28.0",
     // Zstd compression native bindings. not imported

--- a/unreleased_changes/8882.md
+++ b/unreleased_changes/8882.md
@@ -1,0 +1,2 @@
+### Changed
+- Use blosc-java instead of jblosc.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
@@ -225,6 +225,13 @@ class BloscCompressor(val properties: Map[String, CompressionSetting]) extends C
     clevel
   }
 
+  val typesize: Int = properties.get(BloscCompressor.keyTypesize) match {
+    case None                                           => BloscCompressor.defaultTypesize
+    case Some(StringCompressionSetting(typeSizeString)) => typeSizeString.toInt
+    case Some(IntCompressionSetting(typeSizeInt))       => typeSizeInt
+    case _                                              => throw new IllegalArgumentException("Blosc typesize must be int or string")
+  }
+
   val shuffle: Blosc.Shuffle = properties.get(BloscCompressor.keyShuffle) match {
     case None                                          => BloscCompressor.defaultShuffle
     case Some(StringCompressionSetting(shuffleString)) => validateShuffleStr(shuffleString)
@@ -266,13 +273,6 @@ class BloscCompressor(val properties: Map[String, CompressionSetting]) extends C
     case Some(StringCompressionSetting(blockSizeString)) => blockSizeString.toInt
     case Some(IntCompressionSetting(blockSizeInt))       => blockSizeInt
     case _                                               => throw new IllegalArgumentException("Blosc blocksize must be int or string")
-  }
-
-  val typesize: Int = properties.get(BloscCompressor.keyTypesize) match {
-    case None                                           => BloscCompressor.defaultTypesize
-    case Some(StringCompressionSetting(typeSizeString)) => typeSizeString.toInt
-    case Some(IntCompressionSetting(typeSizeInt))       => typeSizeInt
-    case _                                              => throw new IllegalArgumentException("Blosc typesize must be int or string")
   }
 
   override def getId = "blosc"

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
@@ -1,5 +1,6 @@
 package com.scalableminds.webknossos.datastore.datareaders
 
+import com.scalableminds.bloscjava.Blosc
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.util.io.ZipIO.GZIPOutputStream
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDataType
@@ -7,17 +8,13 @@ import com.scalableminds.webknossos.datastore.datareaders.precomputed.compressed
   CompressedSegmentation32,
   CompressedSegmentation64
 }
-import com.sun.jna.ptr.NativeLongByReference
 import org.apache.commons.compress.compressors.lz4.{BlockLZ4CompressorInputStream, BlockLZ4CompressorOutputStream}
 import org.apache.commons.compress.compressors.zstandard.{ZstdCompressorInputStream, ZstdCompressorOutputStream}
-import org.blosc.{BufferSizes, IBloscDll, JBlosc}
 import play.api.libs.json.{Format, JsResult, JsValue, Json}
 
 import java.awt.image.{BufferedImage, DataBufferByte}
 import java.io._
-import java.nio.ByteBuffer
-import java.util
-import java.util.zip.{Deflater, DeflaterOutputStream, GZIPInputStream, Inflater, InflaterInputStream}
+import java.util.zip._
 import javax.imageio.ImageIO
 import javax.imageio.ImageIO.createImageInputStream
 import javax.imageio.stream.ImageInputStream
@@ -186,37 +183,33 @@ class GzipCompressor(val properties: Map[String, CompressionSetting]) extends Co
 }
 
 object BloscCompressor {
-  val AUTOSHUFFLE: Int = -1
-  val NOSHUFFLE = 0
-  val BYTESHUFFLE = 1
-  val BITSHUFFLE = 2
   val keyCname = "cname"
-  val defaultCname = "lz4"
+  val defaultCname = Blosc.Compressor.LZ4
   val keyClevel = "clevel"
   val defaultCLevel = 5
   val keyShuffle = "shuffle"
-  val defaultShuffle: Int = BYTESHUFFLE
+  val defaultShuffle = Blosc.Shuffle.BYTE_SHUFFLE
   val keyBlocksize = "blocksize"
   val defaultBlocksize = 0
-  val supportedShuffle: List[Int] = List(AUTOSHUFFLE, NOSHUFFLE, BYTESHUFFLE, BITSHUFFLE)
-  val supportedCnames: List[String] = List("zstd", "blosclz", defaultCname, "lz4hc", "zlib")
+  val supportedCnames: List[String] = Blosc.Compressor.values().map(_.getValue).toList
   val keyTypesize = "typesize"
   val defaultTypesize = 1
 }
 
 class BloscCompressor(val properties: Map[String, CompressionSetting]) extends Compressor {
-  val cname: String = properties.get(BloscCompressor.keyCname) match {
+  val cname: Blosc.Compressor = properties.get(BloscCompressor.keyCname) match {
     case None                                        => BloscCompressor.defaultCname
     case Some(StringCompressionSetting(cnameString)) => validateCname(cnameString)
     case _                                           => throw new IllegalArgumentException("Blosc cname must be string")
   }
 
-  private def validateCname(cname: String) = {
-    if (!BloscCompressor.supportedCnames.contains(cname))
+  private def validateCname(cname: String): Blosc.Compressor = {
+    val validatedCname = Blosc.Compressor.fromString(cname)
+    if (validatedCname == null)
       throw new IllegalArgumentException(
         "blosc: compressor not supported: '" + cname + "'; expected one of " +
           BloscCompressor.supportedCnames.mkString(","))
-    cname
+    validatedCname
   }
 
   val clevel: Int = properties.get(BloscCompressor.keyClevel) match {
@@ -232,21 +225,40 @@ class BloscCompressor(val properties: Map[String, CompressionSetting]) extends C
     clevel
   }
 
-  val shuffle: Int = properties.get(BloscCompressor.keyShuffle) match {
+  val shuffle: Blosc.Shuffle = properties.get(BloscCompressor.keyShuffle) match {
     case None                                          => BloscCompressor.defaultShuffle
-    case Some(StringCompressionSetting(shuffleString)) => validateShuffle(shuffleString.toInt)
-    case Some(IntCompressionSetting(shuffleInt))       => validateShuffle(shuffleInt)
+    case Some(StringCompressionSetting(shuffleString)) => validateShuffleStr(shuffleString)
+    case Some(IntCompressionSetting(shuffleInt))       => validateShuffleInt(shuffleInt)
     case _                                             => throw new IllegalArgumentException("Blosc shuffle must be int or string")
   }
 
-  private def validateShuffle(shuffle: Int): Int = {
+  private def validateShuffleStr(shuffle: String): Blosc.Shuffle = {
     val supportedShuffleNames =
-      List("-1 (AUTOSHUFFLE), 0 (NOSHUFFLE)", "1 (BYTESHUFFLE)", "2 (BITSHUFFLE)")
+      List("noshuffle", "shuffle", "bitshuffle")
 
-    if (!BloscCompressor.supportedShuffle.contains(shuffle))
+    val validatedShuffle = Blosc.Shuffle.fromString(shuffle)
+    if (validatedShuffle == null)
       throw new IllegalArgumentException(
         f"blosc: shuffle type '$shuffle' not supported. Expected one of ${supportedShuffleNames.mkString(",")}")
-    shuffle
+    validatedShuffle
+  }
+
+  private def validateShuffleInt(shuffle: Int): Blosc.Shuffle = {
+    val supportedShuffleNames =
+      List("-1 (AUTOSHUFFLE)", " 0 (NOSHUFFLE)", "1 (BYTESHUFFLE)", "2 (BITSHUFFLE)")
+
+    val newShuffle = if (shuffle == -1) {
+      if (typesize == 1)
+        2
+      else
+        1
+    } else shuffle
+
+    val validatedShuffle = Blosc.Shuffle.fromInt(newShuffle)
+    if (validatedShuffle == null)
+      throw new IllegalArgumentException(
+        f"blosc: shuffle type '$shuffle' not supported. Expected one of ${supportedShuffleNames.mkString(",")}")
+    validatedShuffle
   }
 
   val blocksize: Int = properties.get(BloscCompressor.keyBlocksize) match {
@@ -269,48 +281,13 @@ class BloscCompressor(val properties: Map[String, CompressionSetting]) extends C
     "compressor=" + getId + "/cname=" + cname + "/clevel=" + clevel.toString + "/blocksize=" + blocksize + "/shuffle=" + shuffle + "/typesize=" + typesize
 
   @throws[IOException]
-  override def compress(input: Array[Byte]): Array[Byte] = {
-    val is = new ByteArrayInputStream(input)
-
-    val baos = new ByteArrayOutputStream
-    passThrough(is, baos)
-    val inputBytes = baos.toByteArray
-    val inputSize = inputBytes.length
-    val outputSize = inputSize + JBlosc.OVERHEAD
-    val inputBuffer = ByteBuffer.wrap(inputBytes)
-    val outBuffer = ByteBuffer.allocate(outputSize)
-    JBlosc.compressCtx(clevel, shuffle, typesize, inputBuffer, inputSize, outBuffer, outputSize, cname, blocksize, 1)
-    val bs = cbufferSizes(outBuffer)
-    val compressedChunk = util.Arrays.copyOfRange(outBuffer.array, 0, bs.getCbytes.toInt)
-    compressedChunk
-  }
+  override def compress(input: Array[Byte]): Array[Byte] =
+    Blosc.compress(input, typesize, cname, clevel, shuffle, blocksize, 1)
 
   @throws[IOException]
-  override def decompress(input: Array[Byte]): Array[Byte] = {
-    val is = new ByteArrayInputStream(input)
+  override def decompress(input: Array[Byte]): Array[Byte] =
+    Blosc.decompress(input, 1)
 
-    val di = new DataInputStream(is)
-    val header = new Array[Byte](JBlosc.OVERHEAD)
-    di.readFully(header)
-    val bs = cbufferSizes(ByteBuffer.wrap(header))
-    val compressedSize = bs.getCbytes.toInt
-    val uncompressedSize = bs.getNbytes.toInt
-    val inBytes = util.Arrays.copyOf(header, compressedSize)
-    di.readFully(inBytes, header.length, compressedSize - header.length)
-    val outBuffer = ByteBuffer.allocate(uncompressedSize)
-    JBlosc.decompressCtx(ByteBuffer.wrap(inBytes), outBuffer, outBuffer.limit, 1)
-
-    outBuffer.array
-  }
-
-  private def cbufferSizes(cbuffer: ByteBuffer) = {
-    val nbytes = new NativeLongByReference
-    val cbytes = new NativeLongByReference
-    val blocksize = new NativeLongByReference
-    IBloscDll.blosc_cbuffer_sizes(cbuffer, nbytes, cbytes, blocksize)
-    val bs = new BufferSizes(nbytes.getValue.longValue, cbytes.getValue.longValue, blocksize.getValue.longValue)
-    bs
-  }
 }
 
 class JpegCompressor() extends Compressor {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingIOService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingIOService.scala
@@ -3,21 +3,11 @@ package com.scalableminds.webknossos.tracingstore.tracings.editablemapping
 import com.scalableminds.util.io.{NamedFunctionStream, ZipIO}
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
+import com.scalableminds.webknossos.datastore.datareaders.zarr3._
 import com.scalableminds.webknossos.datastore.datareaders.{
   BloscCompressor,
   IntCompressionSetting,
   StringCompressionSetting
-}
-import com.scalableminds.webknossos.datastore.datareaders.zarr3.{
-  BloscCodecConfiguration,
-  BytesCodecConfiguration,
-  ChunkGridConfiguration,
-  ChunkGridSpecification,
-  ChunkKeyEncoding,
-  ChunkKeyEncodingConfiguration,
-  EmptyZarr3GroupHeader,
-  Zarr3ArrayHeader,
-  Zarr3DataType
 }
 import com.scalableminds.webknossos.tracingstore.files.TsTempFileService
 import com.typesafe.scalalogging.LazyLogging
@@ -126,9 +116,9 @@ class EditableMappingIOService @Inject()(tempFileService: TsTempFileService) ext
 
   private lazy val compressorConfiguration =
     BloscCodecConfiguration(
-      BloscCompressor.defaultCname,
+      BloscCompressor.defaultCname.getValue,
       BloscCompressor.defaultCLevel,
-      StringCompressionSetting(BloscCodecConfiguration.shuffleSettingFromInt(BloscCompressor.defaultShuffle)),
+      StringCompressionSetting(BloscCodecConfiguration.shuffleSettingFromInt(BloscCompressor.defaultShuffle.getValue)),
       Some(BloscCompressor.defaultTypesize),
       BloscCompressor.defaultBlocksize
     )
@@ -136,9 +126,9 @@ class EditableMappingIOService @Inject()(tempFileService: TsTempFileService) ext
   private lazy val compressor =
     new BloscCompressor(
       Map(
-        BloscCompressor.keyCname -> StringCompressionSetting(BloscCompressor.defaultCname),
+        BloscCompressor.keyCname -> StringCompressionSetting(BloscCompressor.defaultCname.getValue),
         BloscCompressor.keyClevel -> IntCompressionSetting(BloscCompressor.defaultCLevel),
-        BloscCompressor.keyShuffle -> IntCompressionSetting(BloscCompressor.defaultShuffle),
+        BloscCompressor.keyShuffle -> IntCompressionSetting(BloscCompressor.defaultShuffle.getValue),
         BloscCompressor.keyBlocksize -> IntCompressionSetting(BloscCompressor.defaultBlocksize),
         BloscCompressor.keyTypesize -> IntCompressionSetting(BloscCompressor.defaultTypesize)
       ))

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeDataZipHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeDataZipHelper.scala
@@ -1,25 +1,23 @@
 package com.scalableminds.webknossos.tracingstore.tracings.volume
 
-import java.io.{File, FileOutputStream, InputStream}
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.util.io.ZipIO
-import com.scalableminds.util.tools.{Fox, FoxImplicits, JsonHelper}
-import com.scalableminds.webknossos.datastore.dataformats.wkw.WKWDataFormatHelper
+import com.scalableminds.util.tools.Box.tryo
+import com.scalableminds.util.tools.{Box, Fox, FoxImplicits, JsonHelper}
+import com.scalableminds.webknossos.datastore.dataformats.wkw.{WKWDataFormatHelper, WKWFile}
+import com.scalableminds.webknossos.datastore.datareaders.zarr3.Zarr3ArrayHeader
 import com.scalableminds.webknossos.datastore.datareaders.{
   BloscCompressor,
   IntCompressionSetting,
   StringCompressionSetting
 }
-import com.scalableminds.webknossos.datastore.datareaders.zarr3.Zarr3ArrayHeader
-import com.scalableminds.webknossos.datastore.models.{AdditionalCoordinate, BucketPosition}
 import com.scalableminds.webknossos.datastore.models.datasource.DataLayer
+import com.scalableminds.webknossos.datastore.models.{AdditionalCoordinate, BucketPosition}
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeDataZipFormat.VolumeDataZipFormat
-import com.scalableminds.webknossos.datastore.dataformats.wkw.WKWFile
 import com.typesafe.scalalogging.LazyLogging
-import com.scalableminds.util.tools.Box
-import com.scalableminds.util.tools.Box.tryo
 import org.apache.commons.io.IOUtils
 
+import java.io.{File, FileOutputStream, InputStream}
 import java.util.zip.{ZipEntry, ZipFile}
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
@@ -175,9 +173,9 @@ trait VolumeDataZipHelper extends WKWDataFormatHelper with ReversionHelper with 
   private lazy val compressor =
     new BloscCompressor(
       Map(
-        BloscCompressor.keyCname -> StringCompressionSetting(BloscCompressor.defaultCname),
+        BloscCompressor.keyCname -> StringCompressionSetting(BloscCompressor.defaultCname.getValue),
         BloscCompressor.keyClevel -> IntCompressionSetting(BloscCompressor.defaultCLevel),
-        BloscCompressor.keyShuffle -> IntCompressionSetting(BloscCompressor.defaultShuffle),
+        BloscCompressor.keyShuffle -> IntCompressionSetting(BloscCompressor.defaultShuffle.getValue),
         BloscCompressor.keyBlocksize -> IntCompressionSetting(BloscCompressor.defaultBlocksize),
         BloscCompressor.keyTypesize -> IntCompressionSetting(BloscCompressor.defaultTypesize)
       ))

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Zarr3BucketStreamSink.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Zarr3BucketStreamSink.scala
@@ -119,9 +119,9 @@ class Zarr3BucketStreamSink(val layer: VolumeTracingLayer, tracingHasFallbackLay
 
   private lazy val compressorConfiguration =
     BloscCodecConfiguration(
-      BloscCompressor.defaultCname,
+      BloscCompressor.defaultCname.getValue,
       BloscCompressor.defaultCLevel,
-      StringCompressionSetting(BloscCodecConfiguration.shuffleSettingFromInt(BloscCompressor.defaultShuffle)),
+      StringCompressionSetting(BloscCodecConfiguration.shuffleSettingFromInt(BloscCompressor.defaultShuffle.getValue)),
       Some(BloscCompressor.defaultTypesize),
       BloscCompressor.defaultBlocksize
     )
@@ -129,9 +129,9 @@ class Zarr3BucketStreamSink(val layer: VolumeTracingLayer, tracingHasFallbackLay
   private lazy val compressor =
     new BloscCompressor(
       Map(
-        BloscCompressor.keyCname -> StringCompressionSetting(BloscCompressor.defaultCname),
+        BloscCompressor.keyCname -> StringCompressionSetting(BloscCompressor.defaultCname.getValue),
         BloscCompressor.keyClevel -> IntCompressionSetting(BloscCompressor.defaultCLevel),
-        BloscCompressor.keyShuffle -> IntCompressionSetting(BloscCompressor.defaultShuffle),
+        BloscCompressor.keyShuffle -> IntCompressionSetting(BloscCompressor.defaultShuffle.getValue),
         BloscCompressor.keyBlocksize -> IntCompressionSetting(BloscCompressor.defaultBlocksize),
         BloscCompressor.keyTypesize -> IntCompressionSetting(BloscCompressor.defaultTypesize)
       ))


### PR DESCRIPTION
Switch out jblosc (which has been last updated 7 years ago!) with blosc-java. I had to do this, because the JNA version that jblosc references does not work with apple silicon. Also, blosc-java bundles the blosc library so no system library is required.

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)