### PR TITLE
Switch Fontawesome icon to "regular" style

### DIFF
--- a/frontend/javascripts/admin/onboarding.tsx
+++ b/frontend/javascripts/admin/onboarding.tsx
@@ -522,7 +522,7 @@ function OnboardingView() {
             of Springfield&rdquo;, &ldquo;Simpsons Lab&rdquo;, &ldquo;Neuroscience Department&rdquo;
           </Fragment>
         }
-        icon={<i className="fa-regular fa-building icon-big" />}
+        icon={<i className="far fa-building icon-big" />}
       >
         <OrganizationForm onComplete={onCreateOrganizationComplete} />
       </StepHeader>

--- a/frontend/javascripts/components/text_with_description.tsx
+++ b/frontend/javascripts/components/text_with_description.tsx
@@ -45,7 +45,7 @@ const TextWithDescription: React.FC<Props> = (props) => {
           <Tooltip title="Show description" placement="bottom">
             <Popover title="Description" trigger="click" content={markdownDescription}>
               <i
-                className="fa-regular fa-align-justify"
+                className="far fa-align-justify"
                 style={{
                   cursor: "pointer",
                 }}

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -96,8 +96,8 @@ const persistence = new Persistence<PartialState>(
 
 const READ_ONLY_ICON = (
   <span className="fa-stack fa-1x" style={{ width: "1em" }}>
-    <i className="fa-regular fa-pen fa-stack-1x" />
-    <i className="fa-regular fa-slash fa-stack-1x" />
+    <i className="far fa-pen fa-stack-1x" />
+    <i className="far fa-slash fa-stack-1x" />
   </span>
 );
 

--- a/frontend/javascripts/viewer/view/action-bar/tools/brush_presets.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/tools/brush_presets.tsx
@@ -200,9 +200,7 @@ export function ChangeBrushSizePopover() {
                 <BrushPresetButton
                   name="Small"
                   onClick={() => handleUpdateBrushSize(smallBrushSize)}
-                  icon={
-                    <i className="fa-regular fa-circle fa-xs" style={{ transform: "scale(0.6)" }} />
-                  }
+                  icon={<i className="far fa-circle fa-xs" style={{ transform: "scale(0.6)" }} />}
                   brushSize={Math.round(smallBrushSize)}
                 />
               </Col>
@@ -210,7 +208,7 @@ export function ChangeBrushSizePopover() {
                 <BrushPresetButton
                   name="Medium"
                   onClick={() => handleUpdateBrushSize(mediumBrushSize)}
-                  icon={<i className="fa-regular fa-circle fa-sm" />}
+                  icon={<i className="far fa-circle fa-sm" />}
                   brushSize={Math.round(mediumBrushSize)}
                 />
               </Col>
@@ -218,7 +216,7 @@ export function ChangeBrushSizePopover() {
                 <BrushPresetButton
                   name="Large"
                   onClick={() => handleUpdateBrushSize(largeBrushSize)}
-                  icon={<i className="fa-regular fa-circle fa-lg" />}
+                  icon={<i className="far fa-circle fa-lg" />}
                   brushSize={Math.round(largeBrushSize)}
                 />
               </Col>

--- a/frontend/javascripts/viewer/view/action-bar/tools/skeleton_specific_ui.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/tools/skeleton_specific_ui.tsx
@@ -110,7 +110,7 @@ export function SkeletonSpecificButtons() {
         style={NARROW_BUTTON_STYLE}
         title="When activated, clicking and dragging creates nodes like a drawing tool."
       >
-        <i className="fa-regular fa-pen" />
+        <i className="far fa-pen" />
       </ToggleButton>
 
       {isMergerModeEnabled && isMaterializeVolumeAnnotationEnabled && isUserAdminOrManager && (
@@ -165,10 +165,10 @@ function CreateTreeButton() {
             transform: "scale(0.9) translate(-2px, -1px)",
             marginRight: 3,
           }}
-          className="fa-regular fa-project-diagram"
+          className="far fa-project-diagram"
         />
         <i
-          className="fa-regular fa-plus"
+          className="far fa-plus"
           style={{
             position: "absolute",
             top: 13,

--- a/frontend/javascripts/viewer/view/action-bar/tools/tool_buttons.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/tools/tool_buttons.tsx
@@ -41,7 +41,7 @@ function MaybeMultiSliceAnnotationInfoIcon() {
   const maybeMultiSliceAnnotationInfoIcon = hasMagWithHigherDimension ? (
     <FastTooltip title="You are annotating in a low magnification. Depending on the used viewport, you might be annotating multiple slices at once.">
       <i
-        className="fa-regular fa-layer-group"
+        className="far fa-layer-group"
         style={{
           marginLeft: 4,
         }}
@@ -60,7 +60,7 @@ export function MoveTool(_props: ToolButtonProps) {
       disabled={false}
       value={AnnotationTool.MOVE.id}
     >
-      <i className="fa-regular fa-arrows-alt" />
+      <i className="far fa-arrows-alt" />
     </ToolRadioButton>
   );
 }
@@ -90,7 +90,7 @@ export function SkeletonTool(_props: ToolButtonProps) {
         style={{
           opacity: disabledInfosForTools[AnnotationTool.SKELETON.id].isDisabled ? 0.5 : 1,
         }}
-        className="fa-regular fa-project-diagram"
+        className="far fa-project-diagram"
       />
     </ToolRadioButton>
   );
@@ -119,7 +119,7 @@ export function BrushTool({ adaptedActiveTool }: ToolButtonProps) {
       value={AnnotationTool.BRUSH.id}
     >
       <i
-        className="fa-regular fa-paint-brush"
+        className="far fa-paint-brush"
         style={{
           opacity: disabledInfosForTools[AnnotationTool.BRUSH.id].isDisabled ? 0.5 : 1,
         }}
@@ -154,7 +154,7 @@ export function EraseBrushTool({ adaptedActiveTool }: ToolButtonProps) {
       value={AnnotationTool.ERASE_BRUSH.id}
     >
       <i
-        className="fa-regular fa-eraser"
+        className="far fa-eraser"
         style={{
           opacity: disabledInfosForTools[AnnotationTool.ERASE_BRUSH.id].isDisabled ? 0.5 : 1,
         }}
@@ -217,7 +217,7 @@ export function EraseTraceTool({ adaptedActiveTool }: ToolButtonProps) {
       value={AnnotationTool.ERASE_TRACE.id}
     >
       <i
-        className="fa-regular fa-eraser"
+        className="far fa-eraser"
         style={{
           opacity: disabledInfosForTools[AnnotationTool.ERASE_TRACE.id].isDisabled ? 0.5 : 1,
         }}
@@ -245,7 +245,7 @@ export function FillCellTool({ adaptedActiveTool }: ToolButtonProps) {
       value={AnnotationTool.FILL_CELL.id}
     >
       <i
-        className="fa-regular fa-fill-drip"
+        className="far fa-fill-drip"
         style={{
           opacity: disabledInfosForTools[AnnotationTool.FILL_CELL.id].isDisabled ? 0.5 : 1,
           transform: "scaleX(-1)",
@@ -269,7 +269,7 @@ export function VoxelPipetteTool(_props: ToolButtonProps) {
       value={AnnotationTool.VOXEL_PIPETTE.id}
     >
       <i
-        className="fa-regular fa-eye-dropper"
+        className="far fa-eye-dropper"
         style={{
           opacity: disabledInfosForTools[AnnotationTool.VOXEL_PIPETTE.id].isDisabled ? 0.5 : 1,
         }}
@@ -367,7 +367,7 @@ export function ProofreadTool(_props: ToolButtonProps) {
       }}
     >
       <i
-        className="fa-regular fa-clipboard-check"
+        className="far fa-clipboard-check"
         style={{
           opacity: disabledInfosForTools[AnnotationTool.PROOFREAD.id].isDisabled ? 0.5 : 1,
           padding: "0 4px",
@@ -386,7 +386,7 @@ export function LineMeasurementTool(_props: ToolButtonProps) {
       disabled={false}
       value={AnnotationTool.LINE_MEASUREMENT.id}
     >
-      <i className="fa-regular fa-ruler" />
+      <i className="far fa-ruler" />
     </ToolRadioButton>
   );
 }

--- a/frontend/javascripts/viewer/view/action-bar/tools/toolbar_view.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/tools/toolbar_view.tsx
@@ -210,7 +210,7 @@ function ToolSpecificSettings({
             disabled={!isAISelectAvailable}
             title={quickSelectTooltipText}
           >
-            <i className="fa-regular fa-magic icon-margin-right" /> AI
+            <i className="far fa-magic icon-margin-right" /> AI
           </ToggleButton>
 
           <QuickSelectSettingsPopover />

--- a/frontend/javascripts/viewer/view/action-bar/tools/toolkit_switcher_view.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/tools/toolkit_switcher_view.tsx
@@ -66,7 +66,7 @@ export default function ToolkitView() {
         }}
       >
         <Button style={NARROW_BUTTON_STYLE}>
-          <i className="fa-regular fa-tools" />
+          <i className="far fa-tools" />
         </Button>
       </Badge>
     </Dropdown>

--- a/frontend/javascripts/viewer/view/action-bar/tools/volume_specific_ui.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/tools/volume_specific_ui.tsx
@@ -185,8 +185,8 @@ export function OverwriteModeSwitch({
 }
 
 const INTERPOLATION_ICON = {
-  [InterpolationModeEnum.INTERPOLATE]: <i className="fa-regular fa-align-center fa-rotate-90" />,
-  [InterpolationModeEnum.EXTRUDE]: <i className="fa-regular fa-align-justify fa-rotate-90" />,
+  [InterpolationModeEnum.INTERPOLATE]: <i className="far fa-align-center fa-rotate-90" />,
+  [InterpolationModeEnum.EXTRUDE]: <i className="far fa-align-justify fa-rotate-90" />,
 };
 
 export function VolumeInterpolationButton() {
@@ -455,7 +455,7 @@ export function ProofreadingComponents() {
         style={NARROW_BUTTON_STYLE}
         onClick={() => handleToggleAutomaticMeshRendering(!autoRenderMeshes)}
       >
-        <i className="fa-regular fa-dice-d20" />
+        <i className="far fa-dice-d20" />
       </ToggleButton>
       <ToggleButton
         active={selectiveVisibilityInProofreading}
@@ -467,7 +467,7 @@ export function ProofreadingComponents() {
           handleToggleSelectiveVisibilityInProofreading(!selectiveVisibilityInProofreading)
         }
       >
-        <i className="fa-regular fa-highlighter" />
+        <i className="far fa-highlighter" />
       </ToggleButton>
       <ToggleButton
         active={isMultiSplitActive}

--- a/frontend/javascripts/viewer/view/action-bar/undo_redo_actions.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/undo_redo_actions.tsx
@@ -29,7 +29,7 @@ function UndoRedoActions({ hasTracing, isBusy }: Props) {
         disabled={isBusy}
         hideContentWhenLoading
       >
-        <i className="fa-regular fa-undo" aria-hidden="true" />
+        <i className="far fa-undo" aria-hidden="true" />
       </AsyncButton>
       <AsyncButton
         className="narrow undo-redo-button hide-on-small-screen"
@@ -39,7 +39,7 @@ function UndoRedoActions({ hasTracing, isBusy }: Props) {
         disabled={isBusy}
         hideContentWhenLoading
       >
-        <i className="fa-regular fa-redo" aria-hidden="true" />
+        <i className="far fa-redo" aria-hidden="true" />
       </AsyncButton>
     </Space.Compact>
   );

--- a/frontend/javascripts/viewer/view/action-bar/view_modes_view.tsx
+++ b/frontend/javascripts/viewer/view/action-bar/view_modes_view.tsx
@@ -11,13 +11,10 @@ import {
 import { NARROW_BUTTON_STYLE } from "./tools/tool_helpers";
 
 const VIEW_MODE_TO_ICON = {
-  [constants.MODE_PLANE_TRACING]: <i className="fa-regular fa-th-large" />,
-  [constants.MODE_ARBITRARY]: <i className="fa-regular fa-globe" />,
+  [constants.MODE_PLANE_TRACING]: <i className="far fa-th-large" />,
+  [constants.MODE_ARBITRARY]: <i className="far fa-globe" />,
   [constants.MODE_ARBITRARY_PLANE]: (
-    <i
-      className="fa-regular fa-square-full"
-      style={{ transform: "scale(0.8, 1) rotate(-45deg)" }}
-    />
+    <i className="far fa-square-full" style={{ transform: "scale(0.8, 1) rotate(-45deg)" }} />
   ),
 };
 

--- a/frontend/javascripts/viewer/view/context_menu.tsx
+++ b/frontend/javascripts/viewer/view/context_menu.tsx
@@ -248,7 +248,7 @@ function measureAndShowLengthBetweenNodes(
       lengthInUnit,
       LongUnitToShortUnitMap[voxelSizeUnit],
     )} (${formatLengthAsVx(lengthInVx)}).`,
-    icon: <i className="fa-regular fa-ruler" />,
+    icon: <i className="far fa-ruler" />,
   });
 }
 
@@ -273,7 +273,7 @@ function measureAndShowFullTreeLength(treeId: number, treeName: string, voxelSiz
       formatNumberToLength(lengthInUnit, LongUnitToShortUnitMap[voxelSizeUnit]),
       formatLengthAsVx(lengthInVx),
     ),
-    icon: <i className="fa-regular fa-ruler" />,
+    icon: <i className="far fa-ruler" />,
   });
 }
 
@@ -1874,8 +1874,8 @@ function ContextMenuInner() {
         "distanceInfo",
         <FastTooltip title="Distance to the active Node of the active Tree">
           <>
-            <i className="fa-regular fa-ruler" /> {distanceToSelection[0]} ({distanceToSelection[1]}
-            ) to this {maybeClickedNodeId != null ? "Node" : "Position"}
+            <i className="far fa-ruler" /> {distanceToSelection[0]} ({distanceToSelection[1]}) to
+            this {maybeClickedNodeId != null ? "Node" : "Position"}
             {copyIconWithTooltip(distanceToSelection[0], "Copy the distance")}
           </>
         </FastTooltip>,
@@ -1903,7 +1903,7 @@ function ContextMenuInner() {
         getInfoMenuItem(
           "copy-cell",
           <>
-            <i className="fa-regular fa-tag segment-context-icon" />
+            <i className="far fa-tag segment-context-icon" />
             Segment Name:{" "}
             {segmentName.length > maxNameLength
               ? truncateStringToLength(segmentName, maxNameLength)
@@ -1942,7 +1942,7 @@ function ContextMenuInner() {
       getInfoMenuItem(
         "boundingBoxPositionInfo",
         <>
-          <i className="fa-regular fa-dice-d6 segment-context-icon" />
+          <i className="far fa-dice-d6 segment-context-icon" />
           <>Bounding Box: </>
           <div style={{ marginLeft: 22, marginTop: -5 }}>
             {boundingBoxInfoLabel}

--- a/frontend/javascripts/viewer/view/left-border-tabs/layer_settings_tab.tsx
+++ b/frontend/javascripts/viewer/view/left-border-tabs/layer_settings_tab.tsx
@@ -452,7 +452,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
 
   getMergeWithFallbackLayerButton = (layer: APIDataLayer) => (
     <div onClick={() => this.setState({ layerToMergeWithFallback: layer })}>
-      <i className="fa-regular fa-object-ungroup icon-margin-right" />
+      <i className="far fa-object-ungroup icon-margin-right" />
       Merge this volume annotation with its fallback layer
     </div>
   );
@@ -466,7 +466,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
       <FastTooltip title="Delete this annotation layer.">
         <i
           onClick={() => this.deleteAnnotationLayerIfConfirmed(readableName, type, tracingId)}
-          className="fa-regular fa-trash icon-margin-right"
+          className="far fa-trash icon-margin-right"
         />
       </FastTooltip>
     </div>
@@ -481,7 +481,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
     <div
       onClick={() => this.deleteAnnotationLayerIfConfirmed(readableName, type, tracingId, layer)}
     >
-      <i className="fa-regular fa-trash icon-margin-right" />
+      <i className="far fa-trash icon-margin-right" />
       Delete this annotation layer
     </div>
   );
@@ -556,7 +556,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
 
     return (
       <div onClick={triggerComputeSegmentIndexFileJob}>
-        <i className="fa-regular fa-database icon-margin-right" />
+        <i className="far fa-database icon-margin-right" />
         Compute a Segment Index file
       </div>
     );
@@ -828,7 +828,7 @@ class DatasetSettings extends React.PureComponent<DatasetSettingsProps, State> {
                 placement="left"
               >
                 <i
-                  className="fa-regular fa-paint-brush icon-margin-right"
+                  className="far fa-paint-brush icon-margin-right"
                   style={{
                     opacity: 0.7,
                   }}

--- a/frontend/javascripts/viewer/view/right-border-tabs/comment_tab/comment.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/comment_tab/comment.tsx
@@ -85,7 +85,7 @@ function Comment({ comment, isActive }: CommentProps) {
             }}
           >
             <a onClick={handleClick}>
-              <i className="fa-regular fa-comment-dots" />
+              <i className="far fa-comment-dots" />
             </a>
           </span>
         </ActiveCommentPopover>

--- a/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segment_list_item.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segment_list_item.tsx
@@ -649,7 +649,7 @@ function _SegmentListItem({
           {isCentered ? (
             <FastTooltip title="This segment is currently centered in the data viewports.">
               <i
-                className="fa-regular fa-crosshairs deemphasized"
+                className="far fa-crosshairs deemphasized"
                 style={{
                   marginLeft: 4,
                 }}
@@ -659,7 +659,7 @@ function _SegmentListItem({
           {segment.id === activeCellId ? (
             <FastTooltip title="The currently active segment id belongs to this segment.">
               <i
-                className="fa-regular fa-paint-brush deemphasized"
+                className="far fa-paint-brush deemphasized"
                 style={{
                   marginLeft: 4,
                 }}

--- a/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/segments_tab/segments_view.tsx
@@ -1073,7 +1073,7 @@ class SegmentsView extends React.Component<Props, State> {
   getSetGroupColorMenuItem = (groupId: number | null): ItemType => {
     return {
       key: "changeGroupColor",
-      icon: <i className="fa-regular fa-eye-dropper fa-sm fa-icon fa-fw" />,
+      icon: <i className="far fa-eye-dropper fa-sm fa-icon fa-fw" />,
       label: (
         <ChangeColorMenuItemContent
           title="Change Segment Color"
@@ -1093,7 +1093,7 @@ class SegmentsView extends React.Component<Props, State> {
   getResetGroupColorMenuItem = (groupId: number | null): ItemType => {
     return {
       key: "resetGroupColor",
-      icon: <i className="fa-regular fa-undo" />,
+      icon: <i className="far fa-undo" />,
       label: (
         <div
           onClick={() => {
@@ -1142,7 +1142,7 @@ class SegmentsView extends React.Component<Props, State> {
   getComputeMeshesAdHocMenuItem = (groupId: number | null): ItemType => {
     return {
       key: "computeAdHoc",
-      icon: <i className="fa-regular fa-dice-d20 fa-fw fa-icon" />,
+      icon: <i className="far fa-dice-d20 fa-fw fa-icon" />,
       label: (
         <div
           onClick={() => {
@@ -1176,7 +1176,7 @@ class SegmentsView extends React.Component<Props, State> {
           </div>
         </>
       ),
-      icon: <i className="fa-regular fa-ruler fa-fw fa-icon" />,
+      icon: <i className="far fa-ruler fa-fw fa-icon" />,
     };
   };
 
@@ -1184,7 +1184,7 @@ class SegmentsView extends React.Component<Props, State> {
     return {
       key: "loadByFile",
       disabled: this.props.currentMeshFile == null,
-      icon: <i className="fa-regular fa-dice-d20 fa-icon fa-fw" />,
+      icon: <i className="far fa-dice-d20 fa-icon fa-fw" />,
       label: (
         <div
           onClick={() => {

--- a/frontend/javascripts/viewer/view/right-border-tabs/trees_tab/skeleton_tab_view.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/trees_tab/skeleton_tab_view.tsx
@@ -975,13 +975,13 @@ class SkeletonTabView extends React.PureComponent<Props, State> {
                     onClick={this.toggleAllTrees}
                     title="Toggle Visibility of All Trees (1)"
                     disabled={isEditingDisabled}
-                    icon={<i className="fa-regular fa-toggle-on" />}
+                    icon={<i className="far fa-toggle-on" />}
                   />
                   <ButtonComponent
                     onClick={this.toggleInactiveTrees}
                     title="Toggle Visibility of Inactive Trees (2)"
                     disabled={isEditingDisabled}
-                    icon={<i className="fa-regular fa-toggle-off" />}
+                    icon={<i className="far fa-toggle-off" />}
                   />
                   <ButtonComponent
                     onClick={this.props.onSelectNextTreeBackward}

--- a/frontend/javascripts/viewer/view/right-border-tabs/trees_tab/tree_hierarchy_renderers.tsx
+++ b/frontend/javascripts/viewer/view/right-border-tabs/trees_tab/tree_hierarchy_renderers.tsx
@@ -95,7 +95,7 @@ export function renderTreeNode(
   const maybeProofreadingIcon =
     tree.type === TreeTypeEnum.AGGLOMERATE ? (
       <FastTooltip title="Agglomerate Skeleton">
-        <i className="fa-regular fa-clipboard-check icon-margin-right" />
+        <i className="far fa-clipboard-check icon-margin-right" />
       </FastTooltip>
     ) : null;
 
@@ -140,7 +140,7 @@ const createMenuForTree = (tree: Tree, props: Props, hideContextMenu: () => void
       {
         key: "changeTreeColor",
         disabled: isEditingDisabled,
-        icon: <i className="fa-regular fa-eye-dropper fa-sm " />,
+        icon: <i className="far fa-eye-dropper fa-sm " />,
         label: (
           <ChangeColorMenuItemContent
             key={`changeTreeColor-${tree.treeId}`}
@@ -158,7 +158,7 @@ const createMenuForTree = (tree: Tree, props: Props, hideContextMenu: () => void
         onClick: () => shuffleTreeColor(tree.treeId),
         title: "Shuffle Tree Color",
         disabled: isEditingDisabled,
-        icon: <i className="fa-regular fa-adjust" />,
+        icon: <i className="far fa-adjust" />,
         label: "Shuffle Tree Color",
       },
       {
@@ -171,7 +171,7 @@ const createMenuForTree = (tree: Tree, props: Props, hideContextMenu: () => void
         },
         title: "Duplicate Tree",
         disabled: isEditingDisabled,
-        icon: <i className="fa-regular fa-clone" />,
+        icon: <i className="far fa-clone" />,
         label: "Duplicate Tree",
       },
       {
@@ -183,7 +183,7 @@ const createMenuForTree = (tree: Tree, props: Props, hideContextMenu: () => void
         },
         title: "Delete Tree",
         disabled: isEditingDisabled,
-        icon: <i className="fa-regular fa-trash" />,
+        icon: <i className="far fa-trash" />,
         label: "Delete Tree",
       },
       {
@@ -193,7 +193,7 @@ const createMenuForTree = (tree: Tree, props: Props, hideContextMenu: () => void
           hideContextMenu();
         },
         title: "Measure Tree Length",
-        icon: <i className="fa-regular fa-ruler" />,
+        icon: <i className="far fa-ruler" />,
         label: "Measure Tree Length",
       },
       {
@@ -204,7 +204,7 @@ const createMenuForTree = (tree: Tree, props: Props, hideContextMenu: () => void
           hideContextMenu();
         },
         title: "Hide/Show All Other Trees",
-        icon: <i className="fa-regular fa-eye" />,
+        icon: <i className="far fa-eye" />,
         label: "Hide/Show All Other Trees",
       },
       {
@@ -226,7 +226,7 @@ const createMenuForTree = (tree: Tree, props: Props, hideContextMenu: () => void
               hideContextMenu();
             },
             title: "Convert to Normal Tree",
-            icon: <span className="fa-regular fa-clipboard-check" />,
+            icon: <span className="far fa-clipboard-check" />,
             label: "Convert to Normal Tree",
           }
         : null,
@@ -459,7 +459,7 @@ const createMenuForTreeGroup = (
           toggleHideInactiveTrees();
           hideContextMenu();
         },
-        icon: <i className="fa-regular fa-eye" />,
+        icon: <i className="far fa-eye" />,
         label: "Hide/Show all other trees",
       },
       {
@@ -468,13 +468,13 @@ const createMenuForTreeGroup = (
           if (id === MISSING_GROUP_ID) shuffleAllTreeColors();
           else shuffleTreeGroupColors(id);
         },
-        icon: <i className="fa-regular fa-adjust" />,
+        icon: <i className="far fa-adjust" />,
         label: "Shuffle Tree Group Colors",
       },
       {
         key: "setTreeGroupColor",
         disabled: isEditingDisabled,
-        icon: <i className="fa-regular fa-eye-dropper fa-sm " />,
+        icon: <i className="far fa-eye-dropper fa-sm " />,
         label: (
           <ChangeColorMenuItemContent
             key={`changeTreeGroupColor-${id}`}
@@ -549,6 +549,6 @@ function handleMeasureSkeletonLength(treeId: number, treeName: string) {
       formatNumberToLength(lengthInUnit, LongUnitToShortUnitMap[dataSourceUnit]),
       formatLengthAsVx(lengthInVx),
     ),
-    icon: <i className="fa-regular fa-ruler" />,
+    icon: <i className="far fa-ruler" />,
   });
 }

--- a/frontend/stylesheets/main.less
+++ b/frontend/stylesheets/main.less
@@ -1,5 +1,5 @@
-@import "../../node_modules/@fortawesome/fontawesome-pro/css/fontawesone.min.css";
-@import "../../node_modules/@fortawesome/fontawesome-pro/css/regular.min.css";
+@import "./fontawesome-5.15.4-pro/less/fontawesome.less";
+@import "./fontawesome-5.15.4-pro/less/regular.less";
 @import "../../node_modules/flexlayout-react/style/light.css";
 @import "../../node_modules/antd/dist/reset.css";
 @import "../../node_modules/react-tooltip/dist/react-tooltip.css";


### PR DESCRIPTION
This PR switches all FontAwesome icon to the "regular" style, which is closer to the Antd icons.

<img width="3308" height="1040" alt="image" src="https://github.com/user-attachments/assets/37f33b45-c485-405e-9302-48545bbdcfef" />


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### TODOs:
- [ ] Figure out how to host Fontawesome Pro

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
