### PR TITLE
Fix standalone datastore config for agglomerateSkeleton,agglomerateGraph

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -67,7 +67,15 @@ class DataStoreConfig @Inject()(configuration: Configuration) extends ConfigRead
       val objectKeyPrefix: String = get[String]("datastore.s3Upload.objectKeyPrefix")
       val credentialName: String = get[String]("datastore.s3Upload.credentialName")
     }
-    val children = List(WebKnossos, WatchFileSystem, Cache, AdHocMesh, Redis, AgglomerateSkeleton, DataVaults, S3Upload)
+    val children = List(WebKnossos,
+                        WatchFileSystem,
+                        Cache,
+                        AdHocMesh,
+                        Redis,
+                        AgglomerateSkeleton,
+                        AgglomerateGraph,
+                        DataVaults,
+                        S3Upload)
   }
 
   object SlackNotifications {

--- a/webknossos-datastore/conf/standalone-datastore.conf
+++ b/webknossos-datastore/conf/standalone-datastore.conf
@@ -79,7 +79,8 @@ datastore {
     address = "localhost"
     port = 6379
   }
-  agglomerateSkeleton.maxEdges = 10000
+  agglomerateSkeleton.maxEdges = 1000000
+  agglomerateGraph.maxEdges = 10000000
   dataVaults {
     # Global data vault access credentials. Not available during explore, only during data loading.
     # Example: {type = "S3AccessKey", name = "s3://example/uri/prefix", identifier = "someKeyId", secret = "someSecret"}


### PR DESCRIPTION
standalone datastores use the standalone-datastore.conf, not application.conf. Also this was not caught eagerly because the list of children wasn’t updated. in DataStoreConfig.scala.

Also the skeleton limit was out of sync with application.conf.