### PR TITLE
Add s3 upload config to standalone datastore config

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -66,7 +66,7 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
       val objectKeyPrefix: String = get[String]("datastore.s3Upload.objectKeyPrefix")
       val credentialName: String = get[String]("datastore.s3Upload.credentialName")
     }
-    val children = List(WebKnossos, WatchFileSystem, Cache, AdHocMesh, Redis, AgglomerateSkeleton)
+    val children = List(WebKnossos, WatchFileSystem, Cache, AdHocMesh, Redis, AgglomerateSkeleton, S3Upload)
   }
 
   object SlackNotifications {

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -89,6 +89,12 @@ datastore {
     # The credentials are selected by uri prefix, so different s3 uri styles may need duplicated credential entries.
     credentials = []
   }
+  s3Upload {
+    enabled = false
+    # Use the name of a credential in the dataVaults section here to use it for uploads.
+    credentialName = "s3://example/uri/prefix"
+    objectKeyPrefix = "webknossos-uploads"
+  }
 }
 
 slackNotifications {


### PR DESCRIPTION
This was unfortunately not asserted because the children reference was missing.

### Steps to test:
- CI

------
- [x] Needs datastore update after deployment
