### PR TITLE
Reject uploadToPaths/publish when organization storage quota is exceeded

### DIFF
--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -22,7 +22,7 @@ import com.typesafe.scalalogging.LazyLogging
 import models.dataset._
 import models.dataset.credential.CredentialDAO
 import models.job.JobDAO
-import models.organization.OrganizationDAO
+import models.organization.{OrganizationDAO, OrganizationService}
 import models.storage.UsedStorageService
 import models.team.TeamDAO
 import models.user.UserDAO
@@ -41,6 +41,7 @@ class WKRemoteDataStoreController @Inject()(
     dataStoreDAO: DataStoreDAO,
     organizationDAO: OrganizationDAO,
     usedStorageService: UsedStorageService,
+    organizationService: OrganizationService,
     layerToLinkService: LayerToLinkService,
     datasetDAO: DatasetDAO,
     userDAO: UserDAO,
@@ -63,9 +64,7 @@ class WKRemoteDataStoreController @Inject()(
           organization <- organizationDAO.findOne(uploadInfo.organization)(GlobalAccessContext) ?~> Messages(
             "organization.notFound",
             uploadInfo.organization) ~> NOT_FOUND
-          usedStorageBytes <- organizationDAO.getUsedStorage(organization._id)
-          _ <- Fox.runOptional(organization.includedStorageBytes)(includedStorage =>
-            Fox.fromBool(usedStorageBytes + uploadInfo.totalFileSizeInBytes.getOrElse(0L) <= includedStorage)) ?~> "dataset.upload.storageExceeded" ~> FORBIDDEN
+          _ <- organizationService.assertUsedStorageNotExceeded(organization, uploadInfo.totalFileSizeInBytes) ?~> "dataset.upload.storageExceeded" ~> FORBIDDEN
           _ <- Fox.fromBool(organization._id == user._organization) ?~> "notAllowed" ~> FORBIDDEN
           _ <- datasetService.assertValidDatasetName(uploadInfo.name)
           _ <- Fox.fromBool(dataStore.onlyAllowedOrganization.forall(_ == organization._id)) ?~> "dataset.upload.Datastore.restricted"

--- a/app/models/dataset/UploadToPathsService.scala
+++ b/app/models/dataset/UploadToPathsService.scala
@@ -30,8 +30,9 @@ import controllers.{
   ReserveMagUploadToPathRequest
 }
 import models.folder.FolderDAO
-import models.organization.OrganizationDAO
+import models.organization.{OrganizationDAO, OrganizationService}
 import models.user.User
+import play.api.http.Status.FORBIDDEN
 import play.api.i18n.MessagesProvider
 import utils.WkConf
 import security.RandomIDGenerator
@@ -40,6 +41,7 @@ import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
 class UploadToPathsService @Inject()(datasetService: DatasetService,
+                                     organizationService: OrganizationService,
                                      organizationDAO: OrganizationDAO,
                                      datasetDAO: DatasetDAO,
                                      dataStoreDAO: DataStoreDAO,
@@ -59,6 +61,7 @@ class UploadToPathsService @Inject()(datasetService: DatasetService,
                                                           mp: MessagesProvider): Fox[UsableDataSource] =
     for {
       organization <- organizationDAO.findOne(requestingUser._organization)
+      _ <- organizationService.assertUsedStorageNotExceeded(organization) ?~> "dataset.upload.storageExceeded" ~> FORBIDDEN
       _ <- Fox.runIf(parameters.requireUniqueName)(
         datasetService.checkNameAvailable(parameters.datasetName, organization._id))
       _ <- datasetService.assertValidDatasetName(parameters.datasetName)

--- a/app/models/organization/OrganizationService.scala
+++ b/app/models/organization/OrganizationService.scala
@@ -73,6 +73,14 @@ class OrganizationService @Inject()(organizationDAO: OrganizationDAO,
       ) ++ adminOnlyInfo
   }
 
+  def assertUsedStorageNotExceeded(organization: Organization,
+                                   additionalRequestedStorage: Option[Long] = None): Fox[Unit] =
+    for {
+      usedStorageBytes <- organizationDAO.getUsedStorage(organization._id)
+      _ <- Fox.runOptional(organization.includedStorageBytes)(includedStorage =>
+        Fox.fromBool(usedStorageBytes + additionalRequestedStorage.getOrElse(0L) <= includedStorage)) ?~> "organization.storageExceeded"
+    } yield ()
+
   def findOneByInviteOrDefault(inviteOpt: Option[Invite])(implicit ctx: DBAccessContext): Fox[Organization] =
     inviteOpt match {
       case Some(invite) => organizationDAO.findOne(invite._organization) ?~> "organization.notFound.byInvite"

--- a/conf/messages
+++ b/conf/messages
@@ -49,6 +49,7 @@ organization.creditOrder.notAuthorized=You are not authorized to order WEBKNOSSO
 organization.creditOrder.notPositive=You cannot order a negative number of WEBKNOSSOS credits.
 organization.listCreditTransactions.onlyAdmin=Only organization admins can list credit transactions.
 organization.listPlanUpdates.onlyAdmin=Only organization admins can list plan updates.
+organization.storageExceeded=The storage quota of the organization is exceeded.
 
 termsOfService.versionMismatch=Terms of service version mismatch. Current version is {0}, received acceptance for {1}
 


### PR DESCRIPTION
The uploadToPaths protocol does not currently include information about the size of the to-be-published dataset. But we can still reject it if the organization’s storage quota is _already_ full.

### Steps to test:
(I already tested locally)
- Set custom storage quota for your organization (via db or `POST /pricing/updatePlan`)
- Set reportUsedStorageEnabled for your local datastore in postgres
- Wait for storage scan (can be hastened by changing interval in application.conf)
- Try to publish dataset via libs (e.g. upload with transfer_mode=COPY)
- Should be allowed if the orga storage quota is not yet full, rejected otherwise

------
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
