### PR TITLE
WIP Fully async FossilDB calls via AsyncIterator

### DIFF
--- a/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
@@ -3,7 +3,7 @@ package com.scalableminds.util.io
 import java.io._
 import java.nio.file.{Files, Path}
 import java.util.zip.{GZIPOutputStream => DefaultGZIPOutputStream, _}
-import com.scalableminds.util.tools.{Fox, FoxImplicits, TextUtils}
+import com.scalableminds.util.tools.{AsyncIterator, Fox, FoxImplicits, TextUtils}
 import com.typesafe.scalalogging.LazyLogging
 import com.scalableminds.util.tools.{Box, Empty, Failure, Full}
 import com.scalableminds.util.tools.Box.tryo
@@ -86,6 +86,17 @@ object ZipIO extends LazyLogging with FoxImplicits {
     }
   }
 
+  def zip(sources: AsyncIterator[NamedStream], out: OutputStream, level: Int)(
+      implicit ec: ExecutionContext): Fox[Unit] = {
+    val zipOut = startZip(out)
+    if (level != -1) zipOut.stream.setLevel(level)
+    for {
+      _ <- zipAsyncIterator(sources, zipOut)
+      _ = zipOut.close()
+      _ = out.close()
+    } yield ()
+  }
+
   private def zipIterator(sources: Iterator[NamedStream], zip: OpenZip)(implicit ec: ExecutionContext): Fox[Unit] =
     if (!sources.hasNext) {
       Fox.successful(())
@@ -98,6 +109,17 @@ object ZipIO extends LazyLogging with FoxImplicits {
           logger.warn("Error packing zip: " + TextUtils.stackTraceAsString(e))
           throw new Exception(e.getMessage)
       }
+    }
+
+  private def zipAsyncIterator(sources: AsyncIterator[NamedStream], zip: OpenZip)(
+      implicit ec: ExecutionContext): Fox[Unit] =
+    sources.nextBatch().flatMap {
+      case Nil => Fox.successful(())
+      case batch =>
+        for {
+          _ <- Fox.serialCombined(batch)(s => zip.withFile(s.normalizedName)(s.writeTo))
+          _ <- zipAsyncIterator(sources, zip)
+        } yield ()
     }
 
   def startZip(out: OutputStream): OpenZip =

--- a/util/src/main/scala/com/scalableminds/util/tools/AsyncIterator.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/AsyncIterator.scala
@@ -1,0 +1,5 @@
+package com.scalableminds.util.tools
+
+trait AsyncIterator[+A] {
+  def nextBatch(): Fox[List[A]]
+}

--- a/util/src/main/scala/com/scalableminds/util/tools/Fox.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/Fox.scala
@@ -108,6 +108,20 @@ object Fox extends FoxImplicits {
     runNext(Nil)
   }
 
+  // Run serially over async batches, fail on the first failure
+  def serialCombined[A, B](it: AsyncIterator[A])(f: A => Fox[B])(implicit ec: ExecutionContext): Fox[List[B]] = {
+    def runNext(results: List[B]): Fox[List[B]] =
+      it.nextBatch().flatMap {
+        case Nil => Fox.successful(results.reverse)
+        case batch =>
+          for {
+            batchResults <- serialCombined(batch)(f)
+            allResults <- runNext(batchResults.reverse ::: results)
+          } yield allResults
+      }
+    runNext(Nil)
+  }
+
   // Run batches in parallel. Sequentially run the elements within each batch.
   def batchCombined[A, B](seq: Seq[A], parallelity: Int)(f: A => Fox[B])(implicit ec: ExecutionContext): Fox[List[B]] =
     if (parallelity <= 0)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -136,6 +136,28 @@ class FossilDBClient(collection: String,
       startAfterKey: Option[String],
       prefix: Option[String],
       version: Option[Long] = None,
+      limit: Option[Int] = None)(implicit fromByteArray: Array[Byte] => Box[T]): Fox[List[VersionedKeyValuePair[T]]] = {
+    def flatCombineTuples[A, B, C](keys: List[A], versions: List[B], values: List[Box[C]]) = {
+      val boxTuples: List[Box[(A, B, C)]] = keys.zip(versions).zip(values).map {
+        case ((k, v), Full(value)) => Full(k, v, value)
+        case _                     => Empty
+      }
+      boxTuples.flatten
+    }
+
+    for {
+      reply <- wrapException(stub.getMultipleKeys(GetMultipleKeysRequest(collection, startAfterKey, prefix, version, limit)))
+      _ <- assertSuccess(reply.success, reply.errorMessage)
+      parsedValues: List[Box[T]] = reply.values.map(v => fromByteArray(v.toByteArray)).toList
+    } yield flatCombineTuples(reply.keys.toList, reply.actualVersions.toList, parsedValues).map { t =>
+      VersionedKeyValuePair(VersionedKey(t._1, t._2), t._3)
+    }
+  }
+
+  def getMultipleKeysBlocking[T](
+      startAfterKey: Option[String],
+      prefix: Option[String],
+      version: Option[Long] = None,
       limit: Option[Int] = None)(implicit fromByteArray: Array[Byte] => Box[T]): List[VersionedKeyValuePair[T]] = {
     def flatCombineTuples[A, B, C](keys: List[A], versions: List[B], values: List[Box[C]]) = {
       val boxTuples: List[Box[(A, B, C)]] = keys.zip(versions).zip(values).map {
@@ -147,9 +169,7 @@ class FossilDBClient(collection: String,
 
     val reply = blockingStub.getMultipleKeys(GetMultipleKeysRequest(collection, startAfterKey, prefix, version, limit))
     if (!reply.success) throw new Exception(reply.errorMessage.getOrElse(""))
-    val parsedValues: List[Box[T]] = reply.values.map { v =>
-      fromByteArray(v.toByteArray)
-    }.toList
+    val parsedValues: List[Box[T]] = reply.values.map(v => fromByteArray(v.toByteArray)).toList
     flatCombineTuples(reply.keys.toList, reply.actualVersions.toList, parsedValues).map { t =>
       VersionedKeyValuePair(VersionedKey(t._1, t._2), t._3)
     }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -52,7 +52,6 @@ class FossilDBClient(collection: String,
   private val channel =
     NettyChannelBuilder.forAddress(address, port).maxInboundMessageSize(Int.MaxValue).usePlaintext.build
   private val stub = FossilDBGrpc.stub(channel)
-  private val blockingStub = FossilDBGrpc.blockingStub(channel)
   private val healthStub = HealthGrpc.newFutureStub(channel)
   lazy val authority: String = f"$address:$port"
 
@@ -150,27 +149,6 @@ class FossilDBClient(collection: String,
       _ <- assertSuccess(reply.success, reply.errorMessage)
       parsedValues: List[Box[T]] = reply.values.map(v => fromByteArray(v.toByteArray)).toList
     } yield flatCombineTuples(reply.keys.toList, reply.actualVersions.toList, parsedValues).map { t =>
-      VersionedKeyValuePair(VersionedKey(t._1, t._2), t._3)
-    }
-  }
-
-  def getMultipleKeysBlocking[T](
-      startAfterKey: Option[String],
-      prefix: Option[String],
-      version: Option[Long] = None,
-      limit: Option[Int] = None)(implicit fromByteArray: Array[Byte] => Box[T]): List[VersionedKeyValuePair[T]] = {
-    def flatCombineTuples[A, B, C](keys: List[A], versions: List[B], values: List[Box[C]]) = {
-      val boxTuples: List[Box[(A, B, C)]] = keys.zip(versions).zip(values).map {
-        case ((k, v), Full(value)) => Full(k, v, value)
-        case _                     => Empty
-      }
-      boxTuples.flatten
-    }
-
-    val reply = blockingStub.getMultipleKeys(GetMultipleKeysRequest(collection, startAfterKey, prefix, version, limit))
-    if (!reply.success) throw new Exception(reply.errorMessage.getOrElse(""))
-    val parsedValues: List[Box[T]] = reply.values.map(v => fromByteArray(v.toByteArray)).toList
-    flatCombineTuples(reply.keys.toList, reply.actualVersions.toList, parsedValues).map { t =>
       VersionedKeyValuePair(VersionedKey(t._1, t._2), t._3)
     }
   }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/FossilDBClient.scala
@@ -145,12 +145,14 @@ class FossilDBClient(collection: String,
     }
 
     for {
-      reply <- wrapException(stub.getMultipleKeys(GetMultipleKeysRequest(collection, startAfterKey, prefix, version, limit)))
+      reply <- wrapException(
+        stub.getMultipleKeys(GetMultipleKeysRequest(collection, startAfterKey, prefix, version, limit)))
       _ <- assertSuccess(reply.success, reply.errorMessage)
       parsedValues: List[Box[T]] = reply.values.map(v => fromByteArray(v.toByteArray)).toList
-    } yield flatCombineTuples(reply.keys.toList, reply.actualVersions.toList, parsedValues).map { t =>
-      VersionedKeyValuePair(VersionedKey(t._1, t._2), t._3)
-    }
+    } yield
+      flatCombineTuples(reply.keys.toList, reply.actualVersions.toList, parsedValues).map { t =>
+        VersionedKeyValuePair(VersionedKey(t._1, t._2), t._3)
+      }
   }
 
   def getMultipleKeysByList[T](keys: Seq[String], version: Option[Long], batchSize: Int = 1000)(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingStreams.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingStreams.scala
@@ -1,121 +1,60 @@
 package com.scalableminds.webknossos.tracingstore.tracings.editablemapping
 
+import com.scalableminds.util.tools.{AsyncIterator, Fox}
 import com.scalableminds.webknossos.datastore.AgglomerateGraph.AgglomerateGraph
 import com.scalableminds.webknossos.datastore.SegmentToAgglomerateProto.SegmentToAgglomerateChunkProto
 import com.scalableminds.webknossos.tracingstore.tracings.volume.ReversionHelper
-import com.scalableminds.webknossos.tracingstore.tracings.{
-  FossilDBClient,
-  KeyValueStoreImplicits,
-  VersionedKeyValuePair
-}
-import com.scalableminds.util.tools.Full
+import com.scalableminds.webknossos.tracingstore.tracings.{FossilDBClient, KeyValueStoreImplicits}
 
-import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
 
 class VersionedAgglomerateToGraphIterator(prefix: String,
                                           segmentToAgglomerateDataStore: FossilDBClient,
-                                          version: Option[Long] = None)
-    extends Iterator[(String, AgglomerateGraph, Long)]
+                                          version: Option[Long] = None)(implicit ec: ExecutionContext)
+    extends AsyncIterator[(String, AgglomerateGraph, Long)]
     with ReversionHelper
     with KeyValueStoreImplicits {
   private val batchSize = 64
-
   private var currentStartAfterKey: Option[String] = None
-  private var currentBatchIterator: Iterator[VersionedKeyValuePair[Array[Byte]]] = fetchNext
-  private var nextGraph: Option[VersionedKeyValuePair[AgglomerateGraph]] = None
 
-  private def fetchNext: Iterator[VersionedKeyValuePair[Array[Byte]]] =
-    segmentToAgglomerateDataStore.getMultipleKeys(currentStartAfterKey, Some(prefix), version, Some(batchSize)).iterator
-
-  private def fetchNextAndSave = {
-    currentBatchIterator = fetchNext
-    currentBatchIterator
-  }
-
-  @tailrec
-  private def getNextNonRevertedGraph: Option[VersionedKeyValuePair[AgglomerateGraph]] =
-    if (currentBatchIterator.hasNext) {
-      val chunk = currentBatchIterator.next()
-      currentStartAfterKey = Some(chunk.key)
-      val graphParsedBox = fromProtoBytes[AgglomerateGraph](chunk.value)
-      graphParsedBox match {
-        case _ if isRevertedElement(chunk.value) => getNextNonRevertedGraph
-        case Full(graphParsed)                   => Some(VersionedKeyValuePair(versionedKey = chunk.versionedKey, value = graphParsed))
-        case _                                   => getNextNonRevertedGraph
+  override def nextBatch(): Fox[List[(String, AgglomerateGraph, Long)]] =
+    segmentToAgglomerateDataStore
+      .getMultipleKeys[Array[Byte]](currentStartAfterKey, Some(prefix), version, Some(batchSize))
+      .flatMap { rawBatch =>
+        if (rawBatch.isEmpty) Fox.successful(Nil)
+        else {
+          currentStartAfterKey = rawBatch.lastOption.map(_.key)
+          val parsed = rawBatch.filterNot(item => isRevertedElement(item.value)).flatMap { item =>
+            fromProtoBytes[AgglomerateGraph](item.value).toOption.map(graph => (item.key, graph, item.version))
+          }
+          if (parsed.nonEmpty) Fox.successful(parsed)
+          else nextBatch()
+        }
       }
-    } else {
-      if (!fetchNextAndSave.hasNext) None
-      else getNextNonRevertedGraph
-    }
-
-  override def hasNext: Boolean =
-    if (nextGraph.isDefined) true
-    else {
-      nextGraph = getNextNonRevertedGraph
-      nextGraph.isDefined
-    }
-
-  override def next(): (String, AgglomerateGraph, Long) = {
-    val nextRes = nextGraph match {
-      case Some(bucket) => bucket
-      case None         => getNextNonRevertedGraph.getOrElse(throw new NoSuchElementException())
-    }
-    nextGraph = None
-    (nextRes.key, nextRes.value, nextRes.version)
-  }
-
 }
 
 class VersionedSegmentToAgglomerateChunkIterator(prefix: String,
                                                  segmentToAgglomerateDataStore: FossilDBClient,
-                                                 version: Option[Long] = None)
-    extends Iterator[(String, SegmentToAgglomerateChunkProto, Long)]
+                                                 version: Option[Long] = None)(implicit ec: ExecutionContext)
+    extends AsyncIterator[(String, SegmentToAgglomerateChunkProto, Long)]
     with ReversionHelper
     with KeyValueStoreImplicits {
   private val batchSize = 64
-
   private var currentStartAfterKey: Option[String] = None
-  private var currentBatchIterator: Iterator[VersionedKeyValuePair[Array[Byte]]] = fetchNext
-  private var nextChunk: Option[VersionedKeyValuePair[SegmentToAgglomerateChunkProto]] = None
 
-  private def fetchNext: Iterator[VersionedKeyValuePair[Array[Byte]]] =
-    segmentToAgglomerateDataStore.getMultipleKeys(currentStartAfterKey, Some(prefix), version, Some(batchSize)).iterator
-
-  private def fetchNextAndSave = {
-    currentBatchIterator = fetchNext
-    currentBatchIterator
-  }
-
-  @tailrec
-  private def getNextNonRevertedChunk: Option[VersionedKeyValuePair[SegmentToAgglomerateChunkProto]] =
-    if (currentBatchIterator.hasNext) {
-      val chunk = currentBatchIterator.next()
-      currentStartAfterKey = Some(chunk.key)
-      val chunkParsedBox = fromProtoBytes[SegmentToAgglomerateChunkProto](chunk.value)
-      chunkParsedBox match {
-        case _ if isRevertedElement(chunk.value) => getNextNonRevertedChunk
-        case Full(chunkParsed)                   => Some(VersionedKeyValuePair(versionedKey = chunk.versionedKey, value = chunkParsed))
-        case _                                   => getNextNonRevertedChunk
+  override def nextBatch(): Fox[List[(String, SegmentToAgglomerateChunkProto, Long)]] =
+    segmentToAgglomerateDataStore
+      .getMultipleKeys[Array[Byte]](currentStartAfterKey, Some(prefix), version, Some(batchSize))
+      .flatMap { rawBatch =>
+        if (rawBatch.isEmpty) Fox.successful(Nil)
+        else {
+          currentStartAfterKey = rawBatch.lastOption.map(_.key)
+          val parsed = rawBatch.filterNot(item => isRevertedElement(item.value)).flatMap { item =>
+            fromProtoBytes[SegmentToAgglomerateChunkProto](item.value).toOption.map(chunk =>
+              (item.key, chunk, item.version))
+          }
+          if (parsed.nonEmpty) Fox.successful(parsed)
+          else nextBatch()
+        }
       }
-    } else {
-      if (!fetchNextAndSave.hasNext) None
-      else getNextNonRevertedChunk
-    }
-
-  override def hasNext: Boolean =
-    if (nextChunk.isDefined) true
-    else {
-      nextChunk = getNextNonRevertedChunk
-      nextChunk.isDefined
-    }
-
-  override def next(): (String, SegmentToAgglomerateChunkProto, Long) = {
-    val nextRes = nextChunk match {
-      case Some(bucket) => bucket
-      case None         => getNextNonRevertedChunk.getOrElse(throw new NoSuchElementException())
-    }
-    nextChunk = None
-    (nextRes.key, nextRes.value, nextRes.version)
-  }
-
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/VersionedFossilDbIterator.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/VersionedFossilDbIterator.scala
@@ -1,59 +1,18 @@
 package com.scalableminds.webknossos.tracingstore.tracings.editablemapping
 
-import com.scalableminds.util.tools.FoxImplicits
-import com.scalableminds.webknossos.tracingstore.tracings.{
-  FossilDBClient,
-  KeyValueStoreImplicits,
-  VersionedKeyValuePair
-}
-import com.typesafe.scalalogging.LazyLogging
-
-import scala.annotation.tailrec
+import com.scalableminds.util.tools.{AsyncIterator, Fox}
+import com.scalableminds.webknossos.tracingstore.tracings.{FossilDBClient, KeyValueStoreImplicits, VersionedKeyValuePair}
 
 class VersionedFossilDbIterator(prefix: String, fossilDbClient: FossilDBClient, version: Option[Long] = None)
-    extends Iterator[VersionedKeyValuePair[Array[Byte]]]
-    with KeyValueStoreImplicits
-    with LazyLogging
-    with FoxImplicits {
+    extends AsyncIterator[VersionedKeyValuePair[Array[Byte]]]
+    with KeyValueStoreImplicits {
   private val batchSize = 64
-
   private var currentStartAfterKey: Option[String] = None
-  private var currentBatchIterator: Iterator[VersionedKeyValuePair[Array[Byte]]] = fetchNext()
-  private var nextKeyValuePair: Option[VersionedKeyValuePair[Array[Byte]]] = None
 
-  private def fetchNext() =
-    fossilDbClient.getMultipleKeys(currentStartAfterKey, Some(prefix), version, Some(batchSize)).iterator
-
-  private def fetchNextAndSave = {
-    currentBatchIterator = fetchNext()
-    currentBatchIterator
-  }
-
-  @tailrec
-  private def getNextKeyValuePair: Option[VersionedKeyValuePair[Array[Byte]]] =
-    if (currentBatchIterator.hasNext) {
-      val keyValuePair = currentBatchIterator.next()
-      currentStartAfterKey = Some(keyValuePair.key)
-      Some(keyValuePair)
-    } else {
-      if (!fetchNextAndSave.hasNext) None
-      else getNextKeyValuePair
+  override def nextBatch(): Fox[List[VersionedKeyValuePair[Array[Byte]]]] =
+    fossilDbClient.getMultipleKeys[Array[Byte]](currentStartAfterKey, Some(prefix), version, Some(batchSize)).map {
+      batch =>
+        currentStartAfterKey = batch.lastOption.map(_.key)
+        batch
     }
-
-  override def hasNext: Boolean =
-    if (nextKeyValuePair.isDefined) true
-    else {
-      nextKeyValuePair = getNextKeyValuePair
-      nextKeyValuePair.isDefined
-    }
-
-  override def next(): VersionedKeyValuePair[Array[Byte]] = {
-    val nextRes = nextKeyValuePair match {
-      case Some(value) => value
-      case None        => getNextKeyValuePair.getOrElse(throw new NoSuchElementException())
-    }
-    nextKeyValuePair = None
-    nextRes
-  }
-
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/VersionedFossilDbIterator.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/VersionedFossilDbIterator.scala
@@ -1,7 +1,11 @@
 package com.scalableminds.webknossos.tracingstore.tracings.editablemapping
 
 import com.scalableminds.util.tools.{AsyncIterator, Fox}
-import com.scalableminds.webknossos.tracingstore.tracings.{FossilDBClient, KeyValueStoreImplicits, VersionedKeyValuePair}
+import com.scalableminds.webknossos.tracingstore.tracings.{
+  FossilDBClient,
+  KeyValueStoreImplicits,
+  VersionedKeyValuePair
+}
 
 class VersionedFossilDbIterator(prefix: String, fossilDbClient: FossilDBClient, version: Option[Long] = None)
     extends AsyncIterator[VersionedKeyValuePair[Array[Byte]]]

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/MergedVolume.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/MergedVolume.scala
@@ -55,8 +55,8 @@ class MergedVolume(elementClass: ElementClassProto, initialLargestSegmentId: Lon
     } yield ()
   }
 
-  def addIdSetFromBucketStream(bucketStream: AsyncIterator[(BucketPosition, Array[Byte])],
-                               allowedMags: Set[Vec3Int])(implicit ec: ExecutionContext): Fox[Unit] = {
+  def addIdSetFromBucketStream(bucketStream: AsyncIterator[(BucketPosition, Array[Byte])], allowedMags: Set[Vec3Int])(
+      implicit ec: ExecutionContext): Fox[Unit] = {
     val idSet: mutable.Set[Long] = scala.collection.mutable.Set()
     for {
       _ <- Fox.serialCombined(bucketStream) {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/MergedVolume.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/MergedVolume.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.tracingstore.tracings.volume
 
 import java.io.File
 import com.scalableminds.util.geometry.Vec3Int
-import com.scalableminds.util.tools.{ByteUtils, Fox}
+import com.scalableminds.util.tools.{AsyncIterator, ByteUtils, Fox}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing.ElementClassProto
 import com.scalableminds.webknossos.datastore.geometry.Vec3IntProto
@@ -55,18 +55,20 @@ class MergedVolume(elementClass: ElementClassProto, initialLargestSegmentId: Lon
     } yield ()
   }
 
-  def addIdSetFromBucketStream(bucketStream: Iterator[(BucketPosition, Array[Byte])],
-                               allowedMags: Set[Vec3Int]): Unit = {
+  def addIdSetFromBucketStream(bucketStream: AsyncIterator[(BucketPosition, Array[Byte])],
+                               allowedMags: Set[Vec3Int])(implicit ec: ExecutionContext): Fox[Unit] = {
     val idSet: mutable.Set[Long] = scala.collection.mutable.Set()
-    bucketStream.foreach {
-      case (bucketPosition, data) =>
-        if (allowedMags.contains(bucketPosition.mag)) {
-          val bucketSegmentIds =
-            bucketScanner.collectSegmentIds(data, bytesPerElement, elementsAreSigned, skipZeroes = true)
-          idSet ++= bucketSegmentIds
-        }
-    }
-    addIdSet(idSet)
+    for {
+      _ <- Fox.serialCombined(bucketStream) {
+        case (bucketPosition, data) =>
+          if (allowedMags.contains(bucketPosition.mag)) {
+            val bucketSegmentIds =
+              bucketScanner.collectSegmentIds(data, bytesPerElement, elementsAreSigned, skipZeroes = true)
+            Fox.successful(idSet ++= bucketSegmentIds)
+          } else Fox.successful(())
+      }
+      _ = addIdSet(idSet)
+    } yield ()
   }
 
   private def addIdSet(idSet: mutable.Set[Long]): Unit = idSets += idSet
@@ -94,14 +96,16 @@ class MergedVolume(elementClass: ElementClassProto, initialLargestSegmentId: Lon
     }
 
   def addFromBucketStream(sourceVolumeIndex: Int,
-                          bucketStream: Iterator[(BucketPosition, Array[Byte])],
-                          allowedMags: Option[Set[Vec3Int]] = None): Unit =
-    bucketStream.foreach {
-      case (bucketPosition, bytes) =>
-        if (!isAllZero(bytes) && allowedMags.forall(_.contains(bucketPosition.mag))) {
-          add(sourceVolumeIndex, bucketPosition, bytes)
-        }
-    }
+                          bucketStream: AsyncIterator[(BucketPosition, Array[Byte])],
+                          allowedMags: Option[Set[Vec3Int]] = None)(implicit ec: ExecutionContext): Fox[Unit] =
+    for {
+      _ <- Fox.serialCombined(bucketStream) {
+        case (bucketPosition, bytes) =>
+          if (!isAllZero(bytes) && allowedMags.forall(_.contains(bucketPosition.mag))) {
+            Fox.successful(add(sourceVolumeIndex, bucketPosition, bytes))
+          } else Fox.successful(())
+      }
+    } yield ()
 
   def addFromDataZip(sourceVolumeIndex: Int, zipFile: File)(implicit ec: ExecutionContext): Fox[Unit] =
     withBucketsFromZip(zipFile) { (bucketPosition, bytes) =>

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -357,13 +357,18 @@ trait VolumeTracingBucketHelper
     }
   }
 
-  def bucketStream(volumeLayer: VolumeTracingLayer, version: Option[Long]): Iterator[(BucketPosition, Array[Byte])] = {
+  def bucketStream(volumeLayer: VolumeTracingLayer, version: Option[Long]): AsyncIterator[(BucketPosition, Array[Byte])] = {
     val keyPrefix = buildKeyPrefix(volumeLayer.name)
-    new BucketIterator(keyPrefix,
-                       volumeDataStore,
-                       volumeLayer.expectedUncompressedBucketSize,
-                       version,
-                       volumeLayer.additionalAxes)
+    val versionedIter =
+      new VersionedBucketIterator(keyPrefix,
+                                  volumeDataStore,
+                                  volumeLayer.expectedUncompressedBucketSize,
+                                  version,
+                                  volumeLayer.additionalAxes)
+    new AsyncIterator[(BucketPosition, Array[Byte])] {
+      override def nextBatch(): Fox[List[(BucketPosition, Array[Byte])]] =
+        versionedIter.nextBatch().map(_.map { case (pos, data, _) => (pos, data) })
+    }
   }
 
   def bucketStreamWithVersion(volumeLayer: VolumeTracingLayer,
@@ -376,13 +381,18 @@ trait VolumeTracingBucketHelper
                                 volumeLayer.additionalAxes)
   }
 
-  def bucketStreamFromTemporaryStore(volumeLayer: VolumeTracingLayer): Iterator[(BucketPosition, Array[Byte])] = {
+  def bucketStreamFromTemporaryStore(volumeLayer: VolumeTracingLayer): AsyncIterator[(BucketPosition, Array[Byte])] = {
     val keyPrefix = buildKeyPrefix(volumeLayer.name)
-    val keyValuePairs = temporaryTracingService.getAllVolumeBucketsWithPrefix(keyPrefix)
-    keyValuePairs.flatMap {
+    val items = temporaryTracingService.getAllVolumeBucketsWithPrefix(keyPrefix).flatMap {
       case (bucketKey, data) =>
         parseBucketKey(bucketKey, volumeLayer.additionalAxes).map(tuple => (tuple._2, data))
-    }.iterator
+    }.toList
+    new AsyncIterator[(BucketPosition, Array[Byte])] {
+      private var emitted = false
+      override def nextBatch(): Fox[List[(BucketPosition, Array[Byte])]] =
+        if (!emitted) { emitted = true; Fox.successful(items) }
+        else Fox.successful(Nil)
+    }
   }
 }
 
@@ -420,64 +430,3 @@ class VersionedBucketIterator(prefix: String,
     }
 }
 
-class BucketIterator(prefix: String,
-                     volumeDataStore: FossilDBClient,
-                     expectedUncompressedBucketSize: Int,
-                     version: Option[Long] = None,
-                     additionalAxes: Option[Seq[AdditionalAxis]])
-    extends Iterator[(BucketPosition, Array[Byte])]
-    with KeyValueStoreImplicits
-    with VolumeBucketCompression
-    with BucketKeys
-    with ReversionHelper {
-  private val batchSize = 100
-
-  private var currentStartAfterKey: Option[String] = None
-  private var currentBatchIterator: Iterator[VersionedKeyValuePair[Array[Byte]]] = fetchNext
-  private var nextBucketRaw: Option[VersionedKeyValuePair[Array[Byte]]] = None
-
-  private def fetchNext: Iterator[VersionedKeyValuePair[Array[Byte]]] =
-    volumeDataStore.getMultipleKeysBlocking[Array[Byte]](currentStartAfterKey, Some(prefix), version, Some(batchSize)).iterator
-
-  private def fetchNextAndSave: Iterator[VersionedKeyValuePair[Array[Byte]]] = {
-    currentBatchIterator = fetchNext
-    currentBatchIterator
-  }
-
-  @tailrec
-  private def getNextNonRevertedBucket: Option[VersionedKeyValuePair[Array[Byte]]] =
-    if (currentBatchIterator.hasNext) {
-      val bucket = currentBatchIterator.next()
-      currentStartAfterKey = Some(bucket.key)
-      if (isRevertedElement(bucket) || parseBucketKey(bucket.key, additionalAxes).isEmpty)
-        getNextNonRevertedBucket
-      else
-        Some(bucket)
-    } else {
-      if (!fetchNextAndSave.hasNext) None
-      else getNextNonRevertedBucket
-    }
-
-  override def hasNext: Boolean =
-    if (nextBucketRaw.isDefined) true
-    else {
-      nextBucketRaw = getNextNonRevertedBucket
-      nextBucketRaw.isDefined
-    }
-
-  override def next(): (BucketPosition, Array[Byte]) = {
-    val bucket = nextBucketRaw match {
-      case Some(b) => b
-      case None    => getNextNonRevertedBucket.getOrElse(throw new NoSuchElementException())
-    }
-    nextBucketRaw = None
-    parseBucketKey(bucket.key, additionalAxes)
-      .map {
-        case (_, pos) =>
-          val debugInfo = s"key: ${bucket.key}, ${bucket.value.length} bytes, version ${bucket.version}"
-          (pos, decompressIfNeeded(bucket.value, expectedUncompressedBucketSize, debugInfo))
-      }
-      .getOrElse(
-        throw new IllegalStateException(s"parseBucketKey returned None for key ${bucket.key} despite prior filtering"))
-  }
-}

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -357,7 +357,8 @@ trait VolumeTracingBucketHelper
     }
   }
 
-  def bucketStream(volumeLayer: VolumeTracingLayer, version: Option[Long]): AsyncIterator[(BucketPosition, Array[Byte])] = {
+  def bucketStream(volumeLayer: VolumeTracingLayer,
+                   version: Option[Long]): AsyncIterator[(BucketPosition, Array[Byte])] = {
     val keyPrefix = buildKeyPrefix(volumeLayer.name)
     val versionedIter =
       new VersionedBucketIterator(keyPrefix,
@@ -383,15 +384,17 @@ trait VolumeTracingBucketHelper
 
   def bucketStreamFromTemporaryStore(volumeLayer: VolumeTracingLayer): AsyncIterator[(BucketPosition, Array[Byte])] = {
     val keyPrefix = buildKeyPrefix(volumeLayer.name)
-    val items = temporaryTracingService.getAllVolumeBucketsWithPrefix(keyPrefix).flatMap {
-      case (bucketKey, data) =>
-        parseBucketKey(bucketKey, volumeLayer.additionalAxes).map(tuple => (tuple._2, data))
-    }.toList
+    val items = temporaryTracingService
+      .getAllVolumeBucketsWithPrefix(keyPrefix)
+      .flatMap {
+        case (bucketKey, data) =>
+          parseBucketKey(bucketKey, volumeLayer.additionalAxes).map(tuple => (tuple._2, data))
+      }
+      .toList
     new AsyncIterator[(BucketPosition, Array[Byte])] {
       private var emitted = false
       override def nextBatch(): Fox[List[(BucketPosition, Array[Byte])]] =
-        if (!emitted) { emitted = true; Fox.successful(items) }
-        else Fox.successful(Nil)
+        if (!emitted) { emitted = true; Fox.successful(items) } else Fox.successful(Nil)
     }
   }
 }
@@ -415,18 +418,15 @@ class VersionedBucketIterator(prefix: String,
         if (rawBatch.isEmpty) Fox.successful(Nil)
         else {
           currentStartAfterKey = rawBatch.lastOption.map(_.key)
-          val parsed = rawBatch
-            .filterNot(isRevertedElement)
-            .flatMap { bucket =>
-              parseBucketKey(bucket.key, additionalAxes).map {
-                case (_, pos) =>
-                  val debugInfo = s"key: ${bucket.key}, ${bucket.value.length} bytes, version ${bucket.version}"
-                  (pos, decompressIfNeeded(bucket.value, expectedUncompressedBucketSize, debugInfo), bucket.version)
-              }
+          val parsed = rawBatch.filterNot(isRevertedElement).flatMap { bucket =>
+            parseBucketKey(bucket.key, additionalAxes).map {
+              case (_, pos) =>
+                val debugInfo = s"key: ${bucket.key}, ${bucket.value.length} bytes, version ${bucket.version}"
+                (pos, decompressIfNeeded(bucket.value, expectedUncompressedBucketSize, debugInfo), bucket.version)
             }
+          }
           if (parsed.nonEmpty) Fox.successful(parsed)
           else nextBatch()
         }
     }
 }
-

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.tracingstore.tracings.volume
 
 import com.scalableminds.util.geometry.Vec3Int
-import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import com.scalableminds.util.tools.{AsyncIterator, Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.dataformats.wkw.WKWDataFormatHelper
 import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, DataLayer}
 import com.scalableminds.webknossos.datastore.models.{AdditionalCoordinate, BucketPosition, WebknossosDataRequest}
@@ -367,7 +367,7 @@ trait VolumeTracingBucketHelper
   }
 
   def bucketStreamWithVersion(volumeLayer: VolumeTracingLayer,
-                              version: Option[Long]): Iterator[(BucketPosition, Array[Byte], Long)] = {
+                              version: Option[Long]): AsyncIterator[(BucketPosition, Array[Byte], Long)] = {
     val keyPrefix = buildKeyPrefix(volumeLayer.name)
     new VersionedBucketIterator(keyPrefix,
                                 volumeDataStore,
@@ -390,23 +390,56 @@ class VersionedBucketIterator(prefix: String,
                               volumeDataStore: FossilDBClient,
                               expectedUncompressedBucketSize: Int,
                               version: Option[Long] = None,
-                              additionalAxes: Option[Seq[AdditionalAxis]])
-    extends Iterator[(BucketPosition, Array[Byte], Long)]
+                              additionalAxes: Option[Seq[AdditionalAxis]])(implicit ec: ExecutionContext)
+    extends AsyncIterator[(BucketPosition, Array[Byte], Long)]
     with KeyValueStoreImplicits
     with VolumeBucketCompression
     with BucketKeys
-    with FoxImplicits
+    with ReversionHelper {
+  private val batchSize = 100
+  private var currentStartAfterKey: Option[String] = None
+
+  override def nextBatch(): Fox[List[(BucketPosition, Array[Byte], Long)]] =
+    volumeDataStore.getMultipleKeys[Array[Byte]](currentStartAfterKey, Some(prefix), version, Some(batchSize)).flatMap {
+      rawBatch =>
+        if (rawBatch.isEmpty) Fox.successful(Nil)
+        else {
+          currentStartAfterKey = rawBatch.lastOption.map(_.key)
+          val parsed = rawBatch
+            .filterNot(isRevertedElement)
+            .flatMap { bucket =>
+              parseBucketKey(bucket.key, additionalAxes).map {
+                case (_, pos) =>
+                  val debugInfo = s"key: ${bucket.key}, ${bucket.value.length} bytes, version ${bucket.version}"
+                  (pos, decompressIfNeeded(bucket.value, expectedUncompressedBucketSize, debugInfo), bucket.version)
+              }
+            }
+          if (parsed.nonEmpty) Fox.successful(parsed)
+          else nextBatch()
+        }
+    }
+}
+
+class BucketIterator(prefix: String,
+                     volumeDataStore: FossilDBClient,
+                     expectedUncompressedBucketSize: Int,
+                     version: Option[Long] = None,
+                     additionalAxes: Option[Seq[AdditionalAxis]])
+    extends Iterator[(BucketPosition, Array[Byte])]
+    with KeyValueStoreImplicits
+    with VolumeBucketCompression
+    with BucketKeys
     with ReversionHelper {
   private val batchSize = 100
 
   private var currentStartAfterKey: Option[String] = None
   private var currentBatchIterator: Iterator[VersionedKeyValuePair[Array[Byte]]] = fetchNext
-  private var nextBucket: Option[VersionedKeyValuePair[Array[Byte]]] = None
+  private var nextBucketRaw: Option[VersionedKeyValuePair[Array[Byte]]] = None
 
-  private def fetchNext =
-    volumeDataStore.getMultipleKeys(currentStartAfterKey, Some(prefix), version, Some(batchSize)).iterator
+  private def fetchNext: Iterator[VersionedKeyValuePair[Array[Byte]]] =
+    volumeDataStore.getMultipleKeysBlocking[Array[Byte]](currentStartAfterKey, Some(prefix), version, Some(batchSize)).iterator
 
-  private def fetchNextAndSave = {
+  private def fetchNextAndSave: Iterator[VersionedKeyValuePair[Array[Byte]]] = {
     currentBatchIterator = fetchNext
     currentBatchIterator
   }
@@ -416,53 +449,35 @@ class VersionedBucketIterator(prefix: String,
     if (currentBatchIterator.hasNext) {
       val bucket = currentBatchIterator.next()
       currentStartAfterKey = Some(bucket.key)
-      if (isRevertedElement(bucket) || parseBucketKey(bucket.key, additionalAxes).isEmpty) {
+      if (isRevertedElement(bucket) || parseBucketKey(bucket.key, additionalAxes).isEmpty)
         getNextNonRevertedBucket
-      } else {
+      else
         Some(bucket)
-      }
     } else {
       if (!fetchNextAndSave.hasNext) None
       else getNextNonRevertedBucket
     }
 
   override def hasNext: Boolean =
-    if (nextBucket.isDefined) true
+    if (nextBucketRaw.isDefined) true
     else {
-      nextBucket = getNextNonRevertedBucket
-      nextBucket.isDefined
+      nextBucketRaw = getNextNonRevertedBucket
+      nextBucketRaw.isDefined
     }
-
-  override def next(): (BucketPosition, Array[Byte], Long) = {
-    val nextRes = nextBucket match {
-      case Some(bucket) => bucket
-      case None         => getNextNonRevertedBucket.getOrElse(throw new NoSuchElementException())
-    }
-    nextBucket = None
-    parseBucketKey(nextRes.key, additionalAxes)
-      .map(key => {
-        val debugInfo = s"key: ${nextRes.key}, ${nextRes.value.length} bytes, version ${nextRes.version}"
-        (key._2, decompressIfNeeded(nextRes.value, expectedUncompressedBucketSize, debugInfo), nextRes.version)
-      })
-      .getOrElse(
-        throw new IllegalStateException(s"parseBucketKey returned None for key ${nextRes.key} despite prior filtering"))
-  }
-
-}
-
-class BucketIterator(prefix: String,
-                     volumeDataStore: FossilDBClient,
-                     expectedUncompressedBucketSize: Int,
-                     version: Option[Long] = None,
-                     additionalAxes: Option[Seq[AdditionalAxis]])
-    extends Iterator[(BucketPosition, Array[Byte])] {
-  private val versionedBucketIterator =
-    new VersionedBucketIterator(prefix, volumeDataStore, expectedUncompressedBucketSize, version, additionalAxes)
 
   override def next(): (BucketPosition, Array[Byte]) = {
-    val tuple = versionedBucketIterator.next()
-    (tuple._1, tuple._2)
+    val bucket = nextBucketRaw match {
+      case Some(b) => b
+      case None    => getNextNonRevertedBucket.getOrElse(throw new NoSuchElementException())
+    }
+    nextBucketRaw = None
+    parseBucketKey(bucket.key, additionalAxes)
+      .map {
+        case (_, pos) =>
+          val debugInfo = s"key: ${bucket.key}, ${bucket.value.length} bytes, version ${bucket.version}"
+          (pos, decompressIfNeeded(bucket.value, expectedUncompressedBucketSize, debugInfo))
+      }
+      .getOrElse(
+        throw new IllegalStateException(s"parseBucketKey returned None for key ${bucket.key} despite prior filtering"))
   }
-
-  override def hasNext: Boolean = versionedBucketIterator.hasNext
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -11,7 +11,6 @@ import net.jpountz.lz4.{LZ4Compressor, LZ4Factory, LZ4FastDecompressor}
 import com.scalableminds.util.tools.Box.tryo
 import com.scalableminds.util.tools.{Box, Empty, Failure, Full}
 
-import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
@@ -51,7 +51,8 @@ class VolumeTracingBucketProvider(layer: VolumeTracingLayer)(implicit val ec: Ex
   override def bucketStream(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte])] =
     bucketStream(layer, version)
 
-  override def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
+  override def bucketStreamWithVersion(
+      version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
     bucketStreamWithVersion(layer, version)
 }
 
@@ -71,7 +72,8 @@ class TemporaryVolumeTracingBucketProvider(layer: VolumeTracingLayer)(implicit v
   override def bucketStream(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte])] =
     bucketStreamFromTemporaryStore(layer)
 
-  override def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
+  override def bucketStreamWithVersion(
+      version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
     throw new UnsupportedOperationException // Temporary Volume Tracings do not support versioning
 }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
@@ -23,7 +23,7 @@ trait AbstractVolumeTracingBucketProvider extends BucketProvider with VolumeTrac
 
   def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)]
 
-  def bucketStream(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte])]
+  def bucketStream(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte])]
 }
 
 class VolumeTracingBucketProvider(layer: VolumeTracingLayer)(implicit val ec: ExecutionContext)
@@ -48,7 +48,7 @@ class VolumeTracingBucketProvider(layer: VolumeTracingLayer)(implicit val ec: Ex
       } yield bucketBoxes
     }
 
-  override def bucketStream(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte])] =
+  override def bucketStream(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte])] =
     bucketStream(layer, version)
 
   override def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
@@ -68,7 +68,7 @@ class TemporaryVolumeTracingBucketProvider(layer: VolumeTracingLayer)(implicit v
       data <- loadBucket(layer, readInstruction.bucket, readInstruction.version)
     } yield data
 
-  override def bucketStream(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte])] =
+  override def bucketStream(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte])] =
     bucketStreamFromTemporaryStore(layer)
 
   override def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
@@ -127,7 +127,7 @@ case class VolumeTracingLayer(
   override def containsMag(mag: Vec3Int) =
     true // allow requesting buckets of all mags. database takes care of missing.
 
-  def bucketStream: Iterator[(BucketPosition, Array[Byte])] = bucketProvider.bucketStream(Some(tracing.version))
+  def bucketStream: AsyncIterator[(BucketPosition, Array[Byte])] = bucketProvider.bucketStream(Some(tracing.version))
 
   lazy val expectedUncompressedBucketSize: Int =
     ElementClass.bytesPerElement(elementClass) * scala.math.pow(DataLayer.bucketLength, 3).intValue

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.accesscontext.TokenContext
 import com.scalableminds.util.cache.AlfuCache
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.util.objectid.ObjectId
-import com.scalableminds.util.tools.{Fox, FoxImplicits}
+import com.scalableminds.util.tools.{AsyncIterator, Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
 import com.scalableminds.webknossos.datastore.dataformats.BucketProvider
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryImplicits
@@ -21,7 +21,7 @@ import scala.concurrent.ExecutionContext
 
 trait AbstractVolumeTracingBucketProvider extends BucketProvider with VolumeTracingBucketHelper with FoxImplicits {
 
-  def bucketStreamWithVersion(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte], Long)]
+  def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)]
 
   def bucketStream(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte])]
 }
@@ -51,7 +51,7 @@ class VolumeTracingBucketProvider(layer: VolumeTracingLayer)(implicit val ec: Ex
   override def bucketStream(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte])] =
     bucketStream(layer, version)
 
-  override def bucketStreamWithVersion(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte], Long)] =
+  override def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
     bucketStreamWithVersion(layer, version)
 }
 
@@ -71,7 +71,7 @@ class TemporaryVolumeTracingBucketProvider(layer: VolumeTracingLayer)(implicit v
   override def bucketStream(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte])] =
     bucketStreamFromTemporaryStore(layer)
 
-  override def bucketStreamWithVersion(version: Option[Long] = None): Iterator[(BucketPosition, Array[Byte], Long)] =
+  override def bucketStreamWithVersion(version: Option[Long] = None): AsyncIterator[(BucketPosition, Array[Byte], Long)] =
     throw new UnsupportedOperationException // Temporary Volume Tracings do not support versioning
 }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -477,20 +477,21 @@ class VolumeTracingService @Inject()(
                                     voxelSize: Option[VoxelSize],
                                     os: OutputStream)(implicit ec: ExecutionContext, tc: TokenContext): Fox[Unit] = {
     val volumeLayer = volumeTracingLayer(annotationId, tracingId, tracing)
-    val buckets: Iterator[NamedStream] = volumeDataZipFormat match {
+    val asyncBuckets = volumeLayer.bucketProvider.bucketStream(Some(tracing.version))
+    val namedStreams = volumeDataZipFormat match {
       case VolumeDataZipFormat.wkw =>
         new WKWBucketStreamSink(volumeLayer, tracing.fallbackLayer.nonEmpty)(
-          volumeLayer.bucketProvider.bucketStream(Some(tracing.version)),
+          asyncBuckets,
           tracing.mags.map(mag => vec3IntFromProto(mag)))
       case VolumeDataZipFormat.zarr3 =>
         new Zarr3BucketStreamSink(volumeLayer, tracing.fallbackLayer.nonEmpty)(
-          volumeLayer.bucketProvider.bucketStream(Some(tracing.version)),
+          asyncBuckets,
           tracing.mags.map(mag => vec3IntFromProto(mag)),
           voxelSize)
     }
 
     val before = Instant.now
-    val zipResult = ZipIO.zip(buckets, os, level = Deflater.BEST_SPEED)
+    val zipResult = ZipIO.zip(namedStreams, os, level = Deflater.BEST_SPEED)
 
     zipResult.onComplete { resultBox =>
       logger.info(
@@ -609,8 +610,7 @@ class VolumeTracingService @Inject()(
     for {
       isTemporaryTracing <- temporaryTracingService.isTemporaryTracing(sourceTracingId)
       sourceVolumeLayer = volumeTracingLayer(sourceAnnotationId, sourceTracingId, sourceTracing, isTemporaryTracing)
-      buckets: Iterator[(BucketPosition, Array[Byte])] = sourceVolumeLayer.bucketProvider.bucketStream(
-        Some(sourceTracing.version))
+      buckets = sourceVolumeLayer.bucketProvider.bucketStream(Some(sourceTracing.version))
       destinationVolumeLayer = volumeTracingLayer(newAnnotationId, newTracingId, newTracing)
       fallbackLayer <- getFallbackLayer(sourceAnnotationId, sourceTracing)
       mappingName <- getMappingNameUnlessEditable(sourceTracing)
@@ -721,14 +721,13 @@ class VolumeTracingService @Inject()(
       _ <- Fox.successful(())
       isTemporaryTracing <- temporaryTracingService.isTemporaryTracing(tracingId)
       volumeLayer = volumeTracingLayer(annotationId, tracingId, tracing, isTemporaryTracing = isTemporaryTracing)
-      bucketStream = volumeLayer.bucketStream
-      bucketPosOpt = if (bucketStream.hasNext) {
-        val bucket = bucketStream.next()
-        val bucketPos = bucket._1
-        getPositionOfNonZeroData(bucket._2,
-                                 Vec3Int(bucketPos.voxelMag1X, bucketPos.voxelMag1Y, bucketPos.voxelMag1Z),
-                                 volumeLayer.bytesPerElement)
-      } else None
+      firstBatch <- volumeLayer.bucketStream.nextBatch()
+      bucketPosOpt = firstBatch.headOption.flatMap {
+        case (bucketPos, data) =>
+          getPositionOfNonZeroData(data,
+                                   Vec3Int(bucketPos.voxelMag1X, bucketPos.voxelMag1Y, bucketPos.voxelMag1Z),
+                                   volumeLayer.bytesPerElement)
+      }
     } yield bucketPosOpt
 
   def merge(tracings: Seq[VolumeTracing],
@@ -834,91 +833,93 @@ class VolumeTracingService @Inject()(
       volumeLayers.headOption.map(_.tracing.elementClass).getOrElse(ElementClassProto.uint8)
 
     val magSets = new mutable.HashSet[Set[Vec3Int]]()
-    volumeLayers.foreach { volumeLayer =>
-      val magSet = new mutable.HashSet[Vec3Int]()
-      volumeLayer.bucketStream.foreach {
-        case (bucketPosition, _) =>
-          magSet.add(bucketPosition.mag)
-      }
-      if (magSet.nonEmpty) { // empty tracings should have no impact in this check
-        magSets.add(magSet.toSet)
-      }
-    }
 
     val shouldCreateSegmentIndex =
       volumeSegmentIndexService.shouldCreateSegmentIndexForMerged(volumeLayers.map(_.tracing))
 
-    // If none of the tracings contained any volume data. Do not save buckets, do not touch mag list
-    if (magSets.isEmpty)
-      Fox.successful(MergedVolumeStats.empty(shouldCreateSegmentIndex))
-    else {
-      val magsIntersection: Set[Vec3Int] = magSets.headOption.map { head =>
-        magSets.foldLeft(head) { (acc, element) =>
-          acc.intersect(element)
-        }
-      }.getOrElse(Set.empty)
-
-      val mergedVolume = new MergedVolume(elementClassProto)
-
-      volumeLayers.foreach { volumeLayer =>
-        mergedVolume.addIdSetFromBucketStream(volumeLayer.bucketStream, magsIntersection)
+    for {
+      // Collect mags from all layers to determine their intersection
+      _ <- Fox.serialCombined(volumeLayers) { volumeLayer =>
+        val magSet = new mutable.HashSet[Vec3Int]()
+        for {
+          _ <- Fox.serialCombined(volumeLayer.bucketStream) {
+            case (bucketPosition, _) => Fox.successful(magSet.add(bucketPosition.mag))
+          }
+          _ = if (magSet.nonEmpty) magSets.add(magSet.toSet)
+        } yield ()
       }
 
-      volumeLayers.zipWithIndex.foreach {
-        case (volumeLayer, sourceVolumeIndex) =>
-          mergedVolume.addFromBucketStream(sourceVolumeIndex, volumeLayer.bucketStream, Some(magsIntersection))
+      // If none of the tracings contained any volume data. Do not save buckets, do not touch mag list
+      result <- if (magSets.isEmpty) {
+        Fox.successful(MergedVolumeStats.empty(shouldCreateSegmentIndex))
+      } else {
+        val magsIntersection: Set[Vec3Int] = magSets.headOption.map { head =>
+          magSets.foldLeft(head) { (acc, element) =>
+            acc.intersect(element)
+          }
+        }.getOrElse(Set.empty)
+
+        val mergedVolume = new MergedVolume(elementClassProto)
+
+        for {
+          _ <- Fox.serialCombined(volumeLayers) { volumeLayer =>
+            mergedVolume.addIdSetFromBucketStream(volumeLayer.bucketStream, magsIntersection)
+          }
+          _ <- Fox.serialCombined(volumeLayers.zipWithIndex) {
+            case (volumeLayer, sourceVolumeIndex) =>
+              mergedVolume.addFromBucketStream(sourceVolumeIndex, volumeLayer.bucketStream, Some(magsIntersection))
+          }
+          _ <- Fox.fromBool(ElementClass.largestSegmentIdIsInRange(mergedVolume.largestSegmentId, elementClassProto)) ?~> Messages(
+            "annotation.volume.largestSegmentIdExceedsRange",
+            mergedVolume.largestSegmentId,
+            elementClassProto)
+          mergedAdditionalAxes <- AdditionalAxis
+            .mergeAndAssertSameAdditionalAxes(
+              volumeLayers.map(l => AdditionalAxis.fromProtosAsOpt(l.tracing.additionalAxes)))
+            .toFox
+          firstVolumeLayer <- volumeLayers.headOption.toFox ?~> "merge.noTracings"
+          firstVolumeAnnotationId <- firstVolumeAnnotationIdOpt.toFox
+          fallbackLayer <- getFallbackLayer(firstVolumeAnnotationId, firstVolumeLayer.tracing)
+          segmentIndexBuffer = new VolumeSegmentIndexBuffer(
+            newVolumeTracingId,
+            elementClassProto,
+            volumeLayers.headOption.flatMap(_.tracing.mappingName),
+            volumeSegmentIndexClient,
+            newVersion,
+            remoteDatastoreClient,
+            fallbackLayer,
+            mergedAdditionalAxes,
+            temporaryTracingService,
+            tc,
+            isReadOnly = false,
+            toTemporaryStore = toTemporaryStore
+          )
+          volumeBucketPutBuffer = new FossilDBPutBuffer(volumeDataStore, Some(newVersion))
+          _ <- mergedVolume.withMergedBuckets { (bucketPosition, bucketBytes) =>
+            for {
+              _ <- saveBucket(
+                newVolumeTracingId,
+                firstVolumeLayer.expectedUncompressedBucketSize,
+                bucketPosition,
+                bucketBytes,
+                newVersion,
+                toTemporaryStore,
+                mergedAdditionalAxes,
+                Some(volumeBucketPutBuffer)
+              )
+              _ <- Fox.runIf(shouldCreateSegmentIndex)(
+                updateSegmentIndex(firstVolumeLayer, segmentIndexBuffer, bucketPosition, bucketBytes, Empty, None))
+            } yield ()
+          }
+          _ <- volumeBucketPutBuffer.flush()
+          _ <- segmentIndexBuffer.flush()
+          _ = Instant.logSince(
+            before,
+            s"Merging buckets from ${volumeLayers.length} volume tracings into new $newVolumeTracingId, with createSegmentIndex = $shouldCreateSegmentIndex"
+          )
+        } yield mergedVolume.stats(shouldCreateSegmentIndex)
       }
-      for {
-        _ <- Fox.fromBool(ElementClass.largestSegmentIdIsInRange(mergedVolume.largestSegmentId, elementClassProto)) ?~> Messages(
-          "annotation.volume.largestSegmentIdExceedsRange",
-          mergedVolume.largestSegmentId,
-          elementClassProto)
-        mergedAdditionalAxes <- AdditionalAxis
-          .mergeAndAssertSameAdditionalAxes(
-            volumeLayers.map(l => AdditionalAxis.fromProtosAsOpt(l.tracing.additionalAxes)))
-          .toFox
-        firstVolumeLayer <- volumeLayers.headOption.toFox ?~> "merge.noTracings"
-        firstVolumeAnnotationId <- firstVolumeAnnotationIdOpt.toFox
-        fallbackLayer <- getFallbackLayer(firstVolumeAnnotationId, firstVolumeLayer.tracing)
-        segmentIndexBuffer = new VolumeSegmentIndexBuffer(
-          newVolumeTracingId,
-          elementClassProto,
-          volumeLayers.headOption.flatMap(_.tracing.mappingName),
-          volumeSegmentIndexClient,
-          newVersion,
-          remoteDatastoreClient,
-          fallbackLayer,
-          mergedAdditionalAxes,
-          temporaryTracingService,
-          tc,
-          isReadOnly = false,
-          toTemporaryStore = toTemporaryStore
-        )
-        volumeBucketPutBuffer = new FossilDBPutBuffer(volumeDataStore, Some(newVersion))
-        _ <- mergedVolume.withMergedBuckets { (bucketPosition, bucketBytes) =>
-          for {
-            _ <- saveBucket(
-              newVolumeTracingId,
-              firstVolumeLayer.expectedUncompressedBucketSize,
-              bucketPosition,
-              bucketBytes,
-              newVersion,
-              toTemporaryStore,
-              mergedAdditionalAxes,
-              Some(volumeBucketPutBuffer)
-            )
-            _ <- Fox.runIf(shouldCreateSegmentIndex)(
-              updateSegmentIndex(firstVolumeLayer, segmentIndexBuffer, bucketPosition, bucketBytes, Empty, None))
-          } yield ()
-        }
-        _ <- volumeBucketPutBuffer.flush()
-        _ <- segmentIndexBuffer.flush()
-        _ = Instant.logSince(
-          before,
-          s"Merging buckets from ${volumeLayers.length} volume tracings into new $newVolumeTracingId, with createSegmentIndex = $shouldCreateSegmentIndex"
-        )
-      } yield mergedVolume.stats(shouldCreateSegmentIndex)
-    }
+    } yield result
   }
 
   def importVolumeData(annotationId: ObjectId,
@@ -941,7 +942,7 @@ class VolumeTracingService @Inject()(
           largestSegmentId <- tracing.largestSegmentId.toFox ?~> "annotation.volume.merge.largestSegmentId.unset"
           mergedVolume = new MergedVolume(tracing.elementClass, largestSegmentId)
           _ <- mergedVolume.addIdSetFromDataZip(zipFile)
-          _ = mergedVolume.addFromBucketStream(sourceVolumeIndex = 0, volumeLayer.bucketProvider.bucketStream())
+          _ <- mergedVolume.addFromBucketStream(sourceVolumeIndex = 0, volumeLayer.bucketProvider.bucketStream())
           _ <- mergedVolume.addFromDataZip(sourceVolumeIndex = 1, zipFile)
           _ <- Fox.fromBool(ElementClass.largestSegmentIdIsInRange(mergedVolume.largestSegmentId, tracing.elementClass)) ?~> Messages(
             "annotation.volume.largestSegmentIdExceedsRange",

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -4,7 +4,7 @@ import com.google.inject.Inject
 import com.scalableminds.util.accesscontext.TokenContext
 import com.scalableminds.util.cache.AlfuCache
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
-import com.scalableminds.util.io.{NamedStream, ZipIO}
+import com.scalableminds.util.io.ZipIO
 import com.scalableminds.util.mvc.Formatter
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.time.Instant

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/WKWBucketStreamSink.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/WKWBucketStreamSink.scala
@@ -2,10 +2,10 @@ package com.scalableminds.webknossos.tracingstore.tracings.volume
 
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.util.io.{NamedFunctionStream, NamedStream}
+import com.scalableminds.util.tools.{AsyncIterator, ByteUtils, Fox, FoxImplicits}
 import com.scalableminds.webknossos.datastore.dataformats.wkw.{ChunkType, WKWDataFormatHelper, WKWFile, WKWHeader}
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.{DataLayer, ElementClass}
-import com.scalableminds.util.tools.{ByteUtils, Fox, FoxImplicits}
 
 import java.io.DataOutputStream
 import scala.concurrent.ExecutionContext
@@ -16,29 +16,47 @@ class WKWBucketStreamSink(val layer: DataLayer, tracingHasFallbackLayer: Boolean
     with FoxImplicits
     with ByteUtils {
 
-  def apply(bucketStream: Iterator[(BucketPosition, Array[Byte])], mags: Seq[Vec3Int])(
-      implicit ec: ExecutionContext): Iterator[NamedStream] = {
+  def apply(bucketStream: AsyncIterator[(BucketPosition, Array[Byte])], mags: Seq[Vec3Int])(
+      implicit ec: ExecutionContext): AsyncIterator[NamedStream] = {
     val (dataType, numChannels) = ElementClass.toArrayDataTypeAndChannel(layer.elementClass)
     val header = WKWHeader(1, DataLayer.bucketLength, ChunkType.LZ4, dataType, numChannels)
-    bucketStream.flatMap {
-      case (bucket, data) =>
-        val skipBucket = if (tracingHasFallbackLayer) isRevertedElement(data) else isAllZero(data)
-        if (skipBucket) {
-          // If the tracing has no fallback segmentation, all-zero buckets can be omitted entirely
-          None
-        } else {
-          val filePath = wkwFilePath(bucket)
-          Some(
+
+    new AsyncIterator[NamedStream] {
+      private var bucketsExhausted = false
+      private var headersEmitted = false
+
+      override def nextBatch(): Fox[List[NamedStream]] =
+        if (!bucketsExhausted) {
+          bucketStream.nextBatch().flatMap {
+            case Nil =>
+              bucketsExhausted = true
+              nextBatch()
+            case batch =>
+              val streams: List[NamedStream] = batch.flatMap {
+                case (bucket, data) =>
+                  val skipBucket = if (tracingHasFallbackLayer) isRevertedElement(data) else isAllZero(data)
+                  if (skipBucket) None
+                  else
+                    Some(
+                      NamedFunctionStream(
+                        wkwFilePath(bucket),
+                        os => WKWFile.write(os, header, Array(data).iterator).toFox
+                      ))
+              }
+              if (streams.nonEmpty) Fox.successful(streams)
+              else nextBatch()
+          }
+        } else if (!headersEmitted) {
+          headersEmitted = true
+          Fox.successful(mags.map { mag =>
             NamedFunctionStream(
-              filePath,
-              os => WKWFile.write(os, header, Array(data).iterator).toFox
-            ))
+              f"${mag.toMagLiteral(allowScalar = true)}/$FILENAME_HEADER_WKW",
+              os => Fox.successful(header.writeTo(new DataOutputStream(os), isHeaderFile = true))
+            )
+          }.toList)
+        } else {
+          Fox.successful(Nil)
         }
-      case _ => None
-    } ++ mags.map { mag =>
-      NamedFunctionStream(f"${mag.toMagLiteral(allowScalar = true)}/$FILENAME_HEADER_WKW",
-                          os => Fox.successful(header.writeTo(new DataOutputStream(os), isHeaderFile = true)))
     }
   }
-
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Zarr3BucketStreamSink.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Zarr3BucketStreamSink.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.tracingstore.tracings.volume
 
 import com.scalableminds.util.geometry.{Vec3Double, Vec3Int}
 import com.scalableminds.util.io.{NamedFunctionStream, NamedStream}
-import com.scalableminds.util.tools.{ByteUtils, Fox}
+import com.scalableminds.util.tools.{AsyncIterator, ByteUtils, Fox}
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.dataformats.zarr.Zarr3OutputHelper
 import com.scalableminds.webknossos.datastore.datareaders.zarr3._
@@ -32,35 +32,53 @@ class Zarr3BucketStreamSink(val layer: VolumeTracingLayer, tracingHasFallbackLay
   private lazy val rank = layer.additionalAxes.getOrElse(Seq.empty).length + 4
   private lazy val additionalAxesSorted = reorderAdditionalAxes(layer.additionalAxes.getOrElse(Seq.empty))
 
-  def apply(bucketStream: Iterator[(BucketPosition, Array[Byte])], mags: Seq[Vec3Int], voxelSize: Option[VoxelSize])(
-      implicit ec: ExecutionContext): Iterator[NamedStream] = {
+  def apply(bucketStream: AsyncIterator[(BucketPosition, Array[Byte])],
+            mags: Seq[Vec3Int],
+            voxelSize: Option[VoxelSize])(implicit ec: ExecutionContext): AsyncIterator[NamedStream] = {
 
     val header = Zarr3ArrayHeader.fromDataLayer(layer,
                                                 mags.headOption.getOrElse(Vec3Int.ones),
                                                 additionalCodecs = Seq(BloscCodecConfiguration.defaultForWKZarrOutput))
-    bucketStream.flatMap {
-      case (bucket, data) =>
-        val skipBucket = if (tracingHasFallbackLayer) isAllZero(data) else isRevertedElement(data)
-        if (skipBucket) {
-          // If the tracing has no fallback segmentation, all-zero buckets can be omitted entirely
-          None
-        } else {
-          val filePath = zarrChunkFilePath(defaultLayerName, bucket, additionalAxesSorted)
-          Some(
-            NamedFunctionStream(
-              filePath,
-              os => Fox.successful(os.write(compressor.compress(data)))
-            )
+
+    new AsyncIterator[NamedStream] {
+      private var bucketsExhausted = false
+      private var headersEmitted = false
+
+      override def nextBatch(): Fox[List[NamedStream]] =
+        if (!bucketsExhausted) {
+          bucketStream.nextBatch().flatMap {
+            case Nil =>
+              bucketsExhausted = true
+              nextBatch()
+            case batch =>
+              val streams: List[NamedStream] = batch.flatMap {
+                case (bucket, data) =>
+                  val skipBucket = if (tracingHasFallbackLayer) isAllZero(data) else isRevertedElement(data)
+                  if (skipBucket) None
+                  else
+                    Some(
+                      NamedFunctionStream(
+                        zarrChunkFilePath(defaultLayerName, bucket, additionalAxesSorted),
+                        os => Fox.successful(os.write(compressor.compress(data)))
+                      ))
+              }
+              if (streams.nonEmpty) Fox.successful(streams)
+              else nextBatch()
+          }
+        } else if (!headersEmitted) {
+          headersEmitted = true
+          val magHeaders: List[NamedStream] = mags.map { mag =>
+            NamedFunctionStream.fromJsonSerializable(zarrHeaderFilePath(defaultLayerName, mag), header)
+          }.toList
+          val dsPropsFile: NamedStream = NamedFunctionStream.fromJsonSerializable(
+            UsableDataSource.FILENAME_DATASOURCE_PROPERTIES_JSON,
+            createVolumeDataSource(voxelSize)
           )
+          Fox.successful(magHeaders :+ dsPropsFile)
+        } else {
+          Fox.successful(Nil)
         }
-      case _ => None
-    } ++ mags.map { mag =>
-      NamedFunctionStream.fromJsonSerializable(zarrHeaderFilePath(defaultLayerName, mag), header)
-    } ++ Seq(
-      NamedFunctionStream.fromJsonSerializable(
-        UsableDataSource.FILENAME_DATASOURCE_PROPERTIES_JSON,
-        createVolumeDataSource(voxelSize)
-      ))
+    }
   }
 
   private def createVolumeDataSource(voxelSize: Option[VoxelSize]): UsableDataSource = {


### PR DESCRIPTION
[AI Generated, not yet proofread]

**`util`**
- `AsyncIterator.scala` – new trait with `nextBatch(): Fox[List[A]]`
- `Fox.scala` – new `serialCombined(AsyncIterator[A])` overload
- `ZipIO.scala` – async `zip(AsyncIterator[NamedStream], OutputStream, Int)` overload

**`FossilDBClient.scala`**
- Added async `getMultipleKeys` (uses non-blocking `stub`, returns `Fox[List[VersionedKeyValuePair[T]]]`)
- Removed `getMultipleKeysBlocking` and `blockingStub` entirely – no more blocking gRPC calls

**Iterators / streams**
- `VersionedFossilDbIterator` – now extends `AsyncIterator[VersionedKeyValuePair[Array[Byte]]]`
- `VersionedAgglomerateToGraphIterator`, `VersionedSegmentToAgglomerateChunkIterator` – now extend `AsyncIterator`
- `VersionedBucketIterator` – now extends `AsyncIterator[(BucketPosition, Array[Byte], Long)]`; `BucketIterator` deleted
- `bucketStream` / `bucketStreamFromTemporaryStore` in `VolumeTracingBucketHelper` – return `AsyncIterator[(BucketPosition, Array[Byte])]`
- `VolumeTracingLayer.bucketStream` – field type changed to `AsyncIterator[(BucketPosition, Array[Byte])]`
- `WKWBucketStreamSink` / `Zarr3BucketStreamSink` – `apply` now takes `AsyncIterator[(BucketPosition, Array[Byte])]` and returns `AsyncIterator[NamedStream]` via a small state machine (`bucketsExhausted` → `headersEmitted` → `Nil`)

**`VolumeTracingService`**
- `allDataToOutputStream` – passes `AsyncIterator[NamedStream]` to the new async `ZipIO.zip` overload
- `mergeVolumeData` – mag collection, `addIdSetFromBucketStream`, and `addFromBucketStream` are all async via `Fox.serialCombined(asyncIterator)`
- `MergedVolume.addIdSetFromBucketStream` / `addFromBucketStream` – signatures updated to accept `AsyncIterator`



### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] proofread and clean up
- [ ] test
- [ ] profit

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
