### PR TITLE
Re-allow remote origin for upload routes

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/UploadController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/UploadController.scala
@@ -34,6 +34,8 @@ class UploadController @Inject()(
     slackNotificationService: DSSlackNotificationService)(implicit bodyParsers: PlayBodyParsers, ec: ExecutionContext)
     extends Controller {
 
+  override def allowRemoteOrigin: Boolean = true
+
   def reserveDatasetUpload(): Action[DatasetUploadInfo] =
     Action.async(validateJson[DatasetUploadInfo]) { implicit request =>
       accessTokenService.validateAccessFromTokenContext(


### PR DESCRIPTION
Fixes regression from #9402 (where the upload routes were extracted from DataSourceController into the new UploadController. The new one also needs this line.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1780467070393489

- [x] Needs datastore update after deployment
