### PR TITLE
Fix toggle crosshairs via command palette not working in dataset view

### DIFF
--- a/frontend/javascripts/viewer/view/components/command_palette.tsx
+++ b/frontend/javascripts/viewer/view/components/command_palette.tsx
@@ -130,7 +130,6 @@ export const CommandPalette = () => {
   const theme = getThemeFromUser(activeUser);
 
   const getTabsAndSettingsMenuItems = () => {
-    if (!isInAnnotationView) return [];
     const commands: CommandWithoutId[] = [];
 
     (Object.keys(userConfig) as [keyof UserConfiguration]).forEach((key) => {


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- TBD

### Steps to test:
- Open a dataset (not an annotation) in webknossos
- Open command palette (Ctrl+P / Cmd+P)
- Search for "Toggle Display Crosshair"
- Verify the command is now visible and works

### Root Cause
`getTabsAndSettingsMenuItems` in `command_palette.tsx` had an early-return guard `if (!isInAnnotationView) return []` that prevented all boolean user setting toggles (including `displayCrosshair`) from being registered in the command palette when in dataset view mode.

### Fix
Removed the `!isInAnnotationView` guard so setting toggles are available in the command palette regardless of whether the user is in annotation view or dataset view mode.

### Issues
- fixes WEB-7

------
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable
- [ ] Updated documentation if applicable
- [ ] Adapted wk-libs python client if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered common edge cases
- [ ] Needs datastore update after deployment