### PR TITLE
Give DS Managers access to AI features instead of team managers

### DIFF
--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -6,7 +6,7 @@ import { Alert, Button, Dropdown, Modal, Popover, Space } from "antd";
 import { AsyncButton, type AsyncButtonProps } from "components/async_clickables";
 import { NewVolumeLayerSelection } from "dashboard/advanced_dataset/create_explorative_modal";
 import { useWkSelector } from "libs/react_hooks";
-import { isUserAdminOrTeamManager } from "libs/utils";
+import { isUserAdminOrDatasetManager } from "libs/utils";
 import { ArbitraryVectorInput } from "libs/vector_input";
 import type React from "react";
 import { Fragment, PureComponent, useState } from "react";
@@ -371,7 +371,7 @@ class ActionBarView extends PureComponent<Props, State> {
   render() {
     const { dataset, is2d, showVersionRestore, controlMode, layoutProps, viewMode, activeUser } =
       this.props;
-    const isAdminOrDatasetManager = activeUser && isUserAdminOrTeamManager(activeUser);
+    const isAdminOrDatasetManager = isUserAdminOrDatasetManager(activeUser);
     const isViewMode = controlMode === ControlModeEnum.VIEW;
     const getIsAIAnalysisEnabled = () => {
       const jobsEnabled =

--- a/unreleased_changes/9575.md
+++ b/unreleased_changes/9575.md
@@ -1,0 +1,2 @@
+### Changed
+- Enabled AI features for dataset managers and disabled them for members who are only team managers.


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- IMO testing is not necessary as I did this.
- Test locally and enable jobs
- Log in as a dataset manager only
- use AI features, should work
- log in as team manager only - ai features should not be available


### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1778512776650499

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
