### PR TITLE
In dataset search, also match directoryName

### DIFF
--- a/app/models/dataset/Dataset.scala
+++ b/app/models/dataset/Dataset.scala
@@ -395,7 +395,10 @@ class DatasetDAO @Inject()(sqlClient: SqlClient, datasetLayerDAO: DatasetLayerDA
           val queriedId: String = queryTokens.headOption.getOrElse("")
           q"_id = $queriedId"
         } else {
-          SqlToken.joinBySeparator(queryTokens.map(queryToken => q"POSITION($queryToken IN LOWER(name)) > 0"), " AND ")
+          SqlToken.joinBySeparator(
+            queryTokens.map(queryToken =>
+              q"(POSITION($queryToken IN LOWER(name)) > 0 OR POSITION($queryToken IN LOWER(directoryName)) > 0)"),
+            " AND ")
         }
     }
 

--- a/unreleased_changes/9548.md
+++ b/unreleased_changes/9548.md
@@ -1,0 +1,2 @@
+### Added
+- Dataset search in the dashboard now also finds datasets if only the directoryName matches.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://datasetsearchdirectoryname.webknossos.xyz

### Steps to test:
- Rename a dataset in its settings page
- search for the directoryName (probably the old name) in dashboard
- should be listed

### Issues:
- fixes #9547
- related: #9549

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
