### PR TITLE
Add retry mechanism for some API calls

### DIFF
--- a/frontend/javascripts/admin/api/mesh.ts
+++ b/frontend/javascripts/admin/api/mesh.ts
@@ -2,6 +2,7 @@ import Request from "libs/request";
 import type { APIMeshFileInfo } from "types/api_types";
 import type { Vector3, Vector4 } from "viewer/constants";
 import { doWithToken } from "./token";
+import { retryAsyncFunction } from "libs/utils";
 
 export type MeshChunk = {
   position: Vector3;
@@ -85,34 +86,36 @@ export function getMeshFileChunkData(
   layerName: string,
   batchDescription: MeshChunkDataRequestList,
 ): Promise<ArrayBuffer[]> {
-  return doWithToken(async (token) => {
-    const dracoDataChunks = await Request.sendJSONReceiveArraybuffer(
-      `${dataStoreUrl}/data/datasets/${datasetId}/layers/${layerName}/meshes/chunks/data?token=${token}`,
-      {
-        data: batchDescription,
-        useWebworkerForArrayBuffer: true,
-      },
-    );
-    const chunkCount = batchDescription.requests.length;
-    const jumpPositionsForChunks = [];
-    let cumsum = 0;
-    for (const req of batchDescription.requests) {
-      jumpPositionsForChunks.push(cumsum);
-      cumsum += req.byteSize;
-    }
-    jumpPositionsForChunks.push(cumsum);
-
-    const dataEntries = [];
-    for (let chunkIdx = 0; chunkIdx < chunkCount; chunkIdx++) {
-      // slice() creates a copy of the data, but working with TypedArray Views would cause
-      // issues when transferring the data to a webworker.
-      const dracoData = dracoDataChunks.slice(
-        jumpPositionsForChunks[chunkIdx],
-        jumpPositionsForChunks[chunkIdx + 1],
+  return retryAsyncFunction(() =>
+    doWithToken(async (token) => {
+      const dracoDataChunks = await Request.sendJSONReceiveArraybuffer(
+        `${dataStoreUrl}/data/datasets/${datasetId}/layers/${layerName}/meshes/chunks/data?token=${token}`,
+        {
+          data: batchDescription,
+          useWebworkerForArrayBuffer: true,
+        },
       );
-      dataEntries.push(dracoData);
-    }
+      const chunkCount = batchDescription.requests.length;
+      const jumpPositionsForChunks = [];
+      let cumsum = 0;
+      for (const req of batchDescription.requests) {
+        jumpPositionsForChunks.push(cumsum);
+        cumsum += req.byteSize;
+      }
+      jumpPositionsForChunks.push(cumsum);
 
-    return dataEntries;
-  });
+      const dataEntries = [];
+      for (let chunkIdx = 0; chunkIdx < chunkCount; chunkIdx++) {
+        // slice() creates a copy of the data, but working with TypedArray Views would cause
+        // issues when transferring the data to a webworker.
+        const dracoData = dracoDataChunks.slice(
+          jumpPositionsForChunks[chunkIdx],
+          jumpPositionsForChunks[chunkIdx + 1],
+        );
+        dataEntries.push(dracoData);
+      }
+
+      return dataEntries;
+    }),
+  );
 }

--- a/frontend/javascripts/admin/api/mesh.ts
+++ b/frontend/javascripts/admin/api/mesh.ts
@@ -45,28 +45,30 @@ export function getMeshFileChunksForSegment(
   editableMappingTracingId: string | null | undefined,
   annotationVersion: number | undefined | null,
 ): Promise<MeshSegmentInfo> {
-  return doWithToken((token) => {
-    const params = new URLSearchParams();
-    params.append("token", token);
-    if (targetMappingName != null) {
-      params.append("targetMappingName", targetMappingName);
-    }
-    if (editableMappingTracingId != null) {
-      params.append("editableMappingTracingId", editableMappingTracingId);
-    }
-    const payload: ListMeshChunksRequest = {
-      meshFileName: meshFile.name,
-      segmentId,
-      annotationVersion,
-    };
-    return Request.sendJSONReceiveJSON(
-      `${dataStoreUrl}/data/datasets/${datasetId}/layers/${layerName}/meshes/chunks?${params}`,
-      {
-        data: payload,
-        showErrorToast: false,
-      },
-    );
-  });
+  return retryAsyncFunction(() =>
+    doWithToken((token) => {
+      const params = new URLSearchParams();
+      params.append("token", token);
+      if (targetMappingName != null) {
+        params.append("targetMappingName", targetMappingName);
+      }
+      if (editableMappingTracingId != null) {
+        params.append("editableMappingTracingId", editableMappingTracingId);
+      }
+      const payload: ListMeshChunksRequest = {
+        meshFileName: meshFile.name,
+        segmentId,
+        annotationVersion,
+      };
+      return Request.sendJSONReceiveJSON(
+        `${dataStoreUrl}/data/datasets/${datasetId}/layers/${layerName}/meshes/chunks?${params}`,
+        {
+          data: payload,
+          showErrorToast: false,
+        },
+      );
+    }),
+  );
 }
 
 type MeshChunkDataRequest = {

--- a/frontend/javascripts/admin/api/mesh.ts
+++ b/frontend/javascripts/admin/api/mesh.ts
@@ -1,8 +1,8 @@
 import Request from "libs/request";
+import { retryAsyncFunction } from "libs/utils";
 import type { APIMeshFileInfo } from "types/api_types";
 import type { Vector3, Vector4 } from "viewer/constants";
 import { doWithToken } from "./token";
-import { retryAsyncFunction } from "libs/utils";
 
 export type MeshChunk = {
   position: Vector3;

--- a/frontend/javascripts/admin/rest_api.ts
+++ b/frontend/javascripts/admin/rest_api.ts
@@ -825,10 +825,12 @@ export function getNewestVersionForAnnotation(
   tracingStoreUrl: string,
   annotationId: string,
 ): Promise<number> {
-  return doWithToken((token) =>
-    Request.receiveJSON(
-      `${tracingStoreUrl}/tracings/annotation/${annotationId}/newestVersion?token=${token}`,
-    ).then((obj) => obj.version),
+  return retryAsyncFunction(() =>
+    doWithToken((token) =>
+      Request.receiveJSON(
+        `${tracingStoreUrl}/tracings/annotation/${annotationId}/newestVersion?token=${token}`,
+      ).then((obj) => obj.version),
+    ),
   );
 }
 

--- a/frontend/javascripts/admin/rest_api.ts
+++ b/frontend/javascripts/admin/rest_api.ts
@@ -808,8 +808,10 @@ export function getUpdateActionLog(
     if (newestVersion != null) {
       params.set("newestVersion", newestVersion.toString());
     }
-    const log: APIUpdateActionBatch[] = await Request.receiveJSON(
-      `${tracingStoreUrl}/tracings/annotation/${annotationId}/updateActionLog?${params}`,
+    const log: APIUpdateActionBatch[] = await retryAsyncFunction(() =>
+      Request.receiveJSON(
+        `${tracingStoreUrl}/tracings/annotation/${annotationId}/updateActionLog?${params}`,
+      ),
     );
 
     if (sortAscending) {

--- a/frontend/javascripts/viewer/view/right_border_tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/dataset_info_tab_view.tsx
@@ -563,11 +563,11 @@ class DatasetInfoTabView extends React.PureComponent<Props, State> {
               />
             </FastTooltip>
           </p>
-          <p>
+          <div>
             <Space size={4} wrap>
               {contributorTags}
             </Space>
-          </p>
+          </div>
         </div>
       </>
     );

--- a/unreleased_changes/9551.md
+++ b/unreleased_changes/9551.md
@@ -1,0 +1,2 @@
+### Changed
+- Improved robustness when network connectivity is unstable.


### PR DESCRIPTION
I noticed that simple network errors during getUpdateActionLog and getMeshFileChunkData can cause severe crashes. This PR adds a simple retry mechansim to mitigate this for now. In the future, we could think about increasing robustness further. I also added the same mechanism for other routes.

Please review while ignoring whitespace.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- open version restore view
- load precomputed meshes
- repeat the above while selectively blocking requests in chrome network tab. while the retries are ongoing, you can disable the blocking again

<img width="2100" height="949" alt="image" src="https://github.com/user-attachments/assets/e8176baf-1b68-433a-8adb-fa23d60cf3c5" />


### Issues:
- contributes to #9541 and #9552

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
