### PR TITLE
Preserve the name of the fallback layer when creating a new annotation

### DIFF
--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -267,7 +267,6 @@ class AnnotationService @Inject()(
                                                    existingAnnotationLayers = List.empty,
                                                    previousVersion = None)
           layerName = annotationLayerParameters.name.getOrElse(
-            //AnnotationLayer.defaultNameForType(annotationLayerParameters.typ)
             tracing match {
               case Left(_) => AnnotationLayer.defaultNameForType(annotationLayerParameters.typ)
               case Right(volume) =>

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -267,7 +267,13 @@ class AnnotationService @Inject()(
                                                    existingAnnotationLayers = List.empty,
                                                    previousVersion = None)
           layerName = annotationLayerParameters.name.getOrElse(
-            AnnotationLayer.defaultNameForType(annotationLayerParameters.typ))
+            //AnnotationLayer.defaultNameForType(annotationLayerParameters.typ)
+            tracing match {
+              case Left(_) => AnnotationLayer.defaultNameForType(annotationLayerParameters.typ)
+              case Right(volume) =>
+                volume.fallbackLayer.getOrElse(AnnotationLayer.defaultNameForType(annotationLayerParameters.typ))
+            }
+          )
           newTracingId = TracingId.generate
           _ <- tracing match {
             case Left(skeleton) => tracingStoreClient.saveSkeletonTracing(skeleton, newTracingId)

--- a/unreleased_changes/9571.md
+++ b/unreleased_changes/9571.md
@@ -1,0 +1,2 @@
+### Fixed
+- When creating a new annotation from the dataset table in the dashbaord, the volume annotation layer get the name of the fallback layer instead of always "Volume".


### PR DESCRIPTION
On master, currently, if the client does not specify an explicit name for the volume layer, it is simply named "Volume" instead of after the fallback layers name. This PR changes this behaviour in the backend and preserves the eventual exisiting fallback layer name. 
This could have also been fixed in the frontend but the backend kinda felt like the correct place as it enforces a "sensible fallback" for the volume layer name. Feel free to argue.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- Look for a dataset with a volume layer that is not called "Volume" in your dashboard.
- On master -> in the DS table click "New Anntotation" -> The volume layers name should be "Volume"
- on this branch -> in the DS table click "New Anntotation" -> The volume layers name should match the fallback layers name

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1778513914917669

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)

