### PR TITLE
Fix fast import via url

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
@@ -102,7 +102,7 @@ function DatasetAddRemoteView(props: Props) {
     const maybeDSNameError = form
       .getFieldError(["dataset", "name"])
       .filter((error) => error === messages["dataset.name.already_taken"]);
-    const isNameAlreadyTaken = maybeDSNameError.length === 0;
+    const isNameAlreadyTaken = maybeDSNameError.length > 0;
     if (isNameAlreadyTaken) {
       navigate(`/datasets/${activeUser?.organization}/${form.getFieldValue(["dataset", "name"])}`);
     }

--- a/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
@@ -161,7 +161,7 @@ function DatasetAddRemoteView(props: Props) {
     if (!showLoadingOverlay) setShowLoadingOverlay(true); // show overlay again, e.g. after credentials were passed
 
     const defaultDatasetName = getDefaultDatasetName(url);
-    form.setFieldValue(["dataSource", "id"], { name: defaultDatasetName, team: "" });
+    form.setFieldValue(["dataset", "name"], defaultDatasetName);
 
     try {
       await form.validateFields();

--- a/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
@@ -102,10 +102,10 @@ function DatasetAddRemoteView(props: Props) {
     const maybeDSNameError = form
       .getFieldError(["dataset", "name"])
       .filter((error) => error === messages["dataset.name.already_taken"]);
-    if (maybeDSNameError == null) return;
-    navigate(
-      `/datasets/${activeUser?.organization}/${form.getFieldValue(["dataSource", "id", "name"])}`,
-    );
+    const isNameAlreadyTaken = maybeDSNameError.length === 0;
+    if (isNameAlreadyTaken) {
+      navigate(`/datasets/${activeUser?.organization}/${form.getFieldValue(["dataset", "name"])}`);
+    }
   };
 
   const setEmptyTransformations = (config: DatasourceConfiguration) => {

--- a/unreleased_changes/9557.md
+++ b/unreleased_changes/9557.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fix fast importing / viewing remote datasets via /import?url=<url>.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- test locally and open http://localhost:9000/import?url=https://s3.janelia.org/lavis-lab/Dye_Bioavailability_images/Converted_OME-NGFF/JF608_Lung_20251024_Slide_23_of_2_Region_002_channels.zarr/
 
### Issues:
- partially fixes #9374


------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
