### PR TITLE
Adjust email footer icon spacing

### DIFF
--- a/app/views/mail/emailBaseTemplate.scala.html
+++ b/app/views/mail/emailBaseTemplate.scala.html
@@ -31,27 +31,27 @@
         <a href="https://webknossos.org"
           style="display: inline-block; background-color: #5660ff; border-radius: 50%; width: 44px; height: 44px; line-height: 44px; text-align: center; margin: 0 4px;">
           <img src="https://static.webknossos.org/mails/email-footer-webknossos.png"
-            alt="WEBKNOSSOS" width="44" height="44" style="width: 22px; height: 22px; margin: 11px 11px"/>
+            alt="WEBKNOSSOS" width="44" height="44" style="width: 22px; height: 22px; margin: 11px; display:block;"/>
         </a>
         <a href="https://docs.webknossos.org"
           style="display: inline-block; background-color: #5660ff; border-radius: 50%; width: 44px; height: 44px; line-height: 44px; text-align: center; margin: 0 4px;">
           <img src="https://static.webknossos.org/mails/email-footer-docs.png"
-            alt="Documentation" width="44" height="44" style="width: 22px; height: 22px; margin: 11px 11px"/>
+            alt="Documentation" width="44" height="44" style="width: 22px; height: 22px; margin: 11px; display:block;"/>
         </a>
         <a href="https://www.youtube.com/channel/UCVQqjQ50lJORCZuLxnEE-tA"
           style="display: inline-block; background-color: #5660ff; border-radius: 50%; width: 44px; height: 44px; line-height: 44px; text-align: center; margin: 0 4px;">
           <img src="https://static.webknossos.org/mails/email-footer-youtube.png"
-            alt="YouTube Channel" width="44" height="44" style="width: 22px; height: 22px; margin: 11px 11px"/>
+            alt="YouTube Channel" width="44" height="44" style="width: 22px; height: 22px; margin: 11px; display:block;"/>
         </a>
         <a href="https://twitter.com/webknossos"
           style="display: inline-block; background-color: #5660ff; border-radius: 50%; width: 44px; height: 44px; line-height: 44px; text-align: center; margin: 0 4px;">
           <img src="https://static.webknossos.org/mails/email-footer-twitter.png"
-            alt="Twitter / X" width="44" height="44" style="width: 22px; height: 22px; margin: 11px 11px"/>
+            alt="Twitter / X" width="44" height="44" style="width: 22px; height: 22px; margin: 11px; display:block;"/>
         </a>
         <a href="https://bsky.app/profile/webknossos.org"
           style="display: inline-block; background-color: #5660ff; border-radius: 50%; width: 44px; height: 44px; line-height: 44px; text-align: center; margin: 0 4px;">
           <img src="https://static.webknossos.org/mails/email-footer-bluesky.png"
-            alt="Bluesky" width="44" height="44" style="width: 22px; height: 22px; margin: 11px 11px"/>
+            alt="Bluesky" width="44" height="44" style="width: 22px; height: 22px; margin: 11px; display:block;"/>
         </a>
       </p>
 


### PR DESCRIPTION
Summary
- remove redundant vertical-align styling from footer icon links to prevent inconsistent layout in some email clients
- center icons inside circles by adding symmetric margins on the img elements
