### PR TITLE
Updated PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,9 @@
-### URL of deployed dev instance (used for testing):
-- https://___.webknossos.xyz
+### Summary
+
 
 ### Steps to test:
 - abc
 
-### TODOs:
-- [ ] ...
 
 ### Issues:
 - fixes #


### PR DESCRIPTION
This PR updates the GitHub PR template:

- added a Summary section, otherwise Claude typically does not add one
- removed Dev Deployment, since this is not handles by GH directly when using the `auto-deploy` tag.
- removed ToDo section, as previously [discussed in Slack](https://scm.slack.com/archives/C5AKLAV0B/p1769451461685859)


------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
