### PR TITLE
Fix regression for legacy (v10) manual upload / publish

### DIFF
--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -85,7 +85,7 @@ class WKRemoteDataStoreController @Inject()(
             uploadInfo.folderId,
             user,
             // For the moment, the convert_to_wkw job can only fill the dataset if it is not virtual.
-            isVirtual = !uploadInfo.needsConversion.getOrElse(false)
+            isVirtual = uploadInfo.isVirtual.getOrElse(!uploadInfo.needsConversion.getOrElse(false))
           ) ?~> "dataset.upload.creation.failed"
           _ <- datasetService.addInitialTeams(dataset, uploadInfo.initialTeams, user)(AuthorizedAccessContext(user))
           additionalInfo = ReserveAdditionalInformation(dataset._id, dataset.directoryName)

--- a/unreleased_changes/8984.md
+++ b/unreleased_changes/8984.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a regression where the old (api v10) manualUpload flow would not correctly register datasets.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSLegacyApiController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSLegacyApiController.scala
@@ -149,7 +149,7 @@ class DSLegacyApiController @Inject()(
               request.body.initialTeamIds,
               request.body.folderId,
               Some(request.body.requireUniqueName),
-              None,
+              Some(true),
               needsConversion = None
             )
           ) ?~> "dataset.upload.validation.failed"

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSLegacyApiController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSLegacyApiController.scala
@@ -149,7 +149,7 @@ class DSLegacyApiController @Inject()(
               request.body.initialTeamIds,
               request.body.folderId,
               Some(request.body.requireUniqueName),
-              Some(true),
+              Some(false),
               needsConversion = None
             )
           ) ?~> "dataset.upload.validation.failed"


### PR DESCRIPTION
The old (v10) publish flow uses reserveManualUpload and then relies on the datastore being able to send updates of the dataset to the wk database. That is only allowed if these datasets are not marked as virtual. [This comment](https://github.com/scalableminds/webknossos/blob/a35bbba887e57006a980679199b14399f8fec61c/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala#L57) already explained this, but then the code didn’t do it.

### Steps to test:
- Run worker neuron inference, publish task should work. (I did that)

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Needs datastore update after deployment
