### PR TITLE
helpEmail route: move message from get param to post body

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -6,7 +6,7 @@ import mail.{DefaultMails, Send}
 import models.organization.OrganizationDAO
 import models.user.MultiUserDAO
 import org.apache.pekko.actor.ActorSystem
-import play.api.libs.json.{JsValue, Json, OFormat}
+import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers, Result}
 import play.silhouette.api.Silhouette
 import security.{CertificateValidationService, WkEnv}

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -6,8 +6,8 @@ import mail.{DefaultMails, Send}
 import models.organization.OrganizationDAO
 import models.user.MultiUserDAO
 import org.apache.pekko.actor.ActorSystem
-import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, Result}
+import play.api.libs.json.{JsValue, Json, OFormat}
+import play.api.mvc.{Action, AnyContent, PlayBodyParsers, Result}
 import play.silhouette.api.Silhouette
 import security.{CertificateValidationService, WkEnv}
 import utils.sql.{SimpleSQLDAO, SqlClient}
@@ -16,6 +16,14 @@ import utils.{BuildInfoService, WkConf}
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
+case class HelpEmailParameters(
+    message: String,
+    currentUrl: String
+)
+object HelpEmailParameters {
+  implicit val jsonFormat: OFormat[HelpEmailParameters] = Json.format[HelpEmailParameters]
+}
+
 class Application @Inject()(actorSystem: ActorSystem,
                             multiUserDAO: MultiUserDAO,
                             buildInfoService: BuildInfoService,
@@ -23,7 +31,8 @@ class Application @Inject()(actorSystem: ActorSystem,
                             conf: WkConf,
                             defaultMails: DefaultMails,
                             sil: Silhouette[WkEnv],
-                            certificateValidationService: CertificateValidationService)(implicit ec: ExecutionContext)
+                            certificateValidationService: CertificateValidationService)(implicit ec: ExecutionContext,
+                                                                                        bodyParsers: PlayBodyParsers)
     extends Controller {
 
   private lazy val Mailer =
@@ -55,12 +64,14 @@ class Application @Inject()(actorSystem: ActorSystem,
     }
   }
 
-  def helpEmail(message: String, currentUrl: String): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
-    for {
-      organization <- organizationDAO.findOne(request.identity._organization)
-      multiUser <- multiUserDAO.findOne(request.identity._multiUser)
-      _ = Mailer ! Send(defaultMails.helpMail(multiUser, organization.name, message, currentUrl))
-    } yield Ok
+  def helpEmail(): Action[HelpEmailParameters] = sil.SecuredAction.async(validateJson[HelpEmailParameters]) {
+    implicit request =>
+      for {
+        organization <- organizationDAO.findOne(request.identity._organization)
+        multiUser <- multiUserDAO.findOne(request.identity._multiUser)
+        _ = Mailer ! Send(
+          defaultMails.helpMail(multiUser, organization.name, request.body.message, request.body.currentUrl))
+      } yield Ok
   }
 
   def getSecurityTxt: Action[AnyContent] = Action {

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -6,7 +6,7 @@ GET           /health                                                           
 GET           /checkCertificate                                                                 controllers.Application.checkCertificate()
 POST          /analytics/ingest                                                                 controllers.AnalyticsController.ingestAnalyticsEvents
 POST          /analytics/:eventType                                                             controllers.AnalyticsController.trackAnalyticsEvent(eventType)
-POST          /helpEmail                                                                        controllers.Application.helpEmail(message: String, currentUrl: String)
+POST          /helpEmail                                                                        controllers.Application.helpEmail()
 POST          /triggers/initialData                                                             controllers.InitialDataController.triggerInsert()
 
 # Maintenance

--- a/frontend/javascripts/admin/rest_api.ts
+++ b/frontend/javascripts/admin/rest_api.ts
@@ -2377,15 +2377,10 @@ export function deleteWorkflow(workflowHash: string): Promise<void> {
 
 // ### Help / Feedback userEmail
 export function sendHelpEmail(message: string) {
-  return Request.receiveJSON(
-    `/api/helpEmail?${new URLSearchParams({
-      message,
-      currentUrl: window.location.href,
-    })}`,
-    {
-      method: "POST",
-    },
-  );
+  return Request.sendJSONReceiveJSON(`/api/helpEmail`, {
+    method: "POST",
+    data: { message, currentUrl: window.location.href },
+  });
 }
 
 export function requestSingleSignOnLogin() {


### PR DESCRIPTION
A user pasted a stack trace in the help email and then couldn’t send it, because the GET parameter length limit was in the way. This PR changes the route so that the message is in the request body instead.

### Steps to test:
- In application.conf, set mail.logToStdout=true
- From UI, send help message
- Logging should show the right message.

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1776780995336429?thread_ts=1776763920.190509&cid=C02H5T8Q08P

------
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
