### PR TITLE
Fix shortcuts when tree/segment list is focussed

### DIFF
--- a/frontend/javascripts/libs/input.ts
+++ b/frontend/javascripts/libs/input.ts
@@ -8,7 +8,7 @@ import noop from "lodash-es/noop";
 import { createNanoEvents, type Emitter } from "nanoevents";
 import type { Point2 } from "viewer/constants";
 import constants, { isMac } from "viewer/constants";
-import { addEventListenerWithDelegation, isNoElementFocused } from "./utils";
+import { addEventListenerWithDelegation, isNoEditableElementFocused } from "./utils";
 
 // This is the main Input implementation.
 // Although all keys, buttons and sensor are mapped in
@@ -164,7 +164,7 @@ export class InputKeyboardNoLoop {
           return;
         }
 
-        if (!this.supportInputElements && !isNoElementFocused()) {
+        if (!this.supportInputElements && !isNoEditableElementFocused()) {
           return;
         }
 
@@ -264,7 +264,7 @@ export class InputKeyboard {
           return;
         }
 
-        if (!this.supportInputElements && !isNoElementFocused()) {
+        if (!this.supportInputElements && !isNoEditableElementFocused()) {
           return;
         }
 

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -734,10 +734,23 @@ export function millisecondsToHours(ms: number) {
   return ms / oneHourInMilliseconds;
 }
 
-export function isNoElementFocused(): boolean {
-  // checks whether an <input> or <button> element has the focus
-  // when no element is focused <body> gets the focus
-  return document.activeElement === document.body;
+export function isNoEditableElementFocused(): boolean {
+  // Returns true if no "meaningful" element has focus — i.e. either document.body
+  // is active or the active element is not an interactive input element.
+  // This allows keyboard shortcuts to fire even when non-input elements (e.g. the
+  // tree hierarchy panel) have focus, while still suppressing them when the user
+  // is typing in an <input>, <textarea>, <button>, or contentEditable element.
+  const activeElement = document.activeElement;
+  if (activeElement == null || activeElement === document.body) {
+    return true;
+  }
+  const tag = (activeElement as HTMLElement).tagName?.toUpperCase();
+  return (
+    tag !== "INPUT" &&
+    tag !== "TEXTAREA" &&
+    tag !== "BUTTON" &&
+    !(activeElement as HTMLElement).isContentEditable
+  );
 }
 
 export function isEditableEventTarget(target: EventTarget | null): boolean {

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -744,7 +744,7 @@ export function isNoEditableElementFocused(): boolean {
   if (activeElement == null || activeElement === document.body) {
     return true;
   }
-  const tag = (activeElement as HTMLElement).tagName?.toUpperCase();
+  const tag = activeElement.tagName?.toUpperCase();
   return (
     tag !== "INPUT" &&
     tag !== "TEXTAREA" &&

--- a/frontend/javascripts/viewer/controller.tsx
+++ b/frontend/javascripts/viewer/controller.tsx
@@ -3,7 +3,7 @@ import BrainSpinner, { BrainSpinnerWithError, CoverWithLogin } from "components/
 import { fetchGistContent } from "libs/gist";
 import { InputKeyboardNoLoop } from "libs/input";
 import Toast from "libs/toast";
-import { getUrlParamValue, hasUrlParam, isNoElementFocused } from "libs/utils";
+import { getUrlParamValue, hasUrlParam, isNoEditableElementFocused } from "libs/utils";
 import window, { document } from "libs/window";
 import { type WithBlockerProps, withBlocker } from "libs/with_blocker_hoc";
 import { type RouteComponentProps, withRouter } from "libs/with_router_hoc";
@@ -212,8 +212,9 @@ class Controller extends PureComponent<PropsWithRouter, State> {
     // avoid scrolling while pressing space
     document.addEventListener("keydown", (event: KeyboardEvent) => {
       if (
+        // 32 → Spacebar, 18 → Alt key, 37–40 → Arrow keys
         (event.which === 32 || event.which === 18 || (event.which >= 37 && event.which <= 40)) &&
-        isNoElementFocused()
+        isNoEditableElementFocused()
       ) {
         event.preventDefault();
       }

--- a/frontend/javascripts/viewer/controller/viewmodes/plane_controller.tsx
+++ b/frontend/javascripts/viewer/controller/viewmodes/plane_controller.tsx
@@ -1,6 +1,6 @@
 import { InputKeyboard, InputKeyboardNoLoop, InputMouse, type MouseBindingMap } from "libs/input";
 import Toast from "libs/toast";
-import { isNoElementFocused, waitForElementWithId } from "libs/utils";
+import { isNoEditableElementFocused, waitForElementWithId } from "libs/utils";
 import { document } from "libs/window";
 import intersection from "lodash-es/intersection";
 import union from "lodash-es/union";
@@ -441,8 +441,9 @@ class PlaneController extends PureComponent<Props> {
 
     document.addEventListener("keydown", (event: KeyboardEvent) => {
       if (
+        // 32 → Spacebar, 18 → Alt key, 37–40 → Arrow keys
         (event.which === 32 || event.which === 18 || (event.which >= 37 && event.which <= 40)) &&
-        isNoElementFocused()
+        isNoEditableElementFocused()
       ) {
         event.preventDefault();
       }

--- a/unreleased_changes/9567.md
+++ b/unreleased_changes/9567.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that shortcuts weren't working when the tree/segment list is focussed.


### PR DESCRIPTION
Apparently, antd changed the focus handling of the tree component which is why shortcuts were blocked after selecting items in the sidebars.
Instead of blurring the focus after tree selection, I went for the more generic fix by allowing shortcuts even when HTML elements are focussed that are not editable (input, textarea etc). In some edge cases, that might lead to weird behavior (e.g., after selecting a tree in the sidebar, using the up/down-keys will cycle through the tree list AND move the active camera). However, these scenarios should be very rare and have a low impact. We can iterate on that when we find it to be unsuitable.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- create a tree (group), click on it in the sidebar
- hit c to create a new tree
- rename trees (should still work as usual)

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1778141689415299

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
