### PR TITLE
Remove constraints for reading model voxel sizes

### DIFF
--- a/app/controllers/AiModelController.scala
+++ b/app/controllers/AiModelController.scala
@@ -121,7 +121,6 @@ class AiModelController @Inject()(
 
   def aiModelVoxelSize(aiModelId: ObjectId): Action[AnyContent] = sil.SecuredAction.async { implicit request =>
     for {
-      _ <- organizationService.assertIsSuperUserOrOrganizationHasAiPlan(request.identity)
       aiModel <- aiModelDAO.findOne(aiModelId) ?~> Msg.AiModel.notFound ~> NOT_FOUND
       dataStore <- dataStoreDAO.findOneByName(aiModel._dataStore)
       voxelSize <- aiModelService.findModelVoxelSize(aiModel, dataStore)

--- a/unreleased_changes/9658.md
+++ b/unreleased_changes/9658.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that route /api/v1/aiModels/:id/voxelSize is available for all users 


### PR DESCRIPTION
Remove the Admin/AI plan constraints for reading model voxel sizes. AI Segmentation is enabled for all users (regardless of plan). Fetching a model's voxel size should not need a special permission.

Likely a regression caused by PR #[9477](https://github.com/scalableminds/webknossos/pull/9477)

### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
Test as a regular user or team//dataset manager
1. Open annotation
2. AI Analysis > Run Segmentation
3. Select a BB
4. it should not crash


### Issues:
- fixes #https://scm.slack.com/archives/C02H5T8Q08P/p1780668873524699

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
