### PR TITLE
Validate DataSources more strictly when reading from disk

### DIFF
--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -302,13 +302,16 @@ class WKRemoteDataStoreController @Inject()(
 
     }
 
-  def updateDataSource(name: String, key: String, datasetId: ObjectId): Action[UsableDataSource] =
-    Action.async(validateJson[UsableDataSource]) { implicit request =>
+  def updateDataSource(name: String, key: String, datasetId: ObjectId): Action[DataSource] =
+    Action.async(validateJson[DataSource]) { implicit request =>
       dataStoreService.validateAccess(name, key) { _ =>
         for {
           _ <- datasetDAO.findOne(datasetId)(GlobalAccessContext) ~> NOT_FOUND
-          _ <- datasetDAO.updateDataSource(datasetId, name, request.body.hashCode(), request.body, isUsable = true)(
-            GlobalAccessContext)
+          _ <- datasetDAO.updateDataSource(datasetId,
+                                           name,
+                                           request.body.hashCode(),
+                                           request.body,
+                                           isUsable = request.body.toUsable.isDefined)(GlobalAccessContext)
         } yield Ok
       }
     }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataSource.scala
@@ -31,8 +31,9 @@ trait DataSource {
 object DataSource {
   implicit def dataSourceFormat: Format[DataSource] =
     new Format[DataSource] {
-      def reads(json: JsValue): JsResult[DataSource] =
+      def reads(json: JsValue): JsResult[DataSource] = {
         UnusableDataSource.jsonFormat.reads(json).orElse(UsableDataSource.jsonFormat.reads(json))
+      }
 
       def writes(ds: DataSource): JsValue =
         ds match {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
@@ -135,7 +135,7 @@ class DSRemoteWebknossosClient @Inject()(
         .postJsonWithJsonResponse[ReserveUploadInformation, ReserveAdditionalInformation](info)
     } yield reserveUploadInfo
 
-  def updateDataSource(dataSource: UsableDataSource, datasetId: ObjectId)(implicit tc: TokenContext): Fox[_] =
+  def updateDataSource(dataSource: DataSource, datasetId: ObjectId)(implicit tc: TokenContext): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/datasources/${datasetId.toString}")
       .addQueryString("key" -> dataStoreKey)
       .withTokenFromContext

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceToDiskWriter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceToDiskWriter.scala
@@ -12,7 +12,7 @@ import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext
 import scala.io.Source
 
-trait DataSourceToDiskWriter extends PathUtils with FoxImplicits {
+trait DataSourceToDiskWriter extends PathUtils with DataSourceValidation with FoxImplicits {
 
   private val propertiesFileName = Path.of(UsableDataSource.FILENAME_DATASOURCE_PROPERTIES_JSON)
   private val logFileName = Path.of("datasource-properties-backups.log")
@@ -25,7 +25,7 @@ trait DataSourceToDiskWriter extends PathUtils with FoxImplicits {
     val dataSourcePath = organizationDir.resolve(dataSource.id.directoryName)
 
     for {
-      _ <- Fox.runIf(validate)(validateDataSource(dataSource, organizationDir).toFox)
+      _ <- Fox.runIf(validate)(assertValidateDataSource(dataSource).toFox)
       propertiesFile = dataSourcePath.resolve(propertiesFileName)
       _ <- Fox.runIf(!expectExisting)(ensureDirectoryBox(dataSourcePath).toFox)
       _ <- Fox.runIf(!expectExisting)(Fox.fromBool(!Files.exists(propertiesFile))) ?~> "dataSource.alreadyPresent"
@@ -66,59 +66,6 @@ trait DataSourceToDiskWriter extends PathUtils with FoxImplicits {
       } finally fileWriter.close()
     } catch {
       case e: Exception => Failure(s"Could not back up old contents: ${e.toString}")
-    }
-  }
-
-  private def validateDataSource(dataSource: UsableDataSource, organizationDir: Path): Box[Unit] = {
-    def Check(expression: Boolean, msg: String): Option[String] = if (!expression) Some(msg) else None
-
-    // Check that when mags are sorted by max dimension, all dimensions are sorted.
-    // This means each dimension increases monotonically.
-    val magsSorted = dataSource.dataLayers.map(_.resolutions.sortBy(_.maxDim))
-    val magsXIsSorted = magsSorted.map(_.map(_.x)) == magsSorted.map(_.map(_.x).sorted)
-    val magsYIsSorted = magsSorted.map(_.map(_.y)) == magsSorted.map(_.map(_.y).sorted)
-    val magsZIsSorted = magsSorted.map(_.map(_.z)) == magsSorted.map(_.map(_.z).sorted)
-
-    def pathOk(path: UPath): Boolean =
-      if (path.isRemote) true
-      else {
-        val absoluteWithinDataset =
-          organizationDir.resolve(dataSource.id.directoryName).resolve(path.toLocalPathUnsafe).toAbsolutePath
-        val allowedParent = organizationDir.toAbsolutePath
-        if (absoluteWithinDataset.startsWith(allowedParent)) true else false
-      }
-
-    val errors = List(
-      Check(dataSource.scale.factor.isStrictlyPositive, "DataSource voxel size (scale) is invalid"),
-      Check(magsXIsSorted && magsYIsSorted && magsZIsSorted, "Mags do not monotonically increase in all dimensions"),
-      Check(dataSource.dataLayers.nonEmpty, "DataSource must have at least one dataLayer"),
-      Check(dataSource.dataLayers.forall(!_.boundingBox.isEmpty), "DataSource bounding box must not be empty"),
-      Check(
-        dataSource.segmentationLayers.forall { layer =>
-          ElementClass.segmentationElementClasses.contains(layer.elementClass)
-        },
-        s"Invalid element class for segmentation layer"
-      ),
-      Check(
-        dataSource.segmentationLayers.forall { layer =>
-          ElementClass.largestSegmentIdIsInRange(layer.largestSegmentId, layer.elementClass)
-        },
-        "Largest segment id exceeds range (must be nonnegative, within element class range, and < 2^53)"
-      ),
-      Check(
-        dataSource.dataLayers.map(_.name).distinct.length == dataSource.dataLayers.length,
-        "Layer names must be unique. At least two layers have the same name."
-      ),
-      Check(
-        dataSource.dataLayers.flatMap(_.mags).flatMap(_.path).forall(pathOk),
-        "Mags with explicit paths must stay within the organization directory."
-      )
-    ).flatten
-
-    if (errors.isEmpty) {
-      Full(())
-    } else {
-      ParamFailure("DataSource is invalid", Json.toJson(errors.map(e => Json.obj("error" -> e))))
     }
   }
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceValidation.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataSourceValidation.scala
@@ -1,0 +1,56 @@
+package com.scalableminds.webknossos.datastore.services
+
+import com.scalableminds.util.tools.{Box, Full, ParamFailure}
+import com.scalableminds.webknossos.datastore.models.datasource.{ElementClass, UsableDataSource}
+import play.api.libs.json.Json
+
+trait DataSourceValidation {
+
+  protected def assertValidateDataSource(dataSource: UsableDataSource): Box[Unit] = {
+    val errors = validateDataSourceGetErrors(dataSource)
+    if (errors.isEmpty) {
+      Full(())
+    } else {
+      ParamFailure("DataSource is invalid", Json.toJson(errors.map(e => Json.obj("error" -> e))))
+    }
+  }
+
+  protected def validateDataSourceGetErrors(dataSource: UsableDataSource): Seq[String] = {
+    def check(expression: Boolean, msg: String): Option[String] = if (!expression) Some(msg) else None
+
+    // Check that when mags are sorted by max dimension, all dimensions are sorted.
+    // This means each dimension increases monotonically.
+    val magsSorted = dataSource.dataLayers.map(_.resolutions.sortBy(_.maxDim))
+    val magsXIsSorted = magsSorted.map(_.map(_.x)) == magsSorted.map(_.map(_.x).sorted)
+    val magsYIsSorted = magsSorted.map(_.map(_.y)) == magsSorted.map(_.map(_.y).sorted)
+    val magsZIsSorted = magsSorted.map(_.map(_.z)) == magsSorted.map(_.map(_.z).sorted)
+
+    val errors = List(
+      check(dataSource.scale.factor.isStrictlyPositive, "Voxel size (scale) is negative in at least one dimension."),
+      check(magsXIsSorted && magsYIsSorted && magsZIsSorted, "Mags do not monotonically increase in all dimensions."),
+      check(magsSorted.forall(magsOfLayer => magsOfLayer.length == magsOfLayer.distinct.length),
+            "There are duplicate mags in a layer."),
+      check(dataSource.dataLayers.nonEmpty, "No layers."),
+      check(dataSource.dataLayers.forall(!_.boundingBox.isEmpty), "Empty bounding box in a layer."),
+      check(
+        dataSource.segmentationLayers.forall { layer =>
+          ElementClass.segmentationElementClasses.contains(layer.elementClass)
+        },
+        s"Invalid element class for a segmentation layer."
+      ),
+      check(
+        dataSource.segmentationLayers.forall { layer =>
+          ElementClass.largestSegmentIdIsInRange(layer.largestSegmentId, layer.elementClass)
+        },
+        "Largest segment id exceeds range (must be nonnegative, within element class range, and < 2^53)."
+      ),
+      check(
+        dataSource.dataLayers.map(_.name).distinct.length == dataSource.dataLayers.length,
+        "Layer names must be unique. At least two layers have the same name."
+      )
+    ).flatten
+
+    errors
+  }
+
+}


### PR DESCRIPTION
full datasource validation now also runs when reading datasource-properties.jsons from disk. The result is shown in the dashboard on “show error”

This also fixes a regression from #8844 where you could no longer hit reload on unusable datasets.

It has, however, been slightly relaxed (no more path checks as those have been moved elsewhere in #8844 )

### Steps to test:
- Edit datasource on disk, making it invalid (e.g. introduce duplicate layer names or mags)

### Issues:
- fixes https://scm.slack.com/archives/CMBMU5684/p1747643139269819

------
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
