### PR TITLE
Fix refresh button spinner in voxelytics task list view

### DIFF
--- a/frontend/javascripts/admin/voxelytics/workflow_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_view.tsx
@@ -335,7 +335,7 @@ export default function WorkflowView() {
 
   const {
     data: report,
-    isLoading,
+    isFetching: isLoading,
     isError,
     refetch,
   } = useQuery({

--- a/unreleased_changes/9712.md
+++ b/unreleased_changes/9712.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed the spinner on the refresh button in the voxelytics workflow task list.


### PR DESCRIPTION
Looks like isLoading from React Query is only true during the initial fetch. The refresh button only sets isFetching to true.

I tested that this helps locally with artificially slowed-down responses from the server.