### PR TITLE
When reading zarr connectome files, read mapping name from correct json key

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/connectome/ConnectomeFileUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/connectome/ConnectomeFileUtils.scala
@@ -14,7 +14,8 @@ trait ConnectomeFileUtils {
   protected val keySynapseToSrcAgglomerate = "synapse_to_src_agglomerate"
   protected val keySynapseToDstAgglomerate = "synapse_to_dst_agglomerate"
 
-  protected val attrKeyMetadataMappingName = "metadata/mapping_name"
+  protected val attrKeyMetadataMappingName = "metadata/mapping_name" // Used for legacy (hdf5) only
+  protected val attrKeyMappingName = "mapping_name"
   protected val attrKeySynapseTypeNames = "synapse_type_names"
 
   protected def synapticPartnerKey(direction: SynapticPartnerDirection): String =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/connectome/ZarrConnectomeFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/connectome/ZarrConnectomeFileService.scala
@@ -29,7 +29,7 @@ object ConnectomeFileAttributes extends VoxelyticsZarrArtifactUtils with Connect
       val connectomeFileAttrs = lookUpArtifactAttributes(json)
       for {
         formatVersion <- readArtifactSchemaVersion(json)
-        mappingName <- (connectomeFileAttrs \ attrKeyMetadataMappingName).validate[String]
+        mappingName <- (connectomeFileAttrs \ attrKeyMappingName).validate[String]
         synapseTypeNames <- (connectomeFileAttrs \ attrKeySynapseTypeNames).validate[Seq[String]]
       } yield
         ConnectomeFileAttributes(


### PR DESCRIPTION
There was a mismatch between what voxelytics writes and what webknossos expects for zarr3 connectome files. Adapting wk to vx here.

### Steps to test:
- Open voxelytics-generated zarr3 connectome file

### Issues:
- fixes https://discuss.webknossos.org/t/connectome-file-not-visible-in-connectome-tab/1143/4

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
