### PR TITLE
Exclude schema-hash file when diffing schema dump directories

### DIFF
--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -301,7 +301,7 @@ function checkDbSchema() {
     const schemaDumpDir = getCachedExpectedSchemaDump();
 
     try {
-      safeSpawn("diff", ["--strip-trailing-cr", "-r", dbDumpDir, schemaDumpDir]);
+      safeSpawn("diff", ["--strip-trailing-cr", "-r", "--exclude=.schema-hash", dbDumpDir, schemaDumpDir]);
     } catch (err) {
       throw new Error(`Database schema is not up-to-date:\n${err.stdout}`);
     }


### PR DESCRIPTION
Avoid false positive diff checks, e.g. https://scm.slack.com/archives/CMBMU5684/p1781094986860689 , introduced in #9669 

I tested locally