### PR TITLE
Include AttachmentType in proxy routes

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataProxyController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataProxyController.scala
@@ -8,7 +8,11 @@ import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.datavault.{ByteRange, Encoding}
 import com.scalableminds.webknossos.datastore.datavault.Encoding.Encoding
 import com.scalableminds.webknossos.datastore.helpers.UPath
-import com.scalableminds.webknossos.datastore.models.datasource.{DataLayerAttachments, UsableDataSource}
+import com.scalableminds.webknossos.datastore.models.datasource.{
+  DataLayerAttachments,
+  LayerAttachmentType,
+  UsableDataSource
+}
 import com.scalableminds.webknossos.datastore.services.{DataStoreAccessTokenService, DatasetCache, UserAccessRequest}
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.http.Writeable
@@ -55,6 +59,7 @@ class DataProxyController @Inject()(accessTokenService: DataStoreAccessTokenServ
 
   def proxyAttachment(datasetId: ObjectId,
                       dataLayerName: String,
+                      attachmentType: String,
                       attachmentName: String,
                       path: String): Action[AnyContent] = Action.async { implicit request =>
     accessTokenService.validateAccessFromTokenContext(UserAccessRequest.readDataset(datasetId)) {
@@ -62,10 +67,10 @@ class DataProxyController @Inject()(accessTokenService: DataStoreAccessTokenServ
         _ <- validatePath(path)
         (_, dataLayer) <- datasetCache.getWithLayer(datasetId, dataLayerName) ?~> Messages("dataLayer.notFound",
                                                                                            dataLayerName) ~> NOT_FOUND
-        attachment <- dataLayer.allAttachments.find(_.name == attachmentName).toFox ?~> Messages(
-          "dataLayer.wrongAttachment",
-          dataLayerName,
-          attachmentName) ~> NOT_FOUND
+        attachmentTypeValidated <- LayerAttachmentType.fromString(attachmentType).toFox
+        attachment <- dataLayer.attachments
+          .flatMap(_.getByTypeAndName(attachmentTypeValidated, attachmentName))
+          .toFox ?~> Messages("dataLayer.wrongAttachment", dataLayerName, attachmentName) ~> NOT_FOUND
         attachmentPath <- dataVaultService.vaultPathFor(attachment)
         requestedPath = attachmentPath / path
         byteRange <- ByteRange.fromRequest(request)
@@ -97,10 +102,10 @@ class DataProxyController @Inject()(accessTokenService: DataStoreAccessTokenServ
       path = Some(UPath.fromStringUnsafe(s"./layers/$layerName/mags/${mag.mag.toMagLiteral(allowScalar = true)}")))
 
   private def adaptPathsForAttachments(attachments: DataLayerAttachments, layerName: String): DataLayerAttachments =
-    attachments.mapped(
-      attachment =>
+    attachments.mappedWithType(
+      (attachment, attachmentType) =>
         attachment.copy(
-          path = UPath.fromStringUnsafe(s"./layers/$layerName/attachments/${attachment.name}")
+          path = UPath.fromStringUnsafe(s"./layers/$layerName/attachments/$attachmentType/${attachment.name}")
       ))
 
   private def validatePath(path: String): Fox[Unit] =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayerAttachments.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayerAttachments.scala
@@ -70,6 +70,16 @@ case class DataLayerAttachments(
       cumsum = cumsum.map(attachmentMapping(_))
     )
 
+  def mappedWithType(
+      attachmentMapping: (LayerAttachment, LayerAttachmentType) => LayerAttachment): DataLayerAttachments =
+    DataLayerAttachments(
+      meshes = meshes.map(attachmentMapping(_, LayerAttachmentType.mesh)),
+      agglomerates = agglomerates.map(attachmentMapping(_, LayerAttachmentType.agglomerate)),
+      segmentIndex = segmentIndex.map(attachmentMapping(_, LayerAttachmentType.segmentIndex)),
+      connectomes = connectomes.map(attachmentMapping(_, LayerAttachmentType.connectome)),
+      cumsum = cumsum.map(attachmentMapping(_, LayerAttachmentType.cumsum)),
+    )
+
   def renameByMap(renamingMap: Map[(LayerAttachmentType, String), String]): DataLayerAttachments =
     DataLayerAttachments(
       meshes = meshes.map(a => a.copy(name = renamingMap.getOrElse((LayerAttachmentType.mesh, a.name), a.name))),

--- a/webknossos-datastore/conf/datastore.latest.routes
+++ b/webknossos-datastore/conf/datastore.latest.routes
@@ -13,7 +13,7 @@ GET           /datasets/:datasetId/layers/:dataLayerName/histogram              
 
 # Read mag and attachment data via proxy
 GET           /datasets/:datasetId/proxy/layers/:dataLayerName/mags/:mag/*path                                                                        @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyMag(datasetId: ObjectId, dataLayerName: String, mag: String, path: String)
-GET           /datasets/:datasetId/proxy/layers/:dataLayerName/attachments/:attachmentName/*path                                                      @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyAttachment(datasetId: ObjectId, dataLayerName: String, attachmentName: String, path: String)
+GET           /datasets/:datasetId/proxy/layers/:dataLayerName/attachments/:attachmentType/:attachmentName/*path                                      @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyAttachment(datasetId: ObjectId, dataLayerName: String, attachmentType: String, attachmentName: String, path: String)
 GET           /datasets/:datasetId/proxy/datasource-properties.json                                                                                   @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyDatasource(datasetId: ObjectId)
 
 # Knossos compatible routes


### PR DESCRIPTION
Previously, proxyAttachment only worked if attachment name was unique across attachment types in the layer

Note that the libs use the paths from the proxy datasource-properties.json route, so this isn’t a breaking change (unless someone used the routes manually)

### Steps to test:
- check that /data/datasets/:datasetId/proxy/datasource-properties.json lists correct attachment paths
- check that they work

### Issues:
- fixes #9431

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
