### PR TITLE
Fix annotation download compatibility

### DIFF
--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -562,7 +562,6 @@ class AnnotationIOController @Inject()(
       name <- provider.nameFor(annotation) ?~> "annotation.name.impossible"
       fileExtension = exportExtensionForAnnotation(annotation)
       fileName = URLEncoder.encode(name + fileExtension, "UTF-8").replace("+", "%20")
-      fileNameAscii <- TextUtils.normalizeStrong(name + fileExtension).toFox
       mimeType = exportMimeTypeForAnnotation(annotation)
       _ <- restrictions.allowDownload(requestingUser) ?~> "annotation.download.notAllowed" ~> FORBIDDEN
       dataset <- datasetDAO.findOne(annotation._dataset)(GlobalAccessContext) ?~> "dataset.notFoundForAnnotation" ~> NOT_FOUND
@@ -571,7 +570,7 @@ class AnnotationIOController @Inject()(
     } yield {
       Ok.sendPath(temporaryFile, inline = false)
         .as(mimeType)
-        .withHeaders(CONTENT_DISPOSITION -> s"""attachment; filename="$fileNameAscii"; filename*=UTF-8''$fileName""")
+        .withHeaders(CONTENT_DISPOSITION -> s"""attachment; filename="$fileName"""")
     }
   }
 


### PR DESCRIPTION
- The `filename*` format was incompatible with the current libs client.
- Just using filename with the URLencoded value is not RFC compliant but also works with both Firefox and Chrome.
- I tested that this works with the current libs.
- Note that if the annotation name contains `"` it is replaced by underscore. I think that’s acceptable.
