### PR TITLE
Skip public/bundle in final build (only public/assets is served anyway)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,9 @@ lazy val webknossos = (project in file("."))
     // https://github.com/playframework/playframework/issues/5765#issuecomment-1996991474
     Assets / WebKeys.exportedMappings := Seq(),
     TestAssets / WebKeys.exportedMappings := Seq(),
+    Assets / mappings := (Assets / mappings).value.filter { case (_, path) =>
+      !path.startsWith("public/bundle")
+    },
     updateOptions := updateOptions.value.withLatestSnapshots(true),
     Compile / unmanagedJars ++= {
       val libs = baseDirectory.value / "lib"


### PR DESCRIPTION
Reducing the image size by skipping this unused directory

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
