### PR TITLE
default to sessionId emptystring in mutex request, for compatibility …

### DIFF
--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -451,7 +451,7 @@ class AnnotationController @Inject()(
       _ <- annotationDAO.insertOne(clonedAnnotation)
     } yield clonedAnnotation
 
-  def tryAcquiringAnnotationMutex(id: ObjectId, sessionId: String): Action[AnyContent] =
+  def tryAcquiringAnnotationMutex(id: ObjectId, sessionId: String = ""): Action[AnyContent] =
     sil.SecuredAction.async { implicit request =>
       logTime(slackNotificationService.noticeSlowRequest, durationThreshold = 1 second) {
         for {


### PR DESCRIPTION
…with old sessions

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
