### PR TITLE
Cherry Pick: Speed up shader compilation and avoid WebGL crashes (#8950)

### DIFF
--- a/frontend/javascripts/test/shaders/shader_syntax.spec.ts
+++ b/frontend/javascripts/test/shaders/shader_syntax.spec.ts
@@ -48,6 +48,7 @@ describe("Shader syntax", () => {
       voxelSizeFactor: [1, 1, 1],
       isOrthogonal: true,
       voxelSizeFactorInverted: [1, 1, 1],
+      useInterpolation: false,
       tpsTransformPerLayer: {},
     });
 
@@ -99,6 +100,7 @@ describe("Shader syntax", () => {
       magnificationsCount: mags.length,
       voxelSizeFactor: [1, 1, 1],
       isOrthogonal: true,
+      useInterpolation: false,
       voxelSizeFactorInverted: [1, 1, 1],
       tpsTransformPerLayer: {},
     });
@@ -144,6 +146,7 @@ describe("Shader syntax", () => {
       magnificationsCount: mags.length,
       voxelSizeFactor: [1, 1, 1],
       isOrthogonal: true,
+      useInterpolation: true,
       voxelSizeFactorInverted: [1, 1, 1],
       tpsTransformPerLayer: {},
     });
@@ -181,6 +184,7 @@ describe("Shader syntax", () => {
       magnificationsCount: mags.length,
       voxelSizeFactor: [1, 1, 1],
       isOrthogonal: false,
+      useInterpolation: false,
       voxelSizeFactorInverted: [1, 1, 1],
       tpsTransformPerLayer: {},
     });
@@ -226,6 +230,7 @@ describe("Shader syntax", () => {
       magnificationsCount: mags.length,
       voxelSizeFactor: [1, 1, 1],
       isOrthogonal: false,
+      useInterpolation: true,
       voxelSizeFactorInverted: [1, 1, 1],
       tpsTransformPerLayer: {},
     });
@@ -262,6 +267,7 @@ describe("Shader syntax", () => {
       magnificationsCount: mags.length,
       voxelSizeFactor: [1, 1, 1],
       isOrthogonal: true,
+      useInterpolation: false,
       voxelSizeFactorInverted: [1, 1, 1],
       tpsTransformPerLayer: {},
     });

--- a/frontend/javascripts/viewer/controller/viewmodes/arbitrary_controller.tsx
+++ b/frontend/javascripts/viewer/controller/viewmodes/arbitrary_controller.tsx
@@ -328,6 +328,10 @@ class ArbitraryController extends React.PureComponent<Props> {
         },
       ),
       listenToStoreProperty(
+        (state) => state.datasetConfiguration.interpolation,
+        (interpolation) => this.plane.setLinearInterpolationEnabled(interpolation),
+      ),
+      listenToStoreProperty(
         (state) => state.temporaryConfiguration.flightmodeRecording,
         (isRecording) => {
           if (isRecording) {

--- a/frontend/javascripts/viewer/geometries/crosshair.ts
+++ b/frontend/javascripts/viewer/geometries/crosshair.ts
@@ -20,7 +20,6 @@ class Crosshair {
   SCALE_MIN: number;
   SCALE_MAX: number;
   scale: number;
-  isDirty: boolean;
 
   constructor(scale: number) {
     this.WIDTH = 256;
@@ -28,7 +27,6 @@ class Crosshair {
     this.SCALE_MIN = 0.01;
     this.SCALE_MAX = 1;
     this.scale = 0;
-    this.isDirty = true;
     this.mesh = this.createMesh();
     this.setScale(scale);
   }
@@ -62,7 +60,6 @@ class Crosshair {
     mesh.matrix.multiply(new Matrix4().makeTranslation(0, 0, 0.5));
     mesh.matrix.scale(new Vector3(this.scale, this.scale, this.scale));
     mesh.matrixWorldNeedsUpdate = true;
-    this.isDirty = false;
   }
 
   setScale(value: number) {
@@ -70,7 +67,6 @@ class Crosshair {
 
     if (value > SCALE_MIN && value < SCALE_MAX) {
       this.scale = value;
-      this.isDirty = true;
     }
   }
 

--- a/frontend/javascripts/viewer/geometries/materials/plane_material_factory.ts
+++ b/frontend/javascripts/viewer/geometries/materials/plane_material_factory.ts
@@ -63,6 +63,10 @@ type ShaderMaterialOptions = {
   polygonOffsetFactor?: number;
   polygonOffsetUnits?: number;
 };
+export type PlaneShaderMaterial = ShaderMaterial & {
+  setPositionOffset: (x: number, y: number, z: number) => void;
+  updateUseInterpolation: () => void;
+};
 const RECOMPILATION_THROTTLE_TIME = 500;
 export type Uniforms = Record<
   string,
@@ -116,7 +120,7 @@ function getTextureLayerInfos(): Params["textureLayerInfos"] {
 class PlaneMaterialFactory {
   planeID: OrthoView;
   isOrthogonal: boolean;
-  material: ShaderMaterial | undefined | null;
+  material: PlaneShaderMaterial | undefined | null;
   uniforms: Uniforms = {};
   attributes: Record<string, any> = {};
   shaderId: number;
@@ -170,9 +174,6 @@ class PlaneMaterialFactory {
       },
       zoomValue: {
         value: 1,
-      },
-      useBilinearFiltering: {
-        value: true,
       },
       viewportExtent: {
         value: [0, 0],
@@ -449,22 +450,16 @@ class PlaneMaterialFactory {
         vertexShader: this.getVertexShader(),
         fragmentShader,
       }),
-    );
-    // @ts-expect-error ts-migrate(2739) FIXME: Type '{ derivatives: true; }' is missing the follo... Remove this comment to see the full error message
-    this.material.extensions = {
-      // Necessary for anti-aliasing via fwidth in shader
-      // derivatives: true,
-    };
+    ) as PlaneShaderMaterial;
+
     shaderEditor.addMaterial(this.shaderId, this.material);
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'setPositionOffset' does not exist on typ... Remove this comment to see the full error message
     this.material.setPositionOffset = (x, y, z) => {
       this.uniforms.positionOffset.value.set(x, y, z);
     };
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'setUseBilinearFiltering' does not exist ... Remove this comment to see the full error message
-    this.material.setUseBilinearFiltering = (isEnabled) => {
-      this.uniforms.useBilinearFiltering.value = isEnabled;
+    this.material.updateUseInterpolation = () => {
+      this.recomputeShaders();
     };
 
     this.material.side = DoubleSide;
@@ -981,7 +976,7 @@ class PlaneMaterialFactory {
     this.uniforms[`${name}_gammaCorrectionValue`].value = gammaCorrectionValue;
   }
 
-  getMaterial(): ShaderMaterial {
+  getMaterial(): PlaneShaderMaterial {
     if (this.material == null) {
       throw new Error("Tried to access material, but it is null.");
     }
@@ -1107,7 +1102,8 @@ class PlaneMaterialFactory {
   };
 
   getFragmentShaderWithUniforms(): [string, Uniforms] {
-    const { maximumLayerCountToRender } = Store.getState().temporaryConfiguration.gpuSetup;
+    const state = Store.getState();
+    const { maximumLayerCountToRender } = state.temporaryConfiguration.gpuSetup;
     const [colorLayerNames, segmentationLayerNames, orderedColorLayerNames, globalLayerCount] =
       this.getLayersToRender(maximumLayerCountToRender);
 
@@ -1118,9 +1114,10 @@ class PlaneMaterialFactory {
     );
 
     const textureLayerInfos = getTextureLayerInfos();
-    const { dataset } = Store.getState();
+    const { dataset } = state;
     const voxelSizeFactor = dataset.dataSource.scale.factor;
     const voxelSizeFactorInverted = V3.divide3([1, 1, 1], voxelSizeFactor);
+    const { interpolation } = state.datasetConfiguration;
     const code = getMainFragmentShader({
       globalLayerCount,
       orderedColorLayerNames,
@@ -1131,6 +1128,7 @@ class PlaneMaterialFactory {
       voxelSizeFactor,
       voxelSizeFactorInverted,
       isOrthogonal: this.isOrthogonal,
+      useInterpolation: interpolation,
       tpsTransformPerLayer: this.scaledTpsInvPerLayer,
     });
     return [
@@ -1149,14 +1147,16 @@ class PlaneMaterialFactory {
   }
 
   getVertexShader(): string {
-    const { maximumLayerCountToRender } = Store.getState().temporaryConfiguration.gpuSetup;
+    const state = Store.getState();
+    const { maximumLayerCountToRender } = state.temporaryConfiguration.gpuSetup;
     const [colorLayerNames, segmentationLayerNames, orderedColorLayerNames, globalLayerCount] =
       this.getLayersToRender(maximumLayerCountToRender);
 
     const textureLayerInfos = getTextureLayerInfos();
-    const { dataset } = Store.getState();
+    const { dataset } = state;
     const voxelSizeFactor = dataset.dataSource.scale.factor;
     const voxelSizeFactorInverted = V3.divide3([1, 1, 1], voxelSizeFactor);
+    const { interpolation } = state.datasetConfiguration;
 
     return getMainVertexShader({
       globalLayerCount,
@@ -1168,6 +1168,7 @@ class PlaneMaterialFactory {
       voxelSizeFactor,
       voxelSizeFactorInverted,
       isOrthogonal: this.isOrthogonal,
+      useInterpolation: interpolation,
       tpsTransformPerLayer: this.scaledTpsInvPerLayer,
     });
   }

--- a/frontend/javascripts/viewer/geometries/plane.ts
+++ b/frontend/javascripts/viewer/geometries/plane.ts
@@ -9,6 +9,7 @@ import {
   LineSegments,
   Matrix4,
   Mesh,
+  type Object3DEventMap,
   PlaneGeometry,
   Vector3 as ThreeVector3,
 } from "three";
@@ -19,7 +20,9 @@ import constants, {
   OrthoViewGrayCrosshairColor,
   OrthoViewValues,
 } from "viewer/constants";
-import PlaneMaterialFactory from "viewer/geometries/materials/plane_material_factory";
+import PlaneMaterialFactory, {
+  type PlaneShaderMaterial,
+} from "viewer/geometries/materials/plane_material_factory";
 import { listenToStoreProperty } from "viewer/model/helpers/listener_helpers";
 
 // A subdivision of 100 means that there will be 100 segments per axis
@@ -42,8 +45,7 @@ const DEFAULT_POSITION_OFFSET = [0, 0, 0] as Vector3;
 class Plane {
   // This class is supposed to collect all the Geometries that belong to one single plane such as
   // the plane itself, its texture, borders and crosshairs.
-  // @ts-expect-error ts-migrate(2564) FIXME: Property 'plane' has no initializer and is not def... Remove this comment to see the full error message
-  plane: Mesh<PlaneGeometry, ShaderMaterial, Object3DEventMap>;
+  plane!: Mesh<PlaneGeometry, PlaneShaderMaterial, Object3DEventMap>;
   planeID: OrthoView;
   materialFactory!: PlaneMaterialFactory;
   displayCrosshair: boolean;
@@ -208,8 +210,8 @@ class Plane {
   };
 
   getMeshes = () => [this.plane, this.TDViewBorders, this.crosshair[0], this.crosshair[1]];
-  setLinearInterpolationEnabled = (enabled: boolean) => {
-    this.plane.material.setUseBilinearFiltering(enabled);
+  setLinearInterpolationEnabled = (_enabled: boolean) => {
+    this.plane.material.updateUseInterpolation();
   };
 
   destroy() {

--- a/frontend/javascripts/viewer/shaders/filtering.glsl.ts
+++ b/frontend/javascripts/viewer/shaders/filtering.glsl.ts
@@ -13,20 +13,32 @@ export const getBilinearColorFor: ShaderModule = {
       coordsUVW = coordsUVW + vec3(-0.5, -0.5, 0.0);
       vec2 bifilteringParams = (coordsUVW - floor(coordsUVW)).xy;
       coordsUVW = floor(coordsUVW);
-
       bool supportsPrecomputedBucketAddress = false;
-      vec4 a = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW, supportsPrecomputedBucketAddress);
-      vec4 b = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 0, 0), supportsPrecomputedBucketAddress);
-      vec4 c = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 1, 0), supportsPrecomputedBucketAddress);
-      vec4 d = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 1, 0), supportsPrecomputedBucketAddress);
-      if (a.a < 0.0 || b.a < 0.0 || c.a < 0.0 || d.a < 0.0) {
+
+      // Do not unroll this loop as it will lead to much slower compilation and
+      // possibly WebGL crashes, because some compilers cannot optimize it as well then.
+      vec4 samples[4];
+      int idx = 0;
+      for (int y = 0; y <= 1; y++) {
+          for (int x = 0; x <= 1; x++) {
+              vec3 offset = vec3(x, y, 0);
+              samples[idx] = getColorForCoords(
+                  layerIndex, d_texture_width, packingDegree,
+                  coordsUVW + offset,
+                  supportsPrecomputedBucketAddress
+              );
+              idx++;
+          }
+      }
+
+      if (samples[0].a < 0.0 || samples[1].a < 0.0 || samples[2].a < 0.0 || samples[3].a < 0.0) {
         // We need to check all four colors for a negative parts, because there will be black
         // lines at the borders otherwise (black gets mixed with data)
         return vec4(0.0, 0.0, 0.0, -1.0);
       }
 
-      vec4 ab = mix(a, b, bifilteringParams.x);
-      vec4 cd = mix(c, d, bifilteringParams.x);
+      vec4 ab = mix(samples[0], samples[1], bifilteringParams.x);
+      vec4 cd = mix(samples[2], samples[3], bifilteringParams.x);
 
       return mix(ab, cd, bifilteringParams.y);
     }
@@ -46,29 +58,37 @@ export const getTrilinearColorFor: ShaderModule = {
       coordsUVW = floor(coordsUVW);
       bool supportsPrecomputedBucketAddress = false;
 
-      vec4 a = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW, supportsPrecomputedBucketAddress);
-      vec4 b = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 0, 0), supportsPrecomputedBucketAddress);
-      vec4 c = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 1, 0), supportsPrecomputedBucketAddress);
-      vec4 d = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 1, 0), supportsPrecomputedBucketAddress);
+      // Do not unroll this loop as it will lead to much slower compilation and
+      // possibly WebGL crashes, because some compilers cannot optimize it as well then.
+      vec4 samples[8];
+      int idx = 0;
+      for (int z = 0; z <= 1; z++) {
+          for (int y = 0; y <= 1; y++) {
+              for (int x = 0; x <= 1; x++) {
+                  vec3 offset = vec3(x, y, z);
+                  samples[idx] = getColorForCoords(
+                      layerIndex, d_texture_width, packingDegree,
+                      coordsUVW + offset,
+                      supportsPrecomputedBucketAddress
+                  );
+                  idx++;
+              }
+          }
+      }
 
-      vec4 a2 = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 0, 1), supportsPrecomputedBucketAddress);
-      vec4 b2 = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 0, 1), supportsPrecomputedBucketAddress);
-      vec4 c2 = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(0, 1, 1), supportsPrecomputedBucketAddress);
-      vec4 d2 = getColorForCoords(layerIndex, d_texture_width, packingDegree, coordsUVW + vec3(1, 1, 1), supportsPrecomputedBucketAddress);
-
-      if (a.a < 0.0 || b.a < 0.0 || c.a < 0.0 || d.a < 0.0 ||
-        a2.a < 0.0 || b2.a < 0.0 || c2.a < 0.0 || d2.a < 0.0) {
-        // We need to check all four colors for a negative parts, because there will be black
+      if (samples[0].a < 0.0 || samples[1].a < 0.0 || samples[2].a < 0.0 || samples[3].a < 0.0 ||
+        samples[4].a < 0.0 || samples[5].a < 0.0 || samples[6].a < 0.0 || samples[7].a < 0.0) {
+        // We need to check all eight colors for a negative parts, because there will be black
         // lines at the borders otherwise (black gets mixed with data)
         return vec4(0.0, 0.0, 0.0, -1.0);
       }
 
-      vec4 ab = mix(a, b, bifilteringParams.x);
-      vec4 cd = mix(c, d, bifilteringParams.x);
+      vec4 ab = mix(samples[0], samples[1], bifilteringParams.x);
+      vec4 cd = mix(samples[2], samples[3], bifilteringParams.x);
       vec4 abcd = mix(ab, cd, bifilteringParams.y);
 
-      vec4 ab2 = mix(a2, b2, bifilteringParams.x);
-      vec4 cd2 = mix(c2, d2, bifilteringParams.x);
+      vec4 ab2 = mix(samples[4], samples[5], bifilteringParams.x);
+      vec4 cd2 = mix(samples[6], samples[7], bifilteringParams.x);
 
       vec4 abcd2 = mix(ab2, cd2, bifilteringParams.y);
 
@@ -84,11 +104,10 @@ const getMaybeFilteredColor: ShaderModule = {
       float d_texture_width,
       float packingDegree,
       vec3 worldPositionUVW,
-      bool suppressBilinearFiltering,
       bool supportsPrecomputedBucketAddress
     ) {
       vec4 color;
-      if (!suppressBilinearFiltering && useBilinearFiltering) {
+      <% if (useInterpolation) { %>
         <% if (isOrthogonal) { %>
           if(isFlycamRotated){
             color = getTrilinearColorFor(layerIndex, d_texture_width, packingDegree, worldPositionUVW);
@@ -98,9 +117,9 @@ const getMaybeFilteredColor: ShaderModule = {
         <% } else { %>
           color = getTrilinearColorFor(layerIndex, d_texture_width, packingDegree, worldPositionUVW);
         <% } %>
-      } else {
+      <% } else { %>
         color = getColorForCoords(layerIndex, d_texture_width, packingDegree, worldPositionUVW, supportsPrecomputedBucketAddress);
-      }
+      <% } %>
       return color;
     }
   `,
@@ -118,13 +137,12 @@ export const getMaybeFilteredColorOrFallback: ShaderModule = {
       float d_texture_width,
       float packingDegree,
       vec3 worldPositionUVW,
-      bool suppressBilinearFiltering,
       vec4 fallbackColor,
       bool supportsPrecomputedBucketAddress
     ) {
       MaybeFilteredColor maybe_filtered_color;
       maybe_filtered_color.used_fallback_color = false;
-      maybe_filtered_color.color = getMaybeFilteredColor(layerIndex, d_texture_width, packingDegree, worldPositionUVW, suppressBilinearFiltering, supportsPrecomputedBucketAddress);
+      maybe_filtered_color.color = getMaybeFilteredColor(layerIndex, d_texture_width, packingDegree, worldPositionUVW, supportsPrecomputedBucketAddress);
 
       if (maybe_filtered_color.color.a < 0.0) {
         // Render gray for not-yet-existing data

--- a/frontend/javascripts/viewer/shaders/main_data_shaders.glsl.ts
+++ b/frontend/javascripts/viewer/shaders/main_data_shaders.glsl.ts
@@ -23,6 +23,7 @@ import {
   getSegmentationAlphaIncrement,
 } from "./segmentation.glsl";
 import compileShader from "./shader_module_system";
+import { getColorForCoords } from "./texture_access.glsl";
 import {
   generateCalculateTpsOffsetFunction,
   generateTpsInitialization,
@@ -60,6 +61,7 @@ export type Params = {
   voxelSizeFactor: Vector3;
   voxelSizeFactorInverted: Vector3;
   isOrthogonal: boolean;
+  useInterpolation: boolean;
   tpsTransformPerLayer: Record<string, TPS3D>;
 };
 
@@ -138,7 +140,6 @@ uniform vec3 bboxMax;
 uniform vec3 positionOffset;
 uniform vec3 activeSegmentPosition;
 uniform float zoomValue;
-uniform bool useBilinearFiltering;
 uniform float blendMode;
 uniform vec3 globalMousePosition;
 uniform bool isMouseInCanvas;
@@ -169,7 +170,6 @@ precision highp float;
 ${SHARED_UNIFORM_DECLARATIONS}
 
 flat in vec2 index;
-flat in uvec4 outputCompressedEntry[<%= globalLayerCount %>];
 flat in uint outputMagIdx[<%= globalLayerCount %>];
 flat in uint outputSeed[<%= globalLayerCount %>];
 flat in float outputAddress[<%= globalLayerCount %>];
@@ -277,7 +277,6 @@ void main() {
             <%= name %>_data_texture_width,
             <%= formatNumberAsGLSLFloat(textureLayerInfos[name].packingDegree) %>,
             transformedCoordUVW,
-            false,
             fallbackGray,
             !<%= name %>_has_transform
           );
@@ -435,7 +434,6 @@ out mat4 savedModelMatrix;
 }) %>
 
 flat out vec2 index;
-flat out uvec4 outputCompressedEntry[<%= globalLayerCount %>];
 flat out uint outputMagIdx[<%= globalLayerCount %>];
 flat out uint outputSeed[<%= globalLayerCount %>];
 flat out float outputAddress[<%= globalLayerCount %>];
@@ -452,9 +450,9 @@ ${compileShader(
   isFlightMode,
   transDim,
   getAbsoluteCoords,
+  getColorForCoords,
   getWorldCoordUVW,
   isOutsideOfBoundingBox,
-  getMaybeFilteredColorOrFallback,
   hasSegmentation ? getSegmentId : null,
   getMagnification,
   almostEq,

--- a/frontend/javascripts/viewer/shaders/segmentation.glsl.ts
+++ b/frontend/javascripts/viewer/shaders/segmentation.glsl.ts
@@ -11,6 +11,7 @@ import {
   jsRgb2hsv,
 } from "viewer/shaders/utils.glsl";
 import { getUnrotatedWorldCoordUVW } from "./coords.glsl";
+import { getMaybeFilteredColorOrFallback } from "./filtering.glsl";
 import { hashCombine } from "./hashing.glsl";
 import { attemptMappingLookUp } from "./mappings.glsl";
 import type { ShaderModule } from "./shader_module_system";
@@ -389,7 +390,7 @@ export const getCrossHairOverlay: ShaderModule = {
 };
 
 export const getSegmentId: ShaderModule = {
-  requirements: [convertCellIdToRGB, attemptMappingLookUp],
+  requirements: [convertCellIdToRGB, attemptMappingLookUp, getMaybeFilteredColorOrFallback],
   code: `
 
   <% _.each(segmentationLayerNames, function(segmentationName, layerIndex) { %>

--- a/frontend/javascripts/viewer/shaders/texture_access.glsl.ts
+++ b/frontend/javascripts/viewer/shaders/texture_access.glsl.ts
@@ -129,10 +129,6 @@ export const getColorForCoords: ShaderModule = {
 
       uvec4 compressedEntry = texelFetch(lookup_texture, ivec2(x, y), 0);
 
-      <% if (!isFragment) { %>
-        outputCompressedEntry[globalLayerIndex] = compressedEntry;
-      <% } %>
-
       uint compressedBytes = compressedEntry.a;
       uint foundMagIdx = compressedBytes >> (32u - 5u);
       uint foundLayerIndex = (compressedBytes >> 21u) & (uint(pow(2., 6.)) - 1u);
@@ -189,6 +185,8 @@ export const getColorForCoords: ShaderModule = {
 
       // Will hold [highValue, lowValue];
       vec4 returnValue[2];
+      returnValue[0] = vec4(0.0);
+      returnValue[1] = vec4(0.0);
 
       if (worldPositionUVW.x < 0. || worldPositionUVW.y < 0. || worldPositionUVW.z < 0.) {
         // Negative coordinates would likely produce incorrect bucket look ups due to casting
@@ -207,19 +205,17 @@ export const getColorForCoords: ShaderModule = {
       // To avoid rare rendering artifacts, don't use the precomputed
       // bucket address when being at the border of buckets.
       bool beSafe = isFlycamRotated || !<%= isOrthogonal %>;
-      {
-        renderedMagIdx = outputMagIdx[globalLayerIndex];
-        vec3 coords = floor(getAbsoluteCoords(worldPositionUVW, renderedMagIdx, globalLayerIndex));
-        vec3 absoluteBucketPosition = div(coords, bucketWidth);
-        offsetInBucket = mod(coords, bucketWidth);
-        vec3 offsetInBucketUVW = transDim(offsetInBucket);
-        if (offsetInBucketUVW.x < 0.01 || offsetInBucketUVW.y < 0.01
-            || offsetInBucketUVW.x >= 31. || offsetInBucketUVW.y >= 31.
-            || isNan(offsetInBucketUVW.x) || isNan(offsetInBucketUVW.y)
-            || isNan(offsetInBucketUVW.z)
-          ) {
-          beSafe = true;
-        }
+      renderedMagIdx = outputMagIdx[globalLayerIndex];
+      vec3 coords = floor(getAbsoluteCoords(worldPositionUVW, renderedMagIdx, globalLayerIndex));
+      vec3 absoluteBucketPosition = div(coords, bucketWidth);
+      offsetInBucket = mod(coords, bucketWidth);
+      vec3 offsetInBucketUVW = transDim(offsetInBucket);
+      if (offsetInBucketUVW.x < 0.01 || offsetInBucketUVW.y < 0.01
+          || offsetInBucketUVW.x >= 31. || offsetInBucketUVW.y >= 31.
+          || isNan(offsetInBucketUVW.x) || isNan(offsetInBucketUVW.y)
+          || isNan(offsetInBucketUVW.z)
+        ) {
+        beSafe = true;
       }
 
 

--- a/frontend/javascripts/viewer/view/left-border-tabs/controls_and_rendering_settings_tab.tsx
+++ b/frontend/javascripts/viewer/view/left-border-tabs/controls_and_rendering_settings_tab.tsx
@@ -375,25 +375,23 @@ class ControlsAndRenderingSettingsTab extends PureComponent<ControlsAndRendering
               value={this.props.datasetConfiguration.fourBit}
               onChange={this.onChangeDataset.fourBit}
             />
-            {Constants.MODES_ARBITRARY.includes(this.props.viewMode) ? null : (
-              <div>
-                <SwitchSetting
-                  label={
-                    <FastTooltip title={settingsTooltips.interpolation}>
-                      {settingsLabels.interpolation}
-                    </FastTooltip>
-                  }
-                  value={this.props.datasetConfiguration.interpolation}
-                  onChange={this.onChangeDataset.interpolation}
-                >
-                  {this.props.datasetConfiguration.interpolation && (
-                    <FastTooltip title="Consider disabling interpolation if you notice degraded rendering performance.">
-                      {PERFORMANCE_WARNING_ICON}
-                    </FastTooltip>
-                  )}
-                </SwitchSetting>
-              </div>
-            )}
+            <div>
+              <SwitchSetting
+                label={
+                  <FastTooltip title={settingsTooltips.interpolation}>
+                    {settingsLabels.interpolation}
+                  </FastTooltip>
+                }
+                value={this.props.datasetConfiguration.interpolation}
+                onChange={this.onChangeDataset.interpolation}
+              >
+                {this.props.datasetConfiguration.interpolation && (
+                  <FastTooltip title="Consider disabling interpolation if you notice degraded rendering performance.">
+                    {PERFORMANCE_WARNING_ICON}
+                  </FastTooltip>
+                )}
+              </SwitchSetting>
+            </div>
             <SwitchSetting
               label={
                 <FastTooltip title={settingsTooltips.antialiasRendering}>

--- a/unreleased_changes/8950.md
+++ b/unreleased_changes/8950.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed WebGL crashes for datasets with many layers and sped up shader compilation time.


### PR DESCRIPTION
Cherry pick #8950 with e110f7030c30847de9058ba92625e15437c2e77c as the base.

Use loops for bi- and trilinear filtering in shader to speed up shader compilation and avoid WebGL crashes for datasets with many layers.

Turns out, WebGL drivers usually can optimize loops much better than unrolled ones. In this case, the `getColorForCoords` function is very complex which exacerbates the issue.

There's still a lot of room for improvement, but this is a low-hanging fruit we should definitely pick.

Also allow to disable interpolation in flight and oblique mode and recompute the shader based on whether it is enabled or not. The version for disabled interpolation is much less complex and compiles a lot faster.

As a followup, I'll add a fallback that if interpolation is enabled and the shader compilation crashes, it gets disabled and shader compilation will be retried. I'll also add some analytics events, for example time to first render.

### URL of deployed dev instance (used for testing):
- https://cherrypickwebglcrashfix.webknossos.xyz/

### Steps to test:
- Open a dataset with more than 3 color layers or a dataset that crashes WebGL on master on your machine (for example, the data_types dataset, at least for my machine). WebGL should no longer crash. Also other datasets should load faster and with less lag than on master.
- Measurements for my machine obtained using the Chrome performance tab:
  - 1-color layer 1.7s GPU freeze (now no freeze)
  - 2-color layer 7s GPU freeze (now 0.9s)
  - 3-color layer 14s GPU freeze (now 1.8s)
  - 4-color layer crash (now 2.4s)
  - 5-color layer crash (now 4.5s)
  - 8-color layer crash (now 10.8s)
  - 1-color 1-segmentation layer 3s GPU freeze (now 0.2s)
- Play around with the interpolation setting in all view modes. There might be a freeze during the first toggle since the shader is recompiled. Afterwards, it's usually cached.
- [x] Run the screenshot tests for this branch ([CI run](https://github.com/scalableminds/webknossos/actions/runs/18188353576))

### Issues:
- fixes WebGL crashes for datasets with many layers

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
