### PR TITLE
For custom-model inferences, pass model’s orga id

### DIFF
--- a/app/controllers/AiModelController.scala
+++ b/app/controllers/AiModelController.scala
@@ -235,7 +235,7 @@ class AiModelController @Inject()(
         _ <- Fox.fromBool(request.identity._organization == organization._id) ?~> "job.runInference.notAllowed.organization" ~> FORBIDDEN
         dataset <- datasetDAO.findOneByDirectoryNameAndOrganization(request.body.datasetDirectoryName, organization._id)
         dataStore <- dataStoreDAO.findOneByName(dataset._dataStore) ?~> "dataStore.notFound"
-        _ <- aiModelDAO.findOne(request.body.aiModelId) ?~> "aiModel.notFound"
+        aiModel <- aiModelDAO.findOne(request.body.aiModelId) ?~> "aiModel.notFound"
         _ <- datasetService.assertValidDatasetName(request.body.newDatasetName)
         jobCommand = JobCommand.infer_instances
         boundingBox <- BoundingBox.fromLiteral(request.body.boundingBox).toFox
@@ -246,6 +246,7 @@ class AiModelController @Inject()(
           "layer_name" -> request.body.colorLayerName,
           "bbox" -> boundingBox.toLiteral,
           "model_id" -> request.body.aiModelId,
+          "model_organization_id" -> aiModel._organization,
           "dataset_directory_name" -> request.body.datasetDirectoryName,
           "new_dataset_name" -> request.body.newDatasetName,
           "custom_workflow_provided_by_user" -> request.body.workflowYaml,
@@ -278,7 +279,7 @@ class AiModelController @Inject()(
         _ <- Fox.fromBool(request.identity._organization == organization._id) ?~> "job.runInference.notAllowed.organization" ~> FORBIDDEN
         dataset <- datasetDAO.findOneByDirectoryNameAndOrganization(request.body.datasetDirectoryName, organization._id)
         dataStore <- dataStoreDAO.findOneByName(dataset._dataStore) ?~> "dataStore.notFound"
-        _ <- aiModelDAO.findOne(request.body.aiModelId) ?~> "aiModel.notFound"
+        aiModel <- aiModelDAO.findOne(request.body.aiModelId) ?~> "aiModel.notFound"
         _ <- datasetService.assertValidDatasetName(request.body.newDatasetName)
         jobCommand = JobCommand.infer_neurons
         boundingBox <- BoundingBox.fromLiteral(request.body.boundingBox).toFox
@@ -289,6 +290,7 @@ class AiModelController @Inject()(
           "layer_name" -> request.body.colorLayerName,
           "bbox" -> boundingBox.toLiteral,
           "model_id" -> request.body.aiModelId,
+          "model_organization_id" -> aiModel._organization,
           "dataset_directory_name" -> request.body.datasetDirectoryName,
           "new_dataset_name" -> request.body.newDatasetName,
           "custom_workflow_provided_by_user" -> request.body.workflowYaml,

--- a/unreleased_changes/8926.md
+++ b/unreleased_changes/8926.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed running custom-model worker inferences with models shared from other wk organizations. [#4283](https://github.com/scalableminds/voxelytics/pull/4283)


### PR DESCRIPTION
The worker uses the organization id to find the path of the custom aiModel.

If it was trained in another orga, that orga’s id must be used.

### Steps to test:
(I tested locally)
 - check out corresponding vx pr https://github.com/scalableminds/voxelytics/pull/4283
 - create multi-orga setup (via features.isWkOrgInstance=true)
 - the second orga must also have pricing plan custom, its user must be superuser
 - share the sample model with the new orga
 - in that orga, run it on a dataset
 - workflow should start running in the worker.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1757942045889209

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
