### PR TITLE
Fix order of evolutions

### DIFF
--- a/schema/evolutions/165-annotation-mutex-sessionid.sql
+++ b/schema/evolutions/165-annotation-mutex-sessionid.sql
@@ -1,11 +1,11 @@
 START TRANSACTION;
 
-do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 165 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 164 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
 
 ALTER TABLE webknossos.annotation_mutexes ADD COLUMN sessionId TEXT;
 UPDATE webknossos.annotation_mutexes SET sessionId = _user;
 ALTER TABLE webknossos.annotation_mutexes ALTER COLUMN sessionId SET NOT NULL;
 
-UPDATE webknossos.releaseInformation SET schemaVersion = 166;
+UPDATE webknossos.releaseInformation SET schemaVersion = 165;
 
 COMMIT TRANSACTION;

--- a/schema/evolutions/166-keyboard-shortcuts.sql
+++ b/schema/evolutions/166-keyboard-shortcuts.sql
@@ -1,6 +1,6 @@
 START TRANSACTION;
 
-do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 164 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 165 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
 
 CREATE TABLE webknossos.multiUser_keyboardShortcutsConfigs(
   _multiUser TEXT CONSTRAINT _multiUser_objectId CHECK (_multiUser ~ '^[0-9a-f]{24}$') NOT NULL,
@@ -12,6 +12,6 @@ CREATE TABLE webknossos.multiUser_keyboardShortcutsConfigs(
 ALTER TABLE webknossos.multiUser_keyboardShortcutsConfigs
   ADD CONSTRAINT multiUser_ref FOREIGN KEY(_multiUser) REFERENCES webknossos.multiUsers(_id) ON DELETE CASCADE DEFERRABLE;
 
-UPDATE webknossos.releaseInformation SET schemaVersion = 165;
+UPDATE webknossos.releaseInformation SET schemaVersion = 166;
 
 COMMIT TRANSACTION;

--- a/schema/evolutions/reversions/165-annotation-mutex-sessionid.sql
+++ b/schema/evolutions/reversions/165-annotation-mutex-sessionid.sql
@@ -2,7 +2,7 @@ START TRANSACTION;
 
 do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 165 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
 
-DROP TABLE webknossos.multiUser_keyboardShortcutsConfigs;
+ALTER TABLE webknossos.annotation_mutexes DROP COLUMN sessionId;
 
 UPDATE webknossos.releaseInformation SET schemaVersion = 164;
 

--- a/schema/evolutions/reversions/166-keyboard-shortcuts.sql
+++ b/schema/evolutions/reversions/166-keyboard-shortcuts.sql
@@ -2,7 +2,7 @@ START TRANSACTION;
 
 do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 166 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
 
-ALTER TABLE webknossos.annotation_mutexes DROP COLUMN sessionId;
+DROP TABLE webknossos.multiUser_keyboardShortcutsConfigs;
 
 UPDATE webknossos.releaseInformation SET schemaVersion = 165;
 

--- a/unreleased_changes/9081.md
+++ b/unreleased_changes/9081.md
@@ -2,4 +2,4 @@
 - Keyboard shortcuts are configurable now. They are displayed in a new shortcuts dialog (together with mouse shortcuts which are not editable).
 
 ### Postgres Evolutions
-- [165-keyboard-shortcuts.sql](schema/evolutions/165-keyboard-shortcuts.sql)
+- [166-keyboard-shortcuts.sql](schema/evolutions/166-keyboard-shortcuts.sql)

--- a/unreleased_changes/9561.md
+++ b/unreleased_changes/9561.md
@@ -2,4 +2,4 @@
 - Annotation Mutex mechanism now prevents editing the same annotation in multiple tabs as the same user. This avoids update conflicts.
 
 ### Postgres Evolutions
-- [166-annotation-mutex-sessionid.sql](schema/evolutions/166-annotation-mutex-sessionid.sql)
+- [165-annotation-mutex-sessionid.sql](schema/evolutions/165-annotation-mutex-sessionid.sql)


### PR DESCRIPTION
I just merged #9081 with wrong order of evolutions after using the bumping script. This PR corrects the order again.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- CI should be enough

### TODOs:
- [ ] ...

### Issues:
- fixes evolution order mismatch caused by #9081

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
