### PR TITLE
Add the possibility to add a local application.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ conf/application.conf-e
 .bloop
 .metals
 metals.sbt
+conf/application.local.conf
 
 **/screenshots/*.diff.png
 **/screenshots/*.new.png

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -384,3 +384,5 @@ externalPathDeletionService {
 
 # uncomment these lines for faster restart during local backend development (but beware the then-missing features):
 #slick.checkSchemaOnStartup = false
+
+include "application.local.conf"


### PR DESCRIPTION
This PR adds a the ability to load a local `conf/application.local.conf`:

1. Ignore by `git` by default
2. Ignore / treated as empty by `play` framework if file does not exist
3. Loaded last, so it can overwrite any default values

Overwrite any key with `<key>.<subkey> = <value>`, e.g.: 
```
features.jobsEnabled = true
```

### Steps to test:
1. Start WK without the file `conf/application.local.conf` --> should work
2. Create a `conf/application.local.conf` with a simple config, e.g. `features.jobsEnabled = true` --> verify that WK not has jobs enabled

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
