### PR TITLE
Warn when segment anchor position is out of sync

### DIFF
--- a/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
@@ -649,6 +649,45 @@ class SegmentsView extends React.Component<Props, State> {
     if (segmentAdditionalCoordinates != null) {
       this.props.setAdditionalCoordinates(segmentAdditionalCoordinates);
     }
+    // Fire-and-forget: check anchor position asynchronously without blocking navigation
+    this.checkAnchorPositionSync(segment, visibleSegmentationLayer.name);
+  };
+
+  checkAnchorPositionSync = async (segment: Segment, layerName: string) => {
+    if (!segment.anchorPosition) return;
+
+    try {
+      const voxelValue = await api.data.getDataValue(
+        layerName,
+        segment.anchorPosition,
+        null,
+        segment.additionalCoordinates ?? null,
+      );
+
+      if (voxelValue !== segment.id) {
+        const toastKey = `anchor-out-of-sync-${segment.id}`;
+        Toast.warning(
+          <span>
+            The saved position of segment <strong>{getSegmentName(segment, true)}</strong> no
+            longer contains this segment's ID — it was likely overwritten by another segment. To
+            re-anchor it, activate this segment ID and brush over the saved position again.{" "}
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                Store.dispatch(removeSegmentAction(segment.id, layerName));
+                Toast.close(toastKey);
+              }}
+            >
+              Remove segment.
+            </a>
+          </span>,
+          { key: toastKey, sticky: true },
+        );
+      }
+    } catch (_e) {
+      // Cannot read voxel data at this position; skip the check silently
+    }
   };
 
   handleMeshFileSelected = async (meshFileName: string) => {


### PR DESCRIPTION
### Summary
When navigating to a segment whose stored anchor position no longer contains the expected voxel ID, show a sticky warning toast that:
- Explains the position is out of sync (likely overwritten by another segment)
- Tells the user how to re-anchor (activate the segment ID and brush over the position)
- Offers a one-click "Remove segment" action inline in the toast

The check runs asynchronously after navigation via `api.data.getDataValue()` so it does not block the viewport.

Ref: https://github.com/scalableminds/webknossos/issues/6530

### Steps to test:
1. Open a volume annotation with at least one segment that has an anchor position
2. Paint over the anchor position with a different segment ID
3. Navigate to the original segment (click its name in the segments panel)
4. A warning toast should appear explaining the desync, with a "Remove segment." link

### TODOs:
- [ ] Added changelog entry

### Issues:
- fixes #6530