### PR TITLE
Guard against Zip Slip Attacks

### DIFF
--- a/app/models/annotation/AnnotationUploadService.scala
+++ b/app/models/annotation/AnnotationUploadService.scala
@@ -92,7 +92,7 @@ class AnnotationUploadService @Inject() (tempFileService: WkTempFileService, nml
         } yield if (sharedParsingParameters.useZipName) result.withName(name) else result
         pendingResults ::= parsedResult
       } else {
-        val tempFile: Path = tempFileService.create(file.getPath.replaceAll("/", "_") + filename.toString)
+        val tempFile: Path = tempFileService.create(file.getPath + "_" + filename.toString)
         Files.copy(inputStream, tempFile, StandardCopyOption.REPLACE_EXISTING)
         otherFiles += (file.getPath + filename.toString -> tempFile.toFile)
       }

--- a/test/backend/ZipIOTestSuite.scala
+++ b/test/backend/ZipIOTestSuite.scala
@@ -1,0 +1,137 @@
+package backend
+
+import com.scalableminds.util.box.{Box, Failure, Full}
+import com.scalableminds.util.io.ZipIO
+import org.scalatest.wordspec.AsyncWordSpec
+
+import java.io.{File, FileOutputStream}
+import java.nio.file.{Files, Path}
+import java.util.zip.{ZipEntry, ZipOutputStream}
+
+class ZipIOTestSuite extends AsyncWordSpec {
+
+  private def createZip(entryNames: Seq[String]): File = {
+    val zipFile = Files.createTempFile("zipio-test", ".zip").toFile
+    zipFile.deleteOnExit()
+    val zipOut = new ZipOutputStream(new FileOutputStream(zipFile))
+    try
+      entryNames.foreach { name =>
+        zipOut.putNextEntry(new ZipEntry(name))
+        zipOut.write(s"content of $name".getBytes)
+        zipOut.closeEntry()
+      }
+    finally zipOut.close()
+    zipFile
+  }
+
+  private def createTargetDir(): Path = Files.createTempDirectory("zipio-target")
+
+  private def unzip(zipFile: File, targetDir: Path, truncateCommonPrefix: Boolean = false): Box[List[Path]] =
+    ZipIO.unzipToDirectory(
+      zipFile,
+      targetDir,
+      includeHiddenFiles = false,
+      hiddenFilesWhitelist = List.empty,
+      truncateCommonPrefix = truncateCommonPrefix,
+      excludeFromPrefix = None
+    )
+
+  "ZipIO.unzipToDirectory" should {
+
+    "extract normal, nested files into the target directory" in {
+      val zipFile = createZip(Seq("a.txt", "sub/b.txt", "sub/deeper/c.txt"))
+      val targetDir = createTargetDir()
+
+      val result = unzip(zipFile, targetDir)
+
+      assert(result.isDefined)
+      assert(Files.exists(targetDir.resolve("a.txt")))
+      assert(Files.exists(targetDir.resolve("sub/b.txt")))
+      assert(Files.exists(targetDir.resolve("sub/deeper/c.txt")))
+      assert(Files.readString(targetDir.resolve("a.txt")) == "content of a.txt")
+    }
+
+    "truncate the common prefix of all entries when requested" in {
+      val zipFile = createZip(Seq("root/a.txt", "root/sub/b.txt"))
+      val targetDir = createTargetDir()
+
+      val result = unzip(zipFile, targetDir, truncateCommonPrefix = true)
+
+      assert(result.isDefined)
+      assert(Files.exists(targetDir.resolve("a.txt")))
+      assert(Files.exists(targetDir.resolve("sub/b.txt")))
+      assert(!Files.exists(targetDir.resolve("root")))
+    }
+
+    "reject a zip entry that uses .. segments to escape the target directory (zip slip)" in {
+      val zipFile = createZip(Seq("../evil.txt"))
+      val targetDir = createTargetDir()
+
+      val result = unzip(zipFile, targetDir)
+
+      assert(result.isInstanceOf[Failure])
+      assert(!Files.exists(targetDir.getParent.resolve("evil.txt")))
+    }
+
+    "reject a zip entry that mixes .. segments to still net escape the target directory (zip slip)" in {
+      val zipFile = createZip(Seq("sub/../../evil.txt"))
+      val targetDir = createTargetDir()
+
+      val result = unzip(zipFile, targetDir)
+
+      assert(result.isInstanceOf[Failure])
+      assert(!Files.exists(targetDir.getParent.resolve("evil.txt")))
+    }
+
+    "reject a zip entry with an absolute path (zip slip)" in {
+      val evilFile = Files.createTempFile("zipio-should-not-be-written", ".txt")
+      Files.delete(evilFile)
+      val zipFile = createZip(Seq(evilFile.toAbsolutePath.toString))
+      val targetDir = createTargetDir()
+
+      val result = unzip(zipFile, targetDir)
+
+      assert(result.isInstanceOf[Failure])
+      assert(!Files.exists(evilFile))
+    }
+
+    "not fail benign entries that merely contain .. segments which stay within the target directory" in {
+      val zipFile = createZip(Seq("sub/../a.txt"))
+      val targetDir = createTargetDir()
+
+      val result = unzip(zipFile, targetDir)
+
+      assert(result.isDefined)
+      assert(Files.exists(targetDir.resolve("a.txt")))
+    }
+  }
+
+  "ZipIO.withUnziped" should {
+
+    "expose only entry paths that are safe, relative, and normalized" in {
+      val zipFile = createZip(Seq("a.txt", "sub/b.txt"))
+      var seenPaths: List[Path] = List.empty
+
+      val result = ZipIO.withUnziped(new java.util.zip.ZipFile(zipFile)) { (path, _) =>
+        seenPaths ::= path
+        Full(())
+      }
+
+      assert(result.isDefined)
+      assert(seenPaths.toSet == Set(Path.of("a.txt"), Path.of("sub/b.txt")))
+    }
+
+    "fail with a Failure instead of invoking the callback for unsafe entries" in {
+      val zipFile = createZip(Seq("../evil.txt"))
+      var callbackInvoked = false
+
+      val result = ZipIO.withUnziped(new java.util.zip.ZipFile(zipFile)) { (_, _) =>
+        callbackInvoked = true
+        Full(())
+      }
+
+      assert(result.isInstanceOf[Failure])
+      assert(!callbackInvoked)
+    }
+  }
+}

--- a/unreleased_changes/9769.md
+++ b/unreleased_changes/9769.md
@@ -1,0 +1,2 @@
+### Added
+- Added protection against uploads of malformed zips.

--- a/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
@@ -116,7 +116,7 @@ object ZipIO extends LazyLogging {
           len = source.read(buffer)
           if (len > 0)
             gout.write(buffer, 0, len)
-        };
+        }
         len > 0
       }) ()
     } finally {
@@ -136,7 +136,7 @@ object ZipIO extends LazyLogging {
           len = is.read(buffer)
           if (len > 0)
             os.write(buffer, 0, len)
-        };
+        }
         len > 0
       }) ()
       os.toByteArray
@@ -259,24 +259,35 @@ object ZipIO extends LazyLogging {
     val result = zipEntries.foldLeft[Box[List[A]]](Full(Nil)) { (results, entry) =>
       results match {
         case Full(rs) =>
-          var input: InputStream = null
-          try {
-            input = zip.getInputStream(entry)
-            val path = commonPrefix.relativize(Path.of(entry.getName))
-            val r = f(path, input) match {
-              case Full(result) =>
-                Full(rs :+ result)
-              case Empty =>
-                Empty
-              case f: Failure =>
-                f
-            }
-            input.close()
-            r
-          } catch {
-            case e: Exception =>
-              Failure(e.getMessage)
-          } finally if (input != null) input.close()
+          val rawEntryPath = Path.of(entry.getName)
+          if (rawEntryPath.isAbsolute) {
+            Failure(s"Zip entry has an absolute path and was rejected as a potential zip slip attack: ${entry.getName}")
+          } else {
+            var input: InputStream = null
+            try {
+              input = zip.getInputStream(entry)
+              val path = commonPrefix.relativize(rawEntryPath).normalize()
+              if (path.startsWith("..")) {
+                Failure(
+                  s"Zip entry path escapes the target directory and was rejected as a potential zip slip attack: ${entry.getName}"
+                )
+              } else {
+                val r = f(path, input) match {
+                  case Full(result) =>
+                    Full(rs :+ result)
+                  case Empty =>
+                    Empty
+                  case f: Failure =>
+                    f
+                }
+                input.close()
+                r
+              }
+            } catch {
+              case e: Exception =>
+                Failure(e.getMessage)
+            } finally if (input != null) input.close()
+          }
         case e =>
           e
       }
@@ -307,18 +318,24 @@ object ZipIO extends LazyLogging {
       excludeFromPrefix: Option[List[String]]
   ): Box[List[Path]] =
     withUnziped(zip, includeHiddenFiles, hiddenFilesWhitelist, truncateCommonPrefix, excludeFromPrefix) { (name, in) =>
-      val path = targetDir.resolve(name)
-      if (path.getParent != null) {
-        PathUtils.ensureDirectory(path.getParent)
+      val path = targetDir.resolve(name).normalize()
+      if (!path.startsWith(targetDir.normalize())) {
+        Failure(
+          s"Zip entry resolves outside of the target directory and was rejected as a potential zip slip attack: $name"
+        )
+      } else {
+        if (path.getParent != null) {
+          PathUtils.ensureDirectory(path.getParent)
+        }
+        var out: FileOutputStream = null
+        try {
+          out = new FileOutputStream(path.toFile)
+          IOUtils.copy(in, out)
+          Full(name)
+        } catch {
+          case e: Exception =>
+            Failure(e.getMessage)
+        } finally if (out != null) out.close()
       }
-      var out: FileOutputStream = null
-      try {
-        out = new FileOutputStream(path.toFile)
-        IOUtils.copy(in, out)
-        Full(name)
-      } catch {
-        case e: Exception =>
-          Failure(e.getMessage)
-      } finally if (out != null) out.close()
     }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/files/TempFileService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/files/TempFileService.scala
@@ -29,9 +29,14 @@ trait TempFileService extends LazyLogging {
   private def ensureParent(): Path =
     Files.createDirectories(tmpDir)
 
+  private def sanitizePrefix(prefix: String): String =
+    prefix.replaceAll("/", "_")
+
   def create(prefix: String = "tmpFile", lifeTime: FiniteDuration = 2 hours, isDirectory: Boolean = false): Path = {
     ensureParent()
-    val path = tmpDir.resolve(f"$prefix-${Random.alphanumeric.take(15).mkString("")}")
+    val path = tmpDir.resolve(f"${sanitizePrefix(prefix)}-${Random.alphanumeric.take(15).mkString("")}").normalize()
+    if (!path.startsWith(tmpDir))
+      throw new IllegalArgumentException(s"Refusing to create temp file/dir outside of $tmpDir for prefix '$prefix'")
     logger.info(f"Creating temp ${if (isDirectory) "dir" else "file"} at $path")
     if (isDirectory)
       Files.createDirectory(path)


### PR DESCRIPTION
### Summary
- In the context of #9738 I read a lot about zip and learned about zip slip attacks: extracting a zip where entries contain paths that “leave” the zipfile root (e.g. `../../file`). These paths are allowed in zip and we need to make sure that unpacking such won’t actually write files outside of the target folder.
- Also added some tests for ZipIO
- Vaguely related: also moved prefix sanitation into tempFileService.create from its call site.

### Steps to test:
- CI should be enough

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
