### PR TITLE
Pass annotation id to infer_neurons jobs to enable evaluation

### DIFF
--- a/app/controllers/AiModelController.scala
+++ b/app/controllers/AiModelController.scala
@@ -362,6 +362,7 @@ class AiModelController @Inject()(
           "bbox" -> mag1BoundingBox.toLiteral,
           "model_id" -> request.body.aiModelId,
           "model_organization_id" -> aiModelOpt.map(_._organization),
+          "annotation_id" -> request.body.annotationId,
           "dataset_directory_name" -> dataset.directoryName,
           "new_dataset_name" -> request.body.newDatasetName,
           "invert_color_layer" -> request.body.invertColorLayer,


### PR DESCRIPTION
The worker asserts that annotation_id is present when evaluation is selected. The frontend already sends it, Wk just needs to pass it on.

### Steps to test:
- Set up worker
- In annotation, create a tree and a bbox
- Start neuron inference with evaluation settings
- Worker jobs should start

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1777361052997139
