### PR TITLE
Include null check for novelExperienceInfos

### DIFF
--- a/frontend/javascripts/viewer/model/sagas/many_bucket_updates_warning_saga.tsx
+++ b/frontend/javascripts/viewer/model/sagas/many_bucket_updates_warning_saga.tsx
@@ -3,6 +3,7 @@ import { Button, Checkbox, type CheckboxChangeEvent, Space } from "antd";
 import Toast from "libs/toast";
 import { select, takeEvery } from "typed-redux-saga";
 import type { Saga } from "viewer/model/sagas/effect-generators";
+import type { WebknossosState } from "viewer/store";
 
 const TOO_MANY_BUCKETS_TOAST_KEY = "manyBucketUpdatesWarningToast";
 
@@ -12,7 +13,8 @@ function* manyBucketUpdatesWarning(): Saga<void> {
     showWarningToastInThisSession = value;
   };
   const suppressWarningToast = yield* select(
-    (state) => state.activeUser.novelUserExperienceInfos.suppressManyBucketUpdatesWarning,
+    (state: WebknossosState) =>
+      state.activeUser?.novelUserExperienceInfos.suppressManyBucketUpdatesWarning,
   );
   if (suppressWarningToast) {
     return;


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a publicly available annotation without being logged in -> no error toast :) 
- I tested this on commit ea18578a2c3774765a301165349de9a751deaa40 (the merge of #8961)

### TODOs:
- [ ] test on current master. Wasnt able to run wk locally this morning (https://scm.slack.com/archives/C5AKLAV0B/p1762768096605689)

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1762764001604969
- follow-up for #8961 

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
