### PR TITLE
Preserve mesh visibility during proofreading mesh auto reloading

### DIFF
--- a/frontend/javascripts/viewer/api/api_latest.ts
+++ b/frontend/javascripts/viewer/api/api_latest.ts
@@ -2683,6 +2683,7 @@ class DataApi {
         seedAdditionalCoordinates,
         meshFileName,
         undefined,
+        undefined,
         effectiveLayerName,
       ),
     );

--- a/frontend/javascripts/viewer/model/actions/annotation_actions.ts
+++ b/frontend/javascripts/viewer/model/actions/annotation_actions.ts
@@ -328,6 +328,7 @@ export const addAdHocMeshAction = (
   mappingName: string | null | undefined,
   mappingType: MappingType | null | undefined,
   opacity: number | undefined,
+  isVisible: boolean | undefined,
 ) =>
   ({
     type: "ADD_AD_HOC_MESH",
@@ -338,6 +339,7 @@ export const addAdHocMeshAction = (
     mappingName,
     mappingType,
     opacity: opacity ?? Constants.DEFAULT_MESH_OPACITY,
+    isVisible: isVisible ?? true,
   }) as const;
 
 export const addPrecomputedMeshAction = (
@@ -348,6 +350,7 @@ export const addPrecomputedMeshAction = (
   meshFileName: string,
   mappingName: string | null | undefined,
   opacity: number | undefined,
+  isVisible: boolean | undefined,
 ) =>
   ({
     type: "ADD_PRECOMPUTED_MESH",
@@ -358,6 +361,7 @@ export const addPrecomputedMeshAction = (
     meshFileName,
     mappingName,
     opacity: opacity ?? Constants.DEFAULT_MESH_OPACITY,
+    isVisible: isVisible ?? true,
   }) as const;
 
 export const setCollaborationModeAction = (collaborationMode: AnnotationCollaborationMode) =>

--- a/frontend/javascripts/viewer/model/actions/segmentation_actions.ts
+++ b/frontend/javascripts/viewer/model/actions/segmentation_actions.ts
@@ -8,6 +8,7 @@ export type AdHocMeshInfo = {
   useDataStore?: boolean | null | undefined;
   preferredQuality?: number | null | undefined;
   opacity?: number | undefined;
+  isVisible?: boolean | undefined;
 };
 export type LoadAdHocMeshAction = ReturnType<typeof loadAdHocMeshAction>;
 export type LoadPrecomputedMeshAction = ReturnType<typeof loadPrecomputedMeshAction>;
@@ -36,6 +37,7 @@ export const loadPrecomputedMeshAction = (
   seedAdditionalCoordinates: AdditionalCoordinate[] | undefined | null,
   meshFileName: string,
   opacity: number | undefined,
+  isVisible: boolean | undefined,
   layerName?: string | undefined,
 ) =>
   ({
@@ -45,5 +47,6 @@ export const loadPrecomputedMeshAction = (
     seedAdditionalCoordinates,
     meshFileName,
     opacity,
+    isVisible,
     layerName,
   }) as const;

--- a/frontend/javascripts/viewer/model/reducers/annotation_reducer.ts
+++ b/frontend/javascripts/viewer/model/reducers/annotation_reducer.ts
@@ -374,13 +374,14 @@ function AnnotationReducer(state: WebknossosState, action: Action): WebknossosSt
         mappingName,
         mappingType,
         opacity,
+        isVisible,
       } = action;
       const meshInfo: MeshInformation = {
         segmentId: segmentId,
         seedPosition,
         seedAdditionalCoordinates,
         isLoading: false,
-        isVisible: true,
+        isVisible,
         isPrecomputed: false,
         opacity,
         mappingName,
@@ -420,13 +421,14 @@ function AnnotationReducer(state: WebknossosState, action: Action): WebknossosSt
         meshFileName,
         mappingName,
         opacity,
+        isVisible,
       } = action;
       const meshInfo: MeshInformation = {
         segmentId: segmentId,
         seedPosition,
         seedAdditionalCoordinates,
         isLoading: false,
-        isVisible: true,
+        isVisible,
         isPrecomputed: true,
         opacity,
         meshFileName,

--- a/frontend/javascripts/viewer/model/sagas/meshes/ad_hoc_mesh_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/meshes/ad_hoc_mesh_saga.ts
@@ -327,7 +327,7 @@ function* loadFullAdHocMesh(
   removeExistingMesh: boolean,
 ): Saga<void> {
   let isInitialRequest = true;
-  const { mappingName, mappingType, opacity } = meshExtraInfo;
+  const { mappingName, mappingType, opacity, isVisible } = meshExtraInfo;
   const clippedPosition = clipPositionToCubeBoundary(position, zoomStep, magInfo);
   yield* put(
     addAdHocMeshAction(
@@ -338,6 +338,7 @@ function* loadFullAdHocMesh(
       mappingName,
       mappingType,
       opacity,
+      isVisible,
     ),
   );
   yield* put(startedLoadingMeshAction(layer.name, segmentId));
@@ -664,6 +665,7 @@ function* refreshMesh(action: RefreshMeshAction): Saga<void> {
         meshInfo.seedAdditionalCoordinates,
         meshInfo.meshFileName,
         meshInfo.opacity,
+        meshInfo.isVisible,
         layerName,
       ),
     );

--- a/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/meshes/precomputed_mesh_saga.ts
@@ -113,8 +113,15 @@ function* maybeFetchMeshFiles(action: MaybeFetchMeshFilesAction): Saga<void> {
 }
 
 function* loadPrecomputedMesh(action: LoadPrecomputedMeshAction) {
-  const { segmentId, seedPosition, seedAdditionalCoordinates, meshFileName, layerName, opacity } =
-    action;
+  const {
+    segmentId,
+    seedPosition,
+    seedAdditionalCoordinates,
+    meshFileName,
+    layerName,
+    opacity,
+    isVisible,
+  } = action;
   const layer = yield* select((state) =>
     layerName != null
       ? getSegmentationLayerByName(state.dataset, layerName)
@@ -139,6 +146,7 @@ function* loadPrecomputedMesh(action: LoadPrecomputedMeshAction) {
       meshFileName,
       layer,
       opacity,
+      isVisible,
     ),
     cancel: take(
       ((otherAction: Action) =>
@@ -163,6 +171,7 @@ function* loadPrecomputedMeshForSegmentId(
   meshFileName: string,
   segmentationLayer: APISegmentationLayer,
   opacity: number | undefined,
+  isVisible: boolean | undefined,
 ): Saga<void> {
   const layerName = segmentationLayer.name;
   const annotationVersion = yield* select((state) => state.annotation.version);
@@ -176,6 +185,7 @@ function* loadPrecomputedMeshForSegmentId(
       meshFileName,
       mappingName,
       opacity,
+      isVisible,
     ),
   );
   yield* put(startedLoadingMeshAction(layerName, segmentId));

--- a/frontend/javascripts/viewer/model/sagas/saving/save_saga.tsx
+++ b/frontend/javascripts/viewer/model/sagas/saving/save_saga.tsx
@@ -77,7 +77,8 @@ import {
   waitUntilNoActiveOperations,
 } from "../saga_helpers";
 import {
-  getOpacityByOldAgglomerateId,
+  getMeshDisplayPropsByOldAgglomerateId,
+  type PreservedMeshDisplayProps,
   refreshAffectedMeshes,
   splitAgglomerateInMapping,
   updateMappingWithMerge,
@@ -231,10 +232,11 @@ const SAVING_CONFLICT_TOAST_KEY = "save_conflicts_warning";
 type ApplyingUpdateArtifacts = {
   // All properties having the layer name / tracing id as a key.
   meshIdsToRemovePerLayer: ReadonlyMap<string, ReadonlySet<number>>;
-  // Maps for each layer from agglomerate ids whose meshes should be (re)loaded to the opacity the
-  // reloaded mesh should inherit from the agglomerate it originated from (undefined if no opacity
-  // was stored for the original mesh). The key set defines which meshes to load.
-  meshesToLoadPerLayer: ReadonlyMap<string, ReadonlyMap<number, number | undefined>>;
+  // Maps for each layer from agglomerate ids whose meshes should be (re)loaded to the display
+  // properties (opacity and visibility) the reloaded mesh should inherit from the agglomerate it
+  // originated from (empty if nothing was stored for the original mesh). The key set defines which
+  // meshes to load.
+  meshesToLoadPerLayer: ReadonlyMap<string, ReadonlyMap<number, PreservedMeshDisplayProps>>;
 };
 
 type ApplyingUpdateResults = { success: boolean; artifactInfos: ApplyingUpdateArtifacts };
@@ -615,16 +617,20 @@ export function* tryToIncorporateActions(
   // Maps from the old agglomerate id to a potentially new one.
   // Duplicates are later ignored when refreshing the meshes.
   const meshIdsToRemovePerLayer: Map<string, Set<number>> = new Map();
-  // Maps each layer's agglomerate ids whose meshes should be (re)loaded to the opacity the reloaded
-  // mesh should inherit from the agglomerate it originated from (undefined if no opacity was stored).
-  // The opacities must be gathered here while the original meshes still exist; the meshes are only
-  // removed later in resolveApplyingUpdateArtifacts.
-  const meshesToLoadPerLayer: Map<string, Map<number, number | undefined>> = new Map();
-  function recordMeshToLoad(tracingId: string, agglomerateId: number, opacity: number | undefined) {
+  // Maps each layer's agglomerate ids whose meshes should be (re)loaded to the display properties
+  // (opacity and visibility) the reloaded mesh should inherit from the agglomerate it originated
+  // from (empty if nothing was stored). These must be gathered here while the original meshes still
+  // exist; the meshes are only removed later in resolveApplyingUpdateArtifacts.
+  const meshesToLoadPerLayer: Map<string, Map<number, PreservedMeshDisplayProps>> = new Map();
+  function recordMeshToLoad(
+    tracingId: string,
+    agglomerateId: number,
+    displayProps: PreservedMeshDisplayProps,
+  ) {
     if (!meshesToLoadPerLayer.has(tracingId)) {
       meshesToLoadPerLayer.set(tracingId, new Map());
     }
-    meshesToLoadPerLayer.get(tracingId)?.set(agglomerateId, opacity);
+    meshesToLoadPerLayer.get(tracingId)?.set(agglomerateId, displayProps);
   }
 
   for (const actionBatch of newerActions) {
@@ -781,24 +787,26 @@ export function* tryToIncorporateActions(
           addToSetMap(meshIdsToRemovePerLayer, actionTracingId, agglomerateId1);
           addToSetMap(meshIdsToRemovePerLayer, actionTracingId, agglomerateId2);
           // The merged mesh keeps agglomerateId1 (the source), so it should inherit the source's
-          // opacity. Fall back to the target's opacity in case only the target mesh was loaded.
-          const mergedMeshOpacity = yield* select(
-            (state) =>
+          // opacity and visibility. Fall back to the target's mesh in case only the target mesh was
+          // loaded.
+          const mergedMeshDisplayProps: PreservedMeshDisplayProps = yield* select((state) => {
+            const meshInfo =
               getMeshInfoForSegment(
                 state,
                 state.flycam.additionalCoordinates,
                 actionTracingId,
                 agglomerateId1,
-              )?.opacity ??
+              ) ??
               getMeshInfoForSegment(
                 state,
                 state.flycam.additionalCoordinates,
                 actionTracingId,
                 agglomerateId2,
-              )?.opacity,
-          );
-          // Only agglomerateId1 needs to be reloaded; record it with the opacity to inherit.
-          recordMeshToLoad(actionTracingId, agglomerateId1, mergedMeshOpacity);
+              );
+            return { opacity: meshInfo?.opacity, isVisible: meshInfo?.isVisible };
+          });
+          // Only agglomerateId1 needs to be reloaded; record it with the props to inherit.
+          recordMeshToLoad(actionTracingId, agglomerateId1, mergedMeshDisplayProps);
           // Drop any previously queued reload of agglomerateId2 as it was merged into agglomerateId1.
           meshesToLoadPerLayer.get(actionTracingId)?.delete(agglomerateId2);
           break;
@@ -958,13 +966,14 @@ export function* tryToIncorporateActions(
         const loadedMeshes = yield* select((state) => getAllLoadedMeshes(state, tracingId));
         const loadedMeshesOfSplitAction = loadedMeshes.intersection(oldAgglomerateIds);
         if (loadedMeshesOfSplitAction.size > 0) {
-          // Capture the opacities of the original agglomerates before their meshes are removed,
-          // so each split-off agglomerate can inherit the opacity of the agglomerate it came from.
+          // Capture the opacity and visibility of the original agglomerates before their meshes are
+          // removed, so each split-off agglomerate can inherit the properties of the agglomerate it
+          // came from.
           const additionalCoordinates = yield* select(
             (state) => state.flycam.additionalCoordinates,
           );
-          const opacityByOldAgglomerateId = yield* call(
-            getOpacityByOldAgglomerateId,
+          const displayPropsByOldAgglomerateId = yield* call(
+            getMeshDisplayPropsByOldAgglomerateId,
             tracingId,
             oldAgglomerateIds,
             additionalCoordinates,
@@ -974,9 +983,10 @@ export function* tryToIncorporateActions(
           });
           newAgglomerateIds.forEach((newAggloId) => {
             const oldAggloId = newToOldAgglomerateIds.get(newAggloId);
-            const opacity =
-              oldAggloId != null ? opacityByOldAgglomerateId.get(oldAggloId) : undefined;
-            recordMeshToLoad(tracingId, newAggloId, opacity);
+            const displayProps =
+              (oldAggloId != null ? displayPropsByOldAgglomerateId.get(oldAggloId) : undefined) ??
+              {};
+            recordMeshToLoad(tracingId, newAggloId, displayProps);
           });
         }
       }
@@ -1018,18 +1028,19 @@ function* reloadMeshes(meshesToReloadPerLayer: ApplyingUpdateArtifacts["meshesTo
   // First wait in case an operation is running (e.g. proofreading) until it finishes.
   yield call(waitUntilNoActiveOperations);
   const refreshAffectedMeshesEffects = [];
-  for (const [tracingId, opacityByAgglomerateId] of meshesToReloadPerLayer.entries()) {
+  for (const [tracingId, displayPropsByAgglomerateId] of meshesToReloadPerLayer.entries()) {
     const refreshList: Array<{
       newAgglomerateId: number;
       nodePosition: Vector3;
       opacity?: number;
+      isVisible?: boolean;
     }> = [];
     const { hasSegmentIndex } = yield* select((state) =>
       getVolumeTracingById(state.annotation, tracingId),
     );
     const segments = yield* select((state) => getSegmentsForLayer(state, tracingId));
 
-    for (const [agglomerateId, opacity] of opacityByAgglomerateId) {
+    for (const [agglomerateId, displayProps] of displayPropsByAgglomerateId) {
       const segment = segments.getNullable(agglomerateId);
       // Only load meshes for segments still present.
       if (segment && (segment?.anchorPosition || hasSegmentIndex)) {
@@ -1037,7 +1048,8 @@ function* reloadMeshes(meshesToReloadPerLayer: ApplyingUpdateArtifacts["meshesTo
           newAgglomerateId: agglomerateId,
           // If the annotation has a segment index, the seed position for the mesh generation is ignored. In that case we can simply use [0, 0, 0].
           nodePosition: segment?.anchorPosition ?? [0, 0, 0],
-          opacity,
+          opacity: displayProps.opacity,
+          isVisible: displayProps.isVisible,
         });
       }
     }

--- a/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
@@ -318,6 +318,7 @@ function* loadCoarseMesh(
   position: Vector3,
   additionalCoordinates: AdditionalCoordinate[] | undefined,
   opacity?: number,
+  isVisible?: boolean,
 ): Saga<void> {
   const autoRenderMeshInProofreading = yield* select(
     (state) => state.userConfiguration.autoRenderMeshInProofreading,
@@ -359,6 +360,7 @@ function* loadCoarseMesh(
         additionalCoordinates,
         currentMeshFile.name,
         opacity,
+        isVisible,
         undefined,
       ),
     );
@@ -376,6 +378,7 @@ function* loadCoarseMesh(
         mappingType,
         preferredQuality,
         opacity,
+        isVisible,
       }),
     );
   }
@@ -2136,32 +2139,42 @@ export function* refreshAffectedSegmentItems(
   yield* all(ensureSegmentItemEffects);
 }
 
-// Capture the current opacities of the given old agglomerates' meshes, keyed by agglomerate id, so
-// that reloaded meshes can keep the user-chosen opacity. Duplicate and nullish ids are ignored, so
-// callers can pass the raw oldAgglomerateId of every item even when several share the same id (e.g.
-// a split produces two pieces from the same original agglomerate). Callers must invoke this before
-// any old mesh is removed, otherwise the original opacity can no longer be read.
-export function* getOpacityByOldAgglomerateId(
+// Display properties of a mesh that should survive a reload.
+export type PreservedMeshDisplayProps = {
+  opacity?: number;
+  isVisible?: boolean;
+};
+
+// Capture the current opacity and visibility of the given old agglomerates' meshes, keyed by
+// agglomerate id, so that reloaded meshes can keep the user-chosen opacity and visibility.
+// Duplicate and nullish ids are ignored, so callers can pass the raw oldAgglomerateId of every
+// item even when several share the same id (e.g. a split produces two pieces from the same
+// original agglomerate). Callers must invoke this before any old mesh is removed, otherwise the
+// original mesh display properties can no longer be read.
+export function* getMeshDisplayPropsByOldAgglomerateId(
   layerName: string,
   oldAgglomerateIds: Iterable<number | null | undefined>,
   additionalCoordinates: AdditionalCoordinate[] | null | undefined,
-): Saga<Map<number, number>> {
+): Saga<Map<number, PreservedMeshDisplayProps>> {
   return yield* select((state) => {
-    const opacities = new Map<number, number>();
+    const displayPropsByAgglomerateId = new Map<number, PreservedMeshDisplayProps>();
     for (const oldAgglomerateId of oldAgglomerateIds) {
-      if (oldAgglomerateId != null && !opacities.has(oldAgglomerateId)) {
-        const opacity = getMeshInfoForSegment(
+      if (oldAgglomerateId != null && !displayPropsByAgglomerateId.has(oldAgglomerateId)) {
+        const meshInfo = getMeshInfoForSegment(
           state,
           additionalCoordinates || null,
           layerName,
           Number(oldAgglomerateId),
-        )?.opacity;
-        if (opacity != null) {
-          opacities.set(oldAgglomerateId, opacity);
+        );
+        if (meshInfo != null) {
+          displayPropsByAgglomerateId.set(oldAgglomerateId, {
+            opacity: meshInfo.opacity,
+            isVisible: meshInfo.isVisible,
+          });
         }
       }
     }
-    return opacities;
+    return displayPropsByAgglomerateId;
   });
 }
 
@@ -2171,9 +2184,10 @@ export function* refreshAffectedMeshes(
     oldAgglomerateId?: number;
     newAgglomerateId: number;
     nodePosition: Vector3;
-    // Opacity to apply to the reloaded mesh. If unset, the opacity of the old
-    // mesh (oldAgglomerateId) is used before its removal (see below).
+    // Opacity and visibility to apply to the reloaded mesh. If unset, the values of the old
+    // mesh (oldAgglomerateId) are used before its removal (see below).
     opacity?: number;
+    isVisible?: boolean;
   }>,
 ) {
   // ATTENTION: This saga should usually be called with `spawnUntilCanceled` to avoid that the user
@@ -2184,12 +2198,12 @@ export function* refreshAffectedMeshes(
   // adapted.
   const additionalCoordinates = undefined;
 
-  // Capture the opacities of all old meshes up front, i.e. before any of them are removed below,
-  // so that reloaded meshes keep the user-chosen opacity. This must happen before the removal
-  // loop because removing one item's old mesh must not prevent another item from reading the
-  // original opacity.
-  const opacityByOldAgglomerateId = yield* call(
-    getOpacityByOldAgglomerateId,
+  // Capture the opacity and visibility of all old meshes up front, i.e. before any of them are
+  // removed below, so that reloaded meshes keep the user-chosen opacity and visibility. This must
+  // happen before the removal loop because removing one item's old mesh must not prevent another
+  // item from reading the original properties.
+  const displayPropsByOldAgglomerateId = yield* call(
+    getMeshDisplayPropsByOldAgglomerateId,
     layerName,
     items.map((item) => item.oldAgglomerateId),
     additionalCoordinates,
@@ -2201,13 +2215,14 @@ export function* refreshAffectedMeshes(
   const newlyLoadedIds = new Set();
   const meshLoadingEffects = [];
   for (const item of items) {
-    // The opacity is either passed in explicitly (e.g. by the rebasing saga, which removes the
-    // old mesh before this saga runs) or taken from the old mesh that was captured above.
-    const opacity =
-      item.opacity ??
-      (item.oldAgglomerateId != null
-        ? opacityByOldAgglomerateId.get(item.oldAgglomerateId)
-        : undefined);
+    // Opacity and visibility are either passed in explicitly (e.g. by the rebasing saga, which
+    // removes the old mesh before this saga runs) or taken from the old mesh captured above.
+    const oldDisplayProps =
+      item.oldAgglomerateId != null
+        ? displayPropsByOldAgglomerateId.get(item.oldAgglomerateId)
+        : undefined;
+    const opacity = item.opacity ?? oldDisplayProps?.opacity;
+    const isVisible = item.isVisible ?? oldDisplayProps?.isVisible;
     // Remove old agglomerate mesh(es) and load updated agglomerate mesh(es)
     if (item.oldAgglomerateId && !removedIds.has(item.oldAgglomerateId)) {
       yield* put(removeMeshAction(layerName, Number(item.oldAgglomerateId)));
@@ -2222,6 +2237,7 @@ export function* refreshAffectedMeshes(
           item.nodePosition,
           additionalCoordinates,
           opacity,
+          isVisible,
         );
       });
       newlyLoadedIds.add(item.newAgglomerateId);

--- a/frontend/javascripts/viewer/model_initialization.ts
+++ b/frontend/javascripts/viewer/model_initialization.ts
@@ -980,6 +980,7 @@ async function applyLayerState(stateByLayer: UrlStateByLayer) {
               seedAdditionalCoordinates,
               meshFileName,
               undefined,
+              undefined,
               effectiveLayerName,
             ),
           );

--- a/frontend/javascripts/viewer/view/context_menu/no_node_context_menu_options.tsx
+++ b/frontend/javascripts/viewer/view/context_menu/no_node_context_menu_options.tsx
@@ -179,6 +179,7 @@ export function useNoNodeContextMenuOptions(
         currentMeshFile.name,
         undefined,
         undefined,
+        undefined,
       ),
     );
   };

--- a/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/segments_view.tsx
@@ -246,6 +246,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
         seedAdditionalCoordinates,
         meshFileName,
         undefined,
+        undefined,
       ),
     );
   },

--- a/unreleased_changes/9699.md
+++ b/unreleased_changes/9699.md
@@ -1,3 +1,3 @@
 ### Fixed
-- Fixed that the opacity of agglomerate meshes was reset to the default when the meshes were reloaded after an agglomerate merge/split, including when such changes are synced from other users during live collaboration.
+- Fixed that the opacity and visibility of agglomerate meshes were reset to the default when the meshes were reloaded after an agglomerate merge/split, including when such changes are synced from other users during live collaboration.
 - Fixed that agglomerate meshes were sometimes not refreshed when an agglomerate split performed by another user was applied during live collaboration (the newly split-off agglomerate's mesh was not loaded).

--- a/unreleased_changes/9699.md
+++ b/unreleased_changes/9699.md
@@ -1,3 +1,3 @@
 ### Fixed
-- Fixed that the opacity and visibility of agglomerate meshes were reset to the default when the meshes were reloaded after an agglomerate merge/split, including when such changes are synced from other users during live collaboration.
+- Fixed that the opacity of agglomerate meshes was reset to the default when the meshes were reloaded after an agglomerate merge/split, including when such changes are synced from other users during live collaboration.
 - Fixed that agglomerate meshes were sometimes not refreshed when an agglomerate split performed by another user was applied during live collaboration (the newly split-off agglomerate's mesh was not loaded).

--- a/unreleased_changes/9731.md
+++ b/unreleased_changes/9731.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that the visibility of agglomerate meshes was reset to the default (visible) when the meshes were reloaded after an agglomerate merge/split, including when such changes are synced from other users during live collaboration. See #9699 as a related PR.


### PR DESCRIPTION
### Summary
Preserving the mesh opacity during auto mesh reloading while proofreading was done in #9699. But we noticed that the visibility was always reset to true. So this PR preserves this setting.

### Steps to test:
- Open a proofreading annotation and auto load a mesh
- make the mesh invisible
- make a proofreading action where the loaded mesh is not involved, nothing unexpected should happen
- make a proofreading action where the loaded mesh is involved -> the reloaded mesh should still be invisible
- enable live collab
- in another tab make a proofreading action where no invisible mesh loaded in the first tab is involved, nothing unexpected should happen
- now in the other tab make a proofreading action where the invisible mesh is involved -> should trigger reloading in first tab but the mesh should be invisible. Toggle it visible -> should show the latest mesh


### Issues:
- fixes follow up of #9699

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
