### PR TITLE
Limit Redis Connections

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
@@ -29,7 +29,7 @@ import com.scalableminds.webknossos.datastore.services.segmentindex.{
   ZarrSegmentIndexFileService
 }
 import com.scalableminds.webknossos.datastore.services.uploading.UploadService
-import com.scalableminds.webknossos.datastore.storage.{DataVaultService, S3ClientPoolHolder}
+import com.scalableminds.webknossos.datastore.storage.{DataVaultService, S3ClientPoolHolder, DataStoreRedisStore}
 
 class DataStoreModule extends AbstractModule {
 
@@ -66,5 +66,6 @@ class DataStoreModule extends AbstractModule {
     bind(classOf[DSFullMeshService]).asEagerSingleton()
     bind(classOf[DatasetCache]).asEagerSingleton()
     bind(classOf[S3ClientPoolHolder]).asEagerSingleton()
+    bind(classOf[DataStoreRedisStore]).asEagerSingleton()
   }
 }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RedisTemporaryStore.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/RedisTemporaryStore.scala
@@ -13,7 +13,7 @@ trait RedisTemporaryStore extends LazyLogging with FoxImplicits {
   protected def address: String
   protected def port: Int
   lazy val authority: String = f"$address:$port"
-  private lazy val r = new RedisClientPool(address, port)
+  private lazy val r = new RedisClientPool(address, port, maxConnections = 100)
 
   def find(id: String): Fox[String] =
     withExceptionHandler(_.get(id)).map(_.toFox).flatten

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreModule.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/TracingStoreModule.scala
@@ -15,6 +15,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.{
   TracingDataStore
 }
 import org.apache.pekko.actor.ActorSystem
+import com.scalableminds.webknossos.tracingstore.TracingStoreRedisStore
 
 class TracingStoreModule extends AbstractModule {
 
@@ -37,6 +38,7 @@ class TracingStoreModule extends AbstractModule {
     bind(classOf[TsTempFileService]).asEagerSingleton()
     bind(classOf[TSCleanUpService]).asEagerSingleton()
     bind(classOf[TemporaryMergedVolumeStatsStore]).asEagerSingleton()
+    bind(classOf[TracingStoreRedisStore]).asEagerSingleton()
   }
 
 }


### PR DESCRIPTION
The injector created n of those client stores, and each of those created an m-sized connection pool. This PR limits n to 1 and m to 100.

### URL of deployed dev instance (used for testing):
- https://limitredisconnections.webknossos.xyz

### Steps to test:
- Trace some, should not crash

------
- [x] Needs datastore update after deployment
