### PR TITLE
Use Long instead of Int for meshfile nBuckets property

### DIFF
--- a/unreleased_changes/9555.md
+++ b/unreleased_changes/9555.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed reading zarr3 meshfiles with more than 2^32 hash buckets.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/ZarrMeshFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/ZarrMeshFileService.scala
@@ -27,7 +27,7 @@ case class MeshFileAttributes(
     lodScaleMultiplier: Double,
     transform: Array[Array[Double]],
     hashFunction: String,
-    nBuckets: Int,
+    nBuckets: Long,
     mappingName: Option[String]
 ) extends ArrayArtifactHashing {
   lazy val applyHashFunction: Long => Long = getHashFunction(hashFunction)
@@ -43,7 +43,7 @@ object MeshFileAttributes extends MeshFileUtils with VoxelyticsZarrArtifactUtils
         lodScaleMultiplier <- (meshFileAttrs \ attrKeyLodScaleMultiplier).validate[Double]
         transform <- (meshFileAttrs \ attrKeyTransform).validate[Array[Array[Double]]]
         hashFunction <- (meshFileAttrs \ attrKeyHashFunction).validate[String]
-        nBuckets <- (meshFileAttrs \ attrKeyNBuckets).validate[Int]
+        nBuckets <- (meshFileAttrs \ attrKeyNBuckets).validate[Long]
         mappingName <- (meshFileAttrs \ attrKeyMappingName).validateOpt[String]
       } yield
         MeshFileAttributes(


### PR DESCRIPTION
A user created a meshfile with `"n_buckets": 6014129504`, which does not fit in Int. Using Long should fix that. The hash function that takes this parameter already expects Long anyway.

### Steps to test:
- I tested that the zarr.json that failed to parse on master can now be read
- A full mesh loading test can only be done with a huge meshfile, so I’d say it’s not worth the effort of acquiring one. Let’s test that in production.

### Issues:
- fixes https://discuss.webknossos.org/t/cant-load-the-meshfile-in-wk/1228

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
