### PR TITLE
Make volume tool shortcuts available in Fill Tool again

### DIFF
--- a/frontend/javascripts/viewer/controller/combinations/tool_controls.ts
+++ b/frontend/javascripts/viewer/controller/combinations/tool_controls.ts
@@ -832,7 +832,7 @@ export class VoxelPipetteToolController extends ToolController {
     };
   }
 }
-export class FillCellToolController extends ToolController {
+export class FillCellToolController extends VolumeToolController {
   static getPlaneMouseControls(_planeId: OrthoView): MouseBindingMap {
     return {
       leftClick: (pos: Point2, plane: OrthoView, event: MouseEvent) => {

--- a/unreleased_changes/9720.md
+++ b/unreleased_changes/9720.md
@@ -1,0 +1,2 @@
+### Fixed
+- Reenabled volume tool keyboard shortcuts for the fill tool. For example, pressing `c` now creates a new segment again.


### PR DESCRIPTION
### Summary
Make the volume keyboard shortcuts available in fill tool again. The inheritance was wrong so e.g. shortcut `c` did not work while the fill tool was active

### Steps to test:
- Open an annotation
- activate the fill tool
- move mouse out of very shortcut
- in the footer in the right corner is the active segment id
- press c multiple times -> the active id should increase


### Issues:
- fixes self noticed bug

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)