### PR TITLE
Keep already loaded proofreading helper meshes when auto mesh loading option is turned off

### DIFF
--- a/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
@@ -52,6 +52,7 @@ import {
   getMeshInfoForSegment,
   getSegmentsForLayer,
   getVolumeTracingById,
+  isMeshLoaded,
 } from "viewer/model/accessors/volumetracing_accessor";
 import {
   dispatchMaybeFetchMeshFilesAsync,
@@ -293,13 +294,19 @@ function* subscribeToAnnotationMutexInLiveCollab(proofreadingSagaId: string) {
   return null;
 }
 
-function* ensureSegmentItemAndLoadCoarseMesh(
+function* ensureSegmentItemAndMaybeLoadCoarseMesh(
   layerName: string,
   segmentId: number,
   position: Vector3,
   additionalCoordinates: AdditionalCoordinate[] | undefined,
 ): Saga<void> {
   yield* call(ensureSegmentItem, layerName, segmentId, position, additionalCoordinates);
+  const autoRenderMeshInProofreading = yield* select(
+    (state) => state.userConfiguration.autoRenderMeshInProofreading,
+  );
+  if (!autoRenderMeshInProofreading) {
+    return;
+  }
   yield* call(loadCoarseMesh, layerName, segmentId, position, additionalCoordinates);
 }
 
@@ -319,12 +326,6 @@ function* loadCoarseMesh(
   additionalCoordinates: AdditionalCoordinate[] | undefined,
   opacity?: number,
 ): Saga<void> {
-  const autoRenderMeshInProofreading = yield* select(
-    (state) => state.userConfiguration.autoRenderMeshInProofreading,
-  );
-  if (!autoRenderMeshInProofreading) {
-    return;
-  }
   const dataset = yield* select((state) => state.dataset);
   const layer = getLayerByName(dataset, layerName);
 
@@ -461,7 +462,7 @@ function* proofreadAtPosition(action: ProofreadAtPositionAction): Saga<void> {
 
   /* Load a coarse mesh of the agglomerate at the click position */
   yield* call(
-    ensureSegmentItemAndLoadCoarseMesh,
+    ensureSegmentItemAndMaybeLoadCoarseMesh,
     layerName,
     segmentId,
     position,
@@ -787,8 +788,15 @@ function* handleMergeViaTree(action: MergeTreesAction, ctx: OperationContext): S
     yield* call(refreshAffectedSegmentItems, volumeTracingId, refreshInfos);
     // Now that the segment items are up-to-date we can sync with the back-end and release the mutex.
     yield* call(syncWithBackend, ctx);
-    // Refreshing the meshes might take a while and won't block the saga here.
-    yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+    const shouldDoMeshRefreshing = yield* call(
+      shouldReloadMeshesAfterProofreadAction,
+      volumeTracingId,
+      [sourceInfo.agglomerateId, targetInfo.agglomerateId],
+    );
+    if (shouldDoMeshRefreshing) {
+      // Refreshing the meshes might take a while and won't block the saga here.
+      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+    }
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -1002,8 +1010,16 @@ function* handleSplitViaTree(
     yield* call(refreshAffectedSegmentItems, volumeTracingId, refreshInfos);
     // Now that the segment items are up-to-date we can sync with the back-end and release the mutex.
     yield* call(syncWithBackend, ctx);
-    // Refreshing the meshes might take a while and won't block the saga here.
-    yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+
+    const shouldDoMeshRefreshing = yield* call(
+      shouldReloadMeshesAfterProofreadAction,
+      volumeTracingId,
+      [sourceInfo.agglomerateId, targetInfo.agglomerateId],
+    );
+    if (shouldDoMeshRefreshing) {
+      // Refreshing the meshes might take a while and won't block the saga here.
+      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+    }
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -1267,9 +1283,16 @@ function* performPartitionedMinCut(
     // and release the mutex.
     yield* call(syncWithBackend, ctx);
 
-    // Refreshing the meshes might take a while and won't block the saga
-    // here.
-    yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+    const shouldDoMeshRefreshing = yield* call(
+      shouldReloadMeshesAfterProofreadAction,
+      volumeTracingId,
+      [agglomerateIdBeforeSplit],
+    );
+    if (shouldDoMeshRefreshing) {
+      // Refreshing the meshes might take a while and won't block the saga
+      // here.
+      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+    }
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -1440,8 +1463,16 @@ function* refreshProofreadingSegmentsAndMeshes(
   ];
   yield* call(refreshAffectedSegmentItems, volumeTracingId, refreshInfos);
   yield* call(syncWithBackend, ctx);
-  // Refreshing the meshes might take a while and won't block the saga here.
-  yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+
+  const shouldDoMeshRefreshing = yield* call(
+    shouldReloadMeshesAfterProofreadAction,
+    volumeTracingId,
+    [sourceInfo.agglomerateId, targetInfo.agglomerateId],
+  );
+  if (shouldDoMeshRefreshing) {
+    // Refreshing the meshes might take a while and won't block the saga here.
+    yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+  }
 }
 
 function* handleProofreadMerge(action: ProofreadMergeAction, ctx: OperationContext) {
@@ -1866,9 +1897,16 @@ function* handleProofreadCutFromNeighbors(action: Action, ctx: OperationContext)
 
     yield* call(syncWithBackend, ctx);
 
-    // Refreshing the meshes might take a while and won't block the saga
-    // here.
-    yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+    const shouldDoMeshRefreshing = yield* call(
+      shouldReloadMeshesAfterProofreadAction,
+      volumeTracingId,
+      [targetAgglomerateIdBeforeSplit],
+    );
+    if (shouldDoMeshRefreshing) {
+      // Refreshing the meshes might take a while and won't block the saga
+      // here.
+      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
+    }
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -2134,6 +2172,22 @@ export function* refreshAffectedSegmentItems(
   // By using `all`, we avoid problems which can occur when running too many
   // call effects in a for loop. Also see https://github.com/redux-saga/redux-saga/issues/1592.
   yield* all(ensureSegmentItemEffects);
+}
+
+export function* shouldReloadMeshesAfterProofreadAction(
+  layerName: string,
+  oldAgglomerateIds: number[],
+): Saga<boolean> {
+  const autoRenderMeshInProofreading = yield* select(
+    (state) => state.userConfiguration.autoRenderMeshInProofreading,
+  );
+  if (autoRenderMeshInProofreading) {
+    return true;
+  }
+  const hasAnyInvolvedMeshLoaded = yield* select((state) =>
+    oldAgglomerateIds.some((id) => isMeshLoaded(state, id, layerName)),
+  );
+  return hasAnyInvolvedMeshLoaded;
 }
 
 // Capture the current opacities of the given old agglomerates' meshes, keyed by agglomerate id, so

--- a/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
@@ -788,15 +788,9 @@ function* handleMergeViaTree(action: MergeTreesAction, ctx: OperationContext): S
     yield* call(refreshAffectedSegmentItems, volumeTracingId, refreshInfos);
     // Now that the segment items are up-to-date we can sync with the back-end and release the mutex.
     yield* call(syncWithBackend, ctx);
-    const shouldDoMeshRefreshing = yield* call(
-      shouldReloadMeshesAfterProofreadAction,
-      volumeTracingId,
-      [sourceInfo.agglomerateId, targetInfo.agglomerateId],
-    );
-    if (shouldDoMeshRefreshing) {
-      // Refreshing the meshes might take a while and won't block the saga here.
-      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
-    }
+
+    // Refreshing the meshes might take a while and won't block the saga here.
+    yield* spawnUntilCanceled(maybeRefreshAffectedMeshes, volumeTracingId, refreshInfos);
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -1011,15 +1005,8 @@ function* handleSplitViaTree(
     // Now that the segment items are up-to-date we can sync with the back-end and release the mutex.
     yield* call(syncWithBackend, ctx);
 
-    const shouldDoMeshRefreshing = yield* call(
-      shouldReloadMeshesAfterProofreadAction,
-      volumeTracingId,
-      [sourceInfo.agglomerateId, targetInfo.agglomerateId],
-    );
-    if (shouldDoMeshRefreshing) {
-      // Refreshing the meshes might take a while and won't block the saga here.
-      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
-    }
+    // Refreshing the meshes might take a while and won't block the saga here.
+    yield* spawnUntilCanceled(maybeRefreshAffectedMeshes, volumeTracingId, refreshInfos);
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -1283,16 +1270,9 @@ function* performPartitionedMinCut(
     // and release the mutex.
     yield* call(syncWithBackend, ctx);
 
-    const shouldDoMeshRefreshing = yield* call(
-      shouldReloadMeshesAfterProofreadAction,
-      volumeTracingId,
-      [agglomerateIdBeforeSplit],
-    );
-    if (shouldDoMeshRefreshing) {
-      // Refreshing the meshes might take a while and won't block the saga
-      // here.
-      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
-    }
+    // Refreshing the meshes might take a while and won't block the saga
+    // here.
+    yield* spawnUntilCanceled(maybeRefreshAffectedMeshes, volumeTracingId, refreshInfos);
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -1464,15 +1444,8 @@ function* refreshProofreadingSegmentsAndMeshes(
   yield* call(refreshAffectedSegmentItems, volumeTracingId, refreshInfos);
   yield* call(syncWithBackend, ctx);
 
-  const shouldDoMeshRefreshing = yield* call(
-    shouldReloadMeshesAfterProofreadAction,
-    volumeTracingId,
-    [sourceInfo.agglomerateId, targetInfo.agglomerateId],
-  );
-  if (shouldDoMeshRefreshing) {
-    // Refreshing the meshes might take a while and won't block the saga here.
-    yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
-  }
+  // Refreshing the meshes might take a while and won't block the saga here.
+  yield* spawnUntilCanceled(maybeRefreshAffectedMeshes, volumeTracingId, refreshInfos);
 }
 
 function* handleProofreadMerge(action: ProofreadMergeAction, ctx: OperationContext) {
@@ -1897,16 +1870,9 @@ function* handleProofreadCutFromNeighbors(action: Action, ctx: OperationContext)
 
     yield* call(syncWithBackend, ctx);
 
-    const shouldDoMeshRefreshing = yield* call(
-      shouldReloadMeshesAfterProofreadAction,
-      volumeTracingId,
-      [targetAgglomerateIdBeforeSplit],
-    );
-    if (shouldDoMeshRefreshing) {
-      // Refreshing the meshes might take a while and won't block the saga
-      // here.
-      yield* spawnUntilCanceled(refreshAffectedMeshes, volumeTracingId, refreshInfos);
-    }
+    // Refreshing the meshes might take a while and won't block the saga
+    // here.
+    yield* spawnUntilCanceled(maybeRefreshAffectedMeshes, volumeTracingId, refreshInfos);
   } finally {
     if (unsubscribeFromAnnotationMutex) {
       yield* call(unsubscribeFromAnnotationMutex);
@@ -2217,6 +2183,25 @@ export function* getOpacityByOldAgglomerateId(
     }
     return opacities;
   });
+}
+
+function* maybeRefreshAffectedMeshes(
+  layerName: string,
+  items: Array<{
+    oldAgglomerateId?: number;
+    newAgglomerateId: number;
+    nodePosition: Vector3;
+    opacity?: number; // see refreshAffectedMeshes below.
+  }>,
+) {
+  const shouldDoMeshRefreshing = yield* call(shouldReloadMeshesAfterProofreadAction, layerName, [
+    ...items.map((i) => i.oldAgglomerateId).filter((id) => id != null),
+  ]);
+  if (shouldDoMeshRefreshing) {
+    // Refreshing the meshes might take a while and won't block the saga
+    // here.
+    yield* spawnUntilCanceled(refreshAffectedMeshes, layerName, items);
+  }
 }
 
 export function* refreshAffectedMeshes(

--- a/unreleased_changes/9730.md
+++ b/unreleased_changes/9730.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that auxiliary helping meshes during proofreading were removed upon a proofreading action if the option to auto reload them was turned off. They are now preserved and still auto updated.


### PR DESCRIPTION
### Summary
During proofreading one can enable / disable auto loading of auxiliary meshes. If the toggle is off, but a user has such a mehs loaded and it is involved in a proofreading action (local or from another user during live collab) the mesh should still be refreshed and properly loaded.

### Steps to test:
- Open a proofreading annotation and auto load a mesh
- turn of the auto loading
- make a proofreading action where the loaded mesh is not involved -> should not load a mesh
- make a proofreading action where the loaded mesh is involved -> should reload mesh
- enable live collab
- in another tab make a proofreading action where no loaded mesh of the first tab is involved
- wait in the first tab for the update action to be applied -> no mesh loading should happen
- now in the other tab make a proofreading action where at least one mesh of the first tab is involved -> should trigger reloading in first tab


### Issues:
- fixes bug noticed during testing
- fixes #9727

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
