### PR TITLE
Fix setting initial teams during publish if no write access via folder/admin

### DIFF
--- a/app/models/dataset/DatasetUploadToPathsService.scala
+++ b/app/models/dataset/DatasetUploadToPathsService.scala
@@ -84,7 +84,7 @@ class DatasetUploadToPathsService @Inject()(datasetService: DatasetService,
       )
       _ <- datasetDAO.updateFolder(newDatasetId, parameters.folderId.getOrElse(organization._rootFolder))(
         GlobalAccessContext)
-      _ <- datasetService.addInitialTeams(dataset, parameters.initialTeamIds, requestingUser)
+      _ <- datasetService.addInitialTeams(dataset, parameters.initialTeamIds, requestingUser)(GlobalAccessContext)
       _ <- datasetService.addUploader(dataset, requestingUser._id)(GlobalAccessContext)
     } // Note: not returning the one with layersToLink. Those are managed by the server entirely, so the client doesn’t need their paths.
     yield dataSourceWithPaths


### PR DESCRIPTION
This line should have GlobalAccessContext permissions, same as the one above and below.

We didn’t see this error before, presumably because the requesting users had permissions in the folder anyway.

### Steps to test:
- Publish dataset as non-orga-admin
- should still work

### Issues:
- fixes https://scm.slack.com/archives/CMBMU5684/p1771332622649169