### PR TITLE
avoid conflict 409 error if redis is down during annotation saving

### DIFF
--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
@@ -57,13 +57,13 @@ class AnnotationTransactionService @Inject()(handledGroupIdStore: TracingStoreRe
                               updateGroup: UpdateActionGroup,
                               expiry: FiniteDuration)(implicit ec: ExecutionContext): Fox[Unit] =
     for {
-      _ <- Fox.runIf(transactionGroupIndex > 0)(
-        Fox.assertTrue(
-          uncommittedUpdatesStore.contains(transactionGroupKey(
-            annotationId,
-            transactionId,
-            transactionGroupIndex - 1,
-            version))) ?~> s"Incorrect transaction index. Got: $transactionGroupIndex but ${transactionGroupIndex - 1} does not exist" ~> CONFLICT)
+      _ <- Fox.runIf(transactionGroupIndex > 0) {
+        for {
+          transactionIsPresentUncommitted <- uncommittedUpdatesStore.contains(
+            transactionGroupKey(annotationId, transactionId, transactionGroupIndex - 1, version))
+          _ <- Fox.fromBool(transactionIsPresentUncommitted) ?~> s"Incorrect transaction index. Got: $transactionGroupIndex but ${transactionGroupIndex - 1} does not exist" ~> CONFLICT
+        } yield ()
+      }
       _ <- uncommittedUpdatesStore.insert(
         transactionGroupKey(annotationId, transactionId, transactionGroupIndex, version),
         Json.toJson(updateGroup).toString(),
@@ -269,11 +269,11 @@ class AnnotationTransactionService @Inject()(handledGroupIdStore: TracingStoreRe
       implicit ec: ExecutionContext): Fox[Long] = {
     val errorMessage = s"Incorrect version. Expected: ${previousVersion + 1}; Got: ${updateGroup.version}"
     for {
-      _ <- Fox.assertTrue(
-        handledGroupIdStoreContains(annotationId,
-                                    updateGroup.transactionId,
-                                    updateGroup.version,
-                                    updateGroup.transactionGroupIndex)) ?~> errorMessage ~> CONFLICT
+      groupWasHandled <- handledGroupIdStoreContains(annotationId,
+                                                     updateGroup.transactionId,
+                                                     updateGroup.version,
+                                                     updateGroup.transactionGroupIndex)
+      _ <- Fox.fromBool(groupWasHandled) ?~> errorMessage ~> CONFLICT
     } yield updateGroup.version
   }
 


### PR DESCRIPTION
By not using the Fox.assertTrue, we can separate the fetching of this information from redis (so if that fails we get a generic Failure which later is turned to error 400) and the actual checking of the bool (which we attach the error 409 to).

That way, we don’t get the misleading 409 if redis is unavailable.

We should still expect trouble if redis is unavailable, but at least this detail obscuring what’s happening should be gone.

Testing this is cumbersome, because we need to be in this particular branch and *then* redis needs to die. However, since the code change is very simple, I would assume that testing is not necessary.