### PR TITLE
Fix listing credit transactions for multi-orga users

### DIFF
--- a/app/models/organization/CreditTransaction.scala
+++ b/app/models/organization/CreditTransaction.scala
@@ -102,15 +102,15 @@ class CreditTransactionDAO @Inject()(conf: WkConf,
     )
   }
 
+  // Superusers may read and update transactions of all orgas, but not list them.
   override protected def readAccessQ(requestingUserId: ObjectId): SqlToken =
     q"""${listAccessQ(requestingUserId)}
         OR TRUE in (SELECT isSuperUser FROM webknossos.multiUsers_ WHERE _id IN (SELECT _multiUser FROM webknossos.users_ WHERE _id = $requestingUserId))"""
 
   private def listAccessQ(requestingUserId: ObjectId): SqlToken =
-    q"""(_organization IN (SELECT _organization FROM webknossos.users_ WHERE (isAdmin OR isDatasetManager) AND _multiUser = (SELECT _multiUser FROM webknossos.users_ WHERE _id = $requestingUserId)))
+    q"""(_organization IN (SELECT _organization FROM webknossos.users_ WHERE (isAdmin OR isDatasetManager) AND _id = $requestingUserId))
       OR (_organization IN (SELECT _organization FROM webknossos.teams_ WHERE _id IN (SELECT _team FROM webknossos.user_team_roles WHERE isTeamManager AND _user = $requestingUserId)))"""
 
-  // Any user from an organization can update their credit transactions as for now all users can start paid jobs.
   override protected def updateAccessQ(requestingUserId: ObjectId): SqlToken = readAccessQ(requestingUserId)
 
   override protected def anonymousReadAccessQ(sharingToken: Option[String]): SqlToken = q"FALSE"


### PR DESCRIPTION
Yesterdays fix #9287 was not enough, I overlooked that the access query also allowed listing jobs from all orgas you are in. Now you can *actually* list only the ones of your orga (where you should then also be able to access the job-starting users).

Also removed an outdated comment.

### Steps to test:
(I already tested locally)
- With a multi-orga setup, start a paid job in one orga (no worker required), then switch to the other
- should be able to list credit transactions in organization settings view in both.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1770654613982149?thread_ts=1770650910.696689&cid=C5AKLAV0B

