### PR TITLE
Prevent closing signup modal when pressing AltGr

### DIFF
--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -205,11 +205,12 @@ function CreateAnnotationButton() {
   const ButtonWithAuthentication = withAuthentication<AsyncButtonProps, typeof AsyncButton>(
     AsyncButton,
   );
+
   return (
     <div
-      onKeyDownCapture={(e) => {
+      onKeyDown={(e: React.KeyboardEvent) => {
         // Prevent closing the modal upon pressing some keys.
-        if (e.ctrlKey || e.metaKey || e.key === "AltGraph") {
+        if (e.ctrlKey || e.metaKey || e.key === "AltGraph" || e.getModifierState("AltGraph")) {
           e.stopPropagation();
         }
       }}

--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -208,7 +208,7 @@ function CreateAnnotationButton() {
 
   return (
     <div
-      onKeyDown={(e: React.KeyboardEvent) => {
+      onKeyDownCapture={(e: React.KeyboardEvent) => {
         // Prevent closing the modal upon pressing some keys.
         if (e.ctrlKey || e.metaKey || e.key === "AltGraph" || e.getModifierState("AltGraph")) {
           e.stopPropagation();

--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -206,7 +206,14 @@ function CreateAnnotationButton() {
     AsyncButton,
   );
   return (
-    <>
+    <div
+      onKeyDownCapture={(e) => {
+        // Prevent closing the modal upon pressing some keys.
+        if (e.ctrlKey || e.key === "AltGraph") {
+          e.stopPropagation();
+        }
+      }}
+    >
       <ButtonWithAuthentication
         activeUser={activeUser}
         authenticationMessage="You have to register or login to create an annotation."
@@ -231,7 +238,7 @@ function CreateAnnotationButton() {
           setSelectedSegmentationLayerName={setSelectedLayerName}
         />
       </Modal>
-    </>
+    </div>
   );
 }
 

--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -209,7 +209,7 @@ function CreateAnnotationButton() {
     <div
       onKeyDownCapture={(e) => {
         // Prevent closing the modal upon pressing some keys.
-        if (e.ctrlKey || e.key === "AltGraph") {
+        if (e.ctrlKey || e.metaKey || e.key === "AltGraph") {
           e.stopPropagation();
         }
       }}

--- a/unreleased_changes/8895.md
+++ b/unreleased_changes/8895.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that pressing AltGr, Ctrl or Command closed the authentication modal when viewing a public dataset.


### PR DESCRIPTION
### Steps to test:
- Have an publicly available dataset at hand and open it in a private tab (you have to be logged out to test this)
- click "create annotation" and focus the upcoming registration form, e.g. by clicking on any of the input fields.
- press AltGr or ctrl or your meta key. the modal should remain open. also try some other keys (e.g. tab or enter)
- check that none of these keys closes the modal opon clicking "login instead" in the same modal
- check that the modal still closes when pressing esc

### Issues:
- fixes #8875 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
