### PR TITLE
In deletion service, on FileNotFoundError, assume already deleted.

### DIFF
--- a/tools/deletion-service/main.py
+++ b/tools/deletion-service/main.py
@@ -66,12 +66,11 @@ def poll_for_work(args: argparse.Namespace) -> None:
         try:
             delete_path(path)
             deleted_paths.append(path)
+        except FileNotFoundError:
+            logger.info(f"Got FileNotFoundError while trying to delete {path} – assuming already deleted.")
+            deleted_paths.append(path)
         except Exception as e:
-            if isinstance(e, FileNotFoundError):
-                logger.info(f"Got FileNotFoundError while trying to delete {path} – assuming already deleted.")
-                deleted_paths.append(path)
-            else:
-                logger.exception(f"Could not delete {path}")
+            logger.exception(f"Could not delete {path}")
 
     if deleted_paths:
         logger.info(f"Marking {len(deleted_paths)} paths as deleted in WEBKNOSSOS ...")


### PR DESCRIPTION
on FileNotFoundError, assume already deleted, mark as deleted in db. This avoids endless retries (because if not marked as deleted, the next polling will list this path again).

### Steps to test:
- Set up wk to upload to test s3 bucket
- upload a dataset
- manually delete some mag paths from the bucket (e.g. via s3fs mount)
- Delete the dataset in WK
- run deletion service
- It should log “assuming deleted” for the already-deleted paths
- On next polling, it should not retry them.

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
