### PR TITLE
Fix nd-dataset sliders

### DIFF
--- a/frontend/javascripts/viewer/view/layouting/default_layout_configs.ts
+++ b/frontend/javascripts/viewer/view/layouting/default_layout_configs.ts
@@ -157,6 +157,7 @@ function buildBorder(
     id: `${side}-border`,
     barSize: borderBarSize,
     size: width,
+    enableAutoHide: true,
     children: [
       {
         type: "tab",

--- a/frontend/javascripts/viewer/view/layouting/flex_layout_wrapper.tsx
+++ b/frontend/javascripts/viewer/view/layouting/flex_layout_wrapper.tsx
@@ -1,5 +1,5 @@
 import { sendAnalyticsEvent } from "admin/rest_api";
-import { Layout } from "antd";
+import { ConfigProvider, Layout } from "antd";
 import FastTooltip from "components/fast_tooltip";
 import features from "features";
 import { Actions, DockLocation, Layout as FlexLayoutComponent, Model } from "flexlayout-react";
@@ -12,6 +12,7 @@ import type React from "react";
 import { Fragment, PureComponent } from "react";
 import { connect } from "react-redux";
 import type { Dispatch } from "redux";
+import { getAntdTheme } from "theme";
 import type { BorderTabType, OrthoView } from "viewer/constants";
 import { ArbitraryViews, BorderTabs, OrthoViews } from "viewer/constants";
 import { setBorderOpenStatusAction } from "viewer/model/actions/ui_actions";
@@ -589,11 +590,13 @@ class FlexLayoutWrapper extends PureComponent<Props, State> {
             classNameMapper={this.classNameMapper}
           />
         </div>
-        <Footer className="statusbar-footer">
-          <BorderToggleButton side="left" onClick={() => this.toggleBorder("left")} inFooter />
-          <BorderToggleButton side="right" onClick={() => this.toggleBorder("right")} inFooter />
-          <Statusbar />
-        </Footer>
+        <ConfigProvider theme={getAntdTheme("dark")}>
+          <Footer className="statusbar-footer">
+            <BorderToggleButton side="left" onClick={() => this.toggleBorder("left")} inFooter />
+            <Statusbar />
+            <BorderToggleButton side="right" onClick={() => this.toggleBorder("right")} inFooter />
+          </Footer>
+        </ConfigProvider>
       </Fragment>
     );
   }

--- a/frontend/javascripts/viewer/view/novel_user_experiences/01-present-modern-controls.tsx
+++ b/frontend/javascripts/viewer/view/novel_user_experiences/01-present-modern-controls.tsx
@@ -1,5 +1,5 @@
 import { updateNovelUserExperienceInfos } from "admin/rest_api";
-import { Button, Modal } from "antd";
+import { Modal } from "antd";
 import { useWkSelector } from "libs/react_hooks";
 import { useState } from "react";
 import { useDispatch } from "react-redux";
@@ -35,7 +35,15 @@ export default function PresentModernControls() {
   };
 
   return (
-    <Modal maskClosable={false} open onCancel={closeModal} width={800} footer={null}>
+    <Modal
+      maskClosable={false}
+      open
+      width={800}
+      okText="Enable the Context Menu"
+      cancelText="Keep the Classic Controls"
+      onOk={handleEnableContextMenu}
+      onCancel={handleKeepClassicControls}
+    >
       <h1>Say Hello to the Context Menu</h1>
       <p>
         WEBKNOSSOS now provides an easy-to-use context menu that allows performing even complex
@@ -55,21 +63,9 @@ export default function PresentModernControls() {
         Previously, the right-click was reserved for certain actions, such as creating a node or
         erasing volume data. These actions are now available in their respective tool via left-click
         (e.g., using the dedicated erase tool) or happen automatically (e.g., selecting a node
-        doesn’t require holding shift anymore).
+        doesn't require holding shift anymore).
       </p>
-      <div className="center-item-using-flex">
-        <Button
-          type="primary"
-          onClick={handleEnableContextMenu}
-          style={{
-            marginRight: 12,
-          }}
-        >
-          Enable the Context Menu
-        </Button>
 
-        <Button onClick={handleKeepClassicControls}>Keep the Classic Controls</Button>
-      </div>
       <p
         style={{
           color: "var(--ant-color-text-secondary)",

--- a/frontend/stylesheets/flex_layout_overwrites.less
+++ b/frontend/stylesheets/flex_layout_overwrites.less
@@ -16,14 +16,6 @@
   border-color: var(--ant-color-border);
 }
 
-.flexlayout__border_left {
-  border-right: none;
-}
-
-.flexlayout__border_right {
-  border-left: none;
-}
-
 .flexlayout__tabset_tabbar_inner_tab_container_top {
   border: none !important;
 }

--- a/frontend/stylesheets/trace_view/_status_bar.less
+++ b/frontend/stylesheets/trace_view/_status_bar.less
@@ -1,6 +1,6 @@
 .statusbar {
-  margin-left: 35px;
-  margin-right: 35px;
+  margin-left: 25px;
+  margin-right: 25px;
   font-size: 14px;
   display: flex;
   flex-wrap: wrap;
@@ -9,13 +9,15 @@
   .info-element {
     display: inline-block;
     text-align: left;
-    margin-right: 25px;
+    margin-right: 20px;
   }
+
   .keyboard-mouse-icon {
     height: 14px;
     margin-top: 2px;
   }
+
   .shortcut-info-element {
-    margin-left: 25px;
+    margin-left: 20px;
   }
 }

--- a/frontend/stylesheets/trace_view/_tracing_view.less
+++ b/frontend/stylesheets/trace_view/_tracing_view.less
@@ -411,6 +411,7 @@ img.keyboard-mouse-icon:first-child {
     }
   }
 
+  // left/right-border-button is the antd <Button> that is used for the FlexLayout to toggle the left/right-hand side panels
   .left-border-button.footer-button,
   .right-border-button.footer-button {
     position: absolute;
@@ -481,7 +482,7 @@ img.keyboard-mouse-icon:first-child {
   &:hover,
   &:focus,
   &:active {
-    border-color: initial;
+    border: none !important;
     background-color: initial;
     color: initial;
   }


### PR DESCRIPTION
This PR fixes sliders moving between the 4th, 5th ... nth dimension in the WK viewer.

<img width="295" height="145" alt="Screenshot 2026-01-19 at 17 32 45" src="https://github.com/user-attachments/assets/90c6b4f4-f5fc-438f-aeaf-fe16d76dae0c" />

The issue is caused, again, by the antd wrapper components - here `<Popover>` - not having a stable(?) reference of it's child components. Without that ref, Popover cannot correctly determine the position and dimensions of it's children and is erroneously rendered in the bottom, left corner. 
Wrapping our custom `<ArbitraryVectorInput>` in a forward ref fixes the issue. This is identical to PR #9164.

To avoid issues with `React.forwardRef` and React class components, I also refactored the `<VectorInput>` components to React functional components.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
1. Import this nd dataset, if you don't already have a nd-dataset for testing: s3://gs-public-zarr-archive/tubhiswt-4D.ome.zarr/0
2. Open the WK viewer
3. Verify that the popover and slider for the t-dimension work as expected.


### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1768827307888889

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
