### PR TITLE
Add comment to mark no-longer supported job commands

### DIFF
--- a/app/models/job/JobCommand.scala
+++ b/app/models/job/JobCommand.scala
@@ -12,8 +12,10 @@ object JobCommand extends ExtendedEnumeration {
    */
 
   val compute_mesh_file, compute_segment_index_file, convert_to_wkw, export_tiff, find_largest_segment_id,
-  globalize_floodfills, infer_nuclei, infer_neurons, infer_instances, materialize_volume_annotation, render_animation,
-  infer_mitochondria, align_sections, train_model, infer_with_model, train_neuron_model, train_instance_model = Value
+  materialize_volume_annotation, render_animation, align_sections, infer_nuclei, infer_neurons, infer_instances,
+  infer_mitochondria, train_neuron_model, train_instance_model,
+  // No-longer supported jobs, kept here to be able to display old existing jobs:
+  globalize_floodfills, train_model, infer_with_model = Value
 
   val highPriorityJobs: Set[Value] = Set(convert_to_wkw, export_tiff)
   val lowPriorityJobs: Set[Value] = values.diff(highPriorityJobs)


### PR DESCRIPTION
We had some confusion about what kind of jobs are still being started. Reordering and adding a comment here to match the current frontend and worker code.