### PR TITLE
for uploadToPaths, avoid slack notification and upload event, only log instead

### DIFF
--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -669,11 +669,8 @@ class DatasetController @Inject()(userService: UserService,
         _ <- Fox.fromBool(!dataset.isUsable) ?~> s"Dataset is already marked as usable."
         _ <- datasetDAO.updateDatasetStatusByDatasetId(datasetId, newStatus = "", isUsable = true)
         _ <- usedStorageService.refreshStorageReportForDataset(dataset)
-        _ = datasetService.trackNewDataset(dataset,
-                                           request.identity,
-                                           needsConversion = false,
-                                           datasetSizeBytes = 0,
-                                           addVariantLabel = "via uploadToPaths/publish")
+        _ = logger.info(
+          s"Successfully finished uploadToPaths/publish of dataset $datasetId for user ${request.identity._id}")
       } yield Ok
     }
 


### PR DESCRIPTION
Otherwise we’ll get double notifications because most workflows that do publish are via the worker, and we already get job succeeded notifications.