### PR TITLE
Enable experimental collab proofreading for all users

### DIFF
--- a/frontend/javascripts/test/browser/collaboration/live_collaboration.browser_spec.ts
+++ b/frontend/javascripts/test/browser/collaboration/live_collaboration.browser_spec.ts
@@ -18,7 +18,6 @@ import { setCollaborationModeAction } from "viewer/model/actions/annotation_acti
 import { setPositionAction } from "viewer/model/actions/flycam_actions";
 import { proofreadMergeAction } from "viewer/model/actions/proofread_actions";
 import { cycleToolAction } from "viewer/model/actions/ui_actions";
-import { setActiveUserAction } from "viewer/model/actions/user_actions";
 import { setActiveCellAction } from "viewer/model/actions/volumetracing_actions";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { setCollaborationModeForAnnotation, updateDatasetTeams } from "../../../admin/rest_api";
@@ -121,21 +120,6 @@ describe("Live Collaboration", () => {
 
       // Log redux actions
       await page.evaluate(() => (window.webknossos.DEV.flags.logActions = true));
-
-      // Patch the active user in the store to be a superuser so the collaboration
-      // mode controls become available. This only affects the local Redux state —
-      // no backend call is made.
-      const activeUser = await page.evaluate(
-        () => window.webknossos.DEV.store.getState().activeUser,
-      );
-      const setActiveUserActionObj = setActiveUserAction({
-        ...activeUser,
-        isSuperUser: true,
-      } as any);
-      await page.evaluate(
-        (action) => window.webknossos.DEV.store.dispatch(action),
-        setActiveUserActionObj,
-      );
 
       // Activate HDF5 mapping
       await page.evaluate(

--- a/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
@@ -591,9 +591,6 @@ function _ShareModalView(props: Props) {
             </RadioGroup>
           </Col>
         </Row>
-        {/*
-          Concurrent Editing can only be enabled by super users for now.
-        */}
         <Row>
           <Col span={6} style={LEFT_COL_STYLE}>
             Can users edit simultaneously?

--- a/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
@@ -215,7 +215,6 @@ function _ShareModalView(props: Props) {
   const [isChangingInProgress, setIsChangingInProgress] = useState(false);
   const [sharedTeams, setSharedTeams] = useState<APITeam[]>([]);
   const sharingToken = useDatasetSharingToken(dataset);
-  const isCurrentUserSuperUser = useWkSelector((state) => state.activeUser?.isSuperUser);
 
   const othersMayEdit = isAnnotationEditableByNonOwners(annotation);
   const allowConcurrentEditing = annotation.collaborationMode === "Concurrent";
@@ -347,7 +346,7 @@ function _ShareModalView(props: Props) {
 
   const handleConcurrentEditingCheckboxChange = async (event: CheckboxChangeEvent) => {
     const value = event.target.checked;
-    if (value && (!hasEditableMapping(Store.getState()) || !isCurrentUserSuperUser)) {
+    if (value && !hasEditableMapping(Store.getState())) {
       Toast.warning(
         "Concurrent editing is currently only supported for proofreading annotations. Please select a mapping and perform one proofreading action. Afterwards, you may select the Concurrent mode.",
       );
@@ -595,45 +594,43 @@ function _ShareModalView(props: Props) {
         {/*
           Concurrent Editing can only be enabled by super users for now.
         */}
-        {isCurrentUserSuperUser ? (
-          <Row>
-            <Col span={6} style={LEFT_COL_STYLE}>
-              Can users edit simultaneously?
-            </Col>
-            <Col span={18}>
-              <FastTooltip title={concurrentDisabledReason ?? null}>
-                <Checkbox
-                  checked={newAllowConcurrentEditing}
-                  onChange={handleConcurrentEditingCheckboxChange}
-                  disabled={concurrentDisabledReason != null}
-                >
-                  Yes, allow simultaneous editing
-                  <FastTooltip title="Currently not recommended for production use. Requires at least one saved proofreading action.">
-                    <Tag
-                      style={{ marginLeft: 4 }}
-                      color="warning"
-                      icon={<ExclamationCircleOutlined />}
-                      variant="outlined"
-                    >
-                      Experimental
-                    </Tag>
-                  </FastTooltip>
-                </Checkbox>
-              </FastTooltip>
-              <Hint
-                style={{
-                  marginLeft: 24,
-                }}
+        <Row>
+          <Col span={6} style={LEFT_COL_STYLE}>
+            Can users edit simultaneously?
+          </Col>
+          <Col span={18}>
+            <FastTooltip title={concurrentDisabledReason ?? null}>
+              <Checkbox
+                checked={newAllowConcurrentEditing}
+                onChange={handleConcurrentEditingCheckboxChange}
+                disabled={concurrentDisabledReason != null}
               >
-                When enabled, users can edit the annotation in parallel. This feature is
-                experimental and is currently limited to the proofreading tool (
-                <b>skeleton and brushing will be disabled</b>). When disabled, only one user can
-                edit at the same time. We recommend to coordinate the collaboration with your peers
-                to avoid being blocked.
-              </Hint>
-            </Col>
-          </Row>
-        ) : null}
+                Yes, allow simultaneous editing
+                <FastTooltip title="Currently not recommended for production use. Requires at least one saved proofreading action.">
+                  <Tag
+                    style={{ marginLeft: 4 }}
+                    color="warning"
+                    icon={<ExclamationCircleOutlined />}
+                    variant="outlined"
+                  >
+                    Experimental
+                  </Tag>
+                </FastTooltip>
+              </Checkbox>
+            </FastTooltip>
+            <Hint
+              style={{
+                marginLeft: 24,
+              }}
+            >
+              When enabled, users can edit the annotation in parallel. This feature is experimental
+              and is currently limited to the proofreading tool (
+              <b>skeleton and brushing will be disabled</b>). When disabled, only one user can edit
+              at the same time. We recommend to coordinate the collaboration with your peers to
+              avoid being blocked.
+            </Hint>
+          </Col>
+        </Row>
       </PricingEnforcedBlur>
     </Modal>
   );

--- a/unreleased_changes/9726.md
+++ b/unreleased_changes/9726.md
@@ -1,0 +1,2 @@
+### Added
+- Added an experimental "live collaboration" mode that can be enabled in the "Share" dialog of an annotation. When enabled, multiple users can work in parallel on the same annotation. Note that this feature only allows to use the proofreading tool at the moment.


### PR DESCRIPTION
### Summary
Enables experimental collab proofreading for all users (not only super users).

### Steps to test:
- create an annotation, select an editable mapping, open share modal

### Issues:
- contributes to #5789 

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
