### PR TITLE
Fix publication list query for anonymous users

### DIFF
--- a/app/models/dataset/Publication.scala
+++ b/app/models/dataset/Publication.scala
@@ -9,7 +9,7 @@ import play.api.http.Status.NOT_FOUND
 import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.{JsObject, Json}
 import com.scalableminds.util.objectid.ObjectId
-import utils.sql.{SQLDAO, SqlClient}
+import utils.sql.{SQLDAO, SqlClient, SqlToken}
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
@@ -54,6 +54,8 @@ class PublicationDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionConte
     extends SQLDAO[Publication, PublicationsRow, Publications](sqlClient) {
   protected val collection = Publications
   protected def resultConverter = GetResultPublicationsRow
+
+  override protected def anonymousReadAccessQ(sharingToken: Option[String]): SqlToken = q"FALSE"
 
   protected def parse(r: PublicationsRow): Fox[Publication] =
     Fox.successful(

--- a/app/models/dataset/Publication.scala
+++ b/app/models/dataset/Publication.scala
@@ -55,7 +55,7 @@ class PublicationDAO @Inject()(sqlClient: SqlClient)(implicit ec: ExecutionConte
   protected val collection = Publications
   protected def resultConverter = GetResultPublicationsRow
 
-  override protected def anonymousReadAccessQ(sharingToken: Option[String]): SqlToken = q"FALSE"
+  override protected def anonymousReadAccessQ(sharingToken: Option[String]): SqlToken = q"TRUE"
 
   protected def parse(r: PublicationsRow): Fox[Publication] =
     Fox.successful(

--- a/unreleased_changes/9515.md
+++ b/unreleased_changes/9515.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where the publication list route for logged-out users would be empty


### PR DESCRIPTION
fixes regression from #9405

### Steps to test:
- Make sure a publication is in the database (shoul be the case with initialData)
- api/publications should list it when logged in *and* when logged out.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1777043219043469

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)