### PR TITLE
Make annotation layer name check deferrable, fixing false positives

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -276,17 +276,6 @@ class AnnotationController @Inject()(
       } yield JsonOk(Messages("annotation.edit.success"))
   }
 
-  def editAnnotationLayer(typ: String, id: ObjectId, tracingId: String): Action[JsValue] =
-    sil.SecuredAction.async(parse.json) { implicit request =>
-      for {
-        annotation <- provider.provideAnnotation(typ, id, request.identity) ~> NOT_FOUND
-        restrictions <- provider.restrictionsFor(typ, id) ?~> "restrictions.notFound" ~> NOT_FOUND
-        _ <- restrictions.allowUpdate(request.identity) ?~> "notAllowed" ~> FORBIDDEN
-        newLayerName = (request.body \ "name").as[String]
-        _ <- annotationLayerDAO.updateName(annotation._id, tracingId, newLayerName) ?~> "annotation.edit.failed"
-      } yield JsonOk(Messages("annotation.edit.success"))
-    }
-
   def annotationsForTask(taskId: ObjectId): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       for {

--- a/conf/evolutions/149-annotation-layer-name-check-deferrable.sql
+++ b/conf/evolutions/149-annotation-layer-name-check-deferrable.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+do $$ begin ASSERT (select schemaVersion from webknossos.releaseInformation) = 139, 'Previous schema version mismatch'; end; $$ LANGUAGE plpgsql;
+
+ALTER TABLE webknossos.annotation_layers DROP CONSTRAINT annotation_layers_name__annotation_key;
+ALTER TABLE webknossos.annotation_layers ADD CONSTRAINT annotation_layers_name__annotation_key UNIQUE (name, _annotation) DEFERRABLE INITIALLY DEFERRED;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 140;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/149-annotation-layer-name-check-deferrable.sql
+++ b/conf/evolutions/reversions/149-annotation-layer-name-check-deferrable.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+do $$ begin ASSERT (select schemaVersion from webknossos.releaseInformation) = 140, 'Previous schema version mismatch'; end; $$ LANGUAGE plpgsql;
+
+ALTER TABLE webknossos.annotation_layers DROP CONSTRAINT annotation_layers_name__annotation_key;
+ALTER TABLE webknossos.annotation_layers ADD CONSTRAINT annotation_layers_name__annotation_key UNIQUE (name, _annotation);
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 139;
+
+COMMIT TRANSACTION;

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -156,7 +156,6 @@ POST          /userToken/generate                                               
 POST          /annotations/upload                                                               controllers.AnnotationIOController.upload()
 POST          /annotations/:typ/:id/duplicate                                                   controllers.AnnotationController.duplicate(typ: String, id: ObjectId)
 PATCH         /annotations/:typ/:id/edit                                                        controllers.AnnotationController.editAnnotation(typ: String, id: ObjectId)
-PATCH         /annotations/:typ/:id/editLayer/:tracingId                                        controllers.AnnotationController.editAnnotationLayer(typ: String, id: ObjectId, tracingId: String)
 
 PATCH         /annotations/:typ/:id/finish                                                      controllers.AnnotationController.finish(typ: String, id: ObjectId, timestamp: Long)
 PATCH         /annotations/:typ/finish                                                          controllers.AnnotationController.finishAll(typ: String, timestamp: Long)

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
 
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(139);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(140);
 COMMIT TRANSACTION;
 
 
@@ -59,7 +59,7 @@ CREATE TABLE webknossos.annotation_layers(
   typ webknossos.ANNOTATION_LAYER_TYPE NOT NULL,
   name TEXT NOT NULL CHECK (name ~* '^[A-Za-z0-9\-_\.\$]+$'),
   statistics JSONB NOT NULL,
-  UNIQUE (name, _annotation),
+  UNIQUE (name, _annotation) DEFERRABLE INITIALLY DEFERRED,
   PRIMARY KEY (_annotation, tracingId),
   CONSTRAINT statisticsIsJsonObject CHECK(jsonb_typeof(statistics) = 'object')
 );


### PR DESCRIPTION
- removes unused route editAnnotationLayer
- change to transactionally update annotation layers in postgres, after it was reported by tracingstore side
- make the name unique check deferrable, so it is only checked on the transaction commit.
- This fixes the following error scenario: The user renames layer 1 from A to B and layer 2 from C to A. This is legitimate, as no duplicate names exist if the order is correct. However, since the postgres updates are not guaranteed to come in the same order, this could previously lead to false positive duplicate checks.

### Steps to test:
- Create annotation with multiple volume annotation layers
- rename multiple ones of them such that the name that was previously taken by one layer is then immediately taken by another. Should not fail. Save and reload should work and show the correct names.

### Issues:
- fixes #8647

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
