### PR TITLE
Run CI on push events

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -3,11 +3,8 @@ name: CI Pipeline
 on:
   push:
     branches:
-      - master
-    tags:
       - '*'
-  pull_request:
-    branches:
+    tags:
       - '*'
   workflow_dispatch: {}
 
@@ -153,17 +150,7 @@ jobs:
       - name: "Install System Dependencies"
         run: sudo apt-get update && sudo apt-get install -y libdraco-dev
 
-      - name: "Custom environment variables (Pull Request)"
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          NORMALIZED_BRANCH="${GITHUB_HEAD_REF//[\/-]/_}"
-          DOCKER_TAG="${NORMALIZED_BRANCH}__${GITHUB_RUN_ID}"
-          echo "DOCKER_TAG=$DOCKER_TAG" | tee -a "$GITHUB_ENV"
-          echo "NORMALIZED_BRANCH=$NORMALIZED_BRANCH" | tee -a "$GITHUB_ENV"
-          echo "CI_BUILD_NUM=$GITHUB_RUN_ID" | tee -a "$GITHUB_ENV"
-
       - name: "Custom environment variables (Not Pull Request)"
-        if: ${{ github.event_name != 'pull_request' }}
         run: |
           CI_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           NORMALIZED_BRANCH=${CI_BRANCH//[\/-]/_}
@@ -266,58 +253,48 @@ jobs:
         run: docker compose --file .github/docker-compose.yml down --volumes --remove-orphans
 
       - uses: docker/login-action@v3
-        if: ${{ github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Push webknossos image
-        if: ${{ ! startsWith(github.ref, 'refs/tags/') &&
-          github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') && github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/retry
         with:
           run: docker push "scalableminds/webknossos:${{ env.DOCKER_TAG }}"
           retries: 5
           retry_delay_seconds: 10
       - name: Push normalized webknossos image
-        if: ${{ github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/retry
         with:
           run: docker push "scalableminds/webknossos:${{ env.NORMALIZED_BRANCH }}"
           retries: 5
           retry_delay_seconds: 10
       - name: Push webknossos-datastore image
-        if: ${{ ! startsWith(github.ref, 'refs/tags/') &&
-          github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') && github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/retry
         with:
           run: docker push "scalableminds/webknossos-datastore:${{ env.DOCKER_TAG }}"
           retries: 5
           retry_delay_seconds: 10
       - name: Push normalized webknossos-datastore image
-        if: ${{ github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/retry
         with:
           run: docker push "scalableminds/webknossos-datastore:${{ env.NORMALIZED_BRANCH }}"
           retries: 5
           retry_delay_seconds: 10
       - name: Push webknossos-tracingstore image
-        if: ${{ ! startsWith(github.ref, 'refs/tags/') &&
-          github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') && github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/retry
         with:
           run: docker push "scalableminds/webknossos-tracingstore:${{ env.DOCKER_TAG }}"
           retries: 5
           retry_delay_seconds: 10
       - name: Push normalized webknossos-tracingstore image
-        if: ${{ github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: ./.github/actions/retry
         with:
           run: docker push "scalableminds/webknossos-tracingstore:${{ env.NORMALIZED_BRANCH }}"


### PR DESCRIPTION
### Changes to the CI
- Run CI only on push, but on all branches. Because of that, branches will now check out `/refs/pulls/*/head` instead of `/refs/pulls/*/merge` (Which caused a few bugs for some branches).
- The CI will not run for external PRs
