### PR TITLE
Allow downloading annotations with unicode in filenames

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -571,7 +571,7 @@ class AnnotationIOController @Inject()(
     } yield {
       Ok.sendPath(temporaryFile, inline = false)
         .as(mimeType)
-        .withHeaders(CONTENT_DISPOSITION -> s"""attachment; filename=$fileNameAscii; filename*=UTF-8''$fileName""")
+        .withHeaders(CONTENT_DISPOSITION -> s"""attachment; filename="$fileNameAscii"; filename*=UTF-8''$fileName""")
     }
   }
 


### PR DESCRIPTION
Play refused to write unicode strings directly into the CONTENT-DISPOSITION header. Best practice appears to be to percent-encode and use the `filename*` field with an ascii-only `filename` field as fallback. I tested with Firefox and Chrome. Also checked that this is the only relevant CONTENT-DISPOSITION header in the codebase.

### URL of deployed dev instance (used for testing):
- https://downloadunicode.webknossos.xyz

### Steps to test:
- Give an annotation a name with unicode, spaces, special chars all around
- Hit Download, should work, filename should look ok.

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1771876310321079

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
