### PR TITLE
Fix VX workflower viewer crashing

### DIFF
--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -566,7 +566,10 @@ export default function TaskListView({
             }}
           />
           {foreignWorkflow != null ? (
-            <Link to={`/workflows/${foreignWorkflow[0]}?runId=${foreignWorkflow[1]}`}>
+            <Link
+              to={`/workflows/${foreignWorkflow[0]}?runId=${foreignWorkflow[1]}`}
+              reloadDocument
+            >
               {task.taskName}
               &nbsp;
               <ExportOutlined />
@@ -833,6 +836,10 @@ function aggregateTaskInfos(
   }
 
   const taskInfo = allTaskInfos.find((t) => t.taskName === task.taskName) as VoxelyticsTaskInfo;
+  if (taskInfo === undefined) {
+    throw new Error(`Task info not found for task ${task.taskName}.`);
+  }
+
   if (runId != null) {
     const taskRun = taskInfo.runs.find((tr) => tr.runId === runId);
     if (taskRun === undefined) {


### PR DESCRIPTION
This fixed a crash with the VX workflow viewer.

<img width="1519" height="1123" alt="image" src="https://github.com/user-attachments/assets/b23df507-17db-4d6d-a9de-0660c4a8d057" />

This crash occured when trying to click on Link to a different VX report including a specific run ID. I believe the root cause is a race condition between a full reload of the VX workflow view (including fetch the report from the backend) and a local React state update because the component is watching the URL parameters for `runId` changes. (see `useSearchParams` hook in `task_list_view.tsx`). Accessing a `runId` from a (foreign) workflow report does not work and crashes. 

<img width="747" height="416" alt="Screenshot 2026-03-24 at 09 45 04" src="https://github.com/user-attachments/assets/e215493b-bb25-4e7a-90ea-406aae46e925" />

The proposed changes include:
- better error reporting when failing to load the run by id
- a hard page refresh on the link to avoid the race condition. This is more of a workaround/quick fix than a proper solution

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- I haven't be able to test any of this due to lack of proper workflow runs.


### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1774284429500699

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
