### PR TITLE
Hotfix broken maximized viewport on page load

### DIFF
--- a/frontend/javascripts/viewer/view/input_catcher.tsx
+++ b/frontend/javascripts/viewer/view/input_catcher.tsx
@@ -6,7 +6,7 @@ import lassoPointedSolidBorderCursor from "@images/cursors/lasso-pointed-solid-b
 import paintBrushSolidBorderCursor from "@images/cursors/paint-brush-solid-border.svg";
 import rulerPointedBorderCursor from "@images/cursors/ruler-pointed-border.svg";
 import { useEffectOnlyOnce, useKeyPress, useWkSelector } from "libs/react_hooks";
-import { waitForCondition } from "libs/utils";
+import { sleep, waitForCondition } from "libs/utils";
 import isEqual from "lodash-es/isEqual";
 import type * as React from "react";
 import { useRef } from "react";
@@ -76,11 +76,22 @@ export async function initializeInputCatcherSizes() {
   // In an interval of 100 ms we check whether the input catchers can be initialized
   const pollInterval = 100;
   await waitForCondition(() => {
-    const { tdCamera } = Store.getState().viewModeData.plane;
-    // The isNaN check is important because the initial zoom value of the
-    // 3D viewport is flaky, otherwise.
-    return renderedInputCatchers.size > 0 && !Number.isNaN(tdCamera.left);
+    if (renderedInputCatchers.size === 0) {
+      return false;
+    }
+    if (renderedInputCatchers.has("TDView")) {
+      // If (and only if) the 3D viewport is visible (e.g., it might be invisible
+      // due to another tab being maximized), we need to do an isNaN check here
+      // to await proper initialization.
+      // Otherwise, the initial zoom value of the 3D viewport would be flaky.
+      const { tdCamera } = Store.getState().viewModeData.plane;
+      return !Number.isNaN(tdCamera.left);
+    }
+    
+    return true;
   }, pollInterval);
+  // Without this sleep, maximized viewports are not rendered correctly on page load.
+  await sleep(50);
   recalculateInputCatcherSizes();
 }
 

--- a/frontend/javascripts/viewer/view/input_catcher.tsx
+++ b/frontend/javascripts/viewer/view/input_catcher.tsx
@@ -87,7 +87,7 @@ export async function initializeInputCatcherSizes() {
       const { tdCamera } = Store.getState().viewModeData.plane;
       return !Number.isNaN(tdCamera.left);
     }
-    
+
     return true;
   }, pollInterval);
   // Without this sleep, maximized viewports are not rendered correctly on page load.

--- a/unreleased_changes/9505.md
+++ b/unreleased_changes/9505.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a layout issue when an annotation or dataset was opened with a maximized viewport.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- maximize one tab (test xy and 3d viewport) and reload the page -> should look correct
- check a reload without a maximized tab

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1776869214800469

------
(Please delete unneeded items, merge only when none are left open)
- [X] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
