### PR TITLE
Fix proofreading crosshair not rendering correctly in YZ and XZ viewports

### DIFF
--- a/frontend/javascripts/viewer/shaders/segmentation.glsl.ts
+++ b/frontend/javascripts/viewer/shaders/segmentation.glsl.ts
@@ -345,7 +345,7 @@ export const getProofreadingCrossHairOverlay: ShaderModule = {
         return vec4(0.0);
       }
 
-      vec3 flooredGlobalPosUVW = transDim(floor(worldCoordUVW));
+      vec3 flooredGlobalPosUVW = floor(worldCoordUVW);
       vec3 activeSegmentPosUVW = transDim(proofreadingMarkerPosition);
 
       // Compute the anisotropy of the dataset so that the cross hair looks the same in

--- a/unreleased_changes/9560.md
+++ b/unreleased_changes/9560.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed the proofreading crosshair not rendering correctly in the YZ and XZ viewports (only XY was correct).


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Open a dataset with a volume annotation in proofreading mode
- Click a segment to set the proofreading marker position
- Verify the crosshair renders correctly in all three orthogonal viewports (XY, YZ, XZ)

### Problem

The proofreading crosshair (the white plus-sign marker rendered in the ortho viewports) only rendered correctly in the XY viewport. In YZ and XZ it either didn't appear at all or appeared at the wrong position.

### Root cause

`getProofreadingCrossHairOverlay` receives `worldCoordUVW`, which is already in viewport-local UVW space (the main shader calls `getWorldCoordUVW()` which internally applies `transDim` to permute from world XYZ to UVW). The function then applied `transDim` a second time:

```glsl
vec3 flooredGlobalPosUVW = transDim(floor(worldCoordUVW));  // BUG: double transDim
```

Since `transDim` is self-inverse, this double application sends the coordinate back to world XYZ space. The depth check then compared the wrong axis — e.g. for the YZ viewport it compared `worldZ` of the fragment against `markerX` of the marker instead of `worldX == markerX`.

For XY, `transDim` is identity so the double application was harmless, which is why XY worked.

This was introduced in **254d0946f6 "Allow rotating ortho view (#8614)"**, which replaced `globalPosition` (a raw world XYZ value, where `transDim` was correct) with `worldCoordUVW` (already in UVW space) but kept the `transDim` wrapper.

### Fix

Remove the erroneous `transDim` call since `worldCoordUVW` is already in UVW space:

```glsl
vec3 flooredGlobalPosUVW = floor(worldCoordUVW);
```

### TODOs:
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment