### PR TITLE
Tweak "Recent Conversions" UI

### DIFF
--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -461,7 +461,7 @@ function NewJobsAlert({ jobs }: { jobs: APIJob[] }) {
         const { tooltip, icon } = TOOLTIP_MESSAGES_AND_ICONS[job.state];
         return (
           <Row key={job.id} gutter={16}>
-            <Col span={10}>
+            <Col>
               <Tooltip title={tooltip}>{icon}</Tooltip>{" "}
               {job.state === "SUCCESS" && job.resultLink ? (
                 <Link to={job.resultLink}>{job.datasetName}</Link>
@@ -481,7 +481,7 @@ function NewJobsAlert({ jobs }: { jobs: APIJob[] }) {
           marginTop: 12,
         }}
       >
-        <Col span={10}>
+        <Col>
           <Link to="/jobs" title="Jobs Overview">
             See complete list
           </Link>


### PR DESCRIPTION
A PR for a small UI tweak. When uploading a dataset, WK will show a short notification about your recent conversion jobs. For some reason this information was not allowed to use the full width of the screen. This PR fixes that.

#### Before
<img width="1019" height="414" alt="Screenshot 2025-10-14 at 14 36 49" src="https://github.com/user-attachments/assets/200c467d-ff9f-4de9-8873-7fe76870038f" />


#### After 
<img width="1151" height="168" alt="Screenshot 2025-10-14 at 14 38 30" src="https://github.com/user-attachments/assets/10e2b39e-fd80-4df5-809b-35e3f0a4df98" />


### Steps to test:
 1. Enable worker
 2. Upload any image as new DS
 3. TADA

### Issues:
- fixes #nada

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
