### PR TITLE
Avoid duplicate edges in edge collection

### DIFF
--- a/frontend/javascripts/test/model/edge_collection.spec.ts
+++ b/frontend/javascripts/test/model/edge_collection.spec.ts
@@ -168,10 +168,6 @@ describe("EdgeCollection", () => {
         target: 4,
       },
       {
-        source: 0,
-        target: 1,
-      },
-      {
         source: 1,
         target: 6,
       },
@@ -200,11 +196,11 @@ describe("EdgeCollection", () => {
         target: 11,
       },
     ].sort(edgeSort);
-    const edgeCollectionA = new EdgeCollection(5).addEdges(edges.slice(0, 8));
+    const edgeCollectionA = new EdgeCollection(5).addEdges(edges.slice(0, 7));
     const edgeCollectionB = new EdgeCollection(5).addEdges(edges.slice(1));
     const { onlyA, onlyB } = diffEdgeCollections(edgeCollectionA, edgeCollectionB, false);
     expect(onlyA.sort(edgeSort)).toEqual([edges[0]]);
-    expect(onlyB.sort(edgeSort)).toEqual(edges.slice(8));
+    expect(onlyB.sort(edgeSort)).toEqual(edges.slice(7));
   });
 
   it("addEdge should not mutate the original edge collection", () => {
@@ -331,5 +327,63 @@ describe("EdgeCollection", () => {
     const deepDiff = diffEdgeCollections(edgeCollectionA, edgeCollectionB, true);
     expect(deepDiff.onlyA).toEqual([]);
     expect(deepDiff.onlyB).toEqual([edgeB, edgeC, edgeD]);
+  });
+
+  it("addEdge should not add a duplicate edge", () => {
+    const edgeA = {
+      source: 0,
+      target: 1,
+    };
+    const duplicateEdgeA = {
+      source: 0,
+      target: 1,
+    };
+    const edgeCollection = new EdgeCollection().addEdge(edgeA).addEdge(duplicateEdgeA);
+    expect(edgeCollection.size()).toBe(1);
+    expect(edgeCollection.outMap.getOrThrow(0)).toEqual([edgeA]);
+    expect(edgeCollection.inMap.getOrThrow(1)).toEqual([edgeA]);
+    expect(edgeCollection.getEdgesForNode(0)).toEqual([edgeA]);
+    expect(edgeCollection.getEdgesForNode(1)).toEqual([edgeA]);
+  });
+
+  it("addEdges should not add duplicate edges", () => {
+    const edgeA = {
+      source: 0,
+      target: 1,
+    };
+    const edgeB = {
+      source: 2,
+      target: 1,
+    };
+    const duplicateEdgeA = {
+      source: 0,
+      target: 1,
+    };
+    const edgeCollection = new EdgeCollection().addEdges([edgeA, edgeB, duplicateEdgeA]).addEdges([edgeA, edgeB, duplicateEdgeA]);
+    expect(edgeCollection.size()).toBe(2);
+    expect(edgeCollection.outMap.getOrThrow(0)).toEqual([edgeA]);
+    expect(edgeCollection.outMap.getOrThrow(2)).toEqual([edgeB]);
+    expect(edgeCollection.inMap.getOrThrow(1)).toEqual([edgeA, edgeB]);
+    expect(edgeCollection.getEdgesForNode(1)).toEqual([edgeA, edgeB]);
+  });
+
+  it("a deduplicated collection should not diff against an equivalent collection without duplicates", () => {
+    const edgeA = {
+      source: 0,
+      target: 1,
+    };
+    const edgeB = {
+      source: 2,
+      target: 1,
+    };
+    const duplicateEdgeA = {
+      source: 0,
+      target: 1,
+    };
+    const withDuplicates = new EdgeCollection().addEdges([edgeA, edgeB, duplicateEdgeA]);
+    const withoutDuplicates = new EdgeCollection().addEdges([edgeA, edgeB]);
+    const { onlyA, onlyB } = diffEdgeCollections(withDuplicates, withoutDuplicates, false);
+    expect(onlyA).toEqual([]);
+    expect(onlyB).toEqual([]);
   });
 });

--- a/frontend/javascripts/test/model/edge_collection.spec.ts
+++ b/frontend/javascripts/test/model/edge_collection.spec.ts
@@ -359,7 +359,9 @@ describe("EdgeCollection", () => {
       source: 0,
       target: 1,
     };
-    const edgeCollection = new EdgeCollection().addEdges([edgeA, edgeB, duplicateEdgeA]).addEdges([edgeA, edgeB, duplicateEdgeA]);
+    const edgeCollection = new EdgeCollection()
+      .addEdges([edgeA, edgeB, duplicateEdgeA])
+      .addEdges([edgeA, edgeB, duplicateEdgeA]);
     expect(edgeCollection.size()).toBe(2);
     expect(edgeCollection.outMap.getOrThrow(0)).toEqual([edgeA]);
     expect(edgeCollection.outMap.getOrThrow(2)).toEqual([edgeB]);

--- a/frontend/javascripts/viewer/model/edge_collection.ts
+++ b/frontend/javascripts/viewer/model/edge_collection.ts
@@ -35,13 +35,18 @@ export default class EdgeCollection implements NotEnumerableByObject {
   addEdges(edges: Edge[], mutate: boolean = false): EdgeCollection {
     const newOutgoingEdges = mutate ? this.outMap : this.outMap.clone();
     const newIngoingEdges = mutate ? this.inMap : this.inMap.clone();
-    const newEdgeCount = this.edgeCount + edges.length;
+    let newEdgeCount = this.edgeCount;
 
     for (const edge of edges) {
       const outgoingEdges = newOutgoingEdges.getNullable(edge.source) || [];
+      if (outgoingEdges.find((existingEdge) => existingEdge.target === edge.target)) {
+        // Edge already exists. Don't add it again.
+        continue;
+      }
       const ingoingEdges = newIngoingEdges.getNullable(edge.target) || [];
       newOutgoingEdges.mutableSet(edge.source, outgoingEdges.concat(edge));
       newIngoingEdges.mutableSet(edge.target, ingoingEdges.concat(edge));
+      newEdgeCount++;
     }
 
     if (mutate) {
@@ -59,6 +64,11 @@ export default class EdgeCollection implements NotEnumerableByObject {
     const newEdgeCount = this.edgeCount + 1;
     const outgoingEdges = this.outMap.getNullable(edge.source) || [];
     const ingoingEdges = this.inMap.getNullable(edge.target) || [];
+
+    if (outgoingEdges.find((existingEdge) => existingEdge.target === edge.target)) {
+      // Edge already exists. Don't add it again.
+      return this;
+    }
 
     if (mutate) {
       this.outMap.mutableSet(edge.source, outgoingEdges.concat(edge));

--- a/frontend/javascripts/viewer/model/sagas/saving/save_saga.tsx
+++ b/frontend/javascripts/viewer/model/sagas/saving/save_saga.tsx
@@ -202,6 +202,12 @@ function* fetchNewestMissingUpdateActions(): Saga<APIUpdateActionBatch[]> {
     return state.annotation.version;
   });
 
+  if (window.ARTIFICAL_DELAY) {
+    console.log("Waiting for", window.ARTIFICAL_DELAY, "seconds.")
+    yield* delay(window.ARTIFICAL_DELAY);
+    console.log("Done waiting. About to request updates beginning from v=", versionOnClient + 1)
+  }
+
   // Fetch all update actions that belong to a version that is newer than
   // versionOnClient. If there are none, the array will be empty.
   // The order is ascending in the version number ([v_n, v_(n+1), ...]).
@@ -214,6 +220,7 @@ function* fetchNewestMissingUpdateActions(): Saga<APIUpdateActionBatch[]> {
     false,
     true,
   );
+  console.log("received:", newerActions);
   return newerActions;
 }
 

--- a/frontend/javascripts/viewer/model/sagas/saving/save_saga.tsx
+++ b/frontend/javascripts/viewer/model/sagas/saving/save_saga.tsx
@@ -202,12 +202,6 @@ function* fetchNewestMissingUpdateActions(): Saga<APIUpdateActionBatch[]> {
     return state.annotation.version;
   });
 
-  if (window.ARTIFICAL_DELAY) {
-    console.log("Waiting for", window.ARTIFICAL_DELAY, "seconds.")
-    yield* delay(window.ARTIFICAL_DELAY);
-    console.log("Done waiting. About to request updates beginning from v=", versionOnClient + 1)
-  }
-
   // Fetch all update actions that belong to a version that is newer than
   // versionOnClient. If there are none, the array will be empty.
   // The order is ascending in the version number ([v_n, v_(n+1), ...]).
@@ -220,7 +214,6 @@ function* fetchNewestMissingUpdateActions(): Saga<APIUpdateActionBatch[]> {
     false,
     true,
   );
-  console.log("received:", newerActions);
   return newerActions;
 }
 

--- a/unreleased_changes/9648.md
+++ b/unreleased_changes/9648.md
@@ -1,2 +1,2 @@
 ### Fixed
-- Fixed that edges could be stored redundantly which could lead to missing edges in rare circumstances.
+- Fixed an issue where edges could be stored redundantly, which could lead to missing edges in rare circumstances.

--- a/unreleased_changes/9648.md
+++ b/unreleased_changes/9648.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that edges could be stored redundantly which could lead to missing edges in rare circumstances.


### PR DESCRIPTION
The PR ensures that adding the same edge(s) to an edge collection is idempotent and doesn't cause redundant edges. This is a hotfix (see https://scm.slack.com/archives/C5AKLAV0B/p1780572589003789 for context).

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
No need to test again in my opinion since I also added regression tests:
- using f4d27ac0a4bb8ef821efc01d3fab9dd85bc2ffef I was able to provoke the missing edge bug
- I created a new annotation and set collab mode to exclusive
- I enabled the artificial delay
- I waited for the delay to kick
- then created multiple nodes and saved
- after the delay passed, the just saved versions were pulled and re-applied
- creating more nodes and then deleting one + saving + reload --> edges were missing

### Issues:
- fixes missing edges / corrupted skeleton bug

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
