### PR TITLE
Enable AI model training for Personal Plan

### DIFF
--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -1,7 +1,6 @@
 import Icon from "@ant-design/icons";
 import AiAnalysisIcon from "@images/icons/icon-ai-analysis.svg?react";
 import { withAuthentication } from "admin/auth/authentication_modal";
-import { hasSomePaidPlan } from "admin/organization/pricing_plan_utils";
 import { createExplorational } from "admin/rest_api";
 import { Alert, Button, Dropdown, Modal, Popover, Space } from "antd";
 import { AsyncButton, type AsyncButtonProps } from "components/async_clickables";
@@ -305,7 +304,6 @@ class ActionBarView extends PureComponent<Props, State> {
 
   renderStartAIJobButton(disabled: boolean, tooltipTextIfDisabled: string): React.ReactNode {
     const tooltipText = disabled ? tooltipTextIfDisabled : "Start a processing job using AI";
-    const orgaHasSomePaidPlan = hasSomePaidPlan(this.props.activeOrganization);
 
     const menuItems = [
       {
@@ -313,15 +311,11 @@ class ActionBarView extends PureComponent<Props, State> {
         onClick: () => Store.dispatch(setAIJobDrawerStateAction("open_ai_inference")),
         label: "Run AI model",
       },
-      ...(orgaHasSomePaidPlan
-        ? [
-            {
-              key: "open_ai_training_button",
-              onClick: () => Store.dispatch(setAIJobDrawerStateAction("open_ai_training")),
-              label: "Train new AI model",
-            },
-          ]
-        : []),
+      {
+        key: "open_ai_training_button",
+        onClick: () => Store.dispatch(setAIJobDrawerStateAction("open_ai_training")),
+        label: "Train new AI model",
+      },
       {
         key: "open_ai_alignment_button",
         onClick: () => Store.dispatch(setAIJobDrawerStateAction("open_ai_alignment")),


### PR DESCRIPTION
This PR enables the "AI Analysis" entry for Model Training for all users (even with Personal Plan). If you select AI Model training you will see the following if you are not a super user and your orga does not have an AI plan:

<img width="1217" height="670" alt="Screenshot 2026-03-03 at 14 38 34" src="https://github.com/user-attachments/assets/58e43e02-8bac-4694-8906-33b3ed3ad61b" />

(The buy AI Addon-card is only visible for Admins, though)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Remove AI plan from orga in DB
- Remove super user from user in DB
- Set orga to Private Plan
- Open annotation and verify

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
