### PR TITLE
Don't crash if maintenance API route fails

### DIFF
--- a/frontend/javascripts/admin/rest_api.ts
+++ b/frontend/javascripts/admin/rest_api.ts
@@ -1921,9 +1921,7 @@ export function getExistingExperienceDomains(): Promise<ExperienceDomainList> {
 }
 
 export async function isInMaintenance(): Promise<boolean> {
-  const allMaintenances: Array<MaintenanceInfo> = await Request.receiveJSON(
-    "/api/maintenances/listCurrentAndUpcoming",
-  );
+  const allMaintenances: Array<MaintenanceInfo> = await listCurrentAndUpcomingMaintenances();
   const currentEpoch = Date.now();
   const currentMaintenance = allMaintenances.find(
     (maintenance) => maintenance.startTime < currentEpoch,

--- a/frontend/javascripts/banners.tsx
+++ b/frontend/javascripts/banners.tsx
@@ -121,7 +121,15 @@ export function MaintenanceBanner() {
   );
 
   const pollMaintenances = useCallback(async () => {
-    const newScheduledMaintenances = await listCurrentAndUpcomingMaintenances();
+    let newScheduledMaintenances;
+    try {
+      newScheduledMaintenances = await listCurrentAndUpcomingMaintenances();
+    } catch {
+      // Only log to the console. The user will be notified by other failing requests
+      // if the network or server is offline.
+      console.warn("Couldn't load maintenance information.");
+      return;
+    }
 
     const upcomingMaintenances = newScheduledMaintenances
       .filter((maintenance) => maintenance.startTime > Date.now())

--- a/unreleased_changes/9739.md
+++ b/unreleased_changes/9739.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a crash when the network request failed that checks whether WEBKNOSSOS is in maintenance mode.


### PR DESCRIPTION
### Summary
The maintenance API route was used without a catch-guard. If the user or the server is offline, this led to a crash.

### Steps to test:
- block the maintenance API request in the devtools (loaded every 60s)

### Issues:
- hopefully fixes https://scm.slack.com/archives/C09UHBKBQFL/p1782752174761069 (it's not entirely clear whether the reported error is exactly the one I fixed but the chances are high)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
