### PR TITLE
On yarn start, poll backend to reduce startup wait times

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "start": "concurrently \"yarn dev\" \"yarn start-backend\" \"yarn start-fossildb\"",
+    "start": "concurrently \"yarn dev\" \"yarn start-backend\" \"yarn start-fossildb\" \"tools/poll-backend.sh\"",
     "start-backend": "sbt \"run 9001\" -jvm-debug 5005 -J-XX:MaxMetaspaceSize=2048m -J-Xmx8g -Dlogger.file=conf/logback-dev.xml",
     "start-fossildb": "fossildb/run.sh > fossildb/logs",
     "dev-gen-tls": "./tools/gen-ssl-dev-certs.sh",

--- a/tools/poll-backend.sh
+++ b/tools/poll-backend.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Polls localhost:9001 until it responds successfully, triggering the Play app to compile.
+echo "Waiting for backend at localhost:9001..."
+until curl -sf -o /dev/null http://localhost:9001; do
+  sleep 0.5
+done
+echo "Backend is up."

--- a/tools/poll-backend.sh
+++ b/tools/poll-backend.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Polls localhost:9001 until it responds successfully, triggering the Play app to compile.
-echo "Waiting for backend at localhost:9001..."
-until curl -sf -o /dev/null http://localhost:9001; do
+until curl -sf -o /dev/null http://localhost:9001/api/buildinfo; do
   sleep 0.5
 done
-echo "Backend is up."


### PR DESCRIPTION
A dev only change: when starting via `yarn start`, poll the backend 9001 directly, triggering full backend startup before vite gets ready to trigger it. This reduces wait times until wk is fully ready.

The script stops polling once successful so that during backend development while the server runs, there isn’t recompilation all the time. This is just about the startup.

### Steps to test:
- `yarn start` should fully start backend even if you don’t visit `localhost:9000`.
- If you do, it should be ready faster