### PR TITLE
Backend submits dataset conversion job, not frontend

### DIFF
--- a/app/controllers/JobController.scala
+++ b/app/controllers/JobController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import play.silhouette.api.Silhouette
-import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
+import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import models.dataset.{DataStoreDAO, DatasetDAO, DatasetLayerAdditionalAxesDAO, DatasetService}
@@ -20,7 +20,6 @@ import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import com.scalableminds.util.enumeration.ExtendedEnumeration
 import com.scalableminds.util.objectid.ObjectId
-import com.scalableminds.webknossos.datastore.models.{LengthUnit, VoxelSize}
 import com.scalableminds.webknossos.datastore.dataformats.zarr.Zarr3OutputHelper
 import com.scalableminds.webknossos.datastore.datareaders.{AxisOrder, FullAxisOrder, NDBoundingBox}
 import com.scalableminds.webknossos.datastore.models.AdditionalCoordinate
@@ -142,35 +141,6 @@ class JobController @Inject()(jobDAO: JobDAO,
       js <- jobService.publicWrites(job)
     } yield Ok(js)
   }
-
-  // Note that the dataset has to be registered by reserveUpload via the datastore first.
-  def runConvertToWkwJob(datasetId: ObjectId, scale: String, unit: Option[String]): Action[AnyContent] =
-    sil.SecuredAction.async { implicit request =>
-      log(Some(slackNotificationService.noticeFailedJobRequest)) {
-        for {
-          dataset <- datasetDAO.findOne(datasetId) ?~> Messages("dataset.notFound", datasetId) ~> NOT_FOUND
-          voxelSizeFactor <- Vec3Double.fromUriLiteral(scale).toFox
-          voxelSizeUnit <- Fox.runOptional(unit)(u => LengthUnit.fromString(u).toFox)
-          voxelSize = VoxelSize.fromFactorAndUnitWithDefault(voxelSizeFactor, voxelSizeUnit)
-          organization <- organizationDAO.findOne(dataset._organization)(GlobalAccessContext) ?~> Messages(
-            "organization.notFound",
-            dataset._organization)
-          _ <- Fox.fromBool(request.identity._organization == organization._id) ?~> "job.convertToWkw.notAllowed.organization" ~> FORBIDDEN
-          command = JobCommand.convert_to_wkw
-          commandArgs = Json.obj(
-            "organization_id" -> organization._id,
-            "organization_display_name" -> organization.name,
-            "dataset_name" -> dataset.name,
-            "dataset_id" -> dataset._id,
-            "dataset_directory_name" -> dataset.directoryName,
-            "voxel_size_factor" -> voxelSize.factor.toUriLiteral,
-            "voxel_size_unit" -> voxelSize.unit
-          )
-          job <- jobService.submitJob(command, commandArgs, request.identity, dataset._dataStore) ?~> "job.couldNotRunCubing"
-          js <- jobService.publicWrites(job)
-        } yield Ok(js)
-      }
-    }
 
   def runComputeMeshFileJob(datasetId: ObjectId,
                             layerName: String,

--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -21,7 +21,7 @@ import com.scalableminds.webknossos.datastore.services.uploading.{
 import com.typesafe.scalalogging.LazyLogging
 import models.dataset._
 import models.dataset.credential.CredentialDAO
-import models.job.JobDAO
+import models.job.{JobDAO, JobService}
 import models.organization.OrganizationDAO
 import models.storage.UsedStorageService
 import models.team.TeamDAO
@@ -46,6 +46,7 @@ class WKRemoteDataStoreController @Inject()(
     userDAO: UserDAO,
     teamDAO: TeamDAO,
     jobDAO: JobDAO,
+    jobService: JobService,
     credentialDAO: CredentialDAO,
     wkSilhouetteEnvironment: WkSilhouetteEnvironment)(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller
@@ -145,6 +146,12 @@ class WKRemoteDataStoreController @Inject()(
                                         isUsable = true)(GlobalAccessContext)
           }
           _ <- Fox.runIf(!request.body.needsConversion)(usedStorageService.refreshStorageReportForDataset(dataset))
+          _ <- Fox.runIf(request.body.needsConversion) {
+            for {
+              voxelSizeFactor <- request.body.voxelSizeFactor.toFox ?~> "dataset.upload.needsConversion.missingVoxelSize"
+              _ <- jobService.submitConvertToWkwJob(dataset, user, voxelSizeFactor, request.body.voxelSizeUnit)
+            } yield ()
+          }
         } yield Ok
       }
     }

--- a/app/models/job/JobService.scala
+++ b/app/models/job/JobService.scala
@@ -15,6 +15,7 @@ import models.job.JobCommand.JobCommand
 import models.organization.{CreditTransactionService, OrganizationDAO}
 import models.user.{MultiUserDAO, User, UserDAO, UserService}
 import com.scalableminds.util.tools.Full
+import com.scalableminds.webknossos.datastore.models.LengthUnit.LengthUnit
 import org.apache.pekko.actor.ActorSystem
 import play.api.libs.json.{JsObject, JsValue, Json}
 import security.WkSilhouetteEnvironment
@@ -231,13 +232,11 @@ class JobService @Inject()(wkConf: WkConf,
 
   def submitConvertToWkwJob(dataset: Dataset,
                             user: User,
-                            voxelSizeFactor: String,
-                            voxelSizeUnit: Option[String]): Fox[Unit] =
+                            voxelSizeFactor: Vec3Double,
+                            voxelSizeUnit: Option[LengthUnit]): Fox[Unit] =
     for {
-      voxelSizeFactorParsed <- Vec3Double.fromUriLiteral(voxelSizeFactor).toFox ?~> "job.convertToWkw.invalidVoxelSize"
-      voxelSizeUnitParsed <- Fox.runOptional(voxelSizeUnit)(u => LengthUnit.fromString(u).toFox)
-      voxelSize = VoxelSize.fromFactorAndUnitWithDefault(voxelSizeFactorParsed, voxelSizeUnitParsed)
       organization <- organizationDAO.findOne(dataset._organization)(GlobalAccessContext) ?~> "organization.notFound"
+      voxelSize = VoxelSize.fromFactorAndUnitWithDefault(voxelSizeFactor, voxelSizeUnit)
       commandArgs = Json.obj(
         "organization_id" -> organization._id,
         "organization_display_name" -> organization.name,

--- a/app/models/job/JobService.scala
+++ b/app/models/job/JobService.scala
@@ -2,7 +2,7 @@ package models.job
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Double}
-import com.scalableminds.webknossos.datastore.models.{LengthUnit, VoxelSize}
+import com.scalableminds.webknossos.datastore.models.VoxelSize
 import models.dataset.Dataset
 import com.scalableminds.util.mvc.Formatter
 import com.scalableminds.util.objectid.ObjectId

--- a/app/models/job/JobService.scala
+++ b/app/models/job/JobService.scala
@@ -1,7 +1,9 @@
 package models.job
 
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
-import com.scalableminds.util.geometry.BoundingBox
+import com.scalableminds.util.geometry.{BoundingBox, Vec3Double}
+import com.scalableminds.webknossos.datastore.models.{LengthUnit, VoxelSize}
+import models.dataset.Dataset
 import com.scalableminds.util.mvc.Formatter
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.tools.{Fox, FoxImplicits}
@@ -226,6 +228,27 @@ class JobService @Inject()(wkConf: WkConf,
       _ <- jobDAO.insertOne(job)
       _ = analyticsService.track(RunJobEvent(owner, command))
     } yield job
+
+  def submitConvertToWkwJob(dataset: Dataset,
+                            user: User,
+                            voxelSizeFactor: String,
+                            voxelSizeUnit: Option[String]): Fox[Unit] =
+    for {
+      voxelSizeFactorParsed <- Vec3Double.fromUriLiteral(voxelSizeFactor).toFox ?~> "job.convertToWkw.invalidVoxelSize"
+      voxelSizeUnitParsed <- Fox.runOptional(voxelSizeUnit)(u => LengthUnit.fromString(u).toFox)
+      voxelSize = VoxelSize.fromFactorAndUnitWithDefault(voxelSizeFactorParsed, voxelSizeUnitParsed)
+      organization <- organizationDAO.findOne(dataset._organization)(GlobalAccessContext) ?~> "organization.notFound"
+      commandArgs = Json.obj(
+        "organization_id" -> organization._id,
+        "organization_display_name" -> organization.name,
+        "dataset_name" -> dataset.name,
+        "dataset_id" -> dataset._id,
+        "dataset_directory_name" -> dataset.directoryName,
+        "voxel_size_factor" -> voxelSize.factor.toUriLiteral,
+        "voxel_size_unit" -> voxelSize.unit
+      )
+      _ <- submitJob(JobCommand.convert_to_wkw, commandArgs, user, dataset._dataStore) ?~> "job.couldNotRunCubing"
+    } yield ()
 
   def submitPaidJob(command: JobCommand,
                     commandArgs: JsObject,

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -283,7 +283,6 @@ GET           /jobs/request                                                     
 GET           /jobs                                                                             controllers.JobController.list(command: Option[String], skipForDeletedDatasets: Option[Boolean])
 GET           /jobs/status                                                                      controllers.JobController.status()
 GET           /jobs/getCreditCost                                                               controllers.JobController.getJobCreditCost(command: String, boundingBoxInMag: String)
-POST          /jobs/run/convertToWkw/:datasetId                                                 controllers.JobController.runConvertToWkwJob(datasetId: ObjectId, scale: String, unit: Option[String])
 POST          /jobs/run/computeMeshFile/:datasetId                                              controllers.JobController.runComputeMeshFileJob(datasetId: ObjectId, layerName: String, mag: String, agglomerateView: Option[String])
 POST          /jobs/run/computeSegmentIndexFile/:datasetId                                      controllers.JobController.runComputeSegmentIndexFileJob(datasetId: ObjectId, layerName: String)
 POST          /jobs/run/exportTiff/:datasetId                                                   controllers.JobController.runExportTiffJob(datasetId: ObjectId, bbox: String, additionalCoordinates: Option[String], layerName: Option[String], mag: Option[String], annotationLayerName: Option[String], annotationId: Option[ObjectId], asOmeTiff: Boolean)

--- a/frontend/javascripts/admin/api/jobs.ts
+++ b/frontend/javascripts/admin/api/jobs.ts
@@ -10,7 +10,7 @@ import type {
   RenderAnimationOptions,
   VoxelSize,
 } from "types/api_types";
-import type { UnitLong, Vector3, Vector6 } from "viewer/constants";
+import type { Vector3, Vector6 } from "viewer/constants";
 import { setActiveOrganizationsCreditBalance } from "viewer/model/actions/organization_actions";
 import { Store } from "viewer/singletons";
 import { assertResponseLimit } from "./api_utils";
@@ -92,19 +92,6 @@ export async function retryJob(jobId: string): Promise<APIJob> {
   return Request.receiveJSON(`/api/jobs/${jobId}/retry`, {
     method: "PATCH",
   });
-}
-
-export async function startConvertToWkwJob(
-  datasetId: string,
-  scale: Vector3,
-  unit: UnitLong,
-): Promise<APIJob> {
-  return Request.receiveJSON(
-    `/api/jobs/run/convertToWkw/${datasetId}?scale=${scale.toString()}&unit=${unit}`,
-    {
-      method: "POST",
-    },
-  );
 }
 
 export async function startFindLargestSegmentIdJob(

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -25,7 +25,6 @@ import {
   reserveDatasetUpload,
   sendAnalyticsEvent,
   sendFailedRequestAnalyticsEvent,
-  startConvertToWkwJob,
   type UnfinishedUpload,
 } from "admin/rest_api";
 import {
@@ -386,37 +385,16 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
       const uploadInfo = {
         uploadId,
         needsConversion: this.state.needsConversion,
+        voxelSizeFactor: this.state.needsConversion
+          ? formValues.voxelSizeFactor.toString()
+          : undefined,
+        voxelSizeUnit: this.state.needsConversion ? formValues.voxelSizeUnit : undefined,
       };
       this.setState({
         isFinishing: true,
       });
       finishDatasetUpload(datastoreUrl, uploadInfo).then(
         async ({ newDatasetId }) => {
-          let maybeError;
-
-          if (this.state.needsConversion) {
-            try {
-              const datastore = this.getDatastoreForUrl(datastoreUrl);
-
-              if (!datastore) {
-                throw new Error("Selected datastore does not match available datastores");
-              }
-
-              await startConvertToWkwJob(
-                newDatasetId,
-                formValues.voxelSizeFactor,
-                formValues.voxelSizeUnit,
-              );
-            } catch (error) {
-              maybeError = error;
-            }
-
-            if (maybeError != null) {
-              Toast.error(
-                "The upload was successful, but the conversion for the dataset could not be started. Please try again or contact us if this issue occurs again.",
-              );
-            }
-          }
           this.setState({
             isUploading: false,
             isFinishing: false,
@@ -424,13 +402,11 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
             uploadId: undefined,
           });
 
-          if (maybeError == null) {
-            newestForm.setFieldsValue({
-              name: "",
-              zipFile: [],
-            });
-            this.props.onUploaded(newDatasetId, newDatasetName, this.state.needsConversion);
-          }
+          newestForm.setFieldsValue({
+            name: "",
+            zipFile: [],
+          });
+          this.props.onUploaded(newDatasetId, newDatasetName, this.state.needsConversion);
         },
         (error) => {
           sendFailedRequestAnalyticsEvent("finish_dataset_upload", error, {

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -386,7 +386,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
         uploadId,
         needsConversion: this.state.needsConversion,
         voxelSizeFactor: this.state.needsConversion
-          ? formValues.voxelSizeFactor.toString()
+          ? formValues.voxelSizeFactor
           : undefined,
         voxelSizeUnit: this.state.needsConversion ? formValues.voxelSizeUnit : undefined,
       };

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -393,18 +393,22 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
       });
       finishDatasetUpload(datastoreUrl, uploadInfo).then(
         async ({ newDatasetId }) => {
+          const { needsConversion } = this.state;
           this.setState({
             isUploading: false,
             isFinishing: false,
+            isRetrying: false,
+            uploadProgress: 0,
             unfinishedUploadToContinue: null,
             uploadId: undefined,
+            needsConversion: false,
           });
 
           newestForm.setFieldsValue({
             name: "",
             zipFile: [],
           });
-          this.props.onUploaded(newDatasetId, newDatasetName, this.state.needsConversion);
+          this.props.onUploaded(newDatasetId, newDatasetName, needsConversion);
         },
         (error) => {
           sendFailedRequestAnalyticsEvent("finish_dataset_upload", error, {

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -385,9 +385,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
       const uploadInfo = {
         uploadId,
         needsConversion: this.state.needsConversion,
-        voxelSizeFactor: this.state.needsConversion
-          ? formValues.voxelSizeFactor
-          : undefined,
+        voxelSizeFactor: this.state.needsConversion ? formValues.voxelSizeFactor : undefined,
         voxelSizeUnit: this.state.needsConversion ? formValues.voxelSizeUnit : undefined,
       };
       this.setState({

--- a/unreleased_changes/9538.md
+++ b/unreleased_changes/9538.md
@@ -1,0 +1,2 @@
+### Added
+- Dataset uploads that trigger a conversion job now do so in one request, avoiding some dropped requests due to timeouts.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
@@ -2,6 +2,7 @@ package com.scalableminds.webknossos.datastore.services.uploading
 
 import com.google.inject.Inject
 import com.scalableminds.util.accesscontext.TokenContext
+import com.scalableminds.util.geometry.Vec3Double
 import com.scalableminds.util.io.{PathUtils, ZipIO}
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.time.Instant
@@ -17,6 +18,7 @@ import com.scalableminds.webknossos.datastore.datareaders.zarr.ZarrHeader.FILENA
 import com.scalableminds.webknossos.datastore.datareaders.zarr3.Zarr3ArrayHeader.FILENAME_ZARR_JSON
 import com.scalableminds.webknossos.datastore.explore.ExploreLocalLayerService
 import com.scalableminds.webknossos.datastore.helpers.{DatasetDeleter, DirectoryConstants, UPath}
+import com.scalableminds.webknossos.datastore.models.LengthUnit.LengthUnit
 import com.scalableminds.webknossos.datastore.models.UnfinishedUpload
 import com.scalableminds.webknossos.datastore.models.datasource.UsableDataSource.FILENAME_DATASOURCE_PROPERTIES_JSON
 import com.scalableminds.webknossos.datastore.models.datasource._
@@ -62,8 +64,8 @@ case class ReportDatasetUploadParameters(
     datasetSizeBytes: Long,
     dataSourceOpt: Option[UsableDataSource], // must be set if needsConversion is false
     layersToLink: Seq[LinkedLayerIdentifier],
-    voxelSizeFactor: Option[String],
-    voxelSizeUnit: Option[String]
+    voxelSizeFactor: Option[Vec3Double],
+    voxelSizeUnit: Option[LengthUnit]
 )
 object ReportDatasetUploadParameters {
   implicit val jsonFormat: OFormat[ReportDatasetUploadParameters] =
@@ -83,8 +85,8 @@ object LinkedLayerIdentifiers {
 
 case class UploadInformation(uploadId: String,
                              needsConversion: Option[Boolean],
-                             voxelSizeFactor: Option[String],
-                             voxelSizeUnit: Option[String])
+                             voxelSizeFactor: Option[Vec3Double],
+                             voxelSizeUnit: Option[LengthUnit])
 
 object UploadInformation {
   implicit val jsonFormat: OFormat[UploadInformation] = Json.format[UploadInformation]

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
@@ -61,7 +61,9 @@ case class ReportDatasetUploadParameters(
     needsConversion: Boolean,
     datasetSizeBytes: Long,
     dataSourceOpt: Option[UsableDataSource], // must be set if needsConversion is false
-    layersToLink: Seq[LinkedLayerIdentifier]
+    layersToLink: Seq[LinkedLayerIdentifier],
+    voxelSizeFactor: Option[String],
+    voxelSizeUnit: Option[String]
 )
 object ReportDatasetUploadParameters {
   implicit val jsonFormat: OFormat[ReportDatasetUploadParameters] =
@@ -79,7 +81,10 @@ object LinkedLayerIdentifiers {
   implicit val jsonFormat: OFormat[LinkedLayerIdentifiers] = Json.format[LinkedLayerIdentifiers]
 }
 
-case class UploadInformation(uploadId: String, needsConversion: Option[Boolean])
+case class UploadInformation(uploadId: String,
+                             needsConversion: Option[Boolean],
+                             voxelSizeFactor: Option[String],
+                             voxelSizeUnit: Option[String])
 
 object UploadInformation {
   implicit val jsonFormat: OFormat[UploadInformation] = Json.format[UploadInformation]
@@ -337,7 +342,9 @@ class UploadService @Inject()(dataSourceService: DataSourceService,
           uploadInformation.needsConversion.getOrElse(false),
           datasetSizeBytes,
           dataSourceWithAbsolutePathsOpt,
-          linkedLayerIdentifiers.layersToLink.getOrElse(List.empty)
+          linkedLayerIdentifiers.layersToLink.getOrElse(List.empty),
+          uploadInformation.voxelSizeFactor,
+          uploadInformation.voxelSizeUnit
         )
       ) ?~> "dataset.upload.reportUpload.failed"
     } yield ()


### PR DESCRIPTION
This has the benefit that the job still gets submitted even if the frontend navigated away or timeouted while finishUpload was still running

### Steps to test:
(I tested locally)
- Upload dataset that doesn’t need conversion, should still work as previously
- `yarn enable-jobs`
- Upload dataset that does need conversion (enter voxel size, unit), should also work, should submit convert_to_wkw job.

### Issues:
- fixes #9495

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
