### PR TITLE
fix spacing in VX report log view

### DIFF
--- a/frontend/javascripts/admin/voxelytics/log_tab.tsx
+++ b/frontend/javascripts/admin/voxelytics/log_tab.tsx
@@ -1,7 +1,7 @@
 import { SyncOutlined } from "@ant-design/icons";
 import { getVoxelyticsLogs } from "admin/rest_api";
 import Ansi from "ansi-to-react";
-import { Button, message, Select, Switch } from "antd";
+import { Button, Flex, message, Select, Switch } from "antd";
 import chalk from "chalk";
 import classnames from "classnames";
 import { usePolling } from "libs/react_hooks";
@@ -149,8 +149,8 @@ export default function LogTab({
 
   return (
     <div className={classnames("log-tab", { "log-tab-fullscreen": isFullscreen })}>
-      <div className="log-tab-header">
-        <span style={{ marginRight: 16 }}>
+      <Flex gap="small" justify="end" align="center" className="log-tab-header">
+        <span>
           <Switch
             checked={showTimestamps}
             size="small"
@@ -161,7 +161,7 @@ export default function LogTab({
           Show Timestamps
         </span>
 
-        <span style={{ marginRight: 16 }}>
+        <span>
           <Switch
             checked={isFullscreen}
             size="small"
@@ -182,7 +182,7 @@ export default function LogTab({
             </Select.Option>
           ))}
         </Select>
-      </div>
+      </Flex>
       {logText.length >= LOG_LINE_LIMIT && (
         <p className="log-tab-warning">
           Only the {LOG_LINE_LIMIT} latest log lines are shown.{" "}

--- a/frontend/stylesheets/_voxelytics.less
+++ b/frontend/stylesheets/_voxelytics.less
@@ -52,9 +52,6 @@
         flex-direction: column;
 
         .log-tab-header {
-            display: flex;
-            justify-content: end;
-            align-items: center;
             margin-bottom: 8px;
         }
 


### PR DESCRIPTION
This mini PR fixes the spacing in the VX report logs view between the `Refresh, `Download` etc buttons:

<img width="1043" height="384" alt="Screenshot 2026-04-08 at 09 48 58" src="https://github.com/user-attachments/assets/0b089a4e-f01a-4d1f-b377-a0741975acb6" />

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
1. Open any VX report
2. Switch to Logs tab
3. Check spacing between buttons

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
