### PR TITLE
If dataset deletion is disabled in config, hide the option in dashboard

### DIFF
--- a/frontend/javascripts/dashboard/folders/details_sidebar.tsx
+++ b/frontend/javascripts/dashboard/folders/details_sidebar.tsx
@@ -9,9 +9,9 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getOrganization } from "admin/api/organization";
 import { deleteDatasetOnDisk } from "admin/rest_api";
-import features from "features";
 import { Button, Modal, Progress, Result, Space, Spin, Tag, Tooltip, Typography } from "antd";
 import FormattedId from "components/formatted_id";
+import features from "features";
 import { formatCountToDataAmountUnit, stringToColor } from "libs/format_utils";
 import Markdown from "libs/markdown_adapter";
 import { useWkSelector } from "libs/react_hooks";

--- a/frontend/javascripts/dashboard/folders/details_sidebar.tsx
+++ b/frontend/javascripts/dashboard/folders/details_sidebar.tsx
@@ -9,6 +9,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getOrganization } from "admin/api/organization";
 import { deleteDatasetOnDisk } from "admin/rest_api";
+import features from "features";
 import { Button, Modal, Progress, Result, Space, Spin, Tag, Tooltip, Typography } from "antd";
 import FormattedId from "components/formatted_id";
 import { formatCountToDataAmountUnit, stringToColor } from "libs/format_utils";
@@ -332,7 +333,7 @@ function DatasetsDetails({
           Selected {selectedDatasets.length} of {datasetCount} datasets. Move them to another folder
           with drag and drop.
         </div>
-        {deletableDatasets.length > 0 && (
+        {deletableDatasets.length > 0 && features().allowDeleteDatasets && (
           <Button onClick={() => setShowConfirmDeleteModal(true)} icon={<DeleteOutlined />}>
             Delete {deletableDatasetString}
           </Button>

--- a/unreleased_changes/9536.md
+++ b/unreleased_changes/9536.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that dataset deletion was offered in the dashboard even when disabled in the config. The backend still correctly rejected it.


### PR DESCRIPTION
### Steps to test:
- in application.conf set features.allowDeleteDatasets=false
- in dashboard, select multiple datasets, no delete button should appear
- reset the config, reload, deletion should work again.

### Issues:
- fixes #9534

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
