### PR TITLE
WIP check backend messages file integrity

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Assert no 'SELECT *'  are present in scala files
         run: tools/assert-no-select-asterisk-present.sh
       - name: Check backend messages for duplicates and unused keys
-        run: uv run tools/check_backend_messages.py
+        run: python3 tools/check_backend_messages.py
 
       - name: Lint backend code and check formatting
         run: sbt ";scapegoat; util/scapegoat; webknossosTracingstore/scapegoat; webknossosDatastore/scapegoat; scalafmtCheck; util/scalafmtCheck; webknossosTracingstore/scalafmtCheck; webknossosDatastore/scalafmtCheck"

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -98,7 +98,8 @@ jobs:
         run: tools/assert-complete-migrations.sh
       - name: Assert no 'SELECT *'  are present in scala files
         run: tools/assert-no-select-asterisk-present.sh
-
+      - name: Check backend messages for duplicates and unused keys
+        run: uv run tools/check_backend_messages.py
 
       - name: Lint backend code and check formatting
         run: sbt ";scapegoat; util/scapegoat; webknossosTracingstore/scapegoat; webknossosDatastore/scapegoat; scalafmtCheck; util/scalafmtCheck; webknossosTracingstore/scalafmtCheck; webknossosDatastore/scalafmtCheck"

--- a/conf/messages
+++ b/conf/messages
@@ -403,6 +403,7 @@ folder.move.root=Cannot move the organization’s root folder
 folder.move.self=Cannot move a folder into itself
 folder.update.notAllowed=No write access on this folder
 folder.noWriteAccess=No write access in this folder
+folder.noWriteAccess=This is a duplicate!
 folder.update.name.failed=Failed to update the folder’s name
 folder.update.teams.failed=Failed to update the folder’s allowed teams
 folder.create.failed.teams.failed=Failed to create folder in this location

--- a/tools/check_backend_messages.py
+++ b/tools/check_backend_messages.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Check conf/messages for duplicates and unused keys in Scala code."""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+MESSAGES_FILE = REPO_ROOT / "conf" / "messages"
+SCALA_DIRS = [
+    REPO_ROOT / "app",
+    REPO_ROOT / "util" / "src",
+    REPO_ROOT / "webknossos-datastore" / "app",
+    REPO_ROOT / "webknossos-tracingstore" / "app",
+]
+
+
+def main() -> None:
+    print(f"Hello from check_backend_messages! Checking {MESSAGES_FILE} against Scala sources...")
+
+    keys, duplicates = parse_messages(MESSAGES_FILE)
+
+    errors: list[str] = []
+
+    if duplicates:
+        errors.append(f"Duplicate keys in {MESSAGES_FILE.relative_to(REPO_ROOT)}:")
+        errors.extend(duplicates)
+
+    scala_text = collect_scala_text()
+    unused = find_unused_keys(keys, scala_text)
+
+    if unused:
+        errors.append(f"\nKeys defined in {MESSAGES_FILE.relative_to(REPO_ROOT)} but not used in Scala code:")
+        errors.extend(unused)
+
+    if errors:
+        print("\n".join(errors))
+        sys.exit(1)
+
+    print(f"All done! Checked {len(keys)} message keys.")
+
+
+def parse_messages(path: Path) -> tuple[dict[str, int], list[str]]:
+    """Return (key -> line_number, list_of_duplicate_keys)."""
+    keys: dict[str, int] = {}
+    duplicates: list[str] = []
+
+    for line_number, raw in enumerate(path.read_text().splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = re.match(r"^([A-Za-z][A-Za-z0-9_.]*)\s*=", line)
+        if match:
+            key = match.group(1)
+            if key in keys:
+                duplicates.append(f"  {key!r} (lines {keys[key]} and {line_number})")
+            else:
+                keys[key] = line_number
+
+    return keys, duplicates
+
+
+def collect_scala_text() -> str:
+    """Concatenate all Scala source files into one big string."""
+    parts: list[str] = []
+    for scala_dir in SCALA_DIRS:
+        if not scala_dir.exists():
+            continue
+        for path in scala_dir.rglob("*.scala"):
+            parts.append(path.read_text())
+    return "\n".join(parts)
+
+
+def find_unused_keys(keys: dict[str, int], scala_text: str) -> list[str]:
+    unused: list[str] = []
+    for key in keys:
+        # The key must appear as a quoted string literal somewhere in Scala code
+        if f'"{key}"' not in scala_text:
+            unused.append(f"L{keys[key]}: ‘{key}’ unused in Scala code.")
+    return unused
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_backend_messages.py
+++ b/tools/check_backend_messages.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Check conf/messages for duplicates and unused keys in Scala code."""
 
-import os
 import re
 import sys
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -18,6 +18,7 @@ SCALA_DIRS = [
 
 def main() -> None:
     print(f"Hello from check_backend_messages! Checking {MESSAGES_FILE} against Scala sources...")
+    t0 = time.monotonic()
 
     keys, duplicates = parse_messages(MESSAGES_FILE)
 
@@ -28,17 +29,27 @@ def main() -> None:
         errors.extend(duplicates)
 
     scala_text = collect_scala_text()
+    scala_lines = scala_text.count("\n")
     unused = find_unused_keys(keys, scala_text)
 
     if unused:
         errors.append(f"\nKeys defined in {MESSAGES_FILE.relative_to(REPO_ROOT)} but not used in Scala code:")
         errors.extend(unused)
 
+    undefined = find_undefined_references(keys, scala_text)
+
+    if undefined:
+        errors.append(f"\nKeys referenced in Scala code but not defined in {MESSAGES_FILE.relative_to(REPO_ROOT)}:")
+        errors.extend(sorted(undefined))
+
+    elapsed = time.monotonic() - t0
+
     if errors:
         print("\n".join(errors))
+        print(f"\nAll done with {len(errors)} errors. Checking {len(keys)} message keys against {scala_lines} Scala lines took {elapsed:.2f}s.")
         sys.exit(1)
 
-    print(f"All done! Checked {len(keys)} message keys.")
+    print(f"\nAll done with no errors! Checking {len(keys)} message keys against {scala_lines} Scala lines took {elapsed:.2f}s.")
 
 
 def parse_messages(path: Path) -> tuple[dict[str, int], list[str]]:
@@ -77,8 +88,23 @@ def find_unused_keys(keys: dict[str, int], scala_text: str) -> list[str]:
     for key in keys:
         # The key must appear as a quoted string literal somewhere in Scala code
         if f'"{key}"' not in scala_text:
-            unused.append(f"L{keys[key]}: ‘{key}’ unused in Scala code.")
+            unused.append(f"  ‘{key}’ (L{keys[key]})")
     return unused
+
+
+# Matches strings used as message keys: first arg of Messages(...) or right-hand side of ?~> / ?~!
+_SCALA_KEY_RE = re.compile(r'(?:Messages\(\s*|[?]\~[>!]\s*)"([a-z][a-zA-Z0-9_.]*)"')
+
+
+def find_undefined_references(keys: dict[str, int], scala_text: str) -> list[str]:
+    undefined: list[str] = []
+    seen: set[str] = set()
+    for match in _SCALA_KEY_RE.finditer(scala_text):
+        key = match.group(1)
+        if key not in keys and key not in seen:
+            undefined.append(f"  ‘{key}’")
+            seen.add(key)
+    return undefined
 
 
 if __name__ == "__main__":

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/ZarrMeshFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/ZarrMeshFileService.scala
@@ -197,7 +197,7 @@ class ZarrMeshFileService @Inject()(chunkCacheService: DSChunkCacheService, data
     def lookupOne(segmentId: Long): Fox[Option[List[MeshLodInfo]]] =
       listMeshChunksForSegment(meshFileKey, segmentId, meshFileAttributes).map(Some(_)).orElse(Fox.successful(None))
     if (meshFileKey.attachment.path.isRemote)
-      Fox.batchCombined(segmentIds.toSeq, parallelity = 32)(lookupOne).map(_.flatten)
+      Fox.batchCombined(segmentIds, parallelity = 32)(lookupOne).map(_.flatten)
     else
       Fox.serialCombined(segmentIds)(lookupOne).map(_.flatten)
   }


### PR DESCRIPTION


### Steps to test:
- Script should exit 1 and log useful output if the file is not right (compare run https://github.com/scalableminds/webknossos/actions/runs/25452966524/job/74674826817 )
- Script should exit 0 and CI be green if the file is right

### TODOs:
- [ ] Fix the actual messages usages...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
