### PR TITLE
Mount command palette only once

### DIFF
--- a/frontend/javascripts/router/router.tsx
+++ b/frontend/javascripts/router/router.tsx
@@ -88,7 +88,7 @@ function RootLayout() {
 
   return (
     <Layout>
-      <CommandPalette label={null} />
+      <CommandPalette />
       <Navbar isAuthenticated={isAuthenticated} />
       <Content>
         <ErrorBoundary>

--- a/frontend/javascripts/router/router.tsx
+++ b/frontend/javascripts/router/router.tsx
@@ -85,13 +85,10 @@ const AsyncWorkflowListView = loadable<EmptyObject>(
 
 function RootLayout() {
   const isAuthenticated = useWkSelector((state) => state.activeUser != null);
-  const isAdminView = useWkSelector((state) => !state.uiInformation.isInAnnotationView);
 
   return (
     <Layout>
-      {/* TODO (#9483): always show command palette; remove logic from router
-      within tracing view, the command palette is rendered in the status bar. */}
-      {isAuthenticated && isAdminView && <CommandPalette label={null} />}
+      <CommandPalette label={null} />
       <Navbar isAuthenticated={isAuthenticated} />
       <Content>
         <ErrorBoundary>

--- a/frontend/javascripts/viewer/view/components/command_palette.tsx
+++ b/frontend/javascripts/viewer/view/components/command_palette.tsx
@@ -15,7 +15,7 @@ import compact from "lodash-es/compact";
 import noop from "lodash-es/noop";
 import sortBy from "lodash-es/sortBy";
 import { getAdministrationSubMenu, getAnalysisSubMenu, switchTo } from "navbar";
-import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactCommandPalette, { type Command } from "react-command-palette";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
@@ -98,7 +98,7 @@ const shortCutDictForTools: Record<string, string> = {
   [AnnotationTool.PROOFREAD.id]: "Ctrl + K, O",
 };
 
-export const CommandPalette = ({ label }: { label: string | ReactElement | null }) => {
+export const CommandPalette = () => {
   const dispatch = useDispatch();
 
   const userConfig = useWkSelector((state) => state.userConfiguration);
@@ -468,7 +468,7 @@ export const CommandPalette = ({ label }: { label: string | ReactElement | null 
       commands={commandsWithIds}
       key={paletteKey}
       hotKeys={["ctrl+p", "command+p"]}
-      trigger={label}
+      trigger={null}
       maxDisplayed={100}
       theme={theme === "light" ? commandPaletteLightTheme : commandPaletteDarkTheme}
       onSelect={handleSelect}

--- a/frontend/javascripts/viewer/view/statusbar.tsx
+++ b/frontend/javascripts/viewer/view/statusbar.tsx
@@ -46,7 +46,6 @@ import { setActiveCellAction } from "viewer/model/actions/volumetracing_actions"
 import { getSupportedValueRangeForElementClass } from "viewer/model/bucket_data_handling/data_rendering_logic";
 import { getGlobalDataConnectionInfo } from "viewer/model/data_connection_info";
 import { Store } from "viewer/singletons";
-import { CommandPalette } from "./components/command_palette";
 import { NumberInputPopoverSetting } from "./left_border_tabs/components/number_input_popover_setting";
 
 const { Text } = Typography;
@@ -129,13 +128,9 @@ function RightClickShortcut({ actionDescriptor }: { actionDescriptor: ActionDesc
 const getMoreShortcutsInfo = () => {
   return (
     <>
-      <CommandPalette
-        label={
-          <div style={{ marginLeft: 25 }}>
-            <Text keyboard>Ctrl + P</Text> Commands
-          </div>
-        }
-      />
+      <div style={{ marginLeft: 25 }}>
+        <Text keyboard>Ctrl + P</Text> Commands
+      </div>
       {moreShortcutsLink}
     </>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,6 +97,29 @@ export const viteConfig = {
       },
     },
     hmr: false, // disable Hot Module Replacement for now
+    watch: {
+      ignored: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/app/**",
+        "**/webknossos-tracingstore/**",
+        "**/webknossos-datastore/**",
+        "**/util/**",
+        "**/webknossos-jni/**",
+        "**/conf/**",
+        "**/project/**",
+        "**/docs/**",
+        "**/fossildb/**",
+        "**/target/**",
+        "**/schema/**",
+        "**/tools/**",
+        "**/binaryData/**",
+        "**/coverage/**",
+        "**/public/**",
+        "**/public-test/**",
+        "**/unreleased_changes/**",
+      ],
+    },
   },
   define: {
     // Vite does not automatically provide a `process` polyfill in the

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,29 +97,6 @@ export const viteConfig = {
       },
     },
     hmr: false, // disable Hot Module Replacement for now
-    watch: {
-      ignored: [
-        "**/node_modules/**",
-        "**/dist/**",
-        "**/app/**",
-        "**/webknossos-tracingstore/**",
-        "**/webknossos-datastore/**",
-        "**/util/**",
-        "**/webknossos-jni/**",
-        "**/conf/**",
-        "**/project/**",
-        "**/docs/**",
-        "**/fossildb/**",
-        "**/target/**",
-        "**/schema/**",
-        "**/tools/**",
-        "**/binaryData/**",
-        "**/coverage/**",
-        "**/public/**",
-        "**/public-test/**",
-        "**/unreleased_changes/**",
-      ],
-    },
   },
   define: {
     // Vite does not automatically provide a `process` polyfill in the


### PR DESCRIPTION
### Steps to test:
- Check that command palette works as before (starting via ctrl+p)
- what is new is that the label in the statusbar does not open the palette any more, it only shows the key combo
- next to that, the command palette can be opened from the login view. security and data protection wise, this shouldnt be a problem, given that the command palette could be opened in publically accessible annotations and datasets anyway. 

### Issues:
- fixes #9483 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
