### PR TITLE
Fix share modal layouting

### DIFF
--- a/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
@@ -344,11 +344,6 @@ function _ShareModalView(props: Props) {
     ) : null;
   };
 
-  const radioStyle = {
-    display: "block",
-    height: "30px",
-    lineHeight: "30px",
-  };
   const iconMap = {
     Public: <GlobalOutlined />,
     Internal: <TeamOutlined />,
@@ -418,7 +413,7 @@ function _ShareModalView(props: Props) {
             value={visibility}
             disabled={isChangingInProgress}
           >
-            <Radio style={radioStyle} value="Private" disabled={!hasUpdatePermissions}>
+            <Radio value="Private" disabled={!hasUpdatePermissions}>
               Private
             </Radio>
             <Hint
@@ -429,7 +424,7 @@ function _ShareModalView(props: Props) {
               Only you and your team manager can view this annotation.
             </Hint>
 
-            <Radio style={radioStyle} value="Internal" disabled={!hasUpdatePermissions}>
+            <Radio value="Internal" disabled={!hasUpdatePermissions}>
               Internal
             </Radio>
             <Hint
@@ -442,7 +437,7 @@ function _ShareModalView(props: Props) {
               and copy it to their accounts to edit it.
             </Hint>
 
-            <Radio style={radioStyle} value="Public" disabled={!hasUpdatePermissions}>
+            <Radio value="Public" disabled={!hasUpdatePermissions}>
               Public
             </Radio>
             <Hint
@@ -505,7 +500,7 @@ function _ShareModalView(props: Props) {
               value={newOthersMayEdit}
               disabled={isChangingInProgress}
             >
-              <Radio style={radioStyle} value={false} disabled={!hasUpdatePermissions}>
+              <Radio value={false} disabled={!hasUpdatePermissions}>
                 No, keep it read-only
               </Radio>
               <Hint
@@ -516,7 +511,7 @@ function _ShareModalView(props: Props) {
                 Only you can edit the content of this annotation.
               </Hint>
 
-              <Radio style={radioStyle} value disabled={!hasUpdatePermissions}>
+              <Radio value disabled={!hasUpdatePermissions}>
                 Yes, allow editing
               </Radio>
               <Hint


### PR DESCRIPTION
Fix misplaced radio button labels in share modal:

### Before
<img width="817" height="768" alt="Screenshot 2026-04-10 at 15 44 06" src="https://github.com/user-attachments/assets/a14fa97e-3176-432b-b17f-c6c7f105839c" />


### After
<img width="849" height="763" alt="Screenshot 2026-04-10 at 15 43 26" src="https://github.com/user-attachments/assets/750678fe-797e-4be1-bee5-42389f1ef8b1" />


------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
