### PR TITLE
Fix listing credit transactions for superusers

### DIFF
--- a/app/models/organization/CreditTransaction.scala
+++ b/app/models/organization/CreditTransaction.scala
@@ -114,6 +114,13 @@ class CreditTransactionDAO @Inject()(conf: WkConf,
 
   override protected def anonymousReadAccessQ(sharingToken: Option[String]): SqlToken = q"FALSE"
 
+  override def findAll(implicit ctx: DBAccessContext): Fox[List[CreditTransaction]] =
+    for {
+      accessQuery <- accessQueryFromAccessQ(listAccessQ)
+      r <- run(q"SELECT $columns FROM $existingCollectionName WHERE $accessQuery".as[CreditTransactionsRow])
+      parsed <- parseAll(r)
+    } yield parsed
+
   def getMilliCreditBalance(organizationId: String)(implicit ctx: DBAccessContext): Fox[Int] =
     for {
       accessQuery <- readAccessQuery


### PR DESCRIPTION
Regression from #9405 

this findAll does differ from the parent class, because it uses listAccessQ, not the default readAccessQ, which in this case is different – it allows superUsers to access all creditTransactions across orgas. However, the *list* should still access only those of the current orga.

### Steps to test:
- In multi-orga setup with worker, check that superusers can see credit transactions of their orga in the admin page.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1775553642484799

