### PR TITLE
fix some spacing

### DIFF
--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -7,7 +7,7 @@ import {
   SettingOutlined,
   TeamOutlined,
 } from "@ant-design/icons";
-import { Alert, Breadcrumb, Button, Form, Layout, Menu, Tooltip } from "antd";
+import { Alert, Breadcrumb, Button, Form, Layout, Menu, Space, Tooltip } from "antd";
 import type { ItemType } from "antd/es/menu/interface";
 import { useDatasetSettingsContext } from "dashboard/dataset/dataset_settings_context";
 import features from "features";
@@ -15,7 +15,6 @@ import messages from "messages";
 import type React from "react";
 import { useCallback } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
-import { Unicode } from "viewer/constants";
 import { getReadableURLPart } from "viewer/model/accessors/dataset_accessor";
 
 const { Sider, Content } = Layout;
@@ -228,11 +227,12 @@ const DatasetSettingsView: React.FC = () => {
               marginTop: 8,
             }}
           >
-            <Button type="primary" htmlType="submit">
-              {confirmString}
-            </Button>
-            {Unicode.NonBreakingSpace}
-            <Button onClick={handleCancel}>Cancel</Button>
+            <Space>
+              <Button type="primary" htmlType="submit">
+                {confirmString}
+              </Button>
+              <Button onClick={handleCancel}>Cancel</Button>
+            </Space>
           </FormItem>
         </Form>
       </Content>

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -619,13 +619,13 @@ class ExplorativeAnnotationsView extends PureComponent<Props, State> {
         render: (owner: APIUser | null, annotation: APIAnnotationInfo) => {
           const ownerName = owner != null ? renderOwner(owner) : null;
           const teamTags = annotation.teams.map((t) => (
-            <Tag key={t.id} color={stringToColor(t.name)}>
+            <Tag key={t.id} color={stringToColor(t.name)} variant="outlined">
               {t.name}
             </Tag>
           ));
 
           return (
-            <>
+            <Space orientation="vertical" size="small">
               <Space align="start">
                 <UserOutlined />
                 {ownerName}
@@ -636,7 +636,7 @@ class ExplorativeAnnotationsView extends PureComponent<Props, State> {
                   {teamTags}
                 </Space>
               </Space>
-            </>
+            </Space>
           );
         },
       },

--- a/frontend/javascripts/viewer/view/right_border_tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/dataset_info_tab_view.tsx
@@ -563,7 +563,11 @@ class DatasetInfoTabView extends React.PureComponent<Props, State> {
               />
             </FastTooltip>
           </p>
-          <p>{contributorTags}</p>
+          <p>
+            <Space size={4} wrap>
+              {contributorTags}
+            </Space>
+          </p>
         </div>
       </>
     );


### PR DESCRIPTION
Small PR to fix some spacing issues:

- 2x https://scm.slack.com/archives/C5AKLAV0B/p1777364011190269
- Annotation Dashboard; Owner + Shared Team vertical stacking: <img width="330" height="93" alt="image" src="https://github.com/user-attachments/assets/b2de47d5-7efc-42c0-8bd7-c6dfa777a2d1" />
- Dataset Settings "Save"+"Cancel" button spacing: <img width="628" height="276" alt="image" src="https://github.com/user-attachments/assets/8b0c6f77-c73d-4cf3-8e3b-2270b32f25c2" />


### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- not really necessary


### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
