### PR TITLE
Fix evolution 158

### DIFF
--- a/schema/evolutions/158-move-names-to-multiusers.sql
+++ b/schema/evolutions/158-move-names-to-multiusers.sql
@@ -14,6 +14,8 @@ SET firstName = u.firstName, lastName = u.lastName
 FROM webknossos.users u
 WHERE u._multiUser = m._id;
 
+UPDATE webknossos.multiUsers SET firstName = '<deleted>', lastName = '<deleted>' WHERE firstName IS NULL;
+
 ALTER TABLE webknossos.multiUsers ALTER COLUMN firstName SET NOT NULL;
 ALTER TABLE webknossos.multiUsers ALTER COLUMN lastName SET NOT NULL;
 


### PR DESCRIPTION
The update above this new line, only updates multiUsers that have at least one user. If a multiUser exists with no associated user (e.g. the account was deleted but the multiUser row remains), that multiUser row never gets its firstName/lastName set, leaving them NULL.

To handle this case, we explicitly set those multiusers’ names to "<deleted>".

I already ran the evolution like this, it did the trick. Before this change, the evolution would error.