### PR TITLE
Return fill_value when reading outside of the bounding box

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -67,9 +67,7 @@ class BinaryDataService(val dataBaseDir: Path,
         firstRequest <- requests.headOption.toFox
         // Requests outside of the layer range can be skipped. They will be answered with Empty below.
         indicesWhereOutsideRange: Set[Int] = requests.zipWithIndex.collect {
-          case (request, idx)
-              if !dataLayer.doesContainBucket(request.cuboid.topLeft.toBucket) || !request.dataLayer.containsMag(
-                request.cuboid.mag) =>
+          case (request, idx) if !request.dataLayer.containsMag(request.cuboid.mag) =>
             idx
         }.toSet
         requestsSelected: Seq[DataServiceDataRequest] = requests.zipWithIndex.collect {
@@ -187,7 +185,7 @@ class BinaryDataService(val dataBaseDir: Path,
 
   private def handleBucketRequest(request: DataServiceDataRequest, bucket: BucketPosition)(
       implicit tc: TokenContext): Fox[Array[Byte]] =
-    if (request.dataLayer.doesContainBucket(bucket) && request.dataLayer.containsMag(bucket.mag)) {
+    if (request.dataLayer.containsMag(bucket.mag)) {
       val readInstruction =
         DataReadInstruction(dataBaseDir,
                             request.dataSourceIdOrVolumeDummy,


### PR DESCRIPTION
Since zarr streaming is now strict with those Empty buckets, an edge case came up: There exist Volume Annotations with bounding boxes larger than their fallback layer (created before #7580). So when the fallback layer is requested outside of its bbox, the volume annotation streaming breaks with error 500.

The old code, where these chunks were not attempted to read, and responded immediately with Empty, was more performant for datasets with multiple layers with differing bounding boxes. In the future, we should separate these concepts so that those old annotations can be zarr streamed, while re-introducing this performance optimization. For that we might want to introduce a differentiation between MISSING_BUCKETS (answer 404) and FAILED_BUCKETS (answer 500). The frontend could also retry FAILED_BUCKETS and log (some of) them to the console, while rendering MISSING_BUCKETS as black.

### Issues:
- fixes https://scm.slack.com/archives/CBUKAUPCH/p1756739522356439?thread_ts=1756475134.317319&cid=CBUKAUPCH

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
