### PR TITLE
Fix double-click to rename tree/segment items/groups

### DIFF
--- a/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
@@ -315,7 +315,6 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
 type DispatchProps = ReturnType<typeof mapDispatchToProps>;
 type Props = DispatchProps & StateProps;
 type State = {
-  renamingCounter: number;
   groupTree: SegmentHierarchyNode[];
   searchableTreeItemList: SegmentHierarchyNode[];
   prevProps: Props | null | undefined;
@@ -356,8 +355,8 @@ const rootGroup = {
 class SegmentsView extends React.Component<Props, State> {
   intervalID: ReturnType<typeof setTimeout> | null | undefined;
   unmountBenchmarkListener: (() => void) | undefined;
+  renamingCounter: number = 0;
   state: State = {
-    renamingCounter: 0,
     groupTree: [],
     searchableTreeItemList: [],
     prevProps: null,
@@ -1267,11 +1266,11 @@ class SegmentsView extends React.Component<Props, State> {
   };
 
   onRenameStart = () => {
-    this.setState(({ renamingCounter }) => ({ renamingCounter: renamingCounter + 1 }));
+    this.renamingCounter += 1;
   };
 
   onRenameEnd = () => {
-    this.setState(({ renamingCounter }) => ({ renamingCounter: renamingCounter - 1 }));
+    this.renamingCounter -= 1;
   };
 
   maybeExpandParentGroup = (selectedElement: SegmentHierarchyNode) => {
@@ -1609,7 +1608,7 @@ class SegmentsView extends React.Component<Props, State> {
                                     // Forbid dragging when segments or groups are being renamed,
                                     // since selecting text within the editable input box would not work
                                     // otherwise (instead, the item would be dragged).
-                                    this.state.renamingCounter === 0 && this.props.allowUpdate,
+                                    this.renamingCounter === 0 && this.props.allowUpdate,
                                 }}
                                 multiple
                                 showLine

--- a/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
@@ -1270,7 +1270,7 @@ class SegmentsView extends React.Component<Props, State> {
   };
 
   onRenameEnd = () => {
-    this.renamingCounter -= 1;
+    this.renamingCounter = Math.max(0, this.renamingCounter - 1);
   };
 
   maybeExpandParentGroup = (selectedElement: SegmentHierarchyNode) => {

--- a/frontend/javascripts/viewer/view/right_border_tabs/trees_tab/tree_hierarchy_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/trees_tab/tree_hierarchy_view.tsx
@@ -57,9 +57,13 @@ function TreeHierarchyView(props: Props) {
   const [contextMenuPosition, setContextMenuPosition] = useState<[number, number] | null>(null);
   const [menu, setMenu] = useState<MenuProps | null>(null);
 
-  const [renamingCounter, setRenamingCounter] = useState(0);
-  const increaseRenamingCounter = () => setRenamingCounter((prev) => prev + 1);
-  const decreaseRenamingCounter = () => setRenamingCounter((prev) => Math.max(prev - 1, 0));
+  const renamingCounter = useRef(0);
+  const increaseRenamingCounter = () => {
+    renamingCounter.current += 1;
+  };
+  const decreaseRenamingCounter = () => {
+    renamingCounter.current = Math.max(renamingCounter.current - 1, 0);
+  };
 
   const treeRef = useRef<GetRef<typeof AntdTree>>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -263,7 +267,7 @@ function TreeHierarchyView(props: Props) {
   }
 
   function isNodeDraggable(node: TreeNode): boolean {
-    return props.allowUpdate && node.id !== MISSING_GROUP_ID && renamingCounter === 0;
+    return props.allowUpdate && node.id !== MISSING_GROUP_ID && renamingCounter.current === 0;
   }
 
   // checkedKeys includes all nodes with a "selected" checkbox

--- a/unreleased_changes/9558.md
+++ b/unreleased_changes/9558.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a regression that showed an error message when renaming a tree/segment item/group via double-click.


### PR DESCRIPTION
When doubleclicking on the title of a tree/segment item/group, a "renaming counter" is incremented (it's decremented after renaming). That counter is used to disable drag-and-drop while an item is renamed. Without that logic, one couldn't select text within the editable text box. However, the react state change somehow caused antd to react to a focus event (it's not totally clear to me where that comes from). That focus event is handled by scrolling to the active item which fails (probably because the content of the tree hierarchy item was swapped with the editable box).

This PR fixes the problem by switching react state to a ref and to a class state variable. Both don't cause a rerender (which isn't necessary as the renamingCounter is only accessed when DnD is checked).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create trees, segments and groups for both
- rename the items and also select text while renaming
- move items into other groups

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1777998153117479

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
