### PR TITLE
Add new camera perspectives for animations

### DIFF
--- a/app/controllers/JobController.scala
+++ b/app/controllers/JobController.scala
@@ -31,7 +31,7 @@ object MovieResolutionSetting extends ExtendedEnumeration {
 }
 
 object CameraPositionSetting extends ExtendedEnumeration {
-  val MOVING, STATIC_XZ, STATIC_YZ = Value
+  val MOVING, STATIC_ISOMETRIC, STATIC_XY, STATIC_XZ, STATIC_YZ = Value
 }
 
 case class AnimationJobOptions(

--- a/frontend/javascripts/types/api_types.ts
+++ b/frontend/javascripts/types/api_types.ts
@@ -1280,6 +1280,8 @@ export type FolderUpdater = {
 
 export enum CAMERA_POSITIONS {
   MOVING = "MOVING",
+  STATIC_ISOMETRIC = "STATIC_ISOMETRIC",
+  STATIC_XY = "STATIC_XY",
   STATIC_XZ = "STATIC_XZ",
   STATIC_YZ = "STATIC_YZ",
 }

--- a/frontend/javascripts/viewer/view/action-bar/create_animation_modal.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/create_animation_modal.tsx
@@ -406,11 +406,17 @@ function CreateAnimationModal(props: Props) {
                 <Radio.Button value={CAMERA_POSITIONS.MOVING}>
                   Camera circling around the dataset
                 </Radio.Button>
+                <Radio.Button value={CAMERA_POSITIONS.STATIC_XY}>
+                  Static camera looking at XY-viewport{" "}
+                </Radio.Button>
                 <Radio.Button value={CAMERA_POSITIONS.STATIC_XZ}>
                   Static camera looking at XZ-viewport{" "}
                 </Radio.Button>
                 <Radio.Button value={CAMERA_POSITIONS.STATIC_YZ}>
                   Static camera looking at YZ-viewport{" "}
+                </Radio.Button>
+                <Radio.Button value={CAMERA_POSITIONS.STATIC_ISOMETRIC}>
+                  Static camera with an isometric perspective looking at all 3 viewports{" "}
                 </Radio.Button>
               </Space>
             </Radio.Group>


### PR DESCRIPTION
This PR adds two new camera perspectives for animation jobs:
- static camera looking at XY plane (top-down view on the stack)
- static, isometric camera looking a the corner between XY, XZ, YZ plane


### Steps to test:
- CI should be enough for the frontend, backend changes
- Otherwise see worker PR

### TODOs:
- [ ] Merge related [worker PR first](https://github.com/scalableminds/voxelytics/pull/4279)

### Issues:
- None

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
