### PR TITLE
Fix handling of trailing slashes in RemoteUPath.startsWith

### DIFF
--- a/test/backend/SkeletonUpdateActionsUnitTestSuite.scala
+++ b/test/backend/SkeletonUpdateActionsUnitTestSuite.scala
@@ -2,7 +2,6 @@ package backend
 
 import com.scalableminds.util.geometry.{Vec3Double, Vec3Int}
 import com.scalableminds.webknossos.datastore.SkeletonTracing._
-import com.scalableminds.webknossos.datastore.MetadataEntry.MetadataEntryProto
 import com.scalableminds.webknossos.datastore.helpers.TreeAgglomerateInfo
 import com.scalableminds.webknossos.tracingstore.tracings._
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating._

--- a/test/backend/UPathTestSuite.scala
+++ b/test/backend/UPathTestSuite.scala
@@ -128,23 +128,33 @@ class UPathTestSuite extends AsyncWordSpec {
     }
 
     "correctly answer startsWith" in {
-      assert(UPath.fromStringUnsafe("relative/somewhere").startsWith(UPath.fromStringUnsafe("relative")))
-      assert(!UPath.fromStringUnsafe("relative/somewhere").startsWith(UPath.fromStringUnsafe("elsewhere")))
+      checkStartsWith("relative/somewhere", "relative")
+      checkStartsNotWith("relative/somewhere", "elsewhere")
       // startsWith compares actual parents, not string prefix!
-      assert(!UPath.fromStringUnsafe("relativeElsewhere").startsWith(UPath.fromStringUnsafe("relative")))
-      assert(UPath.fromStringUnsafe("/absolute/somewhere").startsWith(UPath.fromStringUnsafe("/absolute")))
-      assert(!UPath.fromStringUnsafe("/absolute/somewhere").startsWith(UPath.fromStringUnsafe("/elsewhere")))
-      assert(!UPath.fromStringUnsafe("/absolute/somewhere").startsWith(UPath.fromStringUnsafe("https://example.com")))
-      assert(
-        UPath
-          .fromStringUnsafe("https://example.com/path/somewhere")
-          .startsWith(UPath.fromStringUnsafe("https://example.com/path")))
+      checkStartsNotWith("relativeElsewhere", "relative")
+      checkStartsWith("/absolute/somewhere", "/absolute")
+      checkStartsWith("/absolute/somewhere", "/absolute/")
+      // trailing slash is allowed both ways
+      checkStartsWith("/absolute/trailingSlash", "/absolute/trailingSlash/")
+      checkStartsWith("/absolute/trailingSlash/", "/absolute/trailingSlash")
+      checkStartsNotWith("/absolute/somewhere", "/elsewhere")
+      checkStartsNotWith("/absolute/somewhere", "https://example.com")
+      // trailing slash is allowed both ways
+      checkStartsWith("https://example.com/path/somewhere", "https://example.com/path/")
+      checkStartsWith("https://example.com/path/somewhere", "https://example.com/path")
+      checkStartsWith("https://example.com/path/", "https://example.com/path/")
+      checkStartsWith("https://example.com/path", "https://example.com/path/")
+      checkStartsWith("https://example.com/path", "https://example.com/path")
+      checkStartsWith("https://example.com/path/", "https://example.com/path")
       // startsWith compares actual parents, not string prefix!
-      assert(
-        !UPath
-          .fromStringUnsafe("https://example.com/pathSomewhereElse")
-          .startsWith(UPath.fromStringUnsafe("https://example.com/path")))
+      checkStartsNotWith("https://example.com/pathSomewhereElse", "https://example.com/path")
     }
   }
+
+  private def checkStartsWith(pathLiteral1: String, pathLiteral2: String) =
+    assert(UPath.fromStringUnsafe(pathLiteral1).startsWith(UPath.fromStringUnsafe(pathLiteral2)))
+
+  private def checkStartsNotWith(pathLiteral1: String, pathLiteral2: String) =
+    assert(!UPath.fromStringUnsafe(pathLiteral1).startsWith(UPath.fromStringUnsafe(pathLiteral2)))
 
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/UPath.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/UPath.scala
@@ -203,7 +203,10 @@ private case class RemoteUPath(scheme: String, segments: Seq[String]) extends UP
     case otherRemote: RemoteUPath => {
       val thisNormalized = this.normalize
       val otherNormalized = otherRemote.normalize
-      thisNormalized.scheme == otherNormalized.scheme && thisNormalized.segments.startsWith(otherNormalized.segments)
+      val otherSegments =
+        if (otherNormalized.segments.lastOption.contains("")) otherNormalized.segments.dropRight(1)
+        else otherNormalized.segments
+      thisNormalized.scheme == otherNormalized.scheme && thisNormalized.segments.startsWith(otherSegments)
     }
     case _ => false
   }


### PR DESCRIPTION
Previously, `s3://a/b` did not “start with” `s3://a/` because the trailing slash caused trouble. I also added a couple of more tests.

### Steps to test:
- CI should be enough

------
- [x] Needs datastore update after deployment
