### PR TITLE
Use ResizeObservers for input catchers

### DIFF
--- a/frontend/javascripts/viewer/view/input_catcher.tsx
+++ b/frontend/javascripts/viewer/view/input_catcher.tsx
@@ -6,7 +6,6 @@ import lassoPointedSolidBorderCursor from "@images/cursors/lasso-pointed-solid-b
 import paintBrushSolidBorderCursor from "@images/cursors/paint-brush-solid-border.svg";
 import rulerPointedBorderCursor from "@images/cursors/ruler-pointed-border.svg";
 import { useEffectOnlyOnce, useKeyPress, useWkSelector } from "libs/react_hooks";
-import { sleep, waitForCondition } from "libs/utils";
 import isEqual from "lodash-es/isEqual";
 import type * as React from "react";
 import { useRef } from "react";
@@ -72,29 +71,6 @@ function adaptInputCatcher(inputCatcherDOM: HTMLElement, makeQuadratic: boolean)
 
 const renderedInputCatchers = new Map();
 
-export async function initializeInputCatcherSizes() {
-  // In an interval of 100 ms we check whether the input catchers can be initialized
-  const pollInterval = 100;
-  await waitForCondition(() => {
-    if (renderedInputCatchers.size === 0) {
-      return false;
-    }
-    if (renderedInputCatchers.has("TDView")) {
-      // If (and only if) the 3D viewport is visible (e.g., it might be invisible
-      // due to another tab being maximized), we need to do an isNaN check here
-      // to await proper initialization.
-      // Otherwise, the initial zoom value of the 3D viewport would be flaky.
-      const { tdCamera } = Store.getState().viewModeData.plane;
-      return !Number.isNaN(tdCamera.left);
-    }
-
-    return true;
-  }, pollInterval);
-  // Without this sleep, maximized viewports are not rendered correctly on page load.
-  await sleep(50);
-  recalculateInputCatcherSizes();
-}
-
 export function recalculateInputCatcherSizes() {
   const viewportRects: Record<string, Rect> = {
     PLANE_XY: emptyViewportRect,
@@ -148,12 +124,19 @@ function InputCatcher({
   busyBlockingInfo: BusyBlockingInfo;
 }) {
   const domElementRef = useRef<HTMLElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   useEffectOnlyOnce(() => {
     if (domElementRef.current) {
       renderedInputCatchers.set(viewportID, domElementRef.current);
     }
+    let observer: ResizeObserver | null = null;
+    if (wrapperRef.current) {
+      observer = new ResizeObserver(() => recalculateInputCatcherSizes());
+      observer.observe(wrapperRef.current);
+    }
     return () => {
       renderedInputCatchers.delete(viewportID);
+      observer?.disconnect();
     };
   });
 
@@ -181,6 +164,7 @@ function InputCatcher({
       className={`inputcatcher-border ${viewportID}`}
     >
       <div
+        ref={wrapperRef}
         className="flexlayout-dont-overflow"
         onContextMenu={ignoreContextMenu}
         style={{ cursor: busyBlockingInfo.isBusy ? "wait" : cursorForTool[adaptedTool.id] }}

--- a/frontend/javascripts/viewer/view/input_catcher.tsx
+++ b/frontend/javascripts/viewer/view/input_catcher.tsx
@@ -6,7 +6,7 @@ import lassoPointedSolidBorderCursor from "@images/cursors/lasso-pointed-solid-b
 import paintBrushSolidBorderCursor from "@images/cursors/paint-brush-solid-border.svg";
 import rulerPointedBorderCursor from "@images/cursors/ruler-pointed-border.svg";
 import { useEffectOnlyOnce, useKeyPress, useWkSelector } from "libs/react_hooks";
-import { waitForCondition } from "libs/utils";
+import { sleep, waitForCondition } from "libs/utils";
 import isEqual from "lodash-es/isEqual";
 import type * as React from "react";
 import { useRef } from "react";
@@ -76,11 +76,22 @@ export async function initializeInputCatcherSizes() {
   // In an interval of 100 ms we check whether the input catchers can be initialized
   const pollInterval = 100;
   await waitForCondition(() => {
-    const { tdCamera } = Store.getState().viewModeData.plane;
-    // The isNaN check is important because the initial zoom value of the
-    // 3D viewport is flaky, otherwise.
-    return renderedInputCatchers.size > 0 && !Number.isNaN(tdCamera.left);
+    if (renderedInputCatchers.size === 0) {
+      return false;
+    }
+    if (renderedInputCatchers.has("TDView")) {
+      // If (and only if) the 3D viewport is visible (e.g., it might be invisible
+      // due to another tab being maximized), we need to do an isNaN check here
+      // to await proper initialization.
+      // Otherwise, the initial zoom value of the 3D viewport would be flaky.
+      const { tdCamera } = Store.getState().viewModeData.plane;
+      return !Number.isNaN(tdCamera.left);
+    }
+    
+    return true;
   }, pollInterval);
+  // Without this sleep, maximized viewports are not rendered correctly on page load.
+  await sleep(50);
   recalculateInputCatcherSizes();
 }
 

--- a/frontend/javascripts/viewer/view/input_catcher.tsx
+++ b/frontend/javascripts/viewer/view/input_catcher.tsx
@@ -87,7 +87,7 @@ export async function initializeInputCatcherSizes() {
       const { tdCamera } = Store.getState().viewModeData.plane;
       return !Number.isNaN(tdCamera.left);
     }
-    
+
     return true;
   }, pollInterval);
   // Without this sleep, maximized viewports are not rendered correctly on page load.

--- a/frontend/javascripts/viewer/view/layouting/flex_layout_wrapper.tsx
+++ b/frontend/javascripts/viewer/view/layouting/flex_layout_wrapper.tsx
@@ -439,10 +439,7 @@ class FlexLayoutWrapper extends PureComponent<Props, State> {
 
   onLayoutChange = () => {
     const currentLayoutModel = cloneDeep(this.state.model.toJson());
-
-    // Workaround so that onLayoutChange is called after the update of flexlayout.
-    // Calling the method without a timeout results in incorrect calculation of the viewport positions for the rendering.
-    setTimeout(() => this.props.onLayoutChange(currentLayoutModel, this.props.layoutName), 50);
+    this.props.onLayoutChange(currentLayoutModel, this.props.layoutName);
   };
 
   onMaximizeToggle = () => {

--- a/frontend/javascripts/viewer/view/layouting/tracing_layout_view.tsx
+++ b/frontend/javascripts/viewer/view/layouting/tracing_layout_view.tsx
@@ -1,5 +1,4 @@
 import { ConfigProvider, Layout } from "antd";
-import app from "app";
 import ErrorHandling from "libs/error_handling";
 import Request from "libs/request";
 import Toast from "libs/toast";
@@ -31,7 +30,6 @@ import ActionBarView from "viewer/view/action_bar_view";
 import { AiJobsDrawer } from "viewer/view/ai_jobs/ai_jobs_drawer";
 import WkContextMenu from "viewer/view/context_menu/wk_context_menu";
 import DistanceMeasurementTooltip from "viewer/view/distance_measurement_tooltip";
-import { recalculateInputCatcherSizes } from "viewer/view/input_catcher";
 import {
   getLastActiveLayout,
   getLayoutConfig,

--- a/frontend/javascripts/viewer/view/layouting/tracing_layout_view.tsx
+++ b/frontend/javascripts/viewer/view/layouting/tracing_layout_view.tsx
@@ -31,10 +31,7 @@ import ActionBarView from "viewer/view/action_bar_view";
 import { AiJobsDrawer } from "viewer/view/ai_jobs/ai_jobs_drawer";
 import WkContextMenu from "viewer/view/context_menu/wk_context_menu";
 import DistanceMeasurementTooltip from "viewer/view/distance_measurement_tooltip";
-import {
-  initializeInputCatcherSizes,
-  recalculateInputCatcherSizes,
-} from "viewer/view/input_catcher";
+import { recalculateInputCatcherSizes } from "viewer/view/input_catcher";
 import {
   getLastActiveLayout,
   getLayoutConfig,
@@ -179,7 +176,6 @@ class TracingLayoutView extends PureComponent<PropsWithRouter, State> {
       activeLayoutName: lastActiveLayoutName,
       model: layout,
     });
-    initializeInputCatcherSizes();
     window.addEventListener("resize", this.debouncedOnLayoutChange);
     window.addEventListener("touchstart", this.handleTouch);
     window.addEventListener("mouseover", this.handleMouseOver, false);
@@ -217,9 +213,6 @@ class TracingLayoutView extends PureComponent<PropsWithRouter, State> {
   };
 
   onLayoutChange = (model?: Record<string, any>, layoutName?: string) => {
-    recalculateInputCatcherSizes();
-    app.vent.emit("rerender");
-
     if (model != null) {
       this.setState({ model }, () => {
         if (this.props.autoSaveLayouts) {

--- a/unreleased_changes/9505.md
+++ b/unreleased_changes/9505.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a layout issue when an annotation or dataset was opened with a maximized viewport.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] run screenshot test
- [ ] check that this PR does not re-introduce the race condition regarding initial 3d viewport zoom that was fixed in #9479

### Issues:
- follow up to #9505 and #9480

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
