### PR TITLE
Fix that segment stats were sometimes not show in context menu

### DIFF
--- a/frontend/javascripts/viewer/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/dataset_accessor.ts
@@ -727,9 +727,7 @@ export function getEffectiveIntensityRange(
   return layerConfiguration.intensityRange || defaultIntensityRange;
 }
 
-// Note that `hasSegmentIndex` needs to be loaded first (otherwise, the returned
-// value will be undefined). Dispatch an ensureSegmentIndexIsLoadedAction to make
-// sure this info is fetched.
+/** Returns whether the segment index is available for the given layer. Requires `hasSegmentIndex` to be loaded first — dispatch `ensureSegmentIndexIsLoadedAction` before calling this. */
 export function getMaybeSegmentIndexAvailability(
   dataset: APIDataset,
   layerName: string | null | undefined,
@@ -737,7 +735,15 @@ export function getMaybeSegmentIndexAvailability(
   if (layerName == null) {
     return false;
   }
-  return dataset.dataSource.dataLayers.find((layer) => layer.name === layerName)?.hasSegmentIndex;
+  const availability = dataset.dataSource.dataLayers.find(
+    (layer) => layer.name === layerName,
+  )?.hasSegmentIndex;
+  if (availability == null) {
+    console.warn(
+      "getMaybeSegmentIndexAvailability: hasSegmentIndex is not loaded yet. Dispatch ensureSegmentIndexIsLoadedAction first.",
+    );
+  }
+  return availability;
 }
 
 function getURLSanitizedName(dataset: APIDataset | APIDatasetCompact | { name: string }) {

--- a/frontend/javascripts/viewer/view/context_menu/use_segment_statistics.ts
+++ b/frontend/javascripts/viewer/view/context_menu/use_segment_statistics.ts
@@ -2,6 +2,7 @@ import { getSegmentBoundingBoxes, getSegmentSurfaceArea, getSegmentVolumes } fro
 import { formatNumberToArea, formatNumberToVolume } from "libs/format_utils";
 import { useFetch } from "libs/react_helpers";
 import { useWkSelector } from "libs/react_hooks";
+import { useEffect } from "react";
 import { LongUnitToShortUnitMap } from "viewer/constants";
 import {
   getMagInfo,
@@ -12,6 +13,7 @@ import {
   getActiveSegmentationTracing,
   getCurrentMappingName,
 } from "viewer/model/accessors/volumetracing_accessor";
+import { ensureSegmentIndexIsLoadedAction } from "viewer/model/actions/dataset_actions";
 import { getBoundingBoxInMag1 } from "viewer/model/sagas/volume/helpers";
 import { voxelToVolumeInUnit } from "viewer/model/scaleinfo";
 import Store from "viewer/store";
@@ -34,6 +36,13 @@ export function useSegmentStatistics(
     dataset,
     visibleSegmentationLayer?.name,
   );
+
+  useEffect(() => {
+    if (wasSegmentOrMeshClicked) {
+      Store.dispatch(ensureSegmentIndexIsLoadedAction(visibleSegmentationLayer?.name));
+    }
+  }, [wasSegmentOrMeshClicked, visibleSegmentationLayer?.name]);
+
   const mappingName = useWkSelector(getCurrentMappingName);
 
   const isLoadingMessage = "loading";

--- a/unreleased_changes/9545.md
+++ b/unreleased_changes/9545.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed inconsistent display of segment statistics in right-click context menu


### PR DESCRIPTION
This PR fixes a bug with the right-click context menu entry for "Loading segment stats". Previously, depending on whether the Segments tab was active or not, the context menu entry was either available or not.

Only mounting the Segments Tab caused WK to actually load the `hasSegmentIndex` property via an action/saga. With this PR, the context menu can also trigger this action. 

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
1. Open annotation with a segment index file
2. Make sure that the Segments Tab is not active when opening WK. E.g. switch to Skeleton tab. Reload page if Segments tab was active by default
3. Right-click any segment in the XY viewport to bring up context-menu.
4. Check that "Load segment stats" context-menu entry is available.


### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1777480382202009

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
