### PR TITLE
clean up inconsistent schema changes, add changelog for 9269

### DIFF
--- a/schema/evolutions/149-credits-as-ints.sql
+++ b/schema/evolutions/149-credits-as-ints.sql
@@ -55,7 +55,7 @@ BEGIN
                 (_id, _organization, milli_credit_delta, comment, transaction_state, credit_state, expiration_date)
             VALUES
                 (webknossos.generate_object_id(), organization_id, free_milli_credits_amount,
-                 'Free credits for this month', 'Complete', 'AddCredits', next_month_first_day);
+                 'Free credits for this month', 'Complete', 'Pending', next_month_first_day);
         END IF;
     END LOOP;
 END;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1152,7 +1152,7 @@ BEGIN
                 (_id, _organization, milli_credit_delta, comment, transaction_state, credit_state, expiration_date)
             VALUES
                 (webknossos.generate_object_id(), organization_id, free_milli_credits_amount,
-                 'Free credits for this month', 'Complete', 'AddCredits', next_month_first_day);
+                 'Free credits for this month', 'Complete', 'Pending', next_month_first_day);
         END IF;
     END LOOP;
 END;

--- a/unreleased_changes/9269.md
+++ b/unreleased_changes/9269.md
@@ -1,0 +1,2 @@
+### Added
+- Organization admins can now list credit transactions of their organization.


### PR DESCRIPTION
The schema changes in #9269 are only consistent with the evolutions because an old evolution was changed. That creates inconsistent states for instances where that evolution has already run. This PR undoes that.

If we decide we really want this schema change, we’ll need to do it in a new evolution.

Also, the changelog entry was still missing.