### PR TITLE
Fix deduplication of mags/attachments to scan for storage

### DIFF
--- a/app/models/dataset/Dataset.scala
+++ b/app/models/dataset/Dataset.scala
@@ -778,19 +778,31 @@ class DatasetMagsDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionConte
                                  dataStoreId: String,
                                  datasetIdOpt: Option[ObjectId]): Fox[List[DataSourceMagRow]] =
     for {
-      storageRelevantMags <- run(q"""SELECT
-            dataset_id, dataLayerName, mag, path, realPath, hasLocalData, _organization, directoryName
-            FROM (
-              -- rn is the rank of the mags with the same path. We only retrieve the oldest mag with the same path to measure each mag only once.
-              SELECT ds._id AS dataset_id, mag.dataLayerName, mag.mag, mag.path, mag.realPath, mag.hasLocalData,
-                     ds._organization, ds.directoryName, ROW_NUMBER() OVER (PARTITION BY COALESCE(mag.realPath, mag.path) ORDER BY ds.created ASC) AS rn
+      storageRelevantMags <- run(q"""
+            WITH ranked AS (
+              SELECT
+                ds._id AS dataset_id, mag.dataLayerName, mag.mag, mag.path, mag.realPath, mag.hasLocalData,
+                ds._organization, ds._dataStore, ds.directoryName,
+                -- rn is the rank of the mags with the same path. It is used to deduplicate mags with the same path to
+                -- count each physical mag only once. Filtering is done below.
+                ROW_NUMBER() OVER (
+                  PARTITION BY COALESCE(mag.realPath, mag.path)
+                  ORDER BY ds.created ASC
+                ) AS rn
               FROM webknossos.dataset_mags AS mag
-              JOIN webknossos.datasets AS ds ON mag._dataset = ds._id
-              WHERE ds._organization = $organizationId
-                AND ds._dataStore = $dataStoreId
-                ${datasetIdOpt.map(datasetId => q"AND ds._id = $datasetId").getOrElse(q"")}
-            ) AS ranked
-            WHERE rn = 1;""".as[DataSourceMagRow])
+              JOIN webknossos.datasets AS ds
+                ON mag._dataset = ds._id
+            )
+            SELECT
+              dataset_id, dataLayerName, mag, path, realPath, hasLocalData, _organization, directoryName
+            FROM ranked
+            -- Filter !after! grouping mags with the same path,
+            -- so mags shared between organizations are deduplicated properly using rn.
+            WHERE rn = 1
+              AND ranked._organization = $organizationId
+              AND ranked._dataStore = $dataStoreId
+              ${datasetIdOpt.map(datasetId => q"AND ranked.dataset_id = $datasetId").getOrElse(q"")};
+            """.as[DataSourceMagRow])
     } yield storageRelevantMags.toList
 
   def updateMags(datasetId: ObjectId, dataLayers: List[StaticLayer]): Fox[Unit] = {
@@ -1221,23 +1233,30 @@ class DatasetLayerAttachmentsDAO @Inject()(sqlClient: SqlClient)(implicit ec: Ex
                                         dataStoreId: String,
                                         datasetIdOpt: Option[ObjectId]): Fox[List[StorageRelevantDataLayerAttachment]] =
     for {
-      storageRelevantAttachments <- run(q"""SELECT
-                                            _dataset, layerName, name, path, type, _organization, directoryName
-                                            FROM (
-                                              -- rn is the rank of the attachments with the same path. We only retrieve the
-                                              -- oldest attachment with the same path to measuring an attachment only once.
-                                              SELECT
-                                                att._dataset, att.layerName, att.name, att.path, att.type, ds._organization, ds.directoryName,
-                                                ROW_NUMBER() OVER (PARTITION BY att.path ORDER BY ds.created ASC) AS rn
-                                              FROM webknossos.dataset_layer_attachments AS att
-                                              JOIN webknossos.datasets AS ds ON att._dataset = ds._id
-                                              WHERE ds._organization = $organizationId
-                                                AND ds._dataStore = $dataStoreId
-                                                ${datasetIdOpt
-        .map(datasetId => q"AND ds._id = $datasetId")
-        .getOrElse(q"")}
-                                            ) AS ranked
-                                            WHERE rn = 1;""".as[StorageRelevantDataLayerAttachment])
+      storageRelevantAttachments <- run(q"""
+          WITH ranked AS (
+            SELECT
+              att._dataset, att.layerName, att.name, att.path, att.type, ds._organization, ds._dataStore, ds.directoryName,
+              -- rn is the rank of the attachments with the same path. It is used to deduplicate attachments with the same path
+               -- to count each physical attachment only once. Filtering is done below.
+              ROW_NUMBER() OVER (
+                PARTITION BY att.path
+                ORDER BY ds.created ASC
+              ) AS rn
+            FROM webknossos.dataset_layer_attachments AS att
+            JOIN webknossos.datasets AS ds
+              ON att._dataset = ds._id
+          )
+          SELECT
+            _dataset, layerName, name, path, type, _organization, directoryName
+          FROM ranked
+          -- Filter !after! grouping attachments with the same path,
+          -- so attachments shared between organizations are deduplicated properly using rn.
+          WHERE ranked.rn = 1
+            AND ranked._organization = $organizationId
+            AND ranked._dataStore = $dataStoreId
+            ${datasetIdOpt.map(datasetId => q"AND ranked._dataset = $datasetId").getOrElse(q"")};
+           """.as[StorageRelevantDataLayerAttachment])
     } yield storageRelevantAttachments.toList
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -245,6 +245,8 @@ datastore {
     # For GoogleServiceAccount the secret is a json string.
     # The credentials are selected by uri prefix, so different s3 uri styles may need duplicated credential entries.
     credentials = []
+    # Use for local dev scenarios (needs env variable to be defined).
+    # credentials = [{type = "S3AccessKey", name = ${?S3_BUCKET}, identifier = ${?S3_ACCESS_KEY_ID}, secret = ${?S3_SECRET_ACCESS_KEY}}]
   }
 }
 

--- a/conf/evolutions/144-improve-storage-scan.sql
+++ b/conf/evolutions/144-improve-storage-scan.sql
@@ -2,8 +2,8 @@ START TRANSACTION;
 
 do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 143 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
 
-CREATE INDEX ON webknossos.dataset_mags (COALESCE(realPath, path));
-CREATE INDEX ON webknossos.dataset_layer_attachments path
+CREATE INDEX ON webknossos.dataset_mags(COALESCE(realPath, path));
+CREATE INDEX ON webknossos.dataset_layer_attachments(path);
 
 UPDATE webknossos.releaseInformation SET schemaVersion = 144;
 

--- a/conf/evolutions/144-improve-storage-scan.sql
+++ b/conf/evolutions/144-improve-storage-scan.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 143 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+CREATE INDEX ON webknossos.dataset_mags (COALESCE(realPath, path));
+CREATE INDEX ON webknossos.dataset_layer_attachments path
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 144;
+
+COMMIT TRANSACTION;

--- a/conf/evolutions/reversions/144-improve-storage-scan.sql
+++ b/conf/evolutions/reversions/144-improve-storage-scan.sql
@@ -2,7 +2,7 @@ START TRANSACTION;
 
 do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 144 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
 
-DROP INDEX IF EXISTS webknossos.dataset_mags_coalesce_realpath_path_idx;
+DROP INDEX IF EXISTS webknossos.dataset_mags_coalesce_idx;
 DROP INDEX IF EXISTS webknossos.dataset_layer_attachments_path_idx;
 
 UPDATE webknossos.releaseInformation SET schemaVersion = 143;

--- a/conf/evolutions/reversions/144-improve-storage-scan.sql
+++ b/conf/evolutions/reversions/144-improve-storage-scan.sql
@@ -1,0 +1,11 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 144 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+DROP INDEX IF EXISTS webknossos.dataset_mags_coalesce_realpath_path_idx;
+DROP INDEX IF EXISTS webknossos.dataset_layer_attachments_path_idx;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 143;
+
+
+COMMIT TRANSACTION;

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
 
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(143);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(144);
 COMMIT TRANSACTION;
 
 
@@ -849,8 +849,8 @@ CREATE INDEX ON webknossos.invites(tokenValue);
 CREATE INDEX ON webknossos.annotation_privateLinks(accessToken);
 CREATE INDEX ON webknossos.shortLinks(key);
 CREATE INDEX ON webknossos.credit_transactions(credit_state);
-CREATE INDEX ON webknossos.dataset_mags (COALESCE(realPath, path));
-CREATE INDEX ON webknossos.dataset_layer_attachments path
+CREATE INDEX ON webknossos.dataset_mags(COALESCE(realPath, path));
+CREATE INDEX ON webknossos.dataset_layer_attachments(path);
 CREATE INDEX ON webknossos.organization_usedStorage_mags(_organization);
 CREATE INDEX ON webknossos.organization_usedStorage_attachments(_organization);
 

--- a/tools/postgres/schema.sql
+++ b/tools/postgres/schema.sql
@@ -849,9 +849,10 @@ CREATE INDEX ON webknossos.invites(tokenValue);
 CREATE INDEX ON webknossos.annotation_privateLinks(accessToken);
 CREATE INDEX ON webknossos.shortLinks(key);
 CREATE INDEX ON webknossos.credit_transactions(credit_state);
+CREATE INDEX ON webknossos.dataset_mags (COALESCE(realPath, path));
+CREATE INDEX ON webknossos.dataset_layer_attachments path
 CREATE INDEX ON webknossos.organization_usedStorage_mags(_organization);
 CREATE INDEX ON webknossos.organization_usedStorage_attachments(_organization);
-
 
 ALTER TABLE webknossos.annotations
   ADD CONSTRAINT task_ref FOREIGN KEY(_task) REFERENCES webknossos.tasks(_id) ON DELETE SET NULL DEFERRABLE,

--- a/unreleased_changes/8981.md
+++ b/unreleased_changes/8981.md
@@ -1,0 +1,5 @@
+### Fixed
+- Fixed deduplication of storage scans for dataset mags & attachments used accross multiple organizations.
+
+### Postgres Evolutions
+[144-improve-storage-scan.sql](conf/evolutions/144-improve-storage-scan.sql)

--- a/unreleased_changes/8981.md
+++ b/unreleased_changes/8981.md
@@ -1,5 +1,5 @@
 ### Fixed
-- Fixed deduplication of storage scans for dataset mags & attachments used accross multiple organizations.
+- Fixed a bug where storage scans for dataset mags & attachments used accross multiple organizations would count some paths twice.
 
 ### Postgres Evolutions
 [144-improve-storage-scan.sql](conf/evolutions/144-improve-storage-scan.sql)


### PR DESCRIPTION
This PR is a follow up fix for #8789. The problem with #8789 is that it allowed mags to be measured for storage amount multiple times if used across multiple times across multipe organizations. This PR fixes the logical bug in the sql query. Same goes for attachments.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I suggest to test locally.
- On master: Create a new orga (e.g. via `isWkOrgInstance=true` in `application.conf`); 
- also reduce `fetchUsedStorage` time in `application.conf`. e.g. `rescanInterval = 30 seconds` `tickerInterval = 10 seconds`
- Symlink a dataset from the sample_organization into the new orga
- Trigger a dataset rescan in the new orga
- The symlinked dataset's mags should now appear in 
```
SELECT * FROM (SELECT COUNT(*) AS count, COALESCE(realPath, path) as ppath FROM webknossos.dataset_mags
GROUP BY ppath) WHERE count > 1
```
- Check the `webknossos.organization_usedstorage_mags` table. It should list duplicate measurements for the mag paths of the symlinked dataset.
```
SELECT * FROM (SELECT COUNT(*) AS count, path FROM webknossos.organization_usedstorage_mags
GROUP BY path) WHERE count > 1
``` 
- Now checkout this branch. !Do not refresh the schema!
- Run this branch's evolution
-  Wait a bit for the storage rescan and check the `organization_usedstorage_mags` table again. There should no longer be duplicates. The following query's set should be empty now
```
SELECT * FROM (SELECT COUNT(*) AS count, path FROM webknossos.organization_usedstorage_mags
GROUP BY path) WHERE count > 1
``` 

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1759761569291259; follow up for #8789

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Added migration guide entry if applicable (edit the same file as for the changelog)
- [x] Needs datastore update after deployment
