### PR TITLE
Better error message in model initialization for unusable dataset

### DIFF
--- a/frontend/javascripts/messages.tsx
+++ b/frontend/javascripts/messages.tsx
@@ -360,7 +360,6 @@ instead. Only enable this option if you understand its effect. All layers will n
   "dataset.name.already_taken":
     "This name is already being used by a different dataset. Please choose a different name.",
   "dataset.no_data": "No data available! Something seems to be wrong with the dataset.",
-  "dataset.not_imported": "Please double check if you have the dataset imported:",
   "dataset.changed_without_reload":
     "Model.fetch was called for a task with another dataset, without reloading the page.",
   "dataset.import.required.name": "Please provide a name for the dataset.",


### PR DESCRIPTION
Before: 
<img width="302" height="141" alt="image" src="https://github.com/user-attachments/assets/31663868-2229-45c4-b011-d67888ea43bb" />
After: 



### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
