### PR TITLE
In transaction comment, skip model id if it is None

### DIFF
--- a/app/controllers/AiModelController.scala
+++ b/app/controllers/AiModelController.scala
@@ -323,8 +323,9 @@ class AiModelController @Inject() (
           "seed_generator_distance_threshold" -> request.body.seedGeneratorDistanceThreshold,
           "custom_configuration" -> request.body.customConfiguration
         )
+        modelLabel = request.body.aiModelId.map(m => s" with model $m").getOrElse("")
         creditTransactionComment =
-          s"AI custom instance segmentation with model ${request.body.aiModelId} for dataset ${dataset.name}"
+          s"AI custom instance segmentation$modelLabel for dataset ${dataset.name}"
         targetMagBoundingBox <- aiModelService.inferenceBBoxToTargetMag(
           mag1BoundingBox,
           layer,
@@ -399,8 +400,8 @@ class AiModelController @Inject() (
           "eval_min_merger_path_length_nm" -> request.body.evalMinMergerPathLengthNm,
           "custom_configuration" -> request.body.customConfiguration
         )
-        creditTransactionComment =
-          s"AI custom neuron segmentation with model ${request.body.aiModelId} for dataset ${dataset.name}"
+        modelLabel = request.body.aiModelId.map(m => s" with model $m").getOrElse("")
+        creditTransactionComment = s"AI custom neuron segmentation$modelLabel for dataset ${dataset.name}"
         newInferenceJob <- jobService.submitPaidJob(
           jobCommand,
           commandArgs,


### PR DESCRIPTION
### Summary
 - This transaction comment was introduced in #9073 – but since modelId is of type Option[ObjectId] it wrote either Some(asdf) or None.
 - Now the whole “with model x” block is omitted in the None case, and the value is written directly in the Some case.
 - Note that this does not repair existing entries (where this string is in the db). I think that’s not super important, please ping me again if you disagree.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1782806896906389

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
