### PR TITLE
Avoid dynamic import in healthcheck

### DIFF
--- a/frontend/javascripts/admin/datastore_health_check.ts
+++ b/frontend/javascripts/admin/datastore_health_check.ts
@@ -6,6 +6,7 @@ import {
   isInMaintenance as isInMaintenanceAPICall,
   pingHealthEndpoint,
 } from "admin/rest_api";
+import { registerPingFn } from "libs/handle_request_error_helper";
 import Toast from "libs/toast";
 import memoize from "lodash-es/memoize";
 import throttle from "lodash-es/throttle";
@@ -114,3 +115,5 @@ const extractUrls = (str: string): Array<string> => {
 export const pingMentionedDataStores = (str: string): void => {
   extractUrls(str).map(pingDataStoreIfAppropriate);
 };
+
+registerPingFn(pingMentionedDataStores);

--- a/frontend/javascripts/libs/handle_request_error_helper.tsx
+++ b/frontend/javascripts/libs/handle_request_error_helper.tsx
@@ -3,7 +3,9 @@ import type { ServerErrorMessage } from "types/api_types";
 import Toast, { showToastOnce } from "./toast";
 
 let _pingFn: (str: string) => void = () => {
-  console.warn("pingMentionedDataStores was called before registerPingFn — datastore health check skipped");
+  console.warn(
+    "pingMentionedDataStores was called before registerPingFn — datastore health check skipped",
+  );
 };
 
 export function registerPingFn(fn: (str: string) => void): void {

--- a/frontend/javascripts/libs/handle_request_error_helper.tsx
+++ b/frontend/javascripts/libs/handle_request_error_helper.tsx
@@ -2,6 +2,14 @@ import { Button } from "antd";
 import type { ServerErrorMessage } from "types/api_types";
 import Toast, { showToastOnce } from "./toast";
 
+let _pingFn: (str: string) => void = () => {
+  console.warn("pingMentionedDataStores was called before registerPingFn — datastore health check skipped");
+};
+
+export function registerPingFn(fn: (str: string) => void): void {
+  _pingFn = fn;
+}
+
 export const handleError = async (
   requestedUrl: string,
   showErrorToast: boolean,
@@ -9,10 +17,8 @@ export const handleError = async (
   error: Response | Error,
 ): Promise<void> => {
   if (doInvestigate) {
-    // Avoid circular imports via dynamic import
-    const { pingMentionedDataStores } = await import("admin/datastore_health_check");
     // Check whether this request failed due to a problematic datastore
-    pingMentionedDataStores(requestedUrl);
+    _pingFn(requestedUrl);
     if (error instanceof Response) {
       // Handle 401 Unauthorized errors and ensure an understandable error toast is shown.
       // This might happen e.g. after a user logged out everywhere.
@@ -50,7 +56,7 @@ export const handleError = async (
             }
             // Check whether the error chain mentions an url which belongs
             // to a datastore. Then, ping the datastore
-            pingMentionedDataStores(text);
+            _pingFn(text);
 
             /* eslint-disable-next-line prefer-promise-reject-errors */
             return Promise.reject({ ...json, url: requestedUrl });

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -1,6 +1,7 @@
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import { QueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import "admin/datastore_health_check";
 import { getActiveUser } from "admin/rest_api";
 import { message } from "antd";
 import ErrorBoundary from "components/error_boundary";

--- a/unreleased_changes/9634.md
+++ b/unreleased_changes/9634.md
@@ -1,2 +1,2 @@
 ### Fixed
-- Make the datastore healtcheck more robust.
+- Make the datastore healthcheck more robust.

--- a/unreleased_changes/9634.md
+++ b/unreleased_changes/9634.md
@@ -1,0 +1,2 @@
+### Fixed
+- Make the datastore healtcheck more robust.


### PR DESCRIPTION
If a request fails due to network error, a health check is performed by dynamically importinging another module. if that request fails, too, WK crashes. I fixed this by avoiding the circular import altogether.

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- block some network request in the dev tools (e.g., perform find-my-data, block the listed request and then run find-my-data again)
- check that healthcheck requests are made

### Issues:
- contributes to #9540

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
