### PR TITLE
Ensure correct tag exists and is pushed before releasing

### DIFF
--- a/tools/create-gh-release.py
+++ b/tools/create-gh-release.py
@@ -1,9 +1,7 @@
-import datetime
 import re
-import sys
-import os
-import tempfile
 import subprocess
+import sys
+import tempfile
 
 VERSION_REGEX = r"[\d]{1,2}\.[\d]{1,2}.[\d]{0,2}"
 
@@ -63,8 +61,41 @@ def extract_newest_changelog():
 
 
 if __name__ == "__main__":
-
     newest_version, release_body = extract_newest_changelog()
+
+    current_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], text=True
+    ).strip()
+
+    # Check whether the tag already exists locally
+    existing_tag_sha = subprocess.run(
+        ["git", "rev-parse", f"refs/tags/{newest_version}"],
+        capture_output=True,
+        text=True,
+    )
+    if existing_tag_sha.returncode == 0:
+        tag_sha = existing_tag_sha.stdout.strip()
+        # Dereference in case it's an annotated tag object
+        deref = subprocess.run(
+            ["git", "rev-parse", f"refs/tags/{newest_version}^{{}}"],
+            capture_output=True,
+            text=True,
+        )
+        if deref.returncode == 0:
+            tag_sha = deref.stdout.strip()
+        if tag_sha != current_sha:
+            print(
+                f"ERROR: Tag {newest_version} already exists but points to {tag_sha}, "
+                f"not the current HEAD {current_sha}. Aborting."
+            )
+            sys.exit(1)
+        print(f"Tag {newest_version} already exists and matches HEAD.")
+    else:
+        print(f"Creating tag {newest_version} at {current_sha}...")
+        subprocess.run(["git", "tag", newest_version], check=True)
+
+    print(f"Pushing tag {newest_version} to remote...")
+    subprocess.run(["git", "push", "origin", newest_version], check=True)
 
     with tempfile.NamedTemporaryFile("w") as tmp_file:
         tmp_file.write(release_body)
@@ -83,6 +114,7 @@ if __name__ == "__main__":
                 "--title",
                 newest_version,
             ],
+            check=True,
         )
 
         print("Done!")


### PR DESCRIPTION
The old release script did only work correctly when a git tag was created manually for the correct commit **and** pushed to the remote. If that was not the case, `gh` happily creates a new tag pointing to the newest **master on github**. There is a `--target` parameter, but that is also has some footguns.

To solve the problem, I adapted the release script so that a new tag is created and pushed before the actual release is created. If a tag already existed before, it is asserted that it points to the current HEAD to avoid confusions hopefully.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
I mainly tested this in a separate repository with a stripped down version of the script. I tested:
- releasing without a manual tag creation
- releasing with a manual tag creation but without pushing it
- releasing with a manual tag that was also pushed
- releasing with a manual tag that was also pushed but being on another commit (should fail then)

I think, there is no need to test again :crossed_fingers: 

### Issues:
- fixes problems where gh releases did not properly reflect that intended trunk cut off.