### PR TITLE
Make dataset compose voxel-size-aware

### DIFF
--- a/app/models/dataset/ComposeService.scala
+++ b/app/models/dataset/ComposeService.scala
@@ -3,6 +3,7 @@ package models.dataset
 import com.scalableminds.util.accesscontext.DBAccessContext
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import com.scalableminds.webknossos.datastore.explore.ExploreLayerUtils
 import com.scalableminds.webknossos.datastore.models.VoxelSize
 import com.scalableminds.webknossos.datastore.models.datasource._
 import models.user.User
@@ -36,7 +37,8 @@ object ComposeRequestLayer {
 
 class ComposeService @Inject()(datasetDAO: DatasetDAO, dataStoreDAO: DataStoreDAO, datasetService: DatasetService)(
     implicit ec: ExecutionContext)
-    extends FoxImplicits {
+    extends ExploreLayerUtils
+    with FoxImplicits {
 
   def composeDataset(composeRequest: ComposeRequest, user: User)(
       implicit ctx: DBAccessContext,
@@ -53,8 +55,9 @@ class ComposeService @Inject()(datasetDAO: DatasetDAO, dataStoreDAO: DataStoreDA
 
     } yield (dataSource, dataset._id)
 
-  private def getLayerFromComposeLayer(composeLayer: ComposeRequestLayer)(implicit ctx: DBAccessContext,
-                                                                          mp: MessagesProvider): Fox[StaticLayer] =
+  private def getLayerFromComposeLayer(composeLayer: ComposeRequestLayer)(
+      implicit ctx: DBAccessContext,
+      mp: MessagesProvider): Fox[(StaticLayer, VoxelSize)] =
     for {
       dataset <- datasetDAO.findOne(composeLayer.datasetId) ?~> "Dataset not found"
       usableDataSource <- datasetService.usableDataSourceFor(dataset)
@@ -71,7 +74,7 @@ class ComposeService @Inject()(datasetDAO: DatasetDAO, dataStoreDAO: DataStoreDA
                      coordinateTransformations = applyCoordinateTransformations(l.coordinateTransformations)))
         case _ => Fox.failure("Unsupported layer type for composition: " + layer.getClass.getSimpleName)
       }
-    } yield editedLayer
+    } yield (editedLayer, usableDataSource.scale)
 
   private def isComposable(composeRequest: ComposeRequest)(implicit ctx: DBAccessContext): Fox[Boolean] =
     // Check that all datasets are on the same data store
@@ -90,14 +93,14 @@ class ComposeService @Inject()(datasetDAO: DatasetDAO, dataStoreDAO: DataStoreDA
       implicit ctx: DBAccessContext,
       mp: MessagesProvider): Fox[UsableDataSource] =
     for {
-      layers <- Fox.serialCombined(composeRequest.layers.toList)(getLayerFromComposeLayer(_))
+      layersAndVoxelSizes <- Fox.serialCombined(composeRequest.layers.toList)(getLayerFromComposeLayer)
+      (layers, voxelSize) <- adaptLayersAndVoxelSize(layersAndVoxelSizes, Some(composeRequest.voxelSize))
       dataSource = UsableDataSource(
         DataSourceId(datasetDirectoryName, organizationId),
         layers,
-        composeRequest.voxelSize,
+        voxelSize,
         None
       )
-
     } yield dataSource
 
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/ExploreLayerUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/ExploreLayerUtils.scala
@@ -18,7 +18,7 @@ import scala.util.Try
 
 trait ExploreLayerUtils extends FoxImplicits {
 
-  def adaptLayersAndVoxelSize(
+  protected def adaptLayersAndVoxelSize(
       layersWithVoxelSizes: List[(StaticLayer, VoxelSize)],
       preferredVoxelSize: Option[VoxelSize])(implicit ec: ExecutionContext): Fox[(List[StaticLayer], VoxelSize)] =
     for {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
