### PR TITLE
Fix ordering of periodically polled update actions

### DIFF
--- a/frontend/javascripts/viewer/model/sagas/saving/save_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/saving/save_saga.ts
@@ -98,6 +98,7 @@ function* watchForSaveConflicts(): Saga<void> {
       annotationId,
       versionOnClient + 1,
       undefined,
+      false,
       true,
     );
 

--- a/unreleased_changes/8919.md
+++ b/unreleased_changes/8919.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix periodic polling of missing updates when another user edits an annotation.


### PR DESCRIPTION
Due to #8757 the sorting of the polled update actions was wrong. #8757 introduced a new parameter to the `getUpdateActionLog` function while forgetting to change the usage of `getUpdateActionLog` in `save_saga.tsx`.
Not the polling mechanism does loads the updates not truncated and in correct order.

The bug was noticable due to update only being applied version after version as the sorting of the polled update actions was wrong thus leading to the oldest update action / the one with the lowest version number to be applied last. This means that the locally stored annotation version was always only incremented by one for each poll. Making thing buggy.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open an annotation as user A (e.g. turn on othersMayEdit)
- Open the same annotation as user B
- Do multiple annotation actions with visible changes as user A. E.g. brush multiple cells. Then save
- Observe user B. All actions should be applied in one go and not one version every 10 seconds.


### Issues:
- fixes self noticed bug during working on #8723

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
