### PR TITLE
[ResumableUpload] Replace configurable property names with defaults

### DIFF
--- a/frontend/javascripts/libs/resumable_upload/resumable_chunk.ts
+++ b/frontend/javascripts/libs/resumable_upload/resumable_chunk.ts
@@ -2,6 +2,19 @@ import type { ResumableFile } from "./resumable_file";
 import { getTargetURI } from "./resumable_shared";
 import type { ConfigurationHash, ResumableUpload } from "./resumable_upload";
 
+type ResumableChunkState = "pending" | "uploading" | "success" | "error";
+type ResumableChunkRequestParams = {
+  resumableChunkNumber: number;
+  resumableChunkSize: number;
+  resumableCurrentChunkSize: number;
+  resumableTotalSize: number;
+  resumableType: string;
+  resumableIdentifier: string;
+  resumableFilename: string;
+  resumableRelativePath: string;
+  resumableTotalChunks: number;
+};
+
 /**
  * Represents a single chunk of a file to be uploaded.
  */
@@ -22,7 +35,7 @@ export class ResumableChunk {
   endByte: number;
 
   private abortController: AbortController | null = null;
-  private _status: "pending" | "uploading" | "success" | "error" = "pending";
+  private _status: ResumableChunkState = "pending";
   private _message: string = "";
 
   constructor(
@@ -64,9 +77,7 @@ export class ResumableChunk {
       customQueryParameters = customQueryParameters(this.fileObj, this);
     }
 
-    const queryParams = Object.assign({}, customQueryParameters || {});
-
-    const extraParams: Partial<Record<string, any>> = {
+    const queryParams: ResumableChunkRequestParams = {
       resumableChunkNumber: this.offset + 1,
       resumableChunkSize: this.getOpt("chunkSize"),
       resumableCurrentChunkSize: this.endByte - this.startByte,
@@ -80,7 +91,7 @@ export class ResumableChunk {
 
     const targetUrl = getTargetURI(this.resumableObj, {
       ...queryParams,
-      ...extraParams,
+      ...(customQueryParameters || {}),
     });
 
     let customHeaders = this.getOpt("headers");
@@ -139,7 +150,7 @@ export class ResumableChunk {
     this.pendingRetry = false;
     this.callback("progress");
 
-    const standardQueryParameters: Partial<Record<string, any>> = {
+    const standardQueryParameters: ResumableChunkRequestParams = {
       resumableChunkNumber: this.offset + 1,
       resumableChunkSize: this.getOpt("chunkSize"),
       resumableCurrentChunkSize: this.endByte - this.startByte,
@@ -258,7 +269,7 @@ export class ResumableChunk {
     this._status = "pending";
   }
 
-  status(): "pending" | "uploading" | "success" | "error" {
+  status(): ResumableChunkState {
     // if pending retry then that's effectively the same as actively uploading,
     // there might just be a slight delay before the retry starts
     if (this.pendingRetry) return "uploading";

--- a/frontend/javascripts/libs/resumable_upload/resumable_chunk.ts
+++ b/frontend/javascripts/libs/resumable_upload/resumable_chunk.ts
@@ -67,15 +67,15 @@ export class ResumableChunk {
     const queryParams = Object.assign({}, customQueryParameters || {});
 
     const extraParams: Partial<Record<string, any>> = {
-      [this.getOpt("chunkNumberParameterName")]: this.offset + 1,
-      [this.getOpt("chunkSizeParameterName")]: this.getOpt("chunkSize"),
-      [this.getOpt("currentChunkSizeParameterName")]: this.endByte - this.startByte,
-      [this.getOpt("totalSizeParameterName")]: this.fileObjSize,
-      [this.getOpt("typeParameterName")]: this.fileObjType,
-      [this.getOpt("identifierParameterName")]: this.fileObj.uniqueIdentifier,
-      [this.getOpt("fileNameParameterName")]: this.fileObj.fileName,
-      [this.getOpt("relativePathParameterName")]: this.fileObj.relativePath,
-      [this.getOpt("totalChunksParameterName")]: this.fileObj.chunks.length,
+      resumableChunkNumber: this.offset + 1,
+      resumableChunkSize: this.getOpt("chunkSize"),
+      resumableCurrentChunkSize: this.endByte - this.startByte,
+      resumableTotalSize: this.fileObjSize,
+      resumableType: this.fileObjType,
+      resumableIdentifier: this.fileObj.uniqueIdentifier,
+      resumableFilename: this.fileObj.fileName,
+      resumableRelativePath: this.fileObj.relativePath,
+      resumableTotalChunks: this.fileObj.chunks.length,
     };
 
     const targetUrl = getTargetURI(this.resumableObj, {
@@ -140,15 +140,15 @@ export class ResumableChunk {
     this.callback("progress");
 
     const standardQueryParameters: Partial<Record<string, any>> = {
-      [this.getOpt("chunkNumberParameterName")]: this.offset + 1,
-      [this.getOpt("chunkSizeParameterName")]: this.getOpt("chunkSize"),
-      [this.getOpt("currentChunkSizeParameterName")]: this.endByte - this.startByte,
-      [this.getOpt("totalSizeParameterName")]: this.fileObjSize,
-      [this.getOpt("typeParameterName")]: this.fileObjType,
-      [this.getOpt("identifierParameterName")]: this.fileObj.uniqueIdentifier,
-      [this.getOpt("fileNameParameterName")]: this.fileObj.fileName,
-      [this.getOpt("relativePathParameterName")]: this.fileObj.relativePath,
-      [this.getOpt("totalChunksParameterName")]: this.fileObj.chunks.length,
+      resumableChunkNumber: this.offset + 1,
+      resumableChunkSize: this.getOpt("chunkSize"),
+      resumableCurrentChunkSize: this.endByte - this.startByte,
+      resumableTotalSize: this.fileObjSize,
+      resumableType: this.fileObjType,
+      resumableIdentifier: this.fileObj.uniqueIdentifier,
+      resumableFilename: this.fileObj.fileName,
+      resumableRelativePath: this.fileObj.relativePath,
+      resumableTotalChunks: this.fileObj.chunks.length,
     };
 
     let customQueryParameters = this.getOpt("query");
@@ -178,7 +178,7 @@ export class ResumableChunk {
     });
 
     if (this.getOpt("chunkFormat") === "blob") {
-      formData.append(this.getOpt("fileParameterName"), bytes, this.fileObj.fileName);
+      formData.append("file", bytes, this.fileObj.fileName);
       data = formData;
     } else {
       // chunkFormat == base64
@@ -187,8 +187,9 @@ export class ResumableChunk {
         fr.onload = () => resolve(fr.result as string);
         fr.readAsDataURL(bytes);
       });
+
       const base64Data = await readPromise;
-      formData.append(this.getOpt("fileParameterName"), base64Data);
+      formData.append("file", base64Data);
       data = formData;
     }
 

--- a/frontend/javascripts/libs/resumable_upload/resumable_upload.ts
+++ b/frontend/javascripts/libs/resumable_upload/resumable_upload.ts
@@ -20,46 +20,6 @@ export interface ConfigurationHash {
    * Number of simultaneous uploads (Default: `3`)
    */
   simultaneousUploads?: number;
-  /**
-   * The name of the multipart request parameter to use for the file chunk (Default: `file`)
-   */
-  fileParameterName?: string;
-  /**
-   * The name of the chunk index (base-1) in the current upload POST parameter to use for the file chunk (Default: `resumableChunkNumber`)
-   */
-  chunkNumberParameterName?: string;
-  /**
-   * The name of the general chunk size POST parameter to use for the file chunk (Default: `resumableChunkSize`)
-   */
-  chunkSizeParameterName?: string;
-  /**
-   * The name of the current chunk size POST parameter to use for the file chunk (Default: `resumableCurrentChunkSize`)
-   */
-  currentChunkSizeParameterName?: string;
-  /**
-   * The name of the total file size number POST parameter to use for the file chunk (Default: `resumableTotalSize`)
-   */
-  totalSizeParameterName?: string;
-  /**
-   * The name of the file type POST parameter to use for the file chunk (Default: `resumableType`)
-   */
-  typeParameterName?: string;
-  /**
-   * The name of the unique identifier POST parameter to use for the file chunk (Default: `resumableIdentifier`)
-   */
-  identifierParameterName?: string;
-  /**
-   * The name of the original file name POST parameter to use for the file chunk (Default: `resumableFilename`)
-   */
-  fileNameParameterName?: string;
-  /**
-   * The name of the file's relative path POST parameter to use for the file chunk (Default: `resumableRelativePath`)
-   */
-  relativePathParameterName?: string;
-  /**
-   * The name of the total number of chunks POST parameter to use for the file chunk (Default: `resumableTotalChunks`)
-   */
-  totalChunksParameterName?: string;
   throttleProgressCallbacks?: number;
   /**
    * Extra parameters to include in the multipart request with data. This can be an object or a function. If a function, it will be passed a ResumableFile and a ResumableChunk object (Default: `{}`)
@@ -206,16 +166,6 @@ export class ResumableUpload implements EventTarget {
       chunkSize: 1 * 1024 * 1024,
       forceChunkSize: false,
       simultaneousUploads: 3,
-      fileParameterName: "file",
-      chunkNumberParameterName: "resumableChunkNumber",
-      chunkSizeParameterName: "resumableChunkSize",
-      currentChunkSizeParameterName: "resumableCurrentChunkSize",
-      totalSizeParameterName: "resumableTotalSize",
-      typeParameterName: "resumableType",
-      identifierParameterName: "resumableIdentifier",
-      fileNameParameterName: "resumableFilename",
-      relativePathParameterName: "resumableRelativePath",
-      totalChunksParameterName: "resumableTotalChunks",
       throttleProgressCallbacks: 0.5,
       query: {},
       headers: {},


### PR DESCRIPTION
4. (stacked) PR to replace configurable property names with their defaults

- Replaced property names with their default values instead of configurable, variable names. (`fileParameterName`, `chunkNumberParameterName`, `chunkSizeParameterName`, `currentChunkSizeParameterName`, `totalSizeParameterName`, `typeParameterName`, `identifierParameterName`, `fileNameParameterName`, `relativePathParameterName`, `totalChunksParameterName`)

Fixes #9519


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>