### PR TITLE
Allow gzip compressor for zarr2 arrays

### DIFF
--- a/unreleased_changes/9667.md
+++ b/unreleased_changes/9667.md
@@ -1,0 +1,2 @@
+### Added
+- Added support for the gzip compression for zarr2 datasets.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrCompressorFactory.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrCompressorFactory.scala
@@ -1,6 +1,16 @@
 package com.scalableminds.webknossos.datastore.datareaders.zarr
 
-import com.scalableminds.webknossos.datastore.datareaders.{BloscCompressor, CompressionSetting, Compressor, GzipCompressor, IntCompressionSetting, NullCompressor, StringCompressionSetting, ZlibCompressor, ZstdCompressor}
+import com.scalableminds.webknossos.datastore.datareaders.{
+  BloscCompressor,
+  CompressionSetting,
+  Compressor,
+  GzipCompressor,
+  IntCompressionSetting,
+  NullCompressor,
+  StringCompressionSetting,
+  ZlibCompressor,
+  ZstdCompressor
+}
 
 object ZarrCompressorFactory {
   val nullCompressor = new NullCompressor

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrCompressorFactory.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrCompressorFactory.scala
@@ -1,15 +1,6 @@
 package com.scalableminds.webknossos.datastore.datareaders.zarr
 
-import com.scalableminds.webknossos.datastore.datareaders.{
-  BloscCompressor,
-  CompressionSetting,
-  Compressor,
-  IntCompressionSetting,
-  NullCompressor,
-  StringCompressionSetting,
-  ZlibCompressor,
-  ZstdCompressor
-}
+import com.scalableminds.webknossos.datastore.datareaders.{BloscCompressor, CompressionSetting, Compressor, GzipCompressor, IntCompressionSetting, NullCompressor, StringCompressionSetting, ZlibCompressor, ZstdCompressor}
 
 object ZarrCompressorFactory {
   val nullCompressor = new NullCompressor
@@ -25,6 +16,7 @@ object ZarrCompressorFactory {
       case "null"  => nullCompressor
       case "zlib"  => new ZlibCompressor(properties)
       case "blosc" => new BloscCompressor(properties)
+      case "gzip"  => new GzipCompressor(properties)
       case "zstd" => {
         val level = properties.get("level") match {
           case Some(IntCompressionSetting(l)) => l


### PR DESCRIPTION
### Steps to test:
- Open gzip-compressed zarr2 dataset

-----
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
