### PR TITLE
Fix VX Workflow list cache errors

### DIFF
--- a/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
@@ -81,15 +81,16 @@ export default function WorkflowListView() {
     isFetching,
   } = useQuery({
     queryKey: ["voxelyticsWorkflows"],
-    queryFn: () => {
+    queryFn: async () => {
       try {
-        return getVoxelyticsWorkflows();
+        return await getVoxelyticsWorkflows();
       } catch (err) {
         Toast.error("Could not load workflow list.");
         console.error(err);
         throw err;
       }
     },
+    // We use the select to transform the data because it is run on cached and fetched data
     select: (data) => data.map(parseWorkflowInfo),
     refetchInterval: VX_POLLING_INTERVAL ?? false,
   });

--- a/unreleased_changes/9109.md
+++ b/unreleased_changes/9109.md
@@ -1,0 +1,3 @@
+### Fixed
+- Fixed a caching issue with the VX workflow overview page.
+


### PR DESCRIPTION
This PR fixes an issues with the VX Worfklow view. After a while or on page refresh it would show the following error message:
<img width="1207" height="613" alt="Screenshot 2025-12-01 at 10 56 04" src="https://github.com/user-attachments/assets/db2cb363-72b4-4401-8687-bc6c3641b55a" />

1. The error indicates that the workflow list date was not properly transformed, especially the string timestamps were not transformed into JS `Date` objects.
2. Upon closer inspection I noticed that this workflow data is being displayed (and failing) before the request to WK backend is even completed (or started). Hence, the data must be restored from cache.
3. In PR #9095, I introduced the use of `react-query` for fetching the workflow. React-query is configured to cache all requests in the [`localStorage`](https://vscode.dev/github/scalableminds/webknossos/blob/master/frontend/javascripts/main.tsx#L50-L51). In general, the cached data is serialized as JSON strings. 
4. Is suspect, that the workflow list view data including the JS Date objects, is serialized as JSON strings when being cached. Upon restoring the cached JS Date objects are parsed/restored as regular strings not `Date` objects. 🤦 
5. I fixed it by applying the workflow data timestamps to `Date` transformations in a separate `select` (=transform) step in the `react-query` runtime that is being executing both after fetching the data from the server and restoring from the cache. See docs: https://tanstack.com/query/v5/docs/framework/react/reference/useQuery

```
This option can be used to transform or select a part of the data returned by the query function. It affects the returned data value, but does not affect what gets stored in the query cache.
The select function will only run if data changed, or if the reference to the select function itself changes. To optimize, wrap the function in useCallback.
``` 

### Steps to test:
I have not found a way to manual trigger the above error yet. :-/ 

To test the propose solution:
- Clear your browser `localStorage`
- Open the VX workflow list and make sure that it is populated correctly
- Refresh page to trigger a cache response


### Issues:
- fixes a regression from #9095
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1764323131933529

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
