### PR TITLE
Post WK Startup to Slack

### DIFF
--- a/app/Startup.scala
+++ b/app/Startup.scala
@@ -97,6 +97,8 @@ class Startup @Inject()(actorSystem: ActorSystem,
     case _ => ()
   }
 
+  slackNotificationService.noticeStartup(webknossos.BuildInfo.version)
+
   private def ensurePostgresSchema(): Unit = {
     logger.info("Checking database schema...")
 

--- a/app/telemetry/SlackNotificationService.scala
+++ b/app/telemetry/SlackNotificationService.scala
@@ -56,4 +56,10 @@ class SlackNotificationService @Inject()(rpc: RPC, config: WkConf) extends LazyL
       title = "Slow request",
       msg = msg
     )
+
+  def noticeStartup(version: String): Unit =
+    slackClient.info(
+      title = "Startup",
+      msg = s"WEBKNOSSOS version `$version` started"
+    )
 }


### PR DESCRIPTION
Allowing us to see which version was running at particular times, and to notice unplanned restarts.

example message in https://scm.slack.com/archives/CMBMU5684/p1773656560775489

------
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
