### PR TITLE
Restore annotation read access for admins and owner for visibility=Private

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -268,7 +268,18 @@ class AnnotationDAO @Inject()(sqlClient: SqlClient, annotationLayerDAO: Annotati
             (SELECT _organization FROM webknossos.users_ WHERE _id = ${prefix}_user)
             IN (SELECT _organization FROM webknossos.users_ WHERE _id = $requestingUserId)
           )
-        )"""
+        )
+        OR (
+          ${prefix}visibility = ${AnnotationVisibility.Private}
+          AND (
+            ${prefix}_user = $requestingUserId
+            OR (
+              (SELECT _organization FROM webknossos.users_ WHERE _id = ${prefix}_user)
+              IN (SELECT _organization FROM webknossos.users_ WHERE _id = $requestingUserId AND isAdmin)
+            )
+          )
+        )
+        """
 
   override protected def deleteAccessQ(requestingUserId: ObjectId) =
     q"""(_user = $requestingUserId


### PR DESCRIPTION
fixing regression from #9610 

### URL of deployed dev instance (used for testing):
- https://privateanotations.webknossos.xyz

### Steps to test:
- As non-admin user, set an annotation to visibility private in sharing modal
- after reload you should still see your own annotation
- as other non-admin user you should not be able to view it
- as admin user of the same orga, you should be able to see it.

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1780557725510199

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
