### PR TITLE
WIP Frontend-only delayed delete with undo replaces confirm modals

### DIFF
--- a/frontend/javascripts/admin/project/project_list_view.tsx
+++ b/frontend/javascripts/admin/project/project_list_view.tsx
@@ -31,6 +31,7 @@ import FormattedDate from "components/formatted_date";
 import { handleGenericError } from "libs/error_handling";
 import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling, useWkSelector } from "libs/react_hooks";
+import { deleteWithUndo } from "libs/delete_with_undo";
 import Toast from "libs/toast";
 import {
   compareBy,
@@ -112,23 +113,21 @@ function ProjectListView() {
   }
 
   function deleteProject(project: APIProjectWithStatus) {
-    modal.confirm({
-      title: messages["project.delete"],
-      onOk: async () => {
-        setIsLoadingMutation(true);
-        try {
-          await deleteProjectAPI(project.id);
-          queryClient.setQueryData(
-            ["projectsWithStatus", taskTypeId],
-            (currentProjects: APIProjectWithStatus[]) =>
-              currentProjects.filter((p) => p.id !== project.id),
-          );
-        } catch (error) {
-          handleGenericError(error as Error);
-        } finally {
-          setIsLoadingMutation(false);
-        }
-      },
+    const snapshot = queryClient.getQueryData<APIProjectWithStatus[]>([
+      "projectsWithStatus",
+      taskTypeId,
+    ]);
+    deleteWithUndo({
+      item: project,
+      toastMessage: `Project "${project.name}" was deleted.`,
+      deleteApi: deleteProjectAPI,
+      onDelete: () =>
+        queryClient.setQueryData(
+          ["projectsWithStatus", taskTypeId],
+          (current: APIProjectWithStatus[] | undefined) =>
+            (current ?? []).filter((p) => p.id !== project.id),
+        ),
+      onRestore: () => queryClient.setQueryData(["projectsWithStatus", taskTypeId], snapshot),
     });
   }
 

--- a/frontend/javascripts/admin/project/project_list_view.tsx
+++ b/frontend/javascripts/admin/project/project_list_view.tsx
@@ -28,10 +28,10 @@ import {
 import { App, Button, Input, Spin, Table, Tooltip } from "antd";
 import { AsyncLink } from "components/async_clickables";
 import FormattedDate from "components/formatted_date";
+import { deleteWithUndo } from "libs/delete_with_undo";
 import { handleGenericError } from "libs/error_handling";
 import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling, useWkSelector } from "libs/react_hooks";
-import { deleteWithUndo } from "libs/delete_with_undo";
 import Toast from "libs/toast";
 import {
   compareBy,
@@ -119,7 +119,7 @@ function ProjectListView() {
     ]);
     deleteWithUndo({
       item: project,
-      toastMessage: `Project "${project.name}" was deleted.`,
+      toastMessage: `Project “${project.name}” was deleted.`,
       deleteApi: deleteProjectAPI,
       onDelete: () =>
         queryClient.setQueryData(

--- a/frontend/javascripts/admin/scripts/script_list_view.tsx
+++ b/frontend/javascripts/admin/scripts/script_list_view.tsx
@@ -2,14 +2,13 @@ import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
 import { PropTypes } from "@scalableminds/prop-types";
 import AdminPage from "admin/admin_page";
 import { deleteScript as deleteScriptAPI, getScripts } from "admin/rest_api";
-import { App, Button, Input, Space, Spin, Table } from "antd";
+import { Button, Input, Space, Spin, Table } from "antd";
 import FormattedId from "components/formatted_id";
 import LinkButton from "components/link_button";
-import { handleGenericError } from "libs/error_handling";
+import { deleteWithUndo } from "libs/delete_with_undo";
 import Persistence from "libs/persistence";
 import { filterWithSearchQueryAND, localeCompareBy } from "libs/utils";
 import partial from "lodash-es/partial";
-import messages from "messages";
 import type React from "react";
 import { Fragment, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -26,8 +25,6 @@ const persistence = new Persistence<{ searchQuery: string }>(
 );
 
 function ScriptListView() {
-  const { modal } = App.useApp();
-
   const [isLoading, setIsLoading] = useState(true);
   const [scripts, setScripts] = useState<APIScript[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -53,19 +50,13 @@ function ScriptListView() {
   }
 
   function deleteScript(script: APIScript) {
-    modal.confirm({
-      title: messages["script.delete"],
-      onOk: async () => {
-        try {
-          setIsLoading(true);
-          await deleteScriptAPI(script.id);
-          setScripts(scripts.filter((s) => s.id !== script.id));
-        } catch (error) {
-          handleGenericError(error as Error);
-        } finally {
-          setIsLoading(false);
-        }
-      },
+    const snapshot = scripts;
+    deleteWithUndo({
+      item: script,
+      toastMessage: `Script "${script.name}" was deleted.`,
+      deleteApi: deleteScriptAPI,
+      onDelete: () => setScripts((current) => current.filter((s) => s.id !== script.id)),
+      onRestore: () => setScripts(snapshot),
     });
   }
 

--- a/frontend/javascripts/admin/scripts/script_list_view.tsx
+++ b/frontend/javascripts/admin/scripts/script_list_view.tsx
@@ -53,7 +53,7 @@ function ScriptListView() {
     const snapshot = scripts;
     deleteWithUndo({
       item: script,
-      toastMessage: `Script "${script.name}" was deleted.`,
+      toastMessage: `Script “${script.name}” was deleted.`,
       deleteApi: deleteScriptAPI,
       onDelete: () => setScripts((current) => current.filter((s) => s.id !== script.id)),
       onRestore: () => setScripts(snapshot),

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -118,7 +118,7 @@ function TaskListView({ initialFieldValues }: Props) {
     const snapshot = tasks;
     deleteWithUndo({
       item: task,
-      toastMessage: `Task "${task.id}" was deleted.`,
+      toastMessage: `Task “${task.id}” was deleted.`,
       deleteApi: deleteTaskAPI,
       onDelete: () => setTasks((current) => current.filter((t) => t.id !== task.id)),
       onRestore: () => setTasks(snapshot),

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -32,6 +32,7 @@ import FormattedDate from "components/formatted_date";
 import FormattedId from "components/formatted_id";
 import LinkButton from "components/link_button";
 import features from "features";
+import { deleteWithUndo } from "libs/delete_with_undo";
 import { handleGenericError } from "libs/error_handling";
 import { formatSeconds, formatTuple } from "libs/format_utils";
 import Persistence from "libs/persistence";
@@ -114,19 +115,13 @@ function TaskListView({ initialFieldValues }: Props) {
   }
 
   function deleteTask(task: APITask) {
-    modal.confirm({
-      title: messages["task.delete"],
-      onOk: async () => {
-        try {
-          setIsLoading(true);
-          await deleteTaskAPI(task.id);
-          setTasks(tasks.filter((t) => t.id !== task.id));
-        } catch (error) {
-          handleGenericError(error as Error);
-        } finally {
-          setIsLoading(false);
-        }
-      },
+    const snapshot = tasks;
+    deleteWithUndo({
+      item: task,
+      toastMessage: `Task "${task.id}" was deleted.`,
+      deleteApi: deleteTaskAPI,
+      onDelete: () => setTasks((current) => current.filter((t) => t.id !== task.id)),
+      onRestore: () => setTasks(snapshot),
     });
   }
 

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
@@ -25,7 +25,6 @@ import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling } from "libs/react_hooks";
 import { filterWithSearchQueryAND, localeCompareBy } from "libs/utils";
 import partial from "lodash-es/partial";
-import messages from "messages";
 import type React from "react";
 import { Fragment, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
@@ -68,12 +67,11 @@ function TaskTypeListView() {
     const snapshot = queryClient.getQueryData<APITaskType[]>(["taskTypes"]);
     deleteWithUndo({
       item: taskType,
-      toastMessage: `Task type "${taskType.summary}" was deleted.`,
+      toastMessage: `Task type “${taskType.summary}” was deleted.`,
       deleteApi: deleteTaskTypeAPI,
       onDelete: () =>
-        queryClient.setQueryData(
-          ["taskTypes"],
-          (current: APITaskType[] | undefined) => (current ?? []).filter((t) => t.id !== taskType.id),
+        queryClient.setQueryData(["taskTypes"], (current: APITaskType[] | undefined) =>
+          (current ?? []).filter((t) => t.id !== taskType.id),
         ),
       onRestore: () => queryClient.setQueryData(["taskTypes"], snapshot),
     });

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
@@ -15,11 +15,11 @@ import {
   downloadAnnotation,
   getTaskTypes,
 } from "admin/rest_api";
-import { App, Button, Input, Space, Spin, Table, Tag } from "antd";
+import { Button, Input, Space, Spin, Table, Tag } from "antd";
 import { AsyncLink } from "components/async_clickables";
 import FormattedId from "components/formatted_id";
 import LinkButton from "components/link_button";
-import { handleGenericError } from "libs/error_handling";
+import { deleteWithUndo } from "libs/delete_with_undo";
 import Markdown from "libs/markdown_adapter";
 import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling } from "libs/react_hooks";
@@ -46,7 +46,6 @@ function TaskTypeListView() {
   const initialSearchValue = location.hash.slice(1);
 
   const queryClient = useQueryClient();
-  const { modal } = App.useApp();
 
   const { data: taskTypes = [], isFetching: isLoadingTaskTypes } = useQueryWithErrorHandling({
     queryKey: ["taskTypes"],
@@ -57,9 +56,7 @@ function TaskTypeListView() {
   const [searchQuery, setSearchQuery] = useState(() =>
     initialSearchValue !== "" ? initialSearchValue : persistence.load().searchQuery || "",
   );
-  const [isLoadingMutation, setIsLoadingMutation] = useState(false);
-
-  const isLoading = isLoadingTaskTypes || isLoadingMutation;
+  const isLoading = isLoadingTaskTypes;
 
   function handleSearch(event: React.ChangeEvent<HTMLInputElement>): void {
     const newSearchQuery = event.target.value;
@@ -68,21 +65,17 @@ function TaskTypeListView() {
   }
 
   function deleteTaskType(taskType: APITaskType) {
-    modal.confirm({
-      title: messages["taskType.delete"],
-      onOk: async () => {
-        try {
-          setIsLoadingMutation(true);
-          await deleteTaskTypeAPI(taskType.id);
-          queryClient.setQueryData(["taskTypes"], (currentTaskTypes: APITaskType[]) =>
-            currentTaskTypes.filter((p) => p.id !== taskType.id),
-          );
-        } catch (error) {
-          handleGenericError(error as Error);
-        } finally {
-          setIsLoadingMutation(false);
-        }
-      },
+    const snapshot = queryClient.getQueryData<APITaskType[]>(["taskTypes"]);
+    deleteWithUndo({
+      item: taskType,
+      toastMessage: `Task type "${taskType.summary}" was deleted.`,
+      deleteApi: deleteTaskTypeAPI,
+      onDelete: () =>
+        queryClient.setQueryData(
+          ["taskTypes"],
+          (current: APITaskType[] | undefined) => (current ?? []).filter((t) => t.id !== taskType.id),
+        ),
+      onRestore: () => queryClient.setQueryData(["taskTypes"], snapshot),
     });
   }
 

--- a/frontend/javascripts/admin/team/team_list_view.tsx
+++ b/frontend/javascripts/admin/team/team_list_view.tsx
@@ -4,9 +4,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import AdminPage from "admin/admin_page";
 import { deleteTeam as deleteTeamAPI, getEditableTeams, getEditableUsers } from "admin/rest_api";
 import CreateTeamModal from "admin/team/create_team_modal_view";
-import { App, Button, Input, Space, Spin, Table, Tag, Tooltip } from "antd";
+import { Button, Input, Space, Spin, Table, Tag, Tooltip } from "antd";
 import LinkButton from "components/link_button";
-import { handleGenericError } from "libs/error_handling";
+import { deleteWithUndo } from "libs/delete_with_undo";
 import { stringToColor } from "libs/format_utils";
 import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling } from "libs/react_hooks";
@@ -140,14 +140,11 @@ function TeamListView() {
   });
 
   const [searchQuery, setSearchQuery] = useState(() => persistence.load().searchQuery || "");
-  const [isLoadingMutation, setIsLoadingMutation] = useState(false);
   const [isTeamCreationModalVisible, setIsTeamCreationModalVisible] = useState(false);
   const [isTeamEditModalVisible, setIsTeamEditModalVisible] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<APITeam | null>(null);
 
-  const isLoading = isLoadingTeams || isLoadingUsers || isLoadingMutation;
-
-  const { modal } = App.useApp();
+  const isLoading = isLoadingTeams || isLoadingUsers;
 
   function handleSearch(event: React.ChangeEvent<HTMLInputElement>): void {
     const newSearchQuery = event.target.value;
@@ -156,21 +153,17 @@ function TeamListView() {
   }
 
   function deleteTeam(team: APITeam) {
-    modal.confirm({
-      title: messages["team.delete"],
-      onOk: async () => {
-        try {
-          setIsLoadingMutation(true);
-          await deleteTeamAPI(team.id);
-          queryClient.setQueryData(["editableTeams"], (currentTeams: APITeam[]) =>
-            currentTeams.filter((t) => t.id !== team.id),
-          );
-        } catch (error) {
-          handleGenericError(error as Error);
-        } finally {
-          setIsLoadingMutation(false);
-        }
-      },
+    const snapshot = queryClient.getQueryData<APITeam[]>(["editableTeams"]);
+    deleteWithUndo({
+      item: team,
+      toastMessage: `Team "${team.name}" was deleted.`,
+      deleteApi: deleteTeamAPI,
+      onDelete: () =>
+        queryClient.setQueryData(
+          ["editableTeams"],
+          (current: APITeam[] | undefined) => (current ?? []).filter((t) => t.id !== team.id),
+        ),
+      onRestore: () => queryClient.setQueryData(["editableTeams"], snapshot),
     });
   }
 

--- a/frontend/javascripts/admin/team/team_list_view.tsx
+++ b/frontend/javascripts/admin/team/team_list_view.tsx
@@ -156,12 +156,11 @@ function TeamListView() {
     const snapshot = queryClient.getQueryData<APITeam[]>(["editableTeams"]);
     deleteWithUndo({
       item: team,
-      toastMessage: `Team "${team.name}" was deleted.`,
+      toastMessage: `Team “${team.name}” was deleted.`,
       deleteApi: deleteTeamAPI,
       onDelete: () =>
-        queryClient.setQueryData(
-          ["editableTeams"],
-          (current: APITeam[] | undefined) => (current ?? []).filter((t) => t.id !== team.id),
+        queryClient.setQueryData(["editableTeams"], (current: APITeam[] | undefined) =>
+          (current ?? []).filter((t) => t.id !== team.id),
         ),
       onRestore: () => queryClient.setQueryData(["editableTeams"], snapshot),
     });

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -10,14 +10,14 @@ import {
 } from "@ant-design/icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { clearCache, deleteDatasetOnDisk, getDataset } from "admin/rest_api";
-import { type MenuProps, Modal, Typography } from "antd";
+import { type MenuProps, Modal } from "antd";
+import { UndoButton } from "libs/undo_button";
 import CreateExplorativeModal from "dashboard/advanced_dataset/create_explorative_modal";
-import { confirmAsync } from "dashboard/dataset/helper_components";
 import Toast from "libs/toast";
 import window from "libs/window";
 import messages from "messages";
 import type * as React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import type { APIDataset, APIDatasetCompact } from "types/api_types";
 import { getReadableURLPart, getViewDatasetURL } from "viewer/model/accessors/dataset_accessor";
@@ -125,6 +125,7 @@ function DatasetActionView(props: Props) {
 
   const [isReloading, setIsReloading] = useState(false);
   const [isCreateExplorativeModalVisible, setIsCreateExplorativeModalVisible] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const onClearCache = async (compactDataset: APIDatasetCompact) => {
     setIsReloading(true);
@@ -141,47 +142,44 @@ function DatasetActionView(props: Props) {
 
   const onDeleteDataset = async () => {
     const dataset = await getDataset(props.dataset.id);
+    const { folderId } = dataset;
+    const toastKey = `delete-dataset-${dataset.id}`;
 
-    const deleteDataset = await confirmAsync({
-      title: "Danger Zone",
-      content: (
-        <>
-          <Typography.Title level={4} type="danger">
-            Deleting a dataset from disk cannot be undone. Are you certain to delete dataset{" "}
-            {dataset.name}?
-          </Typography.Title>
-          <Typography.Paragraph>
-            Note, WEBKNOSSOS cannot delete datasets that have annotations associated with them.
-          </Typography.Paragraph>
-        </>
-      ),
-      okText: "Yes, delete dataset from disk",
-      okType: "danger",
-    });
-
-    if (!deleteDataset) {
-      return;
-    }
-
-    await deleteDatasetOnDisk(dataset.id);
-
-    Toast.success(
-      messages["dataset.delete_success"]({
-        datasetName: dataset.name,
-      }),
-    );
-
-    // Invalidate the dataset list cache to exclude the deleted dataset
+    const snapshot = queryClient.getQueryData<APIDatasetCompact[]>(["datasetsByFolder", folderId]);
     queryClient.setQueryData(
-      ["datasetsByFolder", dataset.folderId],
-      (oldItems: APIDatasetCompact[] | undefined) => {
-        if (oldItems == null) {
-          return oldItems;
-        }
-        return oldItems.filter((item) => item.id !== dataset.id);
-      },
+      ["datasetsByFolder", folderId],
+      (oldItems: APIDatasetCompact[] | undefined) =>
+        oldItems?.filter((item) => item.id !== dataset.id),
     );
     queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+
+    const undo = () => {
+      if (timeoutRef.current != null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      Toast.close(toastKey);
+      queryClient.setQueryData(["datasetsByFolder", folderId], snapshot);
+      queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+    };
+
+    Toast.info(`Dataset "${dataset.name}" was deleted.`, {
+      key: toastKey,
+      sticky: true,
+      customFooter: <UndoButton onUndo={undo} />,
+    });
+
+    timeoutRef.current = setTimeout(async () => {
+      Toast.close(toastKey);
+      try {
+        await deleteDatasetOnDisk(dataset.id);
+        queryClient.invalidateQueries({ queryKey: ["datasetsByFolder", folderId] });
+        queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+      } catch (_e) {
+        Toast.error(`Failed to delete dataset ${dataset.name}.`);
+        queryClient.setQueryData(["datasetsByFolder", folderId], snapshot);
+      }
+    }, 5000);
   };
 
   const disabledWhenReloadingStyle = getDisabledWhenReloadingStyle(isReloading);

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -11,10 +11,10 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { clearCache, deleteDatasetOnDisk, getDataset } from "admin/rest_api";
 import { type MenuProps, Modal } from "antd";
-import { UNDO_SECONDS } from "libs/delete_with_undo";
-import { UndoButton } from "libs/undo_button";
 import CreateExplorativeModal from "dashboard/advanced_dataset/create_explorative_modal";
+import { UNDO_SECONDS } from "libs/delete_with_undo";
 import Toast from "libs/toast";
+import { UndoButton } from "libs/undo_button";
 import window from "libs/window";
 import messages from "messages";
 import type * as React from "react";
@@ -164,7 +164,7 @@ function DatasetActionView(props: Props) {
       queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
     };
 
-    Toast.info(`Dataset "${dataset.name}" was deleted.`, {
+    Toast.info(`Dataset “${dataset.name}” was deleted.`, {
       key: toastKey,
       sticky: true,
       customFooter: <UndoButton onUndo={undo} seconds={UNDO_SECONDS} />,

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -11,6 +11,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { clearCache, deleteDatasetOnDisk, getDataset } from "admin/rest_api";
 import { type MenuProps, Modal } from "antd";
+import { UNDO_SECONDS } from "libs/delete_with_undo";
 import { UndoButton } from "libs/undo_button";
 import CreateExplorativeModal from "dashboard/advanced_dataset/create_explorative_modal";
 import Toast from "libs/toast";
@@ -166,7 +167,7 @@ function DatasetActionView(props: Props) {
     Toast.info(`Dataset "${dataset.name}" was deleted.`, {
       key: toastKey,
       sticky: true,
-      customFooter: <UndoButton onUndo={undo} />,
+      customFooter: <UndoButton onUndo={undo} seconds={UNDO_SECONDS} />,
     });
 
     timeoutRef.current = setTimeout(async () => {
@@ -179,7 +180,7 @@ function DatasetActionView(props: Props) {
         Toast.error(`Failed to delete dataset ${dataset.name}.`);
         queryClient.setQueryData(["datasetsByFolder", folderId], snapshot);
       }
-    }, 5000);
+    }, UNDO_SECONDS * 1000);
   };
 
   const disabledWhenReloadingStyle = getDisabledWhenReloadingStyle(isReloading);

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
@@ -4,6 +4,7 @@ import { SettingsTitle } from "admin/account/helpers/settings_title";
 import { deleteDatasetOnDisk } from "admin/rest_api";
 import { Button, Col, Row } from "antd";
 import Toast from "libs/toast";
+import { UNDO_SECONDS } from "libs/delete_with_undo";
 import { UndoButton } from "libs/undo_button";
 import { useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
@@ -48,7 +49,7 @@ const DatasetSettingsDeleteTab = () => {
     Toast.info(`Dataset "${dataset.name}" was deleted.`, {
       key: toastKey,
       sticky: true,
-      customFooter: <UndoButton onUndo={undo} />,
+      customFooter: <UndoButton onUndo={undo} seconds={UNDO_SECONDS} />,
     });
 
     timeoutRef.current = setTimeout(async () => {
@@ -61,7 +62,7 @@ const DatasetSettingsDeleteTab = () => {
         Toast.error(`Failed to delete dataset ${dataset.name}.`);
         queryClient.setQueryData(["datasetsByFolder", dataset.folderId], snapshot);
       }
-    }, 5000);
+    }, UNDO_SECONDS * 1000);
   }, [dataset, navigate, queryClient]);
 
   return (

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
@@ -3,8 +3,8 @@ import { SettingsCard } from "admin/account/helpers/settings_card";
 import { SettingsTitle } from "admin/account/helpers/settings_title";
 import { deleteDatasetOnDisk } from "admin/rest_api";
 import { Button, Col, Row } from "antd";
-import Toast from "libs/toast";
 import { UNDO_SECONDS } from "libs/delete_with_undo";
+import Toast from "libs/toast";
 import { UndoButton } from "libs/undo_button";
 import { useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
@@ -46,7 +46,7 @@ const DatasetSettingsDeleteTab = () => {
       queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
     };
 
-    Toast.info(`Dataset "${dataset.name}" was deleted.`, {
+    Toast.info(`Dataset “${dataset.name}” was deleted.`, {
       key: toastKey,
       sticky: true,
       customFooter: <UndoButton onUndo={undo} seconds={UNDO_SECONDS} />,

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
@@ -4,47 +4,64 @@ import { SettingsTitle } from "admin/account/helpers/settings_title";
 import { deleteDatasetOnDisk } from "admin/rest_api";
 import { Button, Col, Row } from "antd";
 import Toast from "libs/toast";
-import messages from "messages";
-import { useCallback, useState } from "react";
+import { UndoButton } from "libs/undo_button";
+import { useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
+import type { APIDatasetCompact } from "types/api_types";
 import { useDatasetSettingsContext } from "./dataset_settings_context";
-import { confirmAsync } from "./helper_components";
 
 const DatasetSettingsDeleteTab = () => {
   const { dataset } = useDatasetSettingsContext();
-  const [isDeleting, setIsDeleting] = useState(false);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleDeleteButtonClicked = useCallback(async () => {
     if (!dataset) {
       return;
     }
 
-    const deleteDataset = await confirmAsync({
-      title: `Deleting a dataset on disk cannot be undone. Are you certain to delete dataset ${dataset.name}? Note that the name of a dataset is not guaranteed to be free to use afterwards.`,
-      okText: "Yes, Delete Dataset on Disk now",
-    });
+    const toastKey = `delete-dataset-${dataset.id}`;
+    const snapshot = queryClient.getQueryData<APIDatasetCompact[]>([
+      "datasetsByFolder",
+      dataset.folderId,
+    ]);
 
-    if (!deleteDataset) {
-      return;
-    }
-
-    setIsDeleting(true);
-    await deleteDatasetOnDisk(dataset.id);
-    Toast.success(
-      messages["dataset.delete_success"]({
-        datasetName: dataset.name,
-      }),
+    queryClient.setQueryData(
+      ["datasetsByFolder", dataset.folderId],
+      (oldItems: APIDatasetCompact[] | undefined) =>
+        oldItems?.filter((item) => item.id !== dataset.id),
     );
-    setIsDeleting(false);
-    // Invalidate the dataset list cache to exclude the deleted dataset
-    queryClient.invalidateQueries({
-      queryKey: ["datasetsByFolder", dataset.folderId],
-    });
     queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
-
     navigate("/dashboard");
+
+    const undo = () => {
+      if (timeoutRef.current != null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      Toast.close(toastKey);
+      queryClient.setQueryData(["datasetsByFolder", dataset.folderId], snapshot);
+      queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+    };
+
+    Toast.info(`Dataset "${dataset.name}" was deleted.`, {
+      key: toastKey,
+      sticky: true,
+      customFooter: <UndoButton onUndo={undo} />,
+    });
+
+    timeoutRef.current = setTimeout(async () => {
+      Toast.close(toastKey);
+      try {
+        await deleteDatasetOnDisk(dataset.id);
+        queryClient.invalidateQueries({ queryKey: ["datasetsByFolder", dataset.folderId] });
+        queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+      } catch (_e) {
+        Toast.error(`Failed to delete dataset ${dataset.name}.`);
+        queryClient.setQueryData(["datasetsByFolder", dataset.folderId], snapshot);
+      }
+    }, 5000);
   }, [dataset, navigate, queryClient]);
 
   return (
@@ -65,7 +82,7 @@ const DatasetSettingsDeleteTab = () => {
                   Admins, dataset managers and team managers of the datasets' team(s) are allowed to
                   delete datasets.
                 </p>
-                <Button danger loading={isDeleting} onClick={handleDeleteButtonClicked}>
+                <Button danger onClick={handleDeleteButtonClicked}>
                   Delete Dataset on Disk
                 </Button>
               </>

--- a/frontend/javascripts/dashboard/folders/details_sidebar.tsx
+++ b/frontend/javascripts/dashboard/folders/details_sidebar.tsx
@@ -10,14 +10,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getOrganization } from "admin/api/organization";
 import { deleteDatasetOnDisk } from "admin/rest_api";
 import { Button, Result, Space, Spin, Tag, Tooltip } from "antd";
-import { UNDO_SECONDS } from "libs/delete_with_undo";
-import { UndoButton } from "libs/undo_button";
 import FormattedId from "components/formatted_id";
 import features from "features";
+import { UNDO_SECONDS } from "libs/delete_with_undo";
 import { formatCountToDataAmountUnit, stringToColor } from "libs/format_utils";
 import Markdown from "libs/markdown_adapter";
 import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
+import { UndoButton } from "libs/undo_button";
 import { pluralize } from "libs/utils";
 import keyBy from "lodash-es/keyBy";
 import uniq from "lodash-es/uniq";
@@ -316,7 +316,11 @@ function DatasetsDetails({
           with drag and drop.
         </div>
         {deletableDatasets.length > 0 && features().allowDeleteDatasets && (
-          <Button onClick={handleDeleteClick} disabled={isDeletionPending} icon={<DeleteOutlined />}>
+          <Button
+            onClick={handleDeleteClick}
+            disabled={isDeletionPending}
+            icon={<DeleteOutlined />}
+          >
             Delete {deletableDatasetString}
           </Button>
         )}

--- a/frontend/javascripts/dashboard/folders/details_sidebar.tsx
+++ b/frontend/javascripts/dashboard/folders/details_sidebar.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getOrganization } from "admin/api/organization";
 import { deleteDatasetOnDisk } from "admin/rest_api";
 import { Button, Result, Space, Spin, Tag, Tooltip } from "antd";
+import { UNDO_SECONDS } from "libs/delete_with_undo";
 import { UndoButton } from "libs/undo_button";
 import FormattedId from "components/formatted_id";
 import features from "features";
@@ -297,14 +298,14 @@ function DatasetsDetails({
     Toast.info(`${n} ${pluralize("dataset", n)} deleted.`, {
       key: toastKey,
       sticky: true,
-      customFooter: <UndoButton onUndo={undo} />,
+      customFooter: <UndoButton onUndo={undo} seconds={UNDO_SECONDS} />,
     });
 
     timeoutRef.current = setTimeout(() => {
       setIsDeletionPending(false);
       Toast.close(toastKey);
       deleteDatasetsMutation.mutate(deletableDatasets);
-    }, 5000);
+    }, UNDO_SECONDS * 1000);
   };
 
   return (

--- a/frontend/javascripts/dashboard/folders/details_sidebar.tsx
+++ b/frontend/javascripts/dashboard/folders/details_sidebar.tsx
@@ -9,7 +9,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getOrganization } from "admin/api/organization";
 import { deleteDatasetOnDisk } from "admin/rest_api";
-import { Button, Modal, Progress, Result, Space, Spin, Tag, Tooltip, Typography } from "antd";
+import { Button, Result, Space, Spin, Tag, Tooltip } from "antd";
+import { UndoButton } from "libs/undo_button";
 import FormattedId from "components/formatted_id";
 import features from "features";
 import { formatCountToDataAmountUnit, stringToColor } from "libs/format_utils";
@@ -19,7 +20,7 @@ import Toast from "libs/toast";
 import { pluralize } from "libs/utils";
 import keyBy from "lodash-es/keyBy";
 import uniq from "lodash-es/uniq";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { APIDatasetCompact, Folder } from "types/api_types";
 import {
   DatasetExtentRow,
@@ -220,10 +221,9 @@ function DatasetsDetails({
   datasetCount: number;
 }) {
   const queryClient = useQueryClient();
-  const [progressInPercent, setProgressInPercent] = useState(0);
-  const [showConfirmDeleteModal, setShowConfirmDeleteModal] = useState(false);
+  const [isDeletionPending, setIsDeletionPending] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const deletableDatasets = selectedDatasets.filter((ds) => ds.isEditable);
-  const numberOfUndeletableDatasets = selectedDatasets.length - deletableDatasets.length;
 
   const updateAndInvalidateQueries = (deletedIds: string[]) => {
     const uniqueFolderIds = uniq(deletableDatasets.map((ds) => ds.folderId));
@@ -244,12 +244,10 @@ function DatasetsDetails({
   const deleteDatasetsMutation = useMutation({
     mutationFn: async (datasets: APIDatasetCompact[]) => {
       const deletedIds: string[] = [];
-      for (let i = 0; i < datasets.length; i++) {
-        const dataset = datasets[i];
+      for (const dataset of datasets) {
         try {
           await deleteDatasetOnDisk(dataset.id);
           deletedIds.push(dataset.id);
-          setProgressInPercent(Math.round(((i + 1) / datasets.length) * 100));
         } catch (_e) {
           Toast.error(`Failed to delete dataset ${dataset.name}.`);
         }
@@ -258,73 +256,56 @@ function DatasetsDetails({
     },
     onSuccess: (deletedIds) => {
       updateAndInvalidateQueries(deletedIds);
-      setShowConfirmDeleteModal(false);
-      setProgressInPercent(0);
-
-      if (deletedIds.length > 0) {
-        Toast.success(
-          `Successfully deleted ${deletedIds.length} ${pluralize("dataset", deletedIds.length)}.`,
-        );
-      }
     },
   });
 
-  const deleteDatasets = () => {
-    deleteDatasetsMutation.mutate(deletableDatasets);
-  };
-
-  const okayButton = (
-    <Button type="primary" danger onClick={deleteDatasets}>
-      Delete
-    </Button>
-  );
-
-  const onCancel = () => {
-    if (!deleteDatasetsMutation.isPending) {
-      setShowConfirmDeleteModal(false);
-    }
-  };
-
-  const cancelButton = <Button onClick={onCancel}>Cancel</Button>;
-
-  // TODO (#9061): Delete once soft-delete is implemented.
-  const cantBeUndoneMessage = (
-    <Typography.Text type="warning" strong>
-      This action cannot be undone.
-    </Typography.Text>
-  );
-
   const deletableDatasetString = `${deletableDatasets.length} ${pluralize("dataset", deletableDatasets.length)}`;
 
-  const confirmModal = (
-    <Modal
-      open={showConfirmDeleteModal}
-      title="Delete Datasets"
-      footer={deleteDatasetsMutation.isPending ? null : [cancelButton, okayButton]}
-      onCancel={onCancel}
-    >
-      {deleteDatasetsMutation.isPending ? (
-        <Progress percent={progressInPercent} />
-      ) : (
-        <>
-          Are you sure you want to delete the following {deletableDatasetString}?
-          <ul>
-            {deletableDatasets.map((dataset) => (
-              <li key={dataset.id}>{dataset.name}</li>
-            ))}
-          </ul>
-          {numberOfUndeletableDatasets > 0 && (
-            <div>
-              The remaining {numberOfUndeletableDatasets} selected{" "}
-              {pluralize("dataset", numberOfUndeletableDatasets)} cannot be deleted, e.g. because
-              you do not have sufficient permissions.
-            </div>
-          )}
-          {cantBeUndoneMessage}
-        </>
-      )}
-    </Modal>
-  );
+  const handleDeleteClick = () => {
+    setIsDeletionPending(true);
+    const uniqueFolderIds = uniq(deletableDatasets.map((ds) => ds.folderId));
+    const snapshots = new Map<string, APIDatasetCompact[] | undefined>();
+    uniqueFolderIds.forEach((folderId) => {
+      snapshots.set(
+        folderId,
+        queryClient.getQueryData<APIDatasetCompact[]>(["datasetsByFolder", folderId]),
+      );
+      queryClient.setQueryData(
+        ["datasetsByFolder", folderId],
+        (oldItems: APIDatasetCompact[] | undefined) =>
+          oldItems?.filter((item) => !deletableDatasets.some((d) => d.id === item.id)),
+      );
+    });
+    queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+
+    const toastKey = "delete-datasets-undo";
+    const n = deletableDatasets.length;
+
+    const undo = () => {
+      if (timeoutRef.current != null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      setIsDeletionPending(false);
+      Toast.close(toastKey);
+      uniqueFolderIds.forEach((folderId) => {
+        queryClient.setQueryData(["datasetsByFolder", folderId], snapshots.get(folderId));
+      });
+      queryClient.invalidateQueries({ queryKey: ["dataset", "search"] });
+    };
+
+    Toast.info(`${n} ${pluralize("dataset", n)} deleted.`, {
+      key: toastKey,
+      sticky: true,
+      customFooter: <UndoButton onUndo={undo} />,
+    });
+
+    timeoutRef.current = setTimeout(() => {
+      setIsDeletionPending(false);
+      Toast.close(toastKey);
+      deleteDatasetsMutation.mutate(deletableDatasets);
+    }, 5000);
+  };
 
   return (
     <div style={{ textAlign: "center" }}>
@@ -334,12 +315,11 @@ function DatasetsDetails({
           with drag and drop.
         </div>
         {deletableDatasets.length > 0 && features().allowDeleteDatasets && (
-          <Button onClick={() => setShowConfirmDeleteModal(true)} icon={<DeleteOutlined />}>
+          <Button onClick={handleDeleteClick} disabled={isDeletionPending} icon={<DeleteOutlined />}>
             Delete {deletableDatasetString}
           </Button>
         )}
       </Space>
-      {confirmModal}
     </div>
   );
 }

--- a/frontend/javascripts/dashboard/folders/folder_tree.tsx
+++ b/frontend/javascripts/dashboard/folders/folder_tree.tsx
@@ -1,15 +1,17 @@
 import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { useQueryClient } from "@tanstack/react-query";
 import { PricingPlanEnum } from "admin/organization/pricing_plan_utils";
-import { Dropdown, type MenuProps, Modal, Tree } from "antd";
+import { Button, Dropdown, type MenuProps, Modal, Tree } from "antd";
 import type { DataNode, DirectoryTreeProps } from "antd/lib/tree";
 import classNames from "classnames";
 import { PricingEnforcedSpan } from "components/pricing_enforcers";
 import Toast from "libs/toast";
+import { pluralize } from "libs/utils";
 import memoizeOne from "memoize-one";
 import type React from "react";
 import { type Key, useCallback, useEffect, useRef, useState } from "react";
 import { type ConnectDropTarget, type DropTargetMonitor, useDrop } from "react-dnd";
-import type { FolderItem } from "types/api_types";
+import { type APIDatasetCompact, type FolderItem } from "types/api_types";
 import type { ArbitraryObject } from "types/type_utils";
 import { DraggableDatasetType } from "../advanced_dataset/dataset_table";
 import {
@@ -316,7 +318,10 @@ export function useDatasetDrop(
   ConnectDropTarget,
 ] {
   const context = useDatasetCollectionContext();
+  const queryClient = useQueryClient();
   const { selectedDatasets, setSelectedDatasets } = context;
+  const targetFolderName =
+    context.queries.folderHierarchyQuery.data?.itemById[folderId]?.title ?? folderId;
   const [collectedProps, drop] = useDrop<
     DnDDropItemProps,
     void,
@@ -335,10 +340,12 @@ export function useDatasetDrop(
           return;
         }
 
+        const datasetsToMove = selectedDatasets;
+
         // Show a modal so that the user cannot do anything else while the datasets are being moved.
         const modal = Modal.info({
           title: "Moving Datasets",
-          content: `Preparing to move ${selectedDatasets.length} datasets...`,
+          content: `Preparing to move ${datasetsToMove.length} datasets...`,
           onCancel: (_close) => {},
           onOk: (_close) => {},
           okText: null,
@@ -346,20 +353,61 @@ export function useDatasetDrop(
 
         let successCounter = 0;
         Promise.all(
-          selectedDatasets.map((ds) =>
+          datasetsToMove.map((ds) =>
             context.queries.updateDatasetMutation.mutateAsync([ds.id, { folderId }]).then(() => {
               successCounter++;
               modal.update({
-                content: `Already moved ${successCounter} of ${selectedDatasets.length} datasets.`,
+                content: `Already moved ${successCounter} of ${datasetsToMove.length} datasets.`,
               });
             }),
           ),
         )
           .then(
-            () => Toast.success(`Successfully moved ${selectedDatasets.length} datasets.`),
+            () => {
+              const toastKey = "move-datasets-undo";
+              const undo = () => {
+                Toast.close(toastKey);
+                datasetsToMove.forEach((ds) => {
+                  queryClient.setQueryData(
+                    ["datasetsByFolder", ds.folderId],
+                    (oldItems: APIDatasetCompact[] | undefined) => {
+                      if (oldItems == null) return oldItems;
+                      return [...oldItems.filter((el) => el.id !== ds.id), ds];
+                    },
+                  );
+                });
+                queryClient.setQueryData(
+                  ["datasetsByFolder", folderId],
+                  (oldItems: APIDatasetCompact[] | undefined) =>
+                    oldItems?.filter((el) => !datasetsToMove.some((ds) => ds.id === el.id)),
+                );
+                Promise.all(
+                  datasetsToMove.map((ds) =>
+                    context.queries.updateDatasetMutation.mutateAsync([
+                      ds.id,
+                      { folderId: ds.folderId },
+                    ]),
+                  ),
+                ).then(
+                  () =>
+                    Toast.success(
+                      `Successfully moved ${datasetsToMove.length} ${pluralize("dataset", datasetsToMove.length)} back.`,
+                    ),
+                  (err) => {
+                    Toast.error("Couldn't undo all moves. See console for details.");
+                    console.error(err);
+                  },
+                );
+              };
+              const n = datasetsToMove.length;
+              Toast.info(`${n} ${pluralize("dataset", n)} moved to "${targetFolderName}".`, {
+                key: toastKey,
+                customFooter: <Button onClick={undo}>Undo</Button>,
+              });
+            },
             (err) => {
               Toast.error(
-                `Couldn't move all ${selectedDatasets.length} datasets. See console for details`,
+                `Couldn't move all ${datasetsToMove.length} datasets. See console for details`,
               );
               console.error(err);
             },
@@ -374,7 +422,33 @@ export function useDatasetDrop(
         const dataset = context.datasets.find((ds) => ds.id === item.datasetId);
 
         if (dataset) {
-          context.queries.updateDatasetMutation.mutateAsync([dataset.id, { folderId }]);
+          const originalFolderId = dataset.folderId;
+          const toastKey = `move-dataset-${dataset.id}`;
+          context.queries.updateDatasetMutation.mutateAsync([dataset.id, { folderId }]).then(() => {
+            const undo = () => {
+              Toast.close(toastKey);
+              queryClient.setQueryData(
+                ["datasetsByFolder", originalFolderId],
+                (oldItems: APIDatasetCompact[] | undefined) => {
+                  if (oldItems == null) return oldItems;
+                  return [...oldItems.filter((el) => el.id !== dataset.id), dataset];
+                },
+              );
+              queryClient.setQueryData(
+                ["datasetsByFolder", folderId],
+                (oldItems: APIDatasetCompact[] | undefined) =>
+                  oldItems?.filter((el) => el.id !== dataset.id),
+              );
+              context.queries.updateDatasetMutation.mutateAsync([
+                dataset.id,
+                { folderId: originalFolderId },
+              ]);
+            };
+            Toast.info(`Dataset “${dataset.name}” was moved to folder “${targetFolderName}”.`, {
+              key: toastKey,
+              customFooter: <Button onClick={undo}>Undo</Button>,
+            });
+          });
         } else {
           Toast.error("Could not move dataset. Please try again.");
         }

--- a/frontend/javascripts/dashboard/folders/folder_tree.tsx
+++ b/frontend/javascripts/dashboard/folders/folder_tree.tsx
@@ -11,7 +11,7 @@ import memoizeOne from "memoize-one";
 import type React from "react";
 import { type Key, useCallback, useEffect, useRef, useState } from "react";
 import { type ConnectDropTarget, type DropTargetMonitor, useDrop } from "react-dnd";
-import { type APIDatasetCompact, type FolderItem } from "types/api_types";
+import type { APIDatasetCompact, FolderItem } from "types/api_types";
 import type { ArbitraryObject } from "types/type_utils";
 import { DraggableDatasetType } from "../advanced_dataset/dataset_table";
 import {

--- a/frontend/javascripts/libs/delete_with_undo.tsx
+++ b/frontend/javascripts/libs/delete_with_undo.tsx
@@ -1,0 +1,49 @@
+import { handleGenericError } from "libs/error_handling";
+import Toast from "libs/toast";
+import { UndoButton } from "libs/undo_button";
+
+export const UNDO_SECONDS = 5;
+
+export function deleteWithUndo<T extends { id: string }>({
+  item,
+  toastMessage,
+  deleteApi,
+  onDelete,
+  onRestore,
+}: {
+  item: T;
+  toastMessage: string;
+  deleteApi: (id: string) => Promise<unknown>;
+  onDelete: () => void;
+  onRestore: () => void;
+}): void {
+  const toastKey = item.id;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  onDelete();
+
+  const undo = () => {
+    if (timeoutId != null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    Toast.close(toastKey);
+    onRestore();
+  };
+
+  Toast.info(toastMessage, {
+    key: toastKey,
+    sticky: true,
+    customFooter: <UndoButton onUndo={undo} seconds={UNDO_SECONDS} />,
+  });
+
+  timeoutId = setTimeout(async () => {
+    Toast.close(toastKey);
+    try {
+      await deleteApi(item.id);
+    } catch (error) {
+      handleGenericError(error as Error);
+      onRestore();
+    }
+  }, UNDO_SECONDS * 1000);
+}

--- a/frontend/javascripts/libs/undo_button.tsx
+++ b/frontend/javascripts/libs/undo_button.tsx
@@ -1,0 +1,19 @@
+import { Button } from "antd";
+import { useEffect, useState } from "react";
+
+export function UndoButton({ onUndo, seconds = 5 }: { onUndo: () => void; seconds?: number }) {
+  const [remaining, setRemaining] = useState(seconds);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRemaining((r) => r - 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <Button onClick={onUndo}>
+      Undo ({remaining})
+    </Button>
+  );
+}

--- a/frontend/javascripts/libs/undo_button.tsx
+++ b/frontend/javascripts/libs/undo_button.tsx
@@ -1,7 +1,7 @@
 import { Button } from "antd";
 import { useEffect, useState } from "react";
 
-export function UndoButton({ onUndo, seconds = 5 }: { onUndo: () => void; seconds?: number }) {
+export function UndoButton({ onUndo, seconds }: { onUndo: () => void; seconds: number }) {
   const [remaining, setRemaining] = useState(seconds);
 
   useEffect(() => {

--- a/frontend/javascripts/libs/undo_button.tsx
+++ b/frontend/javascripts/libs/undo_button.tsx
@@ -11,9 +11,5 @@ export function UndoButton({ onUndo, seconds }: { onUndo: () => void; seconds: n
     return () => clearInterval(interval);
   }, []);
 
-  return (
-    <Button onClick={onUndo}>
-      Undo ({remaining})
-    </Button>
-  );
+  return <Button onClick={onUndo}>Undo ({remaining})</Button>;
 }


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
