### PR TITLE
When reading from zarr3, fix returning fill value for missing chunks

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
@@ -177,7 +177,9 @@ class Zarr3Array(vaultPath: VaultPath,
       parsedShardIndex <- parsedShardIndexCache.getOrLoad(shardPath, readAndParseShardIndex)
       chunkIndexInShardIndex = getChunkIndexInShardIndex(chunkIndex, shardCoordinates)
       (chunkOffset, chunkLength) = parsedShardIndex(chunkIndexInShardIndex)
-      _ <- Fox.fromBool(!(chunkOffset == -1 && chunkLength == -1)) ~> Fox.empty // -1 signifies empty/missing chunk
+      _ <- if (chunkOffset == -1 || chunkLength == -1) {
+        Fox.empty // -1 signifies empty/missing chunk
+      } else Fox.successful(())
       range = Range.Long(chunkOffset, chunkOffset + chunkLength, 1)
     } yield (shardPath, range)
 }


### PR DESCRIPTION
`Fox.fromBool(false) ~> Fox.empty` results in a ParamFailure with the Fox.empty in the chain. Instead, we need the Fox.empty in the toplevel so that it can be correctly matched by the caller.

### Steps to test:
(I tested locally)
- Open sparse zarr3 array, visit `http://localhost:9000/data/zarr/<datasetId>/segmentation/8/0.65.8.32?token=secretSampleUserToken` with coordinates that have no data on disk, but are within the dataset bounding box.
- Should return the array’s fill value, not an error.

### Issues:
- fixes https://scm.slack.com/archives/CBUKAUPCH/p1756477773231079?thread_ts=1756475134.317319&cid=CBUKAUPCH

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
