### PR TITLE
Fix ad hoc mesh infinite loading

### DIFF
--- a/frontend/javascripts/viewer/controller/scene_controller.ts
+++ b/frontend/javascripts/viewer/controller/scene_controller.ts
@@ -185,6 +185,22 @@ class SceneController {
       return cube;
     };
 
+    window.addBox = (position: Vector3) => {
+      const bucketSize = [64, 64, 64];
+      const boxGeometry = new BoxGeometry(...bucketSize);
+      const edgesGeometry = new EdgesGeometry(boxGeometry);
+      const material = new LineBasicMaterial({
+        color: 0xff00ff,
+        linewidth: 1,
+      });
+      const cube = new LineSegments(edgesGeometry, material);
+      cube.position.x = position[0] + 64 / 2;
+      cube.position.y = position[1] + 64 / 2;
+      cube.position.z = position[2] + 64 / 2;
+      this.rootNode.add(cube);
+      return cube;
+    };
+
     // @ts-ignore
     window.addVoxelMesh = (position: Vector3, _cubeLength: Vector3, optColor?: string) => {
       // Shrink voxels a bit so that it's easier to identify individual voxels.

--- a/frontend/javascripts/viewer/model/sagas/meshes/ad_hoc_mesh_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/meshes/ad_hoc_mesh_saga.ts
@@ -429,8 +429,12 @@ function* maybeLoadMeshChunk(
 ): Saga<Vector3[]> {
   const additionalCoordinates = yield* select((state) => state.flycam.additionalCoordinates);
   const threeDMap = getOrAddMapForSegment(layer.name, segmentId, additionalCoordinates);
+  const mag = magInfo.getMagByIndexOrThrow(zoomStep);
+  const paddedPosition = V3.toArray(V3.sub(clippedPosition, mag));
+  const paddedPositionWithinLayer =
+    layer.cube.boundingBox.clipPositionIntoBoundingBox(paddedPosition);
 
-  if (threeDMap.get(clippedPosition)) {
+  if (threeDMap.get(paddedPositionWithinLayer)) {
     return [];
   }
 
@@ -439,7 +443,7 @@ function* maybeLoadMeshChunk(
   }
 
   batchCounterPerSegment[segmentId]++;
-  threeDMap.set(clippedPosition, true);
+  threeDMap.set(paddedPositionWithinLayer, true);
   const scaleFactor = yield* select((state) => state.dataset.dataSource.scale.factor);
   const dataStoreHost = yield* select((state) => state.dataset.dataStore.url);
   const datasetId = yield* select((state) => state.dataset.id);
@@ -448,8 +452,6 @@ function* maybeLoadMeshChunk(
     layer.fallbackLayer != null ? layer.fallbackLayer : layer.name
   }`;
   const tracingStoreUrl = `${tracingStoreHost}/tracings/volume/${layer.name}`;
-
-  const mag = magInfo.getMagByIndexOrThrow(zoomStep);
 
   if (isInitialRequest) {
     sendAnalyticsEvent("request_isosurface", {
@@ -462,9 +464,6 @@ function* maybeLoadMeshChunk(
   const { segmentMeshController } = getSceneController();
 
   const cubeSize = marchingCubeSizeInTargetMag();
-  const paddedPosition = V3.toArray(V3.sub(clippedPosition, mag));
-  const paddedPositionWithinLayer =
-    layer.cube.boundingBox.clipPositionIntoBoundingBox(paddedPosition);
 
   while (retryCount < MAX_RETRY_COUNT) {
     try {

--- a/frontend/javascripts/viewer/model/sagas/meshes/ad_hoc_mesh_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/meshes/ad_hoc_mesh_saga.ts
@@ -428,8 +428,8 @@ function* maybeLoadMeshChunk(
   findNeighbors: boolean,
 ): Saga<Vector3[]> {
   const additionalCoordinates = yield* select((state) => state.flycam.additionalCoordinates);
-  const threeDMap = getOrAddMapForSegment(layer.name, segmentId, additionalCoordinates);
   const mag = magInfo.getMagByIndexOrThrow(zoomStep);
+  const threeDMap = getOrAddMapForSegment(layer.name, segmentId, additionalCoordinates);
   const paddedPosition = V3.toArray(V3.sub(clippedPosition, mag));
   const paddedPositionWithinLayer =
     layer.cube.boundingBox.clipPositionIntoBoundingBox(paddedPosition);


### PR DESCRIPTION
This PR avoids requesting out-of-bounds ad hoc mesh chunks in an infinite loop.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Best test locally with a dataset without segment index
-  please not, that ad hoc meshing is bug for transformed datasets. See https://github.com/scalableminds/webknossos/issues/8913.
- checkout 3fc42bd684921ae9b1a6e8ff38a78b17f163a5c4 to have a visualization of what happens on the master
- View a dataset without a segment index. 
- Load some segments ad hoc mesh. Watch boxes appear -> infinitely mesh requests e.g. going more and more out of bounds.
  - Note: The bounds of the boxes are not correct but still helpful to see at what coordinates mesh chunk requests are sent.
- check out 67f2060d8d23c01ad5ad791683651894d521a400 and do the same again after reload
- now no boxes outside of the segmentation layer should be requested and the request should terminate rather quickly

### TODOs:
- [ ] remove debug bboxes code

### Issues:
- fixes reported here: https://scm.slack.com/archives/C02H5T8Q08P/p1757417432537409?thread_ts=1757338710.530969&cid=C02H5T8Q08P

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
