### PR TITLE
Unify backend rpc addQueryParam methods

### DIFF
--- a/app/models/annotation/WKRemoteTracingStoreClient.scala
+++ b/app/models/annotation/WKRemoteTracingStoreClient.scala
@@ -49,9 +49,9 @@ class WKRemoteTracingStoreClient(
     for {
       _ <- Fox.fromBool(annotationLayer.typ == AnnotationLayerType.Skeleton) ?~> "annotation.download.fetch.notSkeleton"
       skeletonTracing <- rpc(s"${tracingStore.url}/tracings/skeleton/${annotationLayer.tracingId}")
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-        .addQueryString("annotationId" -> annotationId.toString)
-        .addQueryStringOptional("version", version.map(_.toString))
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
+        .addQueryParam("annotationId", annotationId)
+        .addQueryParam("version", version)
         .withLongTimeout
         .getWithProtoResponse[SkeletonTracing](SkeletonTracing)
       fetchedAnnotationLayer <- FetchedAnnotationLayer.fromAnnotationLayer(annotationLayer, Left(skeletonTracing))
@@ -61,7 +61,7 @@ class WKRemoteTracingStoreClient(
   def getSkeletonTracings(tracingIds: List[Option[String]]): Fox[SkeletonTracings] = {
     logger.debug("Called to get multiple SkeletonTracings." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/skeleton/getMultiple")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .withLongTimeout
       .postJsonWithProtoResponse[List[Option[TracingSelector]], SkeletonTracings](tracingIds.map(id =>
         id.map(TracingSelector(_))))(SkeletonTracings)
@@ -70,7 +70,7 @@ class WKRemoteTracingStoreClient(
   def getVolumeTracings(tracingIds: List[Option[String]]): Fox[VolumeTracings] = {
     logger.debug("Called to get multiple VolumeTracings." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/volume/getMultiple")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .withLongTimeout
       .postJsonWithProtoResponse[List[Option[TracingSelector]], VolumeTracings](tracingIds.map(id =>
         id.map(TracingSelector(_))))(VolumeTracings)
@@ -79,8 +79,8 @@ class WKRemoteTracingStoreClient(
   def saveSkeletonTracing(tracing: SkeletonTracing, newTracingId: String): Fox[Unit] = {
     logger.debug(s"Called to save SkeletonTracing at $newTracingId." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/skeleton/save").withLongTimeout
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-      .addQueryString("newTracingId" -> newTracingId)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
+      .addQueryParam("newTracingId", newTracingId)
       .postProto[SkeletonTracing](tracing)
   }
 
@@ -88,7 +88,7 @@ class WKRemoteTracingStoreClient(
   def saveSkeletonTracings(tracings: SkeletonTracingsWithIds): Fox[List[Box[Boolean]]] = {
     logger.debug(s"Called to save ${tracings.tracings.length} SkeletonTracings." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/skeleton/saveMultiple").withLongTimeout
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .postProtoWithJsonResponse[SkeletonTracingsWithIds, List[Box[Boolean]]](tracings)
   }
 
@@ -96,15 +96,15 @@ class WKRemoteTracingStoreClient(
     logger.debug(
       f"Called to save AnnotationProto $annotationId with layers ${annotationProto.annotationLayers.map(_.tracingId).mkString(",")}." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/annotation/save")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-      .addQueryString("annotationId" -> annotationId.toString)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
+      .addQueryParam("annotationId", annotationId)
       .postProto[AnnotationProto](annotationProto)
   }
 
   def getAnnotationProto(annotationId: ObjectId, version: Option[Long]): Fox[AnnotationProto] =
     rpc(s"${tracingStore.url}/tracings/annotation/$annotationId")
-      .addQueryStringOptional("version", version.map(_.toString))
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("version", version)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .getWithProtoResponse[AnnotationProto](AnnotationProto)
 
   // Used in duplicate route. History and version are kept
@@ -117,13 +117,13 @@ class WKRemoteTracingStoreClient(
                           datasetBoundingBox: Option[BoundingBox]): Fox[AnnotationProto] = {
     logger.debug(s"Called to duplicate annotation $annotationId to new id $newAnnotationId." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/annotation/$annotationId/duplicate").withLongTimeout
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-      .addQueryString("newAnnotationId" -> newAnnotationId.toString)
-      .addQueryStringOptional("version", version.map(_.toString))
-      .addQueryStringOptional("datasetBoundingBox", datasetBoundingBox.map(_.toLiteral))
-      .addQueryString("isFromTask" -> isFromTask.toString)
-      .addQueryString("ownerId" -> ownerId.toString)
-      .addQueryString("requestingUserId" -> requestingUserId.toString)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
+      .addQueryParam("newAnnotationId", newAnnotationId)
+      .addQueryParam("version", version)
+      .addQueryParam("datasetBoundingBox", datasetBoundingBox.map(_.toLiteral))
+      .addQueryParam("isFromTask", isFromTask)
+      .addQueryParam("ownerId", ownerId)
+      .addQueryParam("requestingUserId", requestingUserId)
       .postEmptyWithProtoResponse[AnnotationProto]()(AnnotationProto)
   }
 
@@ -137,14 +137,14 @@ class WKRemoteTracingStoreClient(
                                editRotation: Option[Vec3Double] = None,
                                boundingBox: Option[BoundingBox] = None): Fox[Unit] =
     rpc(s"${tracingStore.url}/tracings/skeleton/$skeletonTracingId/duplicate").withLongTimeout
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-      .addQueryString("newAnnotationId" -> newAnnotationId.toString)
-      .addQueryString("newTracingId" -> newTracingId)
-      .addQueryString("ownerId" -> ownerId.toString)
-      .addQueryString("requestingUserId" -> requestingUserId.toString)
-      .addQueryStringOptional("editPosition", editPosition.map(_.toUriLiteral))
-      .addQueryStringOptional("editRotation", editRotation.map(_.toUriLiteral))
-      .addQueryStringOptional("boundingBox", boundingBox.map(_.toLiteral))
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
+      .addQueryParam("newAnnotationId", newAnnotationId)
+      .addQueryParam("newTracingId", newTracingId)
+      .addQueryParam("ownerId", ownerId)
+      .addQueryParam("requestingUserId", requestingUserId)
+      .addQueryParam("editPosition", editPosition.map(_.toUriLiteral))
+      .addQueryParam("editRotation", editRotation.map(_.toUriLiteral))
+      .addQueryParam("boundingBox", boundingBox.map(_.toLiteral))
       .postEmpty()
 
   // Used in task creation. History is dropped, new version will be zero.
@@ -161,16 +161,16 @@ class WKRemoteTracingStoreClient(
                              dataSource: UsableDataSource): Fox[Unit] = {
     annotationDataSourceTemporaryStore.store(newAnnotationId, dataSource, datasetId)
     rpc(s"${tracingStore.url}/tracings/volume/$volumeTracingId/duplicate").withLongTimeout
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-      .addQueryString("newAnnotationId" -> newAnnotationId.toString)
-      .addQueryString("newTracingId" -> newTracingId)
-      .addQueryString("ownerId" -> ownerId.toString)
-      .addQueryString("requestingUserId" -> requestingUserId.toString)
-      .addQueryStringOptional("editPosition", editPosition.map(_.toUriLiteral))
-      .addQueryStringOptional("editRotation", editRotation.map(_.toUriLiteral))
-      .addQueryStringOptional("boundingBox", boundingBox.map(_.toLiteral))
-      .addQueryStringOptional("minMag", magRestrictions.minStr)
-      .addQueryStringOptional("maxMag", magRestrictions.maxStr)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
+      .addQueryParam("newAnnotationId", newAnnotationId)
+      .addQueryParam("newTracingId", newTracingId)
+      .addQueryParam("ownerId", ownerId)
+      .addQueryParam("requestingUserId", requestingUserId)
+      .addQueryParam("editPosition", editPosition.map(_.toUriLiteral))
+      .addQueryParam("editRotation", editRotation.map(_.toUriLiteral))
+      .addQueryParam("boundingBox", boundingBox.map(_.toLiteral))
+      .addQueryParam("minMag", magRestrictions.min)
+      .addQueryParam("maxMag", magRestrictions.max)
       .postEmpty()
   }
 
@@ -182,10 +182,10 @@ class WKRemoteTracingStoreClient(
                             additionalBoundingBoxes: Seq[NamedBoundingBox]): Fox[AnnotationProto] = {
     logger.debug(s"Called to merge ${annotationIds.length} annotations by ids." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/annotation/mergedFromIds").withLongTimeout
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-      .addQueryString("toTemporaryStore" -> toTemporaryStore.toString)
-      .addQueryString("newAnnotationId" -> newAnnotationId.toString)
-      .addQueryString("requestingUserId" -> requestingUserId.toString)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
+      .addQueryParam("toTemporaryStore", toTemporaryStore)
+      .addQueryParam("newAnnotationId", newAnnotationId)
+      .addQueryParam("requestingUserId", requestingUserId)
       .postJsonWithProtoResponse[MergedFromIdsRequest, AnnotationProto](
         MergedFromIdsRequest(annotationIds, ownerIds, additionalBoundingBoxes))(AnnotationProto)
   }
@@ -194,8 +194,8 @@ class WKRemoteTracingStoreClient(
     logger.debug(
       s"Called to merge ${tracings.tracings.length} SkeletonTracings by contents into $newTracingId." + baseInfo)
     rpc(s"${tracingStore.url}/tracings/skeleton/mergedFromContents").withLongTimeout
-      .addQueryString("newTracingId" -> newTracingId)
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("newTracingId", newTracingId)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .postProto[SkeletonTracings](tracings)
   }
 
@@ -209,14 +209,14 @@ class WKRemoteTracingStoreClient(
       s"Called to merge ${tracings.tracings.length} VolumeTracings by contents into $newAnnotationId/$newTracingId." + baseInfo)
     for {
       _ <- rpc(s"${tracingStore.url}/tracings/volume/mergedFromContents")
-        .addQueryString("newTracingId" -> newTracingId)
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+        .addQueryParam("newTracingId", newTracingId)
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
         .postProto[VolumeTracings](tracings)
       packedVolumeDataZips = packVolumeDataZips(initialData.flatten)
       _ = annotationDataSourceTemporaryStore.store(newAnnotationId, dataSource, datasetId)
       _ <- rpc(s"${tracingStore.url}/tracings/volume/$newTracingId/initialDataMultiple").withLongTimeout
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-        .addQueryString("annotationId" -> newAnnotationId.toString)
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
+        .addQueryParam("annotationId", newAnnotationId.toString)
         .postFile(packedVolumeDataZips)
     } yield ()
   }
@@ -235,15 +235,15 @@ class WKRemoteTracingStoreClient(
     annotationDataSourceTemporaryStore.store(annotationId, dataSource, datasetId)
     for {
       _ <- rpc(s"${tracingStore.url}/tracings/volume/save")
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-        .addQueryString("newTracingId" -> newTracingId)
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
+        .addQueryParam("newTracingId", newTracingId)
         .postProto[VolumeTracing](tracing)
       _ <- Fox.runOptional(initialData) { initialDataFile =>
         rpc(s"${tracingStore.url}/tracings/volume/$newTracingId/initialData").withLongTimeout
-          .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-          .addQueryString("annotationId" -> annotationId.toString)
-          .addQueryStringOptional("minMag", magRestrictions.minStr)
-          .addQueryStringOptional("maxMag", magRestrictions.maxStr)
+          .addQueryParam("token", RpcTokenHolder.webknossosToken)
+          .addQueryParam("annotationId", annotationId.toString)
+          .addQueryParam("minMag", magRestrictions.min)
+          .addQueryParam("maxMag", magRestrictions.max)
           .postFile(initialDataFile)
       }
     } yield ()
@@ -260,32 +260,32 @@ class WKRemoteTracingStoreClient(
       _ <- Fox.fromBool(annotationLayer.typ == AnnotationLayerType.Volume) ?~> "annotation.download.fetch.notSkeleton"
       tracingId = annotationLayer.tracingId
       tracing <- rpc(s"${tracingStore.url}/tracings/volume/$tracingId")
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-        .addQueryString("annotationId" -> annotationId.toString)
-        .addQueryStringOptional("version", version.map(_.toString))
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
+        .addQueryParam("annotationId", annotationId)
+        .addQueryParam("version", version)
         .getWithProtoResponse[VolumeTracing](VolumeTracing)
       omitEmptyVolumeDataDueToEditableMapping = tracing.getHasEditableMapping
       data <- Fox.runIf(!skipVolumeAndEdgesData && !omitEmptyVolumeDataDueToEditableMapping) {
         rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataZip").withLongTimeout
-          .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-          .addQueryString("volumeDataZipFormat" -> volumeDataZipFormat.toString)
-          .addQueryString("annotationId" -> annotationId.toString)
-          .addQueryStringOptional("version", version.map(_.toString))
-          .addQueryStringOptional("voxelSizeFactor", voxelSize.map(_.factor.toUriLiteral))
-          .addQueryStringOptional("voxelSizeUnit", voxelSize.map(_.unit.toString))
+          .addQueryParam("token", RpcTokenHolder.webknossosToken)
+          .addQueryParam("volumeDataZipFormat", volumeDataZipFormat.toString)
+          .addQueryParam("annotationId", annotationId)
+          .addQueryParam("version", version)
+          .addQueryParam("voxelSizeFactor", voxelSize.map(_.factor.toUriLiteral))
+          .addQueryParam("voxelSizeUnit", voxelSize.map(_.unit.toString))
           .getWithBytesResponse
       }
       editedMappingEdgesData <- Fox.runIf(!skipVolumeAndEdgesData && tracing.getHasEditableMapping) {
         rpc(s"${tracingStore.url}/tracings/mapping/$tracingId/editedEdgesZip").withLongTimeout
-          .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-          .addQueryStringOptional("version", version.map(_.toString))
+          .addQueryParam("token", RpcTokenHolder.webknossosToken)
+          .addQueryParam("version", version)
           .getWithBytesResponse
       }
       baseMappingNameOpt: Option[String] <- Fox.runIf(!skipVolumeAndEdgesData && tracing.getHasEditableMapping) {
         rpc(s"${tracingStore.url}/tracings/mapping/$tracingId/info").withLongTimeout
-          .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-          .addQueryStringOptional("version", version.map(_.toString))
-          .addQueryString("annotationId" -> annotationId.toString)
+          .addQueryParam("token", RpcTokenHolder.webknossosToken)
+          .addQueryParam("version", version)
+          .addQueryParam("annotationId", annotationId)
           .getWithJsonResponse[JsObject]
           .flatMap(jsObj => JsonHelper.as[String](jsObj \ "baseMappingName").toFox)
       }
@@ -303,10 +303,10 @@ class WKRemoteTracingStoreClient(
     logger.debug(s"Called to get volume data of $tracingId." + baseInfo)
     for {
       data <- rpc(s"${tracingStore.url}/tracings/volume/$tracingId/allDataZip").withLongTimeout
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-        .addQueryString("volumeDataZipFormat" -> volumeDataZipFormat.toString)
-        .addQueryStringOptional("voxelSizeFactor", voxelSize.map(_.factor.toUriLiteral))
-        .addQueryStringOptional("voxelSizeUnit", voxelSize.map(_.unit.toString))
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
+        .addQueryParam("volumeDataZipFormat", volumeDataZipFormat.toString)
+        .addQueryParam("voxelSizeFactor", voxelSize.map(_.factor.toUriLiteral))
+        .addQueryParam("voxelSizeUnit", voxelSize.map(_.unit.toString))
         .getWithBytesResponse
     } yield data
   }
@@ -314,7 +314,7 @@ class WKRemoteTracingStoreClient(
   def resetToBase(annotationId: ObjectId): Fox[Unit] =
     for {
       _ <- rpc(s"${tracingStore.url}/tracings/annotation/$annotationId/resetToBase").withLongTimeout
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
         .postEmpty()
     } yield ()
 

--- a/app/models/dataset/WKRemoteDataStoreClient.scala
+++ b/app/models/dataset/WKRemoteDataStoreClient.scala
@@ -39,18 +39,18 @@ class WKRemoteDataStoreClient(dataStore: DataStore, rpc: RPC) extends LazyLoggin
     logger.debug(
       s"Thumbnail called for: ${dataset._id}, organization: ${dataset._organization}, directoryName: ${dataset.directoryName}, Layer: $dataLayerName")
     rpc(s"${dataStore.url}/data/datasets/${dataset._id}/layers/$dataLayerName/thumbnail.jpg")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
-      .addQueryString("mag" -> mag.toMagLiteral())
-      .addQueryString("x" -> mag1BoundingBox.topLeft.x.toString)
-      .addQueryString("y" -> mag1BoundingBox.topLeft.y.toString)
-      .addQueryString("z" -> mag1BoundingBox.topLeft.z.toString)
-      .addQueryString("width" -> targetMagBoundingBox.width.toString)
-      .addQueryString("height" -> targetMagBoundingBox.height.toString)
-      .addQueryStringOptional("mappingName", mappingName)
-      .addQueryStringOptional("intensityMin", intensityRangeOpt.map(_._1.toString))
-      .addQueryStringOptional("intensityMax", intensityRangeOpt.map(_._2.toString))
-      .addQueryStringOptional("color", colorSettingsOpt.map(_.color.toHtml))
-      .addQueryStringOptional("invertColor", colorSettingsOpt.map(_.isInverted.toString))
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
+      .addQueryParam("mag", mag.toMagLiteral())
+      .addQueryParam("x", mag1BoundingBox.topLeft.x)
+      .addQueryParam("y", mag1BoundingBox.topLeft.y)
+      .addQueryParam("z", mag1BoundingBox.topLeft.z)
+      .addQueryParam("width", targetMagBoundingBox.width)
+      .addQueryParam("height", targetMagBoundingBox.height)
+      .addQueryParam("mappingName", mappingName)
+      .addQueryParam("intensityMin", intensityRangeOpt.map(_._1))
+      .addQueryParam("intensityMax", intensityRangeOpt.map(_._2))
+      .addQueryParam("color", colorSettingsOpt.map(_.color.toHtml))
+      .addQueryParam("invertColor", colorSettingsOpt.map(_.isInverted))
       .getWithBytesResponse
   }
 
@@ -62,21 +62,21 @@ class WKRemoteDataStoreClient(dataStore: DataStore, rpc: RPC) extends LazyLoggin
     val targetMagBoundingBox = mag1BoundingBox / mag
     logger.debug(s"Fetching raw data. Mag $mag, mag1 bbox: $mag1BoundingBox, target-mag bbox: $targetMagBoundingBox")
     rpc(s"${dataStore.url}/data/datasets/${dataset._id}/layers/$layerName/readData")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .postJsonWithBytesResponse(
         RawCuboidRequest(mag1BoundingBox.topLeft, targetMagBoundingBox.size, mag, additionalCoordinates))
   }
 
   def findPositionWithData(dataset: Dataset, dataLayerName: String): Fox[JsObject] =
     rpc(s"${dataStore.url}/data/datasets/${dataset._id}/layers/$dataLayerName/findData")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .getWithJsonResponse[JsObject]
 
   private def urlEncode(text: String) = UriEncoding.encodePathSegment(text, "UTF-8")
 
   def fetchStorageReports(organizationId: String, paths: List[String]): Fox[PathStorageUsageResponse] =
     rpc(s"${dataStore.url}/data/datasets/measureUsedStorage/${urlEncode(organizationId)}")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .silent
       .postJsonWithJsonResponse[PathStorageUsageRequest, PathStorageUsageResponse](PathStorageUsageRequest(paths))
 
@@ -86,7 +86,7 @@ class WKRemoteDataStoreClient(dataStore: DataStore, rpc: RPC) extends LazyLoggin
       cacheKey,
       k =>
         rpc(s"${dataStore.url}/data/datasets/${k._1}/layers/${k._2}/hasSegmentIndex")
-          .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+          .addQueryParam("token", RpcTokenHolder.webknossosToken)
           .silent
           .getWithJsonResponse[Boolean]
     )
@@ -96,33 +96,33 @@ class WKRemoteDataStoreClient(dataStore: DataStore, rpc: RPC) extends LazyLoggin
                            organizationId: String,
                            userToken: String): Fox[ExploreRemoteDatasetResponse] =
     rpc(s"${dataStore.url}/data/datasets/exploreRemote")
-      .addQueryString("token" -> userToken)
+      .addQueryParam("token", userToken)
       .postJsonWithJsonResponse[ExploreRemoteDatasetRequest, ExploreRemoteDatasetResponse](
         ExploreRemoteDatasetRequest(layerParameters, organizationId))
 
   def validatePaths(paths: Seq[UPath]): Fox[List[PathValidationResult]] =
     rpc(s"${dataStore.url}/data/datasets/validatePaths")
-      .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+      .addQueryParam("token", RpcTokenHolder.webknossosToken)
       .postJsonWithJsonResponse[Seq[UPath], List[PathValidationResult]](paths)
 
   def invalidateDatasetInDSCache(datasetId: ObjectId): Fox[Unit] =
     for {
       _ <- rpc(s"${dataStore.url}/data/datasets/$datasetId")
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
         .delete()
     } yield ()
 
   def updateDataSourceOnDisk(datasetId: ObjectId, dataSource: UsableDataSource): Fox[Unit] =
     for {
       _ <- rpc(s"${dataStore.url}/data/datasets/$datasetId")
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
         .putJson(dataSource)
     } yield ()
 
   def deleteOnDisk(datasetId: ObjectId): Fox[Unit] =
     for {
       _ <- rpc(s"${dataStore.url}/data/datasets/$datasetId/deleteOnDisk")
-        .addQueryString("token" -> RpcTokenHolder.webknossosToken)
+        .addQueryParam("token", RpcTokenHolder.webknossosToken)
         .delete()
     } yield ()
 

--- a/app/models/organization/OrganizationService.scala
+++ b/app/models/organization/OrganizationService.scala
@@ -137,7 +137,8 @@ class OrganizationService @Inject()(organizationDAO: OrganizationDAO,
   def createOrganizationDirectory(organizationId: String, dataStoreToken: String): Fox[Unit] = {
     def sendRPCToDataStore(dataStore: DataStore) =
       rpc(s"${dataStore.url}/data/triggers/createOrganizationDirectory")
-        .addQueryString("token" -> dataStoreToken, "organizationId" -> organizationId)
+        .addQueryParam("token", dataStoreToken)
+        .addQueryParam("organizationId", organizationId)
         .postEmpty()
         .futureBox
 

--- a/app/models/voxelytics/LokiClient.scala
+++ b/app/models/voxelytics/LokiClient.scala
@@ -242,7 +242,7 @@ class LokiClient @Inject()(wkConf: WkConf, rpc: RPC, val actorSystem: ActorSyste
                 "values" -> JsArray(values)
             ))
         _ <- rpc(s"${conf.uri}/loki/api/v1/push").silent
-          .addHttpHeaders(HeaderNames.CONTENT_TYPE -> jsonMimeType)
+          .addHttpHeader(HeaderNames.CONTENT_TYPE, jsonMimeType)
           .postJson[JsValue](Json.obj("streams" -> streams))
       } yield ()
     } else {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
@@ -2,9 +2,10 @@ package com.scalableminds.webknossos.datastore.rpc
 
 import com.scalableminds.util.accesscontext.TokenContext
 import com.scalableminds.util.mvc.{Formatter, MimeTypes}
+import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.typesafe.scalalogging.LazyLogging
-import com.scalableminds.util.tools.{Failure, Full, Empty}
+import com.scalableminds.util.tools.{Empty, Failure, Full}
 import play.api.http.{HeaderNames, Status}
 import play.api.libs.json._
 import play.api.libs.ws._
@@ -14,6 +15,7 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 import java.io.File
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 class RPCRequest(val id: Int, val url: String, wsClient: WSClient)(implicit ec: ExecutionContext)
     extends LazyLogging
@@ -25,16 +27,54 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient)(implicit ec: 
   private var logOnFailure: Boolean = true
   private var slowRequestLoggingThreshold = 2 minutes
 
-  def addQueryString(parameters: (String, String)*): RPCRequest = {
-    request = request.addQueryStringParameters(parameters: _*)
+  def addQueryParam(key: String, value: Int): RPCRequest =
+    addQueryParam(key, value.toString)
+
+  def addQueryParam(key: String, value: Long): RPCRequest =
+    addQueryParam(key, value.toString)
+
+  def addQueryParam(key: String, value: Double): RPCRequest =
+    addQueryParam(key, value.toString)
+
+  def addQueryParam(key: String, value: ObjectId): RPCRequest =
+    addQueryParam(key, value.toString)
+
+  def addQueryParam(key: String, value: Boolean): RPCRequest =
+    addQueryParam(key, value.toString)
+
+  def addQueryParam(key: String, valueOptional: Option[String]): RPCRequest =
+    valueOptional.map(addQueryParam(key, _)).getOrElse(this)
+
+  // ClassTags added to work around type erasure (otherwiese, all Option[x] variants would be indistinguishable)
+  // Compare https://stackoverflow.com/a/3309490
+  def addQueryParam[A: ClassTag](key: String, value: Option[Int]): RPCRequest =
+    addQueryParam(key, value.map(_.toString))
+
+  def addQueryParam[A: ClassTag, B: ClassTag](key: String, value: Option[Long]): RPCRequest =
+    addQueryParam(key, value.map(_.toString))
+
+  def addQueryParam[A: ClassTag, B: ClassTag, C: ClassTag](key: String, value: Option[ObjectId]): RPCRequest =
+    addQueryParam(key, value.map(_.toString))
+
+  def addQueryParam[A: ClassTag, B: ClassTag, C: ClassTag, D: ClassTag](key: String,
+                                                                        value: Option[Double]): RPCRequest =
+    addQueryParam(key, value.map(_.toString))
+
+  def addQueryParam[A: ClassTag, B: ClassTag, C: ClassTag, D: ClassTag, E: ClassTag](
+      key: String,
+      value: Option[Boolean]): RPCRequest =
+    addQueryParam(key, value.map(_.toString))
+
+  def addQueryParam(key: String, value: String): RPCRequest = {
+    request = request.addQueryStringParameters(key -> value)
     this
   }
 
   def withTokenFromContext(implicit tc: TokenContext): RPCRequest =
-    addQueryStringOptional("token", tc.userTokenOpt)
+    addQueryParam("token", tc.userTokenOpt)
 
-  def addHttpHeaders(hdrs: (String, String)*): RPCRequest = {
-    request = request.addHttpHeaders(hdrs: _*)
+  def addHttpHeader(headerName: String, headerValue: String): RPCRequest = {
+    request = request.addHttpHeaders(headerName -> headerValue)
     this
   }
 
@@ -75,14 +115,6 @@ class RPCRequest(val id: Int, val url: String, wsClient: WSClient)(implicit ec: 
   def silentIf(condition: Boolean): RPCRequest = {
     if (condition) {
       verbose = false
-    }
-    this
-  }
-
-  def addQueryStringOptional(key: String, valueOptional: Option[String]): RPCRequest = {
-    valueOptional match {
-      case Some(value: String) => request = request.addQueryStringParameters((key, value))
-      case _                   =>
     }
     this
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteTracingstoreClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteTracingstoreClient.scala
@@ -43,7 +43,7 @@ class DSRemoteTracingstoreClient @Inject()(
                                 zarrVersion: Int)(implicit tc: TokenContext): Fox[StaticSegmentationLayer] = {
     val zarrVersionDependantSubPath = getZarrVersionDependantSubPath(zarrVersion)
     rpc(s"$tracingStoreUri/tracings/volume/$zarrVersionDependantSubPath/$tracingId/zarrSource").withTokenFromContext
-      .addQueryStringOptional("tracingName", tracingName)
+      .addQueryParam("tracingName", tracingName)
       .getWithJsonResponse[StaticSegmentationLayer]
   }
 
@@ -76,7 +76,7 @@ class DSRemoteTracingstoreClient @Inject()(
   def getEditableMappingSegmentIdsForAgglomerate(tracingStoreUri: String, tracingId: String, agglomerateId: Long)(
       implicit tc: TokenContext): Fox[EditableMappingSegmentListResult] =
     rpc(s"$tracingStoreUri/tracings/mapping/$tracingId/segmentsForAgglomerate")
-      .addQueryString("agglomerateId" -> agglomerateId.toString)
+      .addQueryParam("agglomerateId", agglomerateId)
       .withTokenFromContext
       .silent
       .getWithJsonResponse[EditableMappingSegmentListResult]

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
@@ -78,77 +78,77 @@ class DSRemoteWebknossosClient @Inject()(
 
   private def reportStatus(): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/status")
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("key", dataStoreKey)
       .patchJson(DataStoreStatus(ok = true, dataStoreUri, Some(reportUsedStorageEnabled)))
 
   def reportDataSource(dataSource: DataSource): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/datasource")
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("key", dataStoreKey)
       .putJson(dataSource)
 
   def getUnfinishedUploadsForUser(organizationName: String)(implicit tc: TokenContext): Fox[List[UnfinishedUpload]] =
     for {
       unfinishedUploads <- rpc(s"$webknossosUri/api/datastores/$dataStoreName/getUnfinishedUploadsForUser")
-        .addQueryString("key" -> dataStoreKey)
-        .addQueryString("organizationName" -> organizationName)
+        .addQueryParam("key", dataStoreKey)
+        .addQueryParam("organizationName", organizationName)
         .withTokenFromContext
         .getWithJsonResponse[List[UnfinishedUpload]]
     } yield unfinishedUploads
 
   def reportUpload(datasetId: ObjectId, parameters: ReportDatasetUploadParameters)(implicit tc: TokenContext): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/reportDatasetUpload")
-      .addQueryString("key" -> dataStoreKey)
-      .addQueryString("datasetId" -> datasetId.toString)
+      .addQueryParam("key", dataStoreKey)
+      .addQueryParam("datasetId", datasetId)
       .withTokenFromContext
       .postJson[ReportDatasetUploadParameters](parameters)
 
   def reportDataSources(dataSources: List[DataSource], organizationId: Option[String]): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/datasources")
-      .addQueryString("key" -> dataStoreKey)
-      .addQueryStringOptional("organizationId", organizationId)
+      .addQueryParam("key", dataStoreKey)
+      .addQueryParam("organizationId", organizationId)
       .silent
       .putJson(dataSources)
 
   def reportRealPaths(dataSourcePaths: List[DataSourcePathInfo]): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/datasources/paths")
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("key", dataStoreKey)
       .silent
       .putJson(dataSourcePaths)
 
   def fetchPaths(datasetId: ObjectId): Fox[List[LayerMagLinkInfo]] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/datasources/$datasetId/paths")
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("key", dataStoreKey)
       .getWithJsonResponse[List[LayerMagLinkInfo]]
 
   def reserveDataSourceUpload(info: ReserveUploadInformation)(
       implicit tc: TokenContext): Fox[ReserveAdditionalInformation] =
     for {
       reserveUploadInfo <- rpc(s"$webknossosUri/api/datastores/$dataStoreName/reserveUpload")
-        .addQueryString("key" -> dataStoreKey)
+        .addQueryParam("key", dataStoreKey)
         .withTokenFromContext
         .postJsonWithJsonResponse[ReserveUploadInformation, ReserveAdditionalInformation](info)
     } yield reserveUploadInfo
 
   def updateDataSource(dataSource: DataSource, datasetId: ObjectId)(implicit tc: TokenContext): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/datasources/${datasetId.toString}")
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("key", dataStoreKey)
       .withTokenFromContext
       .putJson(dataSource)
 
   def deleteDataset(datasetId: ObjectId): Fox[_] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/deleteDataset")
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("key", dataStoreKey)
       .postJson(datasetId)
 
   def getJobExportProperties(jobId: String): Fox[JobExportProperties] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/jobExportProperties")
-      .addQueryString("jobId" -> jobId)
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("jobId", jobId)
+      .addQueryParam("key", dataStoreKey)
       .getWithJsonResponse[JobExportProperties]
 
   override def requestUserAccess(accessRequest: UserAccessRequest)(implicit tc: TokenContext): Fox[UserAccessAnswer] =
     rpc(s"$webknossosUri/api/datastores/$dataStoreName/validateUserAccess")
-      .addQueryString("key" -> dataStoreKey)
+      .addQueryParam("key", dataStoreKey)
       .withTokenFromContext
       .postJsonWithJsonResponse[UserAccessRequest, UserAccessAnswer](accessRequest)
 
@@ -159,7 +159,7 @@ class DSRemoteWebknossosClient @Inject()(
       _ =>
         for {
           tracingStoreInfo <- rpc(s"$webknossosUri/api/tracingstore")
-            .addQueryString("key" -> dataStoreKey)
+            .addQueryParam("key", dataStoreKey)
             .getWithJsonResponse[TracingStoreInfo]
         } yield tracingStoreInfo.url
     )
@@ -174,8 +174,8 @@ class DSRemoteWebknossosClient @Inject()(
       (accessToken, tc.userTokenOpt),
       _ =>
         rpc(s"$webknossosUri/api/annotations/source/$accessToken")
-          .addQueryString("key" -> dataStoreKey)
-          .addQueryStringOptional("userToken", tc.userTokenOpt)
+          .addQueryParam("key", dataStoreKey)
+          .addQueryParam("userToken", tc.userTokenOpt)
           .getWithJsonResponse[AnnotationSource]
     )
 
@@ -187,8 +187,8 @@ class DSRemoteWebknossosClient @Inject()(
       credentialId,
       _ =>
         rpc(s"$webknossosUri/api/datastores/$dataStoreName/findCredential")
-          .addQueryString("credentialId" -> credentialId)
-          .addQueryString("key" -> dataStoreKey)
+          .addQueryParam("credentialId", credentialId)
+          .addQueryParam("key", dataStoreKey)
           .silent
           .getWithJsonResponse[DataVaultCredential]
     )
@@ -196,7 +196,7 @@ class DSRemoteWebknossosClient @Inject()(
   def getDataSource(datasetId: ObjectId): Fox[DataSource] =
     for {
       dataSource <- rpc(s"$webknossosUri/api/datastores/$dataStoreName/datasources/$datasetId")
-        .addQueryString("key" -> dataStoreKey)
+        .addQueryParam("key", dataStoreKey)
         .getWithJsonResponse[DataSource] ?~> "Failed to get data source from remote webknossos"
     } yield dataSource
 
@@ -208,9 +208,9 @@ class DSRemoteWebknossosClient @Inject()(
       (organizationId, datasetDirectoryName),
       _ =>
         rpc(s"$webknossosUri/api/datastores/$dataStoreName/findDatasetId")
-          .addQueryString("key" -> dataStoreKey)
-          .addQueryString("organizationId" -> organizationId)
-          .addQueryString("datasetDirectoryName" -> datasetDirectoryName)
+          .addQueryParam("key", dataStoreKey)
+          .addQueryParam("organizationId", organizationId)
+          .addQueryParam("datasetDirectoryName", datasetDirectoryName)
           .getWithJsonResponse[ObjectId] ?~> "Failed to get dataset id from remote webknossos"
     )
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteDatastoreClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteDatastoreClient.scala
@@ -63,13 +63,13 @@ class TSRemoteDatastoreClient @Inject()(
     for {
       remoteLayerUri <- getRemoteLayerUri(remoteFallbackLayer)
       result <- rpc(s"$remoteLayerUri/data").withTokenFromContext
-        .addQueryString("x" -> pos.x.toString)
-        .addQueryString("y" -> pos.y.toString)
-        .addQueryString("z" -> pos.z.toString)
-        .addQueryString("width" -> "1")
-        .addQueryString("height" -> "1")
-        .addQueryString("depth" -> "1")
-        .addQueryString("mag" -> mag.toMagLiteral())
+        .addQueryParam("x", pos.x)
+        .addQueryParam("y", pos.y)
+        .addQueryParam("z", pos.z)
+        .addQueryParam("width", 1)
+        .addQueryParam("height", 1)
+        .addQueryParam("depth", 1)
+        .addQueryParam("mag", mag.toMagLiteral())
         .silent
         .getWithBytesResponse
     } yield result
@@ -101,7 +101,7 @@ class TSRemoteDatastoreClient @Inject()(
         for {
           remoteLayerUri <- getRemoteLayerUri(k._1)
           result <- rpc(s"$remoteLayerUri/agglomerates/${k._2}/largestAgglomerateId")
-            .addQueryStringOptional("token", k._3)
+            .addQueryParam("token", k._3)
             .silent
             .getWithJsonResponse[Long]
         } yield result

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteWebknossosClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TSRemoteWebknossosClient.scala
@@ -56,21 +56,21 @@ class TSRemoteWebknossosClient @Inject()(
 
   def reportAnnotationUpdates(tracingUpdatesReport: AnnotationUpdatesReport): Fox[WSResponse] =
     rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/handleTracingUpdateReport")
-      .addQueryString("key" -> tracingStoreKey)
+      .addQueryParam("key", tracingStoreKey)
       .silent
       .postJson(Json.toJson(tracingUpdatesReport))
 
   def getDataSourceForAnnotation(annotationId: ObjectId)(implicit tc: TokenContext): Fox[UsableDataSource] =
     rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/dataSource")
-      .addQueryString("annotationId" -> annotationId.toString)
-      .addQueryString("key" -> tracingStoreKey)
+      .addQueryParam("annotationId", annotationId)
+      .addQueryParam("key", tracingStoreKey)
       .withTokenFromContext
       .silent
       .getWithJsonResponse[UsableDataSource]
 
   def getDataStoreUriForDataset(datasetId: ObjectId): Fox[String] =
     rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/dataStoreUri/$datasetId")
-      .addQueryString("key" -> tracingStoreKey)
+      .addQueryParam("key", tracingStoreKey)
       .silent
       .getWithJsonResponse[String]
 
@@ -79,8 +79,8 @@ class TSRemoteWebknossosClient @Inject()(
       annotationId,
       aId =>
         rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/datasetId")
-          .addQueryString("annotationId" -> aId.toString)
-          .addQueryString("key" -> tracingStoreKey)
+          .addQueryParam("annotationId", aId)
+          .addQueryParam("key", tracingStoreKey)
           .silent
           .getWithJsonResponse[ObjectId]
     )
@@ -90,16 +90,16 @@ class TSRemoteWebknossosClient @Inject()(
       tracingId,
       tracingId =>
         rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/annotationId")
-          .addQueryString("tracingId" -> tracingId)
-          .addQueryString("key" -> tracingStoreKey)
+          .addQueryParam("tracingId", tracingId)
+          .addQueryParam("key", tracingStoreKey)
           .silent
           .getWithJsonResponse[ObjectId]
     ) ?~> "annotation.idForTracing.failed"
 
   def updateAnnotation(annotationId: ObjectId, annotationProto: AnnotationProto): Fox[Unit] =
     rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/updateAnnotation")
-      .addQueryString("annotationId" -> annotationId.toString)
-      .addQueryString("key" -> tracingStoreKey)
+      .addQueryParam("annotationId", annotationId)
+      .addQueryParam("key", tracingStoreKey)
       .silent
       .postProto(annotationProto)
 
@@ -107,9 +107,9 @@ class TSRemoteWebknossosClient @Inject()(
                        layerParameters: AnnotationLayerParameters,
                        previousVersion: Long): Fox[Either[SkeletonTracingWithUpdatedTreeIds, VolumeTracing]] = {
     val req = rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/createTracing")
-      .addQueryString("annotationId" -> annotationId.toString)
-      .addQueryString("previousVersion" -> previousVersion.toString) // used for fetching old precedence layers
-      .addQueryString("key" -> tracingStoreKey)
+      .addQueryParam("annotationId", annotationId)
+      .addQueryParam("previousVersion", previousVersion) // used for fetching old precedence layers
+      .addQueryParam("key", tracingStoreKey)
     layerParameters.typ match {
       case AnnotationLayerType.Volume =>
         req
@@ -127,7 +127,7 @@ class TSRemoteWebknossosClient @Inject()(
 
   override def requestUserAccess(accessRequest: UserAccessRequest)(implicit tc: TokenContext): Fox[UserAccessAnswer] =
     rpc(s"$webknossosUri/api/tracingstores/$tracingStoreName/validateUserAccess")
-      .addQueryString("key" -> tracingStoreKey)
+      .addQueryParam("key", tracingStoreKey)
       .withTokenFromContext
       .postJsonWithJsonResponse[UserAccessRequest, UserAccessAnswer](accessRequest)
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingMags.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingMags.scala
@@ -51,7 +51,4 @@ case class MagRestrictions(
     min.getOrElse(0) <= mag.maxDim && max.getOrElse(Int.MaxValue) >= mag.maxDim
 
   def isForbidden(mag: Vec3Int): Boolean = !isAllowed(mag)
-
-  def minStr: Option[String] = min.map(_.toString)
-  def maxStr: Option[String] = max.map(_.toString)
 }


### PR DESCRIPTION
Unifies the adding of query parameters to RPC objects.

Supported types can now all be passed to the same overloaded method addQueryParam. This way, callers don’t need to take care if they need addQueryString (with arrow) or addQueryStringOptional (with comma) and for supported, safe types, the caller doesn’t have to take care of the string conversion.

### Steps to test:
- CI should be enough

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
