### PR TITLE
Configure scalafmt to enforce more modern syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,9 @@
 version = "3.11.1"
 maxColumn = 120
 rewrite.rules = [RedundantBraces, RedundantParens, SortModifiers]
-rewrite.redundantBraces.stringInterpolation = false
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.newSyntax.control = false
 includeCurlyBraceInSelectChains = false
 optIn.breakChainOnFirstMethodDot = false
 project.git = true

--- a/app/ErrorHandler.scala
+++ b/app/ErrorHandler.scala
@@ -1,11 +1,11 @@
 import com.scalableminds.util.Msg
 import play.silhouette.api.actions.SecuredErrorHandler
 
-import javax.inject._
+import javax.inject.*
 import play.api.http.DefaultHttpErrorHandler
-import play.api._
+import play.api.*
 import play.api.mvc.Results.{Forbidden, Unauthorized}
-import play.api.mvc._
+import play.api.mvc.*
 import play.api.routing.Router
 
 import scala.concurrent.Future

--- a/app/Startup.scala
+++ b/app/Startup.scala
@@ -16,11 +16,11 @@ import telemetry.SlackNotificationService
 import utils.WkConf
 import utils.sql.SqlClient
 
-import javax.inject._
+import javax.inject.*
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
-import scala.sys.process._
+import scala.concurrent.duration.*
+import scala.sys.process.*
 
 class Startup @Inject() (
     actorSystem: ActorSystem,

--- a/app/WebknossosModule.scala
+++ b/app/WebknossosModule.scala
@@ -20,7 +20,7 @@ import models.job.{JobService, WorkerLivenessService}
 import models.organization.FreeCreditTransactionService
 import models.storage.UsedStorageService
 import models.task.TaskService
-import models.user._
+import models.user.*
 import models.user.time.TimeSpanService
 import models.voxelytics.LokiClient
 import security.CertificateValidationService

--- a/app/controllers/AnnotationController.scala
+++ b/app/controllers/AnnotationController.scala
@@ -18,15 +18,15 @@ import com.scalableminds.webknossos.tracingstore.tracings.{TracingId, TracingTyp
 import mail.{MailchimpClient, MailchimpTag}
 import models.analytics.{AnalyticsService, CreateAnnotationEvent, OpenAnnotationEvent}
 import models.annotation.AnnotationState.Cancelled
-import models.annotation._
+import models.annotation.*
 import models.dataset.{DatasetDAO, DatasetService}
 import models.project.ProjectDAO
 import models.task.{TaskDAO, TaskService}
 import models.team.{TeamDAO, TeamService}
-import models.user.time._
+import models.user.time.*
 import models.user.{User, UserDAO, UserService}
 import org.apache.pekko.util.Timeout
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import play.silhouette.api.Silhouette
 import security.{URLSharing, UserAwareRequestLogging, WkEnv}
@@ -35,7 +35,7 @@ import utils.WkConf
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 case class ReserveIdParameters(
     domain: AnnotationIdDomain,

--- a/app/controllers/AnnotationIOController.scala
+++ b/app/controllers/AnnotationIOController.scala
@@ -18,7 +18,7 @@ import com.scalableminds.webknossos.datastore.models.annotation.{
   AnnotationLayerType,
   FetchedAnnotationLayer
 }
-import com.scalableminds.webknossos.datastore.models.datasource._
+import com.scalableminds.webknossos.datastore.models.datasource.*
 import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.scalableminds.webknossos.tracingstore.tracings.{TracingId, TracingType}
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeDataZipFormat.VolumeDataZipFormat
@@ -32,15 +32,15 @@ import files.WkTempFileService
 
 import javax.inject.Inject
 import models.analytics.{AnalyticsService, DownloadAnnotationEvent, UploadAnnotationEvent}
-import models.annotation.AnnotationState._
-import models.annotation._
+import models.annotation.AnnotationState.*
+import models.annotation.*
 import models.annotation.nml.NmlResults.NmlParseResult
 import models.annotation.nml.{NmlResults, NmlWriter}
-import models.dataset._
+import models.dataset.*
 import models.organization.OrganizationDAO
 import models.project.ProjectDAO
-import models.task._
-import models.user._
+import models.task.*
+import models.user.*
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
 import play.api.libs.Files.TemporaryFile

--- a/app/controllers/AnnotationPrivateLinkController.scala
+++ b/app/controllers/AnnotationPrivateLinkController.scala
@@ -6,10 +6,10 @@ import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContex
 import com.scalableminds.util.box.Full
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.{WkEnv, WkSilhouetteEnvironment}
 import com.scalableminds.util.objectid.ObjectId

--- a/app/controllers/DataStoreController.scala
+++ b/app/controllers/DataStoreController.scala
@@ -7,7 +7,7 @@ import com.scalableminds.util.tools.Fox
 import javax.inject.Inject
 import models.dataset.{DataStore, DataStoreDAO, DataStoreService}
 import models.user.{MultiUserDAO, UserService}
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.WkEnv
 

--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -25,7 +25,7 @@ import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.scalableminds.webknossos.datastore.services.uploading.LinkedLayerIdentifier
 import mail.{MailchimpClient, MailchimpTag}
 import models.analytics.{AnalyticsService, ChangeDatasetSettingsEvent, OpenDatasetEvent}
-import models.dataset._
+import models.dataset.*
 import models.dataset.explore.{
   ExploreAndAddRemoteDatasetParameters,
   WKExploreRemoteLayerParameters,
@@ -36,7 +36,7 @@ import models.organization.OrganizationDAO
 import models.storage.UsedStorageService
 import models.team.{TeamDAO, TeamService}
 import models.user.{User, UserDAO, UserService}
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import play.silhouette.api.Silhouette
 import security.{AccessibleBySwitchingService, URLSharing, WkEnv}

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -11,12 +11,12 @@ import com.scalableminds.util.tools.Fox
 import com.typesafe.scalalogging.LazyLogging
 import models.aimodels.{AiModel, AiModelCategory, AiModelDAO, AiModelService}
 import models.annotation.{TracingStore, TracingStoreDAO}
-import models.dataset._
+import models.dataset.*
 import models.folder.{Folder, FolderDAO, FolderService}
 import models.project.{Project, ProjectDAO}
 import models.task.{TaskType, TaskTypeDAO}
-import models.team._
-import models.user._
+import models.team.*
+import models.user.*
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.helpers.UPath

--- a/app/controllers/JobController.scala
+++ b/app/controllers/JobController.scala
@@ -7,7 +7,7 @@ import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
 import models.dataset.{DataStoreDAO, DatasetDAO, DatasetLayerAdditionalAxesDAO, DatasetService}
-import models.job._
+import models.job.*
 import models.organization.{CreditTransactionDAO, CreditTransactionService, OrganizationDAO, PricingPlan}
 import models.user.{MultiUserDAO, UserService}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}

--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -15,7 +15,7 @@ import models.task.{BaseAnnotation, TaskParameters}
 import models.user.{Experience, User}
 import com.scalableminds.util.box.Box.tryo
 import play.api.http.HttpEntity
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers, Result}
 import security.WkEnv
 import com.scalableminds.util.objectid.ObjectId

--- a/app/controllers/MaintenanceController.scala
+++ b/app/controllers/MaintenanceController.scala
@@ -13,7 +13,7 @@ import utils.sql.{SQLDAO, SqlClient}
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import com.scalableminds.webknossos.schema.Tables.{Maintenances, MaintenancesRow, GetResultMaintenancesRow}
 import security.WkEnv
 

--- a/app/controllers/OrganizationController.scala
+++ b/app/controllers/OrganizationController.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.{JsNull, Json, OFormat}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import utils.WkConf
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import security.{WkEnv, WkSilhouetteEnvironment}
 
 import scala.concurrent.ExecutionContext

--- a/app/controllers/ProjectController.scala
+++ b/app/controllers/ProjectController.scala
@@ -4,8 +4,8 @@ import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.tools.Fox
 import models.annotation.{AnnotationDAO, AnnotationService, AnnotationType}
-import models.project._
-import models.task._
+import models.project.*
+import models.task.*
 import models.user.UserService
 import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}

--- a/app/controllers/PublicationController.scala
+++ b/app/controllers/PublicationController.scala
@@ -6,7 +6,7 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 
 import models.dataset.{PublicationDAO, PublicationService}
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent}
 import security.WkEnv
 import com.scalableminds.util.objectid.ObjectId

--- a/app/controllers/ScriptController.scala
+++ b/app/controllers/ScriptController.scala
@@ -4,10 +4,10 @@ import com.scalableminds.util.Msg
 
 import javax.inject.Inject
 import com.scalableminds.util.tools.Fox
-import models.task._
+import models.task.*
 import play.silhouette.api.Silhouette
 import models.user.UserService
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.WkEnv
 import com.scalableminds.util.objectid.ObjectId

--- a/app/controllers/TaskController.scala
+++ b/app/controllers/TaskController.scala
@@ -14,12 +14,12 @@ import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import models.annotation.nml.NmlResults.TracingBoxContainer
 import models.project.ProjectDAO
-import models.task._
-import models.user._
-import play.api.libs.json._
+import models.task.*
+import models.user.*
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.WkEnv
 import com.scalableminds.util.objectid.ObjectId

--- a/app/controllers/TaskTypeController.scala
+++ b/app/controllers/TaskTypeController.scala
@@ -6,10 +6,10 @@ import com.scalableminds.util.accesscontext.GlobalAccessContext
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import models.annotation.AnnotationSettings
-import models.task._
+import models.task.*
 import models.user.UserService
-import play.api.libs.json.Reads._
-import play.api.libs.json._
+import play.api.libs.json.Reads.*
+import play.api.libs.json.*
 import com.scalableminds.util.objectid.ObjectId
 
 import javax.inject.Inject

--- a/app/controllers/TeamController.scala
+++ b/app/controllers/TeamController.scala
@@ -3,9 +3,9 @@ package controllers
 import com.scalableminds.util.Msg
 import play.silhouette.api.Silhouette
 import com.scalableminds.util.tools.Fox
-import models.team._
+import models.team.*
 import models.user.UserDAO
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.WkEnv
 import com.scalableminds.util.objectid.ObjectId

--- a/app/controllers/TimeController.scala
+++ b/app/controllers/TimeController.scala
@@ -9,7 +9,7 @@ import models.annotation.{AnnotationState, AnnotationType}
 
 import scala.collection.immutable.ListMap
 import javax.inject.Inject
-import models.user._
+import models.user.*
 import models.user.time.{Month, TimeSpan, TimeSpanDAO, TimeSpanService}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -7,10 +7,10 @@ import com.scalableminds.util.box.{Failure, Full}
 import com.scalableminds.util.tools.Fox
 import models.annotation.{AnnotationDAO, AnnotationService, AnnotationType}
 import models.organization.OrganizationService
-import models.team._
-import models.user._
-import play.api.libs.json._
-import play.api.mvc._
+import models.team.*
+import models.user.*
+import play.api.libs.json.*
+import play.api.mvc.*
 import com.scalableminds.util.objectid.ObjectId
 
 import javax.inject.Inject

--- a/app/controllers/UserTokenController.scala
+++ b/app/controllers/UserTokenController.scala
@@ -14,7 +14,7 @@ import com.scalableminds.webknossos.datastore.services.{
   UserAccessRequest
 }
 import com.scalableminds.webknossos.tracingstore.tracings.TracingId
-import models.annotation._
+import models.annotation.*
 import models.dataset.{DataStoreService, DatasetDAO, DatasetService}
 import models.job.JobDAO
 import models.user.{User, UserService}

--- a/app/controllers/VoxelyticsController.scala
+++ b/app/controllers/VoxelyticsController.scala
@@ -7,9 +7,9 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 import models.organization.OrganizationDAO
 import models.user.UserService
-import models.voxelytics._
-import play.api.libs.json._
-import play.api.mvc._
+import models.voxelytics.*
+import play.api.libs.json.*
+import play.api.mvc.*
 import play.silhouette.api.Silhouette
 import play.silhouette.api.actions.SecuredRequest
 import security.WkEnv

--- a/app/controllers/WKRemoteDataStoreController.scala
+++ b/app/controllers/WKRemoteDataStoreController.scala
@@ -29,7 +29,7 @@ import com.scalableminds.webknossos.datastore.services.uploading.{
   ReportMagUploadParameters
 }
 import com.typesafe.scalalogging.LazyLogging
-import models.dataset._
+import models.dataset.*
 import models.dataset.credential.CredentialDAO
 import models.job.{JobDAO, JobService}
 import models.organization.{OrganizationDAO, OrganizationService}

--- a/app/controllers/WKRemoteTracingStoreController.scala
+++ b/app/controllers/WKRemoteTracingStoreController.scala
@@ -13,8 +13,8 @@ import com.scalableminds.webknossos.tracingstore.AnnotationUpdatesReport
 import com.scalableminds.webknossos.tracingstore.annotation.AnnotationLayerParameters
 import com.scalableminds.webknossos.tracingstore.tracings.TracingId
 import models.analytics.{AnalyticsService, UpdateAnnotationEvent, UpdateAnnotationViewOnlyEvent}
-import models.annotation.AnnotationState._
-import models.annotation._
+import models.annotation.AnnotationState.*
+import models.annotation.*
 import models.dataset.{DatasetDAO, DatasetService}
 import models.user.UserDAO
 import models.user.time.TimeSpanService

--- a/app/controllers/WKRemoteWorkerController.scala
+++ b/app/controllers/WKRemoteWorkerController.scala
@@ -11,7 +11,7 @@ import models.dataset.DatasetDAO
 import models.job.JobCommand.JobCommand
 
 import javax.inject.Inject
-import models.job._
+import models.job.*
 import models.organization.CreditTransactionService
 import models.voxelytics.VoxelyticsDAO
 import play.api.libs.json.Json

--- a/app/mail/DefaultMails.scala
+++ b/app/mail/DefaultMails.scala
@@ -3,7 +3,7 @@ package mail
 import models.organization.Organization
 import models.user.MultiUser
 import utils.WkConf
-import views._
+import views.*
 
 import java.net.URI
 import javax.inject.Inject

--- a/app/mail/MailchimpTicker.scala
+++ b/app/mail/MailchimpTicker.scala
@@ -13,7 +13,7 @@ import models.user.{MultiUser, MultiUserDAO}
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class MailchimpTicker @Inject() (
     val lifecycle: ApplicationLifecycle,

--- a/app/mail/Mailer.scala
+++ b/app/mail/Mailer.scala
@@ -1,9 +1,9 @@
 package mail
 
-import org.apache.pekko.actor._
+import org.apache.pekko.actor.*
 import com.typesafe.scalalogging.LazyLogging
 import javax.mail.internet.InternetAddress
-import org.apache.commons.mail._
+import org.apache.commons.mail.*
 
 case class Send(mail: Mail)
 

--- a/app/models/aimodels/AiModel.scala
+++ b/app/models/aimodels/AiModel.scala
@@ -14,7 +14,7 @@ import models.job.{JobDAO, JobService, JobState}
 import models.user.{User, UserDAO, UserService}
 import play.api.libs.json.{JsObject, Json}
 import slick.dbio.{DBIO, Effect, NoStream}
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import slick.sql.SqlAction
 import com.scalableminds.util.objectid.ObjectId
 import models.organization.OrganizationDAO

--- a/app/models/analytics/AnalyticsEvent.scala
+++ b/app/models/analytics/AnalyticsEvent.scala
@@ -7,7 +7,7 @@ import models.dataset.{DataStore, Dataset}
 import models.job.JobCommand.JobCommand
 import models.organization.Organization
 import models.user.User
-import play.api.libs.json._
+import play.api.libs.json.*
 import com.scalableminds.util.objectid.ObjectId
 
 import scala.concurrent.ExecutionContext

--- a/app/models/analytics/AnalyticsService.scala
+++ b/app/models/analytics/AnalyticsService.scala
@@ -13,12 +13,12 @@ import com.scalableminds.webknossos.datastore.helpers.IntervalScheduler
 import org.apache.pekko.actor.ActorSystem
 import play.api.http.Status.UNAUTHORIZED
 import play.api.inject.ApplicationLifecycle
-import play.api.libs.json._
+import play.api.libs.json.*
 import utils.{BuildInfoService, WkConf}
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class AnalyticsService @Inject() (
     rpc: RPC,

--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -16,10 +16,10 @@ import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import models.annotation.AnnotationState.AnnotationState
 import models.annotation.CollaborationMode.CollaborationMode
 import models.annotation.AnnotationType.AnnotationType
-import play.api.libs.json._
+import play.api.libs.json.*
 import slick.jdbc.GetResult
-import slick.jdbc.GetResult._
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.GetResult.*
+import slick.jdbc.PostgresProfile.api.*
 import slick.jdbc.TransactionIsolation.Serializable
 import slick.sql.SqlAction
 import com.scalableminds.util.objectid.ObjectId
@@ -336,7 +336,7 @@ class AnnotationDAO @Inject() (sqlClient: SqlClient, annotationLayerDAO: Annotat
   // Necessary since a tuple can only have 22 elements
   implicit def GetResultAnnotationCompactInfo: GetResult[AnnotationCompactInfo] =
     prs => {
-      import prs._
+      import prs.*
 
       val id = <<[ObjectId]
       val name = <<[String]

--- a/app/models/annotation/AnnotationReservedIdsService.scala
+++ b/app/models/annotation/AnnotationReservedIdsService.scala
@@ -9,7 +9,7 @@ import com.typesafe.scalalogging.LazyLogging
 import slick.dbio.{DBIO, Effect, NoStream}
 import slick.sql.SqlAction
 import utils.sql.{SimpleSQLDAO, SqlClient, SqlToken}
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 
 import java.util.concurrent.Semaphore
 import javax.inject.Inject

--- a/app/models/annotation/AnnotationRestrictions.scala
+++ b/app/models/annotation/AnnotationRestrictions.scala
@@ -6,10 +6,10 @@ import com.scalableminds.util.tools.Fox.toFox
 
 import javax.inject.Inject
 import models.user.{User, UserService}
-import play.api.libs.json._
-import models.annotation.AnnotationState._
+import play.api.libs.json.*
+import models.annotation.AnnotationState.*
 
-import scala.concurrent._
+import scala.concurrent.*
 
 class AnnotationRestrictions(implicit ec: ExecutionContext) {
   def allowAccess(user: Option[User]): Fox[Boolean] = Fox.successful(false)

--- a/app/models/annotation/AnnotationService.scala
+++ b/app/models/annotation/AnnotationService.scala
@@ -10,12 +10,12 @@ import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, TextUtils}
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.Annotation.{AnnotationLayerProto, AnnotationProto}
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
+import com.scalableminds.webknossos.datastore.SkeletonTracing.*
 import com.scalableminds.webknossos.datastore.VolumeTracing.{VolumeTracing, VolumeTracingOpt, VolumeTracings}
 import com.scalableminds.webknossos.datastore.geometry.ColorProto
 import com.scalableminds.webknossos.datastore.helpers.{NodeDefaults, ProtoGeometryConversions, SkeletonTracingDefaults}
 import com.scalableminds.webknossos.datastore.models.VoxelSize
-import com.scalableminds.webknossos.datastore.models.annotation._
+import com.scalableminds.webknossos.datastore.models.annotation.*
 import com.scalableminds.webknossos.datastore.models.datasource.{
   AdditionalAxis,
   ElementClass,
@@ -33,11 +33,11 @@ import com.scalableminds.webknossos.tracingstore.tracings.volume.{
 }
 import com.typesafe.scalalogging.LazyLogging
 import files.WkTempFileService
-import models.annotation.AnnotationState._
+import models.annotation.AnnotationState.*
 import models.annotation.AnnotationType.AnnotationType
 import models.annotation.handler.SavedTracingInformationHandler
 import models.annotation.nml.NmlWriter
-import models.dataset._
+import models.dataset.*
 import models.organization.OrganizationDAO
 import models.project.ProjectDAO
 import models.task.{Task, TaskDAO, TaskService, TaskTypeDAO}

--- a/app/models/annotation/AnnotationSettings.scala
+++ b/app/models/annotation/AnnotationSettings.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.enumeration.ExtendedEnumeration
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType.TracingType
 import com.scalableminds.webknossos.tracingstore.tracings.volume.MagRestrictions
-import play.api.libs.json._
+import play.api.libs.json.*
 
 object TracingMode extends ExtendedEnumeration {
   type TracingMode = Value

--- a/app/models/annotation/AnnotationStore.scala
+++ b/app/models/annotation/AnnotationStore.scala
@@ -11,7 +11,7 @@ import models.user.User
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class AnnotationStore @Inject() (
     annotationInformationHandlerSelector: AnnotationInformationHandlerSelector,

--- a/app/models/annotation/AnnotationUploadService.scala
+++ b/app/models/annotation/AnnotationUploadService.scala
@@ -14,7 +14,7 @@ import com.typesafe.scalalogging.LazyLogging
 import files.WkTempFileService
 
 import javax.inject.Inject
-import models.annotation.nml.NmlResults._
+import models.annotation.nml.NmlResults.*
 import models.annotation.nml.{NmlParseSuccessWithoutFile, NmlParser, NmlResults}
 import com.scalableminds.util.box.Box.tryo
 import com.scalableminds.webknossos.tracingstore.tracings.GroupUtils

--- a/app/models/annotation/handler/AnnotationInformationHandler.scala
+++ b/app/models/annotation/handler/AnnotationInformationHandler.scala
@@ -6,7 +6,7 @@ import com.scalableminds.util.tools.Fox
 
 import javax.inject.Inject
 import models.annotation.AnnotationType.AnnotationType
-import models.annotation._
+import models.annotation.*
 import models.user.User
 import com.scalableminds.util.objectid.ObjectId
 import models.dataset.{DatasetDAO, DatasetService}

--- a/app/models/annotation/handler/ProjectInformationHandler.scala
+++ b/app/models/annotation/handler/ProjectInformationHandler.scala
@@ -6,7 +6,7 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import models.project.ProjectDAO
 import models.user.{User, UserService}
 import com.scalableminds.util.objectid.ObjectId

--- a/app/models/annotation/handler/SavedTracingInformationHandler.scala
+++ b/app/models/annotation/handler/SavedTracingInformationHandler.scala
@@ -4,12 +4,12 @@ import com.scalableminds.util.Msg
 import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.box.{Empty, Failure, Full}
 import com.scalableminds.util.mvc.Formatter
-import com.scalableminds.util.tools.TextUtils._
+import com.scalableminds.util.tools.TextUtils.*
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import models.dataset.{DatasetDAO, DatasetService}
 import models.user.{MultiUserDAO, User, UserService}
 import com.scalableminds.util.objectid.ObjectId

--- a/app/models/annotation/handler/TaskInformationHandler.scala
+++ b/app/models/annotation/handler/TaskInformationHandler.scala
@@ -6,10 +6,10 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import models.task.TaskDAO
 import models.user.{User, UserService}
-import models.annotation.AnnotationState._
+import models.annotation.AnnotationState.*
 import models.project.ProjectDAO
 import com.scalableminds.util.objectid.ObjectId
 import models.dataset.{DatasetDAO, DatasetService}

--- a/app/models/annotation/handler/TaskTypeInformationHandler.scala
+++ b/app/models/annotation/handler/TaskTypeInformationHandler.scala
@@ -6,10 +6,10 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import models.task.{TaskDAO, TaskTypeDAO}
 import models.user.{User, UserService}
-import models.annotation.AnnotationState._
+import models.annotation.AnnotationState.*
 import com.scalableminds.util.objectid.ObjectId
 import models.dataset.{DatasetDAO, DatasetService}
 

--- a/app/models/annotation/nml/NmlWriter.scala
+++ b/app/models/annotation/nml/NmlWriter.scala
@@ -7,10 +7,10 @@ import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.xml.Xml
 import com.scalableminds.webknossos.datastore.Annotation.AnnotationProto
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
+import com.scalableminds.webknossos.datastore.SkeletonTracing.*
 import com.scalableminds.webknossos.datastore.MetadataEntry.MetadataEntryProto
 import com.scalableminds.webknossos.datastore.VolumeTracing.{Segment, SegmentGroup}
-import com.scalableminds.webknossos.datastore.geometry._
+import com.scalableminds.webknossos.datastore.geometry.*
 import com.scalableminds.webknossos.datastore.models.VoxelSize
 import com.scalableminds.webknossos.datastore.models.annotation.{AnnotationLayerType, FetchedAnnotationLayer}
 import com.scalableminds.webknossos.tracingstore.tracings.AnnotationUserStateUtils

--- a/app/models/configuration/DatasetConfigurationService.scala
+++ b/app/models/configuration/DatasetConfigurationService.scala
@@ -10,7 +10,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.StaticLayer
 import javax.inject.Inject
 import models.dataset.{Dataset, DatasetDAO, DatasetLayerDAO, DatasetService, ThumbnailCachingService}
 import models.user.{User, UserDatasetConfigurationDAO, UserDatasetLayerConfigurationDAO}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.concurrent.ExecutionContext
 

--- a/app/models/dataset/ComposeService.scala
+++ b/app/models/dataset/ComposeService.scala
@@ -9,7 +9,7 @@ import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.explore.ExploreLayerUtils
 import com.scalableminds.webknossos.datastore.models.VoxelSize
 import com.scalableminds.webknossos.datastore.models.datasource.LayerAttachmentType.LayerAttachmentType
-import com.scalableminds.webknossos.datastore.models.datasource._
+import com.scalableminds.webknossos.datastore.models.datasource.*
 import models.user.User
 import play.api.libs.json.{Json, OFormat}
 

--- a/app/models/dataset/VirtualDatasetsRealPathScanService.scala
+++ b/app/models/dataset/VirtualDatasetsRealPathScanService.scala
@@ -10,7 +10,7 @@ import jakarta.inject.Inject
 import org.apache.pekko.actor.ActorSystem
 import play.api.inject.ApplicationLifecycle
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext
 
 class VirtualDatasetsRealPathScanService @Inject() (

--- a/app/models/folder/Folder.scala
+++ b/app/models/folder/Folder.scala
@@ -10,7 +10,7 @@ import models.organization.{Organization, OrganizationDAO}
 import models.team.{TeamDAO, TeamService}
 import models.user.User
 import play.api.libs.json.{JsArray, JsObject, Json, OFormat}
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import slick.sql.SqlAction
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 import com.scalableminds.util.objectid.ObjectId

--- a/app/models/job/Job.scala
+++ b/app/models/job/Job.scala
@@ -8,7 +8,7 @@ import com.scalableminds.webknossos.schema.Tables.{Jobs, JobsRow, GetResultJobsR
 import models.job.JobState.JobState
 import models.job.JobCommand.JobCommand
 import play.api.libs.json.{JsObject, Json, OFormat}
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import slick.jdbc.TransactionIsolation.Serializable
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 import com.scalableminds.util.objectid.ObjectId
@@ -16,7 +16,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.DataSourceStatus
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 case class Job(
     _id: ObjectId,

--- a/app/models/job/Worker.scala
+++ b/app/models/job/Worker.scala
@@ -20,7 +20,7 @@ import utils.WkConf
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 case class Worker(
     _id: ObjectId,

--- a/app/models/organization/CreditTransaction.scala
+++ b/app/models/organization/CreditTransaction.scala
@@ -14,7 +14,7 @@ import models.organization.CreditState.CreditState
 import models.organization.CreditTransactionState.TransactionState
 import slick.dbio.DBIO
 import slick.jdbc.GetResult
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import slick.jdbc.TransactionIsolation.Serializable
 import telemetry.SlackNotificationService
 import utils.WkConf
@@ -73,7 +73,7 @@ class CreditTransactionDAO @Inject() (
 
   implicit val getCreditTransactions: GetResult[CreditTransaction] =
     prs => {
-      import prs._
+      import prs.*
       val transactionId = <<[ObjectId]
       val organizationId = <<[String]
       val relatedTransaction = <<?[ObjectId]

--- a/app/models/organization/Organization.scala
+++ b/app/models/organization/Organization.scala
@@ -17,7 +17,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.LayerAttachmentT
 import models.organization.AiPlan.AiPlan
 import slick.dbio.DBIO
 import slick.jdbc.GetResult
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 
 import javax.inject.Inject

--- a/app/models/project/Project.scala
+++ b/app/models/project/Project.scala
@@ -12,7 +12,7 @@ import models.annotation.{AnnotationState, AnnotationType}
 import models.task.TaskDAO
 import models.team.TeamDAO
 import models.user.{User, UserService}
-import play.api.libs.json._
+import play.api.libs.json.*
 import com.scalableminds.util.objectid.ObjectId
 import utils.sql.{SQLDAO, SqlClient}
 

--- a/app/models/storage/UsedStorageService.scala
+++ b/app/models/storage/UsedStorageService.scala
@@ -29,7 +29,7 @@ import utils.sql.SqlEscaping
 import java.nio.file.Paths
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class UsedStorageService @Inject() (
     val actorSystem: ActorSystem,

--- a/app/models/task/Script.scala
+++ b/app/models/task/Script.scala
@@ -6,7 +6,7 @@ import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.webknossos.schema.Tables.{Scripts, ScriptsRow, GetResultScriptsRow}
 import models.user.{UserDAO, UserService}
-import play.api.libs.json._
+import play.api.libs.json.*
 import com.scalableminds.util.objectid.ObjectId
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 

--- a/app/models/task/Task.scala
+++ b/app/models/task/Task.scala
@@ -10,9 +10,9 @@ import com.scalableminds.webknossos.schema.Tables.{Tasks, TasksRow, GetResultTas
 import com.scalableminds.webknossos.tracingstore.tracings.NamedBoundingBox
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import models.user.Experience
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import slick.jdbc.TransactionIsolation.Serializable
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 

--- a/app/models/task/TaskCreationResult.scala
+++ b/app/models/task/TaskCreationResult.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.box.{Box, Empty, Failure, Full, ParamFailure}
 import com.scalableminds.util.mvc.JsonResultAttributes
 import com.scalableminds.util.tools.Fox
 import play.api.http.Status
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/models/task/TaskType.scala
+++ b/app/models/task/TaskType.scala
@@ -12,7 +12,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.TracingType.TracingTyp
 import com.scalableminds.webknossos.tracingstore.tracings.volume.MagRestrictions
 import models.annotation.{AnnotationSettings, TracingMode}
 import models.team.TeamDAO
-import play.api.libs.json._
+import play.api.libs.json.*
 import utils.sql.{EnumerationArrayValue, SQLDAO, SqlClient}
 
 import javax.inject.Inject

--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -13,7 +13,7 @@ import models.organization.{Organization, OrganizationDAO}
 import models.project.ProjectDAO
 import models.task.TaskTypeDAO
 import models.user.User
-import play.api.libs.json._
+import play.api.libs.json.*
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 import com.scalableminds.util.objectid.ObjectId
 

--- a/app/models/user/Invite.scala
+++ b/app/models/user/Invite.scala
@@ -13,7 +13,7 @@ import javax.inject.Inject
 import models.organization.OrganizationDAO
 import models.team.TeamMembership
 import security.RandomIDGenerator
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import utils.sql.{SQLDAO, SqlClient}
 import utils.WkConf
 

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -1,7 +1,7 @@
 package models.user
 
 import play.silhouette.api.{Identity, LoginInfo}
-import com.scalableminds.util.accesscontext._
+import com.scalableminds.util.accesscontext.*
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
@@ -16,10 +16,10 @@ import com.scalableminds.webknossos.schema.Tables.{
 }
 
 import javax.inject.Inject
-import models.team._
-import play.api.libs.json._
+import models.team.*
+import play.api.libs.json.*
 import slick.jdbc.GetResult
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import slick.jdbc.TransactionIsolation.Serializable
 import utils.sql.{SQLDAO, SimpleSQLDAO, SqlClient, SqlToken}
 import com.scalableminds.util.objectid.ObjectId
@@ -205,7 +205,7 @@ class UserDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
   // Necessary since a tuple can only have 22 elements
   implicit def GetResultUserCompactInfo: GetResult[UserCompactInfo] =
     prs => {
-      import prs._
+      import prs.*
       UserCompactInfo(
         _id = <<[ObjectId],
         _multiUserId = <<[ObjectId],

--- a/app/models/user/UserService.scala
+++ b/app/models/user/UserService.scala
@@ -15,12 +15,12 @@ import com.typesafe.scalalogging.LazyLogging
 import mail.{DefaultMails, Send}
 import models.dataset.DatasetDAO
 import models.organization.OrganizationDAO
-import models.team._
+import models.team.*
 import com.scalableminds.util.box.Box.tryo
 import models.project.ProjectDAO
 import models.task.TaskDAO
 import org.apache.pekko.actor.ActorSystem
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.silhouette.api.LoginInfo
 import play.silhouette.api.services.IdentityService
 import play.silhouette.api.util.PasswordInfo

--- a/app/models/user/WebAuthnCredentials.scala
+++ b/app/models/user/WebAuthnCredentials.scala
@@ -147,8 +147,8 @@ class WebAuthnCredentialDAO @Inject() (sqlClient: SqlClient)(implicit ec: Execut
       _ <- run(
         q"""INSERT INTO $existingCollectionName (_id, _multiUser, credentialId, name, userVerified, backupEligible, backupState,
                                                  serializedAttestationStatement, serializedAttestedCredential, serializedExtensions, signatureCount)
-                       VALUES(${c._id}, ${c._multiUser}, ${credentialId}, ${c.name}, ${userVerified}, ${backupEligible}, ${backupState}, ${serializedAttestationStatement},
-                         ${serializedAttestedCredential}, ${serializedAuthenticatorExtensions}, ${c.credentialRecord.getCounter.toInt})""".asUpdate
+                       VALUES(${c._id}, ${c._multiUser}, $credentialId, ${c.name}, $userVerified, $backupEligible, $backupState, $serializedAttestationStatement,
+                         $serializedAttestedCredential, $serializedAuthenticatorExtensions, ${c.credentialRecord.getCounter.toInt})""".asUpdate
       )
     } yield ()
   }
@@ -163,7 +163,7 @@ class WebAuthnCredentialDAO @Inject() (sqlClient: SqlClient)(implicit ec: Execut
   def removeById(id: ObjectId, multiUser: ObjectId): Fox[Unit] =
     for {
       _ <- run(
-        q"""UPDATE $existingCollectionName SET isDeleted = true WHERE _id = ${id} AND _multiUser=${multiUser}""".asUpdate
+        q"""UPDATE $existingCollectionName SET isDeleted = true WHERE _id = $id AND _multiUser=$multiUser""".asUpdate
       )
     } yield ()
 

--- a/app/models/user/WebAuthnCredentials.scala
+++ b/app/models/user/WebAuthnCredentials.scala
@@ -1,7 +1,7 @@
 package models.user
 
 import tools.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.annotation._
+import com.fasterxml.jackson.annotation.*
 import com.scalableminds.util.accesscontext.DBAccessContext
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.tools.{JsonHelper, Fox}
@@ -13,15 +13,15 @@ import com.scalableminds.webknossos.schema.Tables.{
 }
 import com.webauthn4j.converter.AttestedCredentialDataConverter
 import com.webauthn4j.converter.util.ObjectConverter
-import com.webauthn4j.credential.{CredentialRecordImpl => WebAuthnCredentialRecord}
-import com.webauthn4j.data.attestation.statement._
+import com.webauthn4j.credential.CredentialRecordImpl as WebAuthnCredentialRecord
+import com.webauthn4j.data.attestation.statement.*
 import com.webauthn4j.data.extension.authenticator.{
   AuthenticationExtensionsAuthenticatorOutputs,
   RegistrationExtensionAuthenticatorOutput
 }
 import com.scalableminds.util.box.Box.tryo
 import utils.sql.{SQLDAO, SqlClient}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext

--- a/app/models/user/time/TimeSpanService.scala
+++ b/app/models/user/time/TimeSpanService.scala
@@ -10,7 +10,7 @@ import com.typesafe.scalalogging.LazyLogging
 import mail.{DefaultMails, Send}
 
 import javax.inject.Inject
-import models.annotation._
+import models.annotation.*
 import models.project.ProjectDAO
 import models.task.TaskDAO
 import models.user.{MultiUserDAO, User, UserService}
@@ -19,7 +19,7 @@ import utils.WkConf
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class TimeSpanService @Inject() (
     annotationDAO: AnnotationDAO,

--- a/app/models/voxelytics/LokiClient.scala
+++ b/app/models/voxelytics/LokiClient.scala
@@ -16,7 +16,7 @@ import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import utils.WkConf
 
 import javax.inject.Inject
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 import scala.math.Ordering.Implicits.infixOrderingOps
 

--- a/app/models/voxelytics/VoxelyticsDAO.scala
+++ b/app/models/voxelytics/VoxelyticsDAO.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
 import models.user.User
-import play.api.libs.json._
+import play.api.libs.json.*
 import com.scalableminds.util.objectid.ObjectId
 import utils.sql.{SimpleSQLDAO, SqlClient, SqlToken}
 

--- a/app/models/voxelytics/WorkflowEvents.scala
+++ b/app/models/voxelytics/WorkflowEvents.scala
@@ -2,7 +2,7 @@ package models.voxelytics
 
 import com.scalableminds.util.time.Instant
 import models.voxelytics.VoxelyticsRunState.VoxelyticsRunState
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait WorkflowEvent {}
 

--- a/app/security/CombinedAuthenticatorService.scala
+++ b/app/security/CombinedAuthenticatorService.scala
@@ -1,14 +1,14 @@
 package security
 
 import com.scalableminds.util.time.Instant
-import play.silhouette.api._
+import play.silhouette.api.*
 import play.silhouette.api.crypto.Base64AuthenticatorEncoder
 import play.silhouette.api.services.{AuthenticatorResult, AuthenticatorService}
 import play.silhouette.api.util.{Clock, ExtractableRequest, FingerprintGenerator, IDGenerator}
 import play.silhouette.crypto.{JcaSigner, JcaSignerSettings}
-import play.silhouette.impl.authenticators.{CookieAuthenticator, _}
+import play.silhouette.impl.authenticators.{CookieAuthenticator, *}
 import models.user.UserService
-import play.api.mvc._
+import play.api.mvc.*
 import utils.WkConf
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/security/OpenIdConnectClient.scala
+++ b/app/security/OpenIdConnectClient.scala
@@ -7,7 +7,7 @@ import com.scalableminds.webknossos.datastore.rpc.RPC
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsObject, Json, OFormat}
 import pdi.jwt.JwtJson
-import play.api.libs.ws._
+import play.api.libs.ws.*
 import utils.WkConf
 
 import java.math.BigInteger

--- a/app/security/WebknossosBearerTokenAuthenticatorService.scala
+++ b/app/security/WebknossosBearerTokenAuthenticatorService.scala
@@ -19,7 +19,7 @@ import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.time.Instant
 import utils.WkConf
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 
 class WebknossosBearerTokenAuthenticatorService(

--- a/app/security/WkSilhouetteEnvironment.scala
+++ b/app/security/WkSilhouetteEnvironment.scala
@@ -11,7 +11,7 @@ import utils.WkConf
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 trait WkEnv extends Env {
   type I = User

--- a/app/utils/StoreModules.scala
+++ b/app/utils/StoreModules.scala
@@ -1,6 +1,6 @@
 package utils
 
-import javax.inject._
+import javax.inject.*
 
 class StoreModules @Inject() (conf: WkConf) {
   def localTracingStoreEnabled: Boolean = {

--- a/app/utils/sql/SimpleSQLDAO.scala
+++ b/app/utils/sql/SimpleSQLDAO.scala
@@ -3,7 +3,7 @@ package utils.sql
 import com.scalableminds.util.tools.{Fox, TextUtils}
 import com.typesafe.scalalogging.LazyLogging
 import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
-import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.PostgresProfile.api.*
 import slick.jdbc.TransactionIsolation.Serializable
 import slick.sql.SqlAction
 import slick.util.{Dumpable, TreePrinter}

--- a/app/utils/sql/SqlInterpolation.scala
+++ b/app/utils/sql/SqlInterpolation.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Double}
 import com.scalableminds.util.time.Instant
 import play.api.libs.json.{JsValue, Json}
 import slick.dbio.{Effect, NoStream}
-import slick.jdbc._
+import slick.jdbc.*
 import slick.sql.{SqlAction, SqlStreamingAction}
 import slick.util.DumpInfo
 import com.scalableminds.util.objectid.ObjectId

--- a/test/backend/BoxTestSuite.scala
+++ b/test/backend/BoxTestSuite.scala
@@ -3,7 +3,7 @@ package backend
 import com.scalableminds.util.box.{Box, Empty, Failure, Full, ParamFailure}
 import org.scalatest.wordspec.AsyncWordSpec
 
-import scala.util.{Success, Failure => TryFailure}
+import scala.util.{Success, Failure as TryFailure}
 
 class BoxTestSuite extends AsyncWordSpec {
 

--- a/test/backend/DataVaultTestSuite.scala
+++ b/test/backend/DataVaultTestSuite.scala
@@ -30,7 +30,7 @@ import play.api.test.WsTestClient
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContext.{global => globalExecutionContext}
+import scala.concurrent.ExecutionContext.global as globalExecutionContext
 
 class DataVaultTestSuite extends AsyncWordSpec {
 

--- a/test/backend/Dummies.scala
+++ b/test/backend/Dummies.scala
@@ -1,6 +1,6 @@
 package backend
 
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
+import com.scalableminds.webknossos.datastore.SkeletonTracing.*
 import com.scalableminds.webknossos.datastore.MetadataEntry.MetadataEntryProto
 import com.scalableminds.webknossos.datastore.VolumeTracing.{Segment, VolumeTracing}
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing.ElementClassProto

--- a/test/backend/NMLUnitTestSuite.scala
+++ b/test/backend/NMLUnitTestSuite.scala
@@ -5,7 +5,7 @@ import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.webknossos.datastore.Annotation.AnnotationProto
 
 import java.io.ByteArrayInputStream
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
+import com.scalableminds.webknossos.datastore.SkeletonTracing.*
 import com.scalableminds.webknossos.datastore.geometry.{AdditionalAxisProto, Vec2IntProto}
 import com.scalableminds.webknossos.datastore.models.annotation.{AnnotationLayer, FetchedAnnotationLayer}
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeDataZipFormat

--- a/test/backend/SkeletonUpdateActionsUnitTestSuite.scala
+++ b/test/backend/SkeletonUpdateActionsUnitTestSuite.scala
@@ -1,10 +1,10 @@
 package backend
 
 import com.scalableminds.util.geometry.{Vec3Double, Vec3Int}
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
+import com.scalableminds.webknossos.datastore.SkeletonTracing.*
 import com.scalableminds.webknossos.datastore.helpers.TreeAgglomerateInfo
-import com.scalableminds.webknossos.tracingstore.tracings._
-import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating._
+import com.scalableminds.webknossos.tracingstore.tracings.*
+import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating.*
 import org.scalatest.wordspec.AsyncWordSpec
 
 class SkeletonUpdateActionsUnitTestSuite extends AsyncWordSpec {

--- a/test/backend/SqlInterpolationTestSuite.scala
+++ b/test/backend/SqlInterpolationTestSuite.scala
@@ -6,7 +6,7 @@ import models.job.JobState
 import org.scalatest.wordspec.AsyncWordSpec
 import play.api.libs.json.Json
 import com.scalableminds.util.objectid.ObjectId
-import utils.sql._
+import utils.sql.*
 
 import scala.concurrent.duration.DurationInt
 

--- a/test/e2e/End2EndSpec.scala
+++ b/test/e2e/End2EndSpec.scala
@@ -2,9 +2,9 @@ package e2e
 
 import com.scalableminds.util.io.{PathUtils, ZipIO}
 import com.typesafe.scalalogging.LazyLogging
-import org.scalatestplus.play.guice._
+import org.scalatestplus.play.guice.*
 import org.specs2.main.Arguments
-import org.specs2.mutable._
+import org.specs2.mutable.*
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.test.WithServer
@@ -12,8 +12,8 @@ import play.api.test.WithServer
 import java.io.File
 import java.nio.file.Path
 import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.sys.process._
+import scala.concurrent.duration.*
+import scala.sys.process.*
 
 class End2EndSpec(arguments: Arguments) extends Specification with GuiceFakeApplicationFactory with LazyLogging {
 

--- a/util/src/main/scala/com/scalableminds/util/box/Box.scala
+++ b/util/src/main/scala/com/scalableminds/util/box/Box.scala
@@ -154,7 +154,7 @@ sealed case class Failure(msg: String, exception: Box[Throwable], chain: Box[Fai
   override def ?->(msg: String): Box[Nothing] = ?~>(msg)
 
   override def equals(other: Any): Boolean = (this, other) match {
-    case (_, _: ParamFailure[_])                 => false
+    case (_, _: ParamFailure[?])                 => false
     case (Failure(x, y, z), Failure(x1, y1, z1)) => (x, y, z) == (x1, y1, z1)
     case (x, y: AnyRef)                          => x eq y
     case _                                       => false
@@ -172,7 +172,7 @@ object ParamFailure {
   def apply[T](msg: String, param: T) = new ParamFailure(msg, Empty, Empty, param)
 
   def unapply(in: Box[?]): Option[(String, Box[Throwable], Box[Failure], Any)] = in match {
-    case pf: ParamFailure[_] => Some((pf.msg, pf.exception, pf.chain, pf.param))
+    case pf: ParamFailure[?] => Some((pf.msg, pf.exception, pf.chain, pf.param))
     case _                   => None
   }
 }

--- a/util/src/main/scala/com/scalableminds/util/cache/AlfuCache.scala
+++ b/util/src/main/scala/com/scalableminds/util/cache/AlfuCache.scala
@@ -11,7 +11,7 @@ import scala.jdk.FunctionWrappers.AsJavaBiFunction
 import scala.jdk.FutureConverters.{CompletionStageOps, FutureOps}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class AlfuCache[K, V](store: AsyncCache[K, Box[V]]) {
 

--- a/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/BoundingBox.scala
@@ -86,7 +86,7 @@ case class BoundingBox(topLeft: Vec3Int, width: Int, height: Int, depth: Int) {
 
 object BoundingBox {
 
-  import play.api.libs.json._
+  import play.api.libs.json.*
 
   private val literalPattern =
     "\\s*((?:\\-)?[0-9]+),\\s*((?:\\-)?[0-9]+),\\s*((?:\\-)?[0-9]+)\\s*,\\s*([0-9]+),\\s*([0-9]+),\\s*([0-9]+)\\s*".r

--- a/util/src/main/scala/com/scalableminds/util/geometry/Vec3Double.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Vec3Double.scala
@@ -1,10 +1,10 @@
 package com.scalableminds.util.geometry
 
-import com.scalableminds.util.tools.MathUtils._
-import play.api.libs.json.Json._
-import play.api.libs.json._
+import com.scalableminds.util.tools.MathUtils.*
+import play.api.libs.json.Json.*
+import play.api.libs.json.*
 
-import scala.math._
+import scala.math.*
 
 case class Vec3Double(x: Double, y: Double, z: Double) {
 

--- a/util/src/main/scala/com/scalableminds/util/geometry/Vec3Int.scala
+++ b/util/src/main/scala/com/scalableminds/util/geometry/Vec3Int.scala
@@ -1,8 +1,8 @@
 package com.scalableminds.util.geometry
 
 import com.scalableminds.util.tools.StringNumberConversions.toIntOpt
-import play.api.libs.json.Json._
-import play.api.libs.json._
+import play.api.libs.json.Json.*
+import play.api.libs.json.*
 
 case class Vec3Int(x: Int, y: Int, z: Int) {
   def scale(s: Int): Vec3Int =

--- a/util/src/main/scala/com/scalableminds/util/image/ImageWriter.scala
+++ b/util/src/main/scala/com/scalableminds/util/image/ImageWriter.scala
@@ -1,10 +1,10 @@
 package com.scalableminds.util.image
 
 import java.awt.image.{BufferedImage, DataBufferByte}
-import java.io._
-import javax.imageio._
-import javax.imageio.stream._
-import java.{util => ju}
+import java.io.*
+import javax.imageio.*
+import javax.imageio.stream.*
+import java.util as ju
 import javax.imageio
 
 class ImageWriter(imageType: String, imageExt: String) {

--- a/util/src/main/scala/com/scalableminds/util/io/FileIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/FileIO.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.util.io
 
 import com.scalableminds.util.box.{Box, Failure, Full}
-import java.io._
+import java.io.*
 import com.scalableminds.util.tools.Fox
 import Box.tryo
 import org.apache.commons.io.IOUtils

--- a/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
+++ b/util/src/main/scala/com/scalableminds/util/io/ZipIO.scala
@@ -1,9 +1,9 @@
 package com.scalableminds.util.io
 
 import com.scalableminds.util.box.{Box, Empty, Failure, Full}
-import java.io._
+import java.io.*
 import java.nio.file.{Files, Path}
-import java.util.zip.{GZIPOutputStream => DefaultGZIPOutputStream, _}
+import java.util.zip.{GZIPOutputStream as DefaultGZIPOutputStream, *}
 import com.scalableminds.util.tools.{Fox, TextUtils}
 import com.scalableminds.util.tools.Fox.toFox
 import com.typesafe.scalalogging.LazyLogging

--- a/util/src/main/scala/com/scalableminds/util/time/Instant.scala
+++ b/util/src/main/scala/com/scalableminds/util/time/Instant.scala
@@ -5,7 +5,7 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 import com.typesafe.scalalogging.{LazyLogging, Logger}
 import com.scalableminds.util.box.Box.tryo
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.time.{ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter

--- a/util/src/main/scala/com/scalableminds/util/tools/MathUtils.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/MathUtils.scala
@@ -1,6 +1,6 @@
 package com.scalableminds.util.tools
 
-import scala.Numeric.Implicits._
+import scala.Numeric.Implicits.*
 
 object MathUtils {
   private val EPSILON = 1e-10
@@ -12,7 +12,7 @@ object MathUtils {
   def isNearZero(d: Double): Boolean = d <= EPSILON && d >= -EPSILON
 
   def clamp[T](x: T, lower: T, upper: T)(implicit num: Numeric[T]): T = {
-    import num._
+    import num.*
     lower.max(x).min(upper)
   }
 

--- a/util/src/main/scala/com/scalableminds/util/tools/TristateOptionJsonHelper.scala
+++ b/util/src/main/scala/com/scalableminds/util/tools/TristateOptionJsonHelper.scala
@@ -2,7 +2,7 @@ package com.scalableminds.util.tools
 
 import play.api.libs.json.Json.WithDefaultValues
 import play.api.libs.json.JsonConfiguration.Aux
-import play.api.libs.json._
+import play.api.libs.json.*
 
 // Allows a case class json format that distinguishes between absent keys and keys with the value null
 // See TristateJsonTestSuite for a usage example. The Some(None) default must by set for the case class

--- a/webknossos-datastore/app/DsRequestHandler.scala
+++ b/webknossos-datastore/app/DsRequestHandler.scala
@@ -3,8 +3,8 @@ import com.scalableminds.webknossos.datastore.DataStoreConfig
 import com.scalableminds.webknossos.datastore.helpers.MissingBucketHeaders
 import com.typesafe.scalalogging.LazyLogging
 import play.api.OptionalDevContext
-import play.api.http._
-import play.api.mvc.Results._
+import play.api.http.*
+import play.api.mvc.Results.*
 import play.api.mvc.{Handler, InjectedController, RequestHeader, Result}
 import play.api.routing.Router
 import play.core.WebCommands

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreConfig.scala
@@ -5,7 +5,7 @@ import com.scalableminds.util.tools.ConfigReader
 import com.typesafe.config.Config
 import play.api.Configuration
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class DataStoreConfig @Inject() (configuration: Configuration) extends ConfigReader {
   override val raw: Configuration = configuration

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/DataStoreModule.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.datastore
 import org.apache.pekko.actor.ActorSystem
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
-import com.scalableminds.webknossos.datastore.services._
+import com.scalableminds.webknossos.datastore.services.*
 import com.scalableminds.webknossos.datastore.services.connectome.{
   ConnectomeFileService,
   Hdf5ConnectomeFileService,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/BinaryDataController.scala
@@ -12,14 +12,14 @@ import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.DataStoreConfig
 import com.scalableminds.webknossos.datastore.helpers.MissingBucketHeaders
 import com.scalableminds.webknossos.datastore.image.{ImageCreator, ImageCreatorParameters}
-import com.scalableminds.webknossos.datastore.models.datasource._
+import com.scalableminds.webknossos.datastore.models.datasource.*
 import com.scalableminds.webknossos.datastore.models.requests.{
   DataServiceDataRequest,
   DataServiceMappingRequest,
   DataServiceRequestSettings
 }
-import com.scalableminds.webknossos.datastore.models._
-import com.scalableminds.webknossos.datastore.services._
+import com.scalableminds.webknossos.datastore.models.*
+import com.scalableminds.webknossos.datastore.services.*
 import com.scalableminds.webknossos.datastore.services.mesh.{AdHocMeshRequest, AdHocMeshService, AdHocMeshServiceHolder}
 import com.scalableminds.webknossos.datastore.slacknotification.DSSlackNotificationService
 import com.scalableminds.util.box.Box.tryo

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSMeshController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSMeshController.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.datastore.controllers
 import com.google.inject.Inject
 import com.scalableminds.util.Msg
 import com.scalableminds.util.objectid.ObjectId
-import com.scalableminds.webknossos.datastore.services._
+import com.scalableminds.webknossos.datastore.services.*
 import com.scalableminds.webknossos.datastore.services.mesh.{
   DSFullMeshService,
   FullMeshRequest,

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataSourceController.scala
@@ -27,7 +27,7 @@ import com.scalableminds.webknossos.datastore.helpers.{
   UPath
 }
 import com.scalableminds.webknossos.datastore.models.datasource.{DataLayer, DataSource, UsableDataSource}
-import com.scalableminds.webknossos.datastore.services._
+import com.scalableminds.webknossos.datastore.services.*
 import com.scalableminds.webknossos.datastore.services.connectome.ConnectomeFileService
 import com.scalableminds.webknossos.datastore.services.mesh.{
   DSFullMeshService,
@@ -50,7 +50,7 @@ import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Files
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext
 
 case class PathValidationResult(

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/ZarrStreamingController.scala
@@ -20,15 +20,15 @@ import com.scalableminds.webknossos.datastore.datareaders.zarr3.{NgffZarr3GroupH
 import com.scalableminds.webknossos.datastore.helpers.UPath
 import com.scalableminds.webknossos.datastore.models.VoxelPosition
 import com.scalableminds.webknossos.datastore.models.annotation.{AnnotationLayer, AnnotationLayerType, AnnotationSource}
-import com.scalableminds.webknossos.datastore.models.datasource._
+import com.scalableminds.webknossos.datastore.models.datasource.*
 import com.scalableminds.webknossos.datastore.models.requests.{
   Cuboid,
   DataServiceDataRequest,
   DataServiceRequestSettings
 }
-import com.scalableminds.webknossos.datastore.services._
+import com.scalableminds.webknossos.datastore.services.*
 import play.api.libs.json.{JsValue, Json}
-import play.api.mvc._
+import play.api.mvc.*
 
 import java.nio.file.Path
 import scala.concurrent.ExecutionContext

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/DatasetArrayBucketProvider.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/DatasetArrayBucketProvider.scala
@@ -18,8 +18,8 @@ import com.scalableminds.webknossos.datastore.models.requests.DataReadInstructio
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import com.typesafe.scalalogging.LazyLogging
 
-import scala.concurrent.duration._
-import ucar.ma2.{Array => MultiArray}
+import scala.concurrent.duration.*
+import ucar.ma2.Array as MultiArray
 
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWFile.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWFile.scala
@@ -1,6 +1,6 @@
 package com.scalableminds.webknossos.datastore.dataformats.wkw
 
-import java.io._
+import java.io.*
 import org.apache.commons.io.IOUtils
 import com.google.common.io.LittleEndianDataInputStream
 import com.scalableminds.util.box.{Box, Failure, Full}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/WKWHeader.scala
@@ -1,6 +1,6 @@
 package com.scalableminds.webknossos.datastore.dataformats.wkw
 
-import com.google.common.io.{LittleEndianDataInputStream => DataInputStream}
+import com.google.common.io.LittleEndianDataInputStream as DataInputStream
 import com.scalableminds.util.box.Box
 import com.scalableminds.webknossos.datastore.dataformats.wkw.util.ResourceBox
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDataType
@@ -17,7 +17,7 @@ import com.scalableminds.webknossos.datastore.datareaders.{
 }
 import org.apache.commons.io.IOUtils
 
-import java.io._
+import java.io.*
 import java.nio.{ByteBuffer, ByteOrder}
 import Box.tryo
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/util/ResourceBox.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/dataformats/wkw/util/ResourceBox.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.box.{Box, Failure as BoxFailure}
 import Box.tryo
 
 import scala.util.Using.Releasable
-import scala.util.{Success, Using, Failure => TryFailure}
+import scala.util.{Success, Using, Failure as TryFailure}
 
 object ResourceBox {
   def apply[R](resource: => R): Box[R] =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/BytesConverter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/BytesConverter.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.datastore.datareaders
 import com.scalableminds.util.box.Box
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDataType
 import Box.tryo
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import java.nio.{ByteBuffer, ByteOrder}
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkReader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkReader.scala
@@ -7,7 +7,7 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.datavault.{ByteRange, VaultPath}
 import Box.tryo
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkTyper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/ChunkTyper.scala
@@ -9,7 +9,7 @@ import Box.tryo
 import java.io.ByteArrayInputStream
 import javax.imageio.stream.MemoryCacheImageInputStream
 import scala.util.Using
-import ucar.ma2.{Array => MultiArray, DataType => MADataType}
+import ucar.ma2.{Array as MultiArray, DataType as MADataType}
 
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/Compressor.scala
@@ -14,8 +14,8 @@ import org.apache.commons.compress.compressors.zstandard.{ZstdCompressorInputStr
 import play.api.libs.json.{Format, JsResult, JsValue, Json}
 
 import java.awt.image.{BufferedImage, DataBufferByte}
-import java.io._
-import java.util.zip._
+import java.io.*
+import java.util.zip.*
 import javax.imageio.ImageIO
 import javax.imageio.ImageIO.createImageInputStream
 import javax.imageio.stream.ImageInputStream

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/DatasetArray.scala
@@ -11,7 +11,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.models.AdditionalCoordinate
 import com.scalableminds.webknossos.datastore.models.datasource.AdditionalAxis
 import com.scalableminds.util.box.Box.tryo
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import java.nio.ByteOrder
 import java.util

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/MultiArrayUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/MultiArrayUtils.scala
@@ -4,7 +4,7 @@ import ArrayDataType.ArrayDataType
 import com.scalableminds.util.box.{Box, Failure, Full}
 import com.typesafe.scalalogging.LazyLogging
 import Box.tryo
-import ucar.ma2.{IndexIterator, InvalidRangeException, Range, Array => MultiArray, DataType => MADataType}
+import ucar.ma2.{IndexIterator, InvalidRangeException, Range, Array as MultiArray, DataType as MADataType}
 
 import java.util
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5Array.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5Array.scala
@@ -10,7 +10,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.models.datasource.AdditionalAxis
 import com.typesafe.scalalogging.LazyLogging
 import com.scalableminds.util.box.Box.tryo
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5Header.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5Header.scala
@@ -3,10 +3,10 @@ package com.scalableminds.webknossos.datastore.datareaders.n5
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDataType
 import com.scalableminds.webknossos.datastore.datareaders.ArrayOrder.ArrayOrder
 import com.scalableminds.webknossos.datastore.datareaders.DimensionSeparator.DimensionSeparator
-import com.scalableminds.webknossos.datastore.datareaders._
+import com.scalableminds.webknossos.datastore.datareaders.*
 import com.scalableminds.webknossos.datastore.helpers.JsonImplicits
 import play.api.libs.json.Json.WithDefaultValues
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.nio.ByteOrder
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
@@ -12,7 +12,7 @@ import com.typesafe.scalalogging.LazyLogging
 import com.scalableminds.util.box.Box.tryo
 
 import scala.concurrent.ExecutionContext
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 object PrecomputedArray extends LazyLogging {
   def open(

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/wkw/WKWArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/wkw/WKWArray.scala
@@ -11,7 +11,7 @@ import com.scalableminds.webknossos.datastore.datareaders.{AxisOrder, ChunkUtils
 import com.scalableminds.webknossos.datastore.datavault.{ByteRange, StartEndExclusiveByteRange, VaultPath}
 import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, DataSourceId}
 import Box.tryo
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import java.io.ByteArrayInputStream
 import scala.concurrent.ExecutionContext

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrArray.scala
@@ -5,7 +5,7 @@ import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.util.cache.AlfuCache
 import com.scalableminds.webknossos.datastore.datareaders.{AxisOrder, DatasetArray, DatasetHeader}
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
 import com.scalableminds.webknossos.datastore.models.datasource.AdditionalAxis

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr/ZarrHeader.scala
@@ -17,7 +17,7 @@ import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDat
 import com.scalableminds.webknossos.datastore.helpers.JsonImplicits
 import com.scalableminds.webknossos.datastore.models.datasource.{DataLayer, ElementClass}
 import play.api.libs.json.Json.WithDefaultValues
-import play.api.libs.json._
+import play.api.libs.json.*
 
 case class ZarrHeader(
     zarr_format: Int, // format version number

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Codecs.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Codecs.scala
@@ -16,7 +16,7 @@ import com.scalableminds.webknossos.datastore.helpers.JsonImplicits
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{Format, JsObject, JsResult, JsString, JsSuccess, JsValue, Json, OFormat, Reads, Writes}
 import play.api.libs.json.Json.WithDefaultValues
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import java.util.zip.CRC32C
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/NgffZarr3GroupHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/NgffZarr3GroupHeader.scala
@@ -1,7 +1,7 @@
 package com.scalableminds.webknossos.datastore.datareaders.zarr3
 
 import com.scalableminds.webknossos.datastore.datareaders.zarr.NgffMetadataV0_5
-import play.api.libs.json._
+import play.api.libs.json.*
 
 case class NgffZarr3GroupHeader(
     zarr_format: Int, // must be 3

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3Array.scala
@@ -10,7 +10,7 @@ import com.scalableminds.webknossos.datastore.datavault.{ByteRange, StartEndExcl
 import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, DataSourceId}
 import com.typesafe.scalalogging.LazyLogging
 import com.scalableminds.util.box.Box.tryo
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3ArrayHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3ArrayHeader.scala
@@ -7,11 +7,11 @@ import com.scalableminds.util.tools.JsonHelper
 import com.scalableminds.webknossos.datastore.datareaders.ArrayDataType.ArrayDataType
 import com.scalableminds.webknossos.datastore.datareaders.ArrayOrder.ArrayOrder
 import com.scalableminds.webknossos.datastore.datareaders.DimensionSeparator.DimensionSeparator
-import com.scalableminds.webknossos.datastore.datareaders._
+import com.scalableminds.webknossos.datastore.datareaders.*
 import com.scalableminds.webknossos.datastore.datareaders.zarr3.Zarr3DataType.{Zarr3DataType, raw}
 import com.scalableminds.webknossos.datastore.helpers.JsonImplicits
 import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, DataLayer, ElementClass}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.nio.ByteOrder
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/FileSystemDataVault.scala
@@ -14,7 +14,7 @@ import java.nio.channels.{AsynchronousFileChannel, CompletionHandler}
 import java.nio.file.{Files, Path, StandardOpenOption}
 import java.util.stream.Collectors
 import scala.concurrent.{ExecutionContext, Promise}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class FileSystemDataVault extends DataVault {
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/S3DataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/S3DataVault.scala
@@ -15,7 +15,7 @@ import com.scalableminds.webknossos.datastore.helpers.{S3UriUtils, UPath}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.lang3.builder.HashCodeBuilder
 
-import scala.util.{Failure => TryFailure, Success => TrySuccess}
+import scala.util.{Failure as TryFailure, Success as TrySuccess}
 import software.amazon.awssdk.core.ResponseBytes
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
 import software.amazon.awssdk.services.s3.S3AsyncClient
@@ -33,7 +33,7 @@ import java.net.URI
 import java.util.concurrent.CompletionException
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.CollectionHasAsScala
-import scala.jdk.FutureConverters._
+import scala.jdk.FutureConverters.*
 
 class S3DataVault(
     s3AccessKeyCredential: Option[S3AccessKeyCredential],

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/N5MultiscalesExplorer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/N5MultiscalesExplorer.scala
@@ -5,7 +5,7 @@ import com.scalableminds.util.geometry.{Vec3Double, Vec3Int}
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
-import com.scalableminds.webknossos.datastore.datareaders.n5._
+import com.scalableminds.webknossos.datastore.datareaders.n5.*
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.VoxelSize
 import com.scalableminds.webknossos.datastore.models.datasource.StaticLayer

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NeuroglancerUriExplorer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NeuroglancerUriExplorer.scala
@@ -12,7 +12,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.{LayerViewConfig
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import com.scalableminds.util.box.Box.tryo
 import com.scalableminds.webknossos.datastore.helpers.UPath
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.net.URI
 import scala.concurrent.ExecutionContext

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NgffV0_4Explorer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/explore/NgffV0_4Explorer.scala
@@ -6,7 +6,7 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
-import com.scalableminds.webknossos.datastore.datareaders.zarr._
+import com.scalableminds.webknossos.datastore.datareaders.zarr.*
 import com.scalableminds.webknossos.datastore.datavault.VaultPath
 import com.scalableminds.webknossos.datastore.models.VoxelSize
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/IntervalScheduler.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/IntervalScheduler.scala
@@ -6,7 +6,7 @@ import play.api.inject.ApplicationLifecycle
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import com.scalableminds.util.time.Instant
 
 trait IntervalScheduler {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/models/datasource/DataLayer.scala
@@ -5,10 +5,10 @@ import com.scalableminds.webknossos.datastore.dataformats.{BucketProvider, Datas
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Int}
 import com.scalableminds.webknossos.datastore.helpers.UPath
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait DataLayer {
   def name: String

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/rpc/RPCRequest.scala
@@ -7,14 +7,14 @@ import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.typesafe.scalalogging.LazyLogging
 import play.api.http.{HeaderNames, Status}
-import play.api.libs.json._
-import play.api.libs.ws._
+import play.api.libs.json.*
+import play.api.libs.ws.*
 import com.scalableminds.util.time.Instant
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import java.io.File
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class RPCRequest(val id: Int, val url: String, wsClient: WSClient)(implicit ec: ExecutionContext)
     extends LazyLogging

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/AccessTokenService.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Result
 import play.api.mvc.Results.Forbidden
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext
 
 object AccessMode extends ExtendedEnumeration {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/BinaryDataService.scala
@@ -12,7 +12,7 @@ import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.{DataLayer, DataSourceId, LayerCategory}
 import com.scalableminds.webknossos.datastore.models.requests.{DataReadInstruction, DataServiceDataRequest}
 import com.typesafe.scalalogging.LazyLogging
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 import Box.tryo
 import com.scalableminds.webknossos.datastore.services.mapping.AgglomerateService
 import com.scalableminds.webknossos.datastore.storage.{BucketProviderCache, DataVaultService}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/ChunkCacheService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/ChunkCacheService.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.datastore.services
 import com.scalableminds.util.box.{Box, Full}
 import com.scalableminds.util.cache.AlfuCache
 import com.scalableminds.webknossos.datastore.DataStoreConfig
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 import jakarta.inject.Inject
 
 trait ChunkCacheService {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DSRemoteWebknossosClient.scala
@@ -32,7 +32,7 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.nio.file.Path
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 case class DataStoreStatus(ok: Boolean, url: String)
 object DataStoreStatus {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataConverter.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DataConverter.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.datastore.services
 import com.scalableminds.webknossos.datastore.models.datasource.ElementClass
 import com.scalableminds.webknossos.datastore.services.mesh.DataTypeFunctors
 
-import java.nio._
+import java.nio.*
 import scala.reflect.ClassTag
 
 trait DataConverter {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DatasetErrorLoggingService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/DatasetErrorLoggingService.scala
@@ -14,7 +14,7 @@ import play.api.inject.ApplicationLifecycle
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 trait DatasetErrorLoggingService extends IntervalScheduler with Formatter with LazyLogging {
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/Hdf5AgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/Hdf5AgglomerateService.scala
@@ -18,7 +18,7 @@ import com.scalableminds.webknossos.datastore.helpers.{NodeDefaults, SkeletonTra
 import com.scalableminds.webknossos.datastore.models.datasource.ElementClass
 import com.scalableminds.webknossos.datastore.models.requests.DataServiceDataRequest
 import com.scalableminds.webknossos.datastore.services.DataConverter
-import com.scalableminds.webknossos.datastore.storage._
+import com.scalableminds.webknossos.datastore.storage.*
 
 import java.nio.file.Files
 import java.nio.{ByteBuffer, ByteOrder, LongBuffer}

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/MappingParser.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/MappingParser.scala
@@ -7,7 +7,7 @@ import com.scalableminds.util.time.Instant
 import com.scalableminds.webknossos.datastore.models.datasource.DataLayerMapping
 import com.typesafe.scalalogging.LazyLogging
 
-import java.io._
+import java.io.*
 import java.nio.file.Path
 import scala.collection.mutable
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/ZarrAgglomerateService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mapping/ZarrAgglomerateService.scala
@@ -23,7 +23,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.{DataSourceId, E
 import com.scalableminds.webknossos.datastore.services.DSChunkCacheService
 import com.scalableminds.webknossos.datastore.storage.{AgglomerateFileKey, DataVaultService}
 import com.typesafe.scalalogging.LazyLogging
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import javax.inject.Inject
 import scala.collection.compat.immutable.ArraySeq

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/AdHocMeshService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/AdHocMeshService.scala
@@ -23,9 +23,9 @@ import org.apache.pekko.pattern.ask
 import org.apache.pekko.routing.RoundRobinPool
 import org.apache.pekko.util.Timeout
 
-import java.nio._
+import java.nio.*
 import scala.collection.mutable
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext}
 import scala.reflect.ClassTag
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/DSFullMeshService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/DSFullMeshService.scala
@@ -13,7 +13,7 @@ import com.scalableminds.webknossos.datastore.DataStoreConfig
 import com.scalableminds.webknossos.datastore.models.datasource.{DataLayer, SegmentationLayer, UsableDataSource}
 import com.scalableminds.webknossos.datastore.models.requests.Cuboid
 import com.scalableminds.webknossos.datastore.models.{AdditionalCoordinate, VoxelPosition}
-import com.scalableminds.webknossos.datastore.services._
+import com.scalableminds.webknossos.datastore.services.*
 import com.typesafe.scalalogging.LazyLogging
 import com.scalableminds.util.box.Box.tryo
 import com.scalableminds.webknossos.datastore.services.mapping.MappingService

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/FullMeshHelper.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/FullMeshHelper.scala
@@ -74,7 +74,7 @@ trait FullMeshHelper extends LazyLogging {
     val outputNumBytesLong = 80L + 4L + chunkBytesTotal
     if (outputNumBytesLong > Int.MaxValue)
       throw new IllegalStateException(
-        s"Mesh is too large to combine into a single STL buffer: $outputNumBytesLong bytes (${numFacesLong} faces). " +
+        s"Mesh is too large to combine into a single STL buffer: $outputNumBytesLong bytes ($numFacesLong faces). " +
           "Use per-chunk surface area computation instead."
       )
     val constantStlHeader = Array.fill[Byte](80)(0)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/ZarrMeshFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/mesh/ZarrMeshFileService.scala
@@ -17,7 +17,7 @@ import com.scalableminds.webknossos.datastore.services.{
 }
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.libs.json.{JsResult, JsValue, Reads}
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/segmentindex/ZarrSegmentIndexFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/segmentindex/ZarrSegmentIndexFileService.scala
@@ -14,7 +14,7 @@ import com.scalableminds.webknossos.datastore.services.{
   DSChunkCacheService,
   VoxelyticsZarrArtifactUtils
 }
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import play.api.libs.json.{JsResult, JsValue, Reads}
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/CumsumParser.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/CumsumParser.scala
@@ -5,7 +5,7 @@ import com.google.gson.stream.JsonReader
 import com.scalableminds.util.time.Instant
 import com.typesafe.scalalogging.LazyLogging
 
-import java.io._
+import java.io.*
 import java.util
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/S3ClientPool.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/storage/S3ClientPool.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.DurationConverters.ScalaDurationOps
 import scala.jdk.OptionConverters.RichOptional
-import scala.util.{Failure => TryFailure, Success => TrySuccess}
+import scala.util.{Failure as TryFailure, Success as TrySuccess}
 
 class S3ClientPool(ws: WSClient) {
 

--- a/webknossos-slick-codegen/src/main/scala/com/scalableminds/codegen/SchemaCodeGenerator.scala
+++ b/webknossos-slick-codegen/src/main/scala/com/scalableminds/codegen/SchemaCodeGenerator.scala
@@ -4,7 +4,7 @@ import org.slf4j.LoggerFactory
 import slick.basic.DatabaseConfig
 import slick.codegen.SourceCodeGenerator
 import slick.jdbc.JdbcProfile
-import slick.{model => slickModel}
+import slick.model as slickModel
 
 import java.io.{BufferedWriter, File, FileOutputStream, OutputStreamWriter}
 import java.net.URI

--- a/webknossos-tracingstore/app/TsRequestHandler.scala
+++ b/webknossos-tracingstore/app/TsRequestHandler.scala
@@ -2,7 +2,7 @@ import com.scalableminds.util.mvc.{ApiVersioning, ExtendedController}
 import com.scalableminds.webknossos.tracingstore.TracingStoreConfig
 import com.typesafe.scalalogging.LazyLogging
 import play.api.OptionalDevContext
-import play.api.http._
+import play.api.http.*
 import play.api.mvc.{Handler, InjectedController, RequestHeader}
 import play.api.routing.Router
 import play.core.WebCommands

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class AnnotationTransactionService @Inject() (
     handledGroupIdStore: TracingStoreRedisStore,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/TSAnnotationService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/TSAnnotationService.scala
@@ -20,7 +20,7 @@ import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, 
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 import com.scalableminds.webknossos.datastore.models.annotation.AnnotationLayerType
-import com.scalableminds.webknossos.tracingstore.tracings._
+import com.scalableminds.webknossos.tracingstore.tracings.*
 import com.scalableminds.webknossos.tracingstore.tracings.editablemapping.{
   EditableMappingLayer,
   EditableMappingService,
@@ -32,7 +32,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.skeleton.{
   SkeletonTracingWithUpdatedTreeIds
 }
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating.SkeletonUpdateAction
-import com.scalableminds.webknossos.tracingstore.tracings.volume._
+import com.scalableminds.webknossos.tracingstore.tracings.volume.*
 import com.scalableminds.webknossos.tracingstore.{TSRemoteDatastoreClient, TSRemoteWebknossosClient}
 import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.{JsObject, JsValue, Json}

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/UpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/UpdateActions.scala
@@ -6,9 +6,9 @@ import com.scalableminds.webknossos.tracingstore.tracings.editablemapping.{
   MergeAgglomerateUpdateAction,
   SplitAgglomerateUpdateAction
 }
-import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating._
-import com.scalableminds.webknossos.tracingstore.tracings.volume._
-import play.api.libs.json._
+import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating.*
+import com.scalableminds.webknossos.tracingstore.tracings.volume.*
+import play.api.libs.json.*
 
 trait UpdateAction {
   def actionTimestamp: Option[Long]

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/SkeletonTracingController.scala
@@ -19,7 +19,7 @@ import com.scalableminds.webknossos.datastore.controllers.Controller
 import com.scalableminds.webknossos.datastore.services.UserAccessRequest
 import com.scalableminds.webknossos.tracingstore.annotation.TSAnnotationService
 import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
-import com.scalableminds.webknossos.tracingstore.tracings.skeleton._
+import com.scalableminds.webknossos.tracingstore.tracings.skeleton.*
 import com.scalableminds.webknossos.tracingstore.tracings.TracingSelector
 import com.scalableminds.webknossos.tracingstore.{TSRemoteWebknossosClient, TracingStoreAccessTokenService}
 import play.api.libs.json.Json

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TSAnnotationController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/TSAnnotationController.scala
@@ -27,7 +27,7 @@ import com.scalableminds.webknossos.tracingstore.annotation.{
   UpdateActionGroup
 }
 import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
-import com.scalableminds.webknossos.tracingstore.tracings._
+import com.scalableminds.webknossos.tracingstore.tracings.*
 import com.scalableminds.webknossos.tracingstore.tracings.editablemapping.EditableMappingMergeService
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.SkeletonTracingService
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeTracingService

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/controllers/VolumeTracingController.scala
@@ -32,7 +32,7 @@ import com.scalableminds.webknossos.datastore.services.mesh.FullMeshRequest
 import com.scalableminds.webknossos.tracingstore.annotation.{AnnotationTransactionService, TSAnnotationService}
 import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.scalableminds.webknossos.tracingstore.tracings.editablemapping.EditableMappingService
-import com.scalableminds.webknossos.tracingstore.tracings.volume._
+import com.scalableminds.webknossos.tracingstore.tracings.volume.*
 import com.scalableminds.webknossos.tracingstore.tracings.{
   KeyValueStoreConversions,
   TemporaryMergedVolumeStatsStore,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/slacknotification/TSSlackNotificationService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/slacknotification/TSSlackNotificationService.scala
@@ -24,7 +24,7 @@ class TSSlackNotificationService @Inject() (rpc: RPC, config: TracingStoreConfig
     if (!msg.contains("UNAVAILABLE")) { // Filter out expected errors during fossildb restart
       slackClient.warn(
         title = "Error during fossildb write",
-        msg = s"$requestType request to FossilDB failed: ${msg}"
+        msg = s"$requestType request to FossilDB failed: $msg"
       )
     }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/NamedBoundingBox.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/NamedBoundingBox.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.tracingstore.tracings
 import play.api.libs.json.{Json, OFormat}
 import com.scalableminds.util.geometry.BoundingBox
 import com.scalableminds.util.image.Color
-import com.scalableminds.webknossos.datastore.geometry.{NamedBoundingBoxProto => ProtoBoundingBox}
+import com.scalableminds.webknossos.datastore.geometry.NamedBoundingBoxProto as ProtoBoundingBox
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating.SkeletonUpdateActionHelper
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingDataStore.scala
@@ -6,7 +6,7 @@ import com.scalableminds.webknossos.tracingstore.TracingStoreConfig
 import com.scalableminds.webknossos.tracingstore.slacknotification.TSSlackNotificationService
 import com.typesafe.scalalogging.LazyLogging
 import play.api.inject.ApplicationLifecycle
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingMigrationService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/TracingMigrationService.scala
@@ -6,7 +6,7 @@ import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.SkeletonTracing.SkeletonTracing
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
-import com.scalableminds.webknossos.datastore.geometry.{ColorProto, NamedBoundingBoxProto => ProtoBox}
+import com.scalableminds.webknossos.datastore.geometry.{ColorProto, NamedBoundingBoxProto as ProtoBox}
 import scalapb.GeneratedMessage
 
 import scala.concurrent.ExecutionContext

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingIOService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingIOService.scala
@@ -8,7 +8,7 @@ import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
-import com.scalableminds.webknossos.datastore.datareaders.zarr3._
+import com.scalableminds.webknossos.datastore.datareaders.zarr3.*
 import com.scalableminds.webknossos.datastore.datavault.{FileSystemDataVault, VaultPath}
 import com.scalableminds.webknossos.datastore.helpers.UPath
 import com.scalableminds.webknossos.datastore.models.datasource.DataSourceId
@@ -19,7 +19,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.{KeyValueStoreConversi
 import com.typesafe.scalalogging.LazyLogging
 import jakarta.inject.Inject
 import play.api.libs.json.Json
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import java.io.{BufferedOutputStream, File, FileOutputStream}
 import java.nio.ByteBuffer

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingLayer.scala
@@ -20,7 +20,7 @@ import com.scalableminds.webknossos.datastore.models.datasource.{
   ElementClass,
   SegmentationLayer
 }
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import com.scalableminds.webknossos.tracingstore.annotation.TSAnnotationService

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingService.scala
@@ -22,7 +22,7 @@ import com.scalableminds.webknossos.datastore.helpers.{
   ProtoGeometryConversions,
   SkeletonTracingDefaults
 }
-import com.scalableminds.webknossos.datastore.models._
+import com.scalableminds.webknossos.datastore.models.*
 import com.scalableminds.webknossos.datastore.models.datasource.ElementClass
 import com.scalableminds.webknossos.datastore.models.requests.DataServiceDataRequest
 import com.scalableminds.webknossos.datastore.services.mesh.{AdHocMeshRequest, AdHocMeshService, AdHocMeshServiceHolder}
@@ -46,7 +46,7 @@ import play.api.libs.json.{JsObject, Json, OFormat}
 
 import java.util
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 case class FallbackDataKey(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/editablemapping/EditableMappingUpdateActions.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.tracingstore.tracings.editablemapping
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.webknossos.tracingstore.annotation.{LayerUpdateAction, UpdateAction}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait EditableMappingUpdateAction extends LayerUpdateAction {
   override def withActionTracingId(newTracingId: String): EditableMappingUpdateAction

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/MultiComponentTreeSplitter.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/MultiComponentTreeSplitter.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.tracingstore.tracings.skeleton
 import com.scalableminds.webknossos.datastore.SkeletonTracing.{Tree, TreeGroup}
 import com.scalableminds.webknossos.tracingstore.tracings.GroupUtils
 import org.jgrapht.alg.connectivity.ConnectivityInspector
-import org.jgrapht.graph.{Multigraph, _}
+import org.jgrapht.graph.{Multigraph, *}
 
 import scala.jdk.CollectionConverters.ListHasAsScala
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -10,7 +10,7 @@ import com.scalableminds.webknossos.datastore.SkeletonTracing.{SkeletonTracing, 
 import com.scalableminds.webknossos.datastore.geometry.NamedBoundingBoxProto
 import com.scalableminds.webknossos.datastore.helpers.{ProtoGeometryConversions, SkeletonTracingDefaults}
 import com.scalableminds.webknossos.datastore.models.datasource.AdditionalAxis
-import com.scalableminds.webknossos.tracingstore.tracings._
+import com.scalableminds.webknossos.tracingstore.tracings.*
 
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeValidator.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeValidator.scala
@@ -2,7 +2,7 @@ package com.scalableminds.webknossos.tracingstore.tracings.skeleton
 
 import com.scalableminds.util.box.{Box, Failure, Full}
 import com.scalableminds.util.datastructures.UnionFind
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
+import com.scalableminds.webknossos.datastore.SkeletonTracing.*
 import com.scalableminds.webknossos.tracingstore.tracings.GroupUtils
 
 import scala.collection.mutable

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActionHelper.scala
@@ -1,6 +1,6 @@
 package com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating
 
-import com.scalableminds.webknossos.datastore.SkeletonTracing._
+import com.scalableminds.webknossos.datastore.SkeletonTracing.*
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 
 trait SkeletonUpdateActionHelper extends ProtoGeometryConversions {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/updating/SkeletonUpdateActions.scala
@@ -1,6 +1,6 @@
 package com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating
 
-import com.scalableminds.webknossos.tracingstore.tracings._
+import com.scalableminds.webknossos.tracingstore.tracings.*
 import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
 import com.scalableminds.util.image.Color
 import com.scalableminds.util.objectid.ObjectId
@@ -22,7 +22,7 @@ import com.scalableminds.webknossos.datastore.helpers.{
 import com.scalableminds.webknossos.datastore.models.AdditionalCoordinate
 import com.scalableminds.webknossos.tracingstore.annotation.{LayerUpdateAction, UpdateAction, UserStateUpdateAction}
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.updating.TreeType.TreeType
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait SkeletonUpdateAction extends LayerUpdateAction {
   def applyOn(tracing: SkeletonTracing): SkeletonTracing

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingBucketHelper.scala
@@ -8,7 +8,7 @@ import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.dataformats.wkw.WKWDataFormatHelper
 import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, DataLayer}
 import com.scalableminds.webknossos.datastore.models.{AdditionalCoordinate, BucketPosition, WebknossosDataRequest}
-import com.scalableminds.webknossos.tracingstore.tracings._
+import com.scalableminds.webknossos.tracingstore.tracings.*
 import com.typesafe.scalalogging.LazyLogging
 import net.jpountz.lz4.{LZ4Compressor, LZ4Factory, LZ4FastDecompressor}
 import com.scalableminds.util.box.Box.tryo

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingLayer.scala
@@ -12,11 +12,11 @@ import com.scalableminds.webknossos.datastore.dataformats.BucketProvider
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 import com.scalableminds.webknossos.datastore.models.BucketPosition
 import com.scalableminds.webknossos.datastore.models.datasource.LayerViewConfiguration.LayerViewConfiguration
-import com.scalableminds.webknossos.datastore.models.datasource._
+import com.scalableminds.webknossos.datastore.models.datasource.*
 import com.scalableminds.webknossos.datastore.models.requests.DataReadInstruction
 import com.scalableminds.webknossos.datastore.storage.DataVaultService
 import com.scalableminds.webknossos.tracingstore.tracings.{FossilDBClient, TemporaryTracingService}
-import ucar.ma2.{Array => MultiArray}
+import ucar.ma2.Array as MultiArray
 
 import scala.concurrent.ExecutionContext
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingMags.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingMags.scala
@@ -3,7 +3,7 @@ package com.scalableminds.webknossos.tracingstore.tracings.volume
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.webknossos.datastore.models.datasource.{StaticLayer, UsableDataSource}
 import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing
-import com.scalableminds.webknossos.datastore.geometry.{Vec3IntProto => ProtoPoint3D}
+import com.scalableminds.webknossos.datastore.geometry.Vec3IntProto as ProtoPoint3D
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 import play.api.libs.json.{Format, Json}
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -18,25 +18,25 @@ import com.scalableminds.webknossos.datastore.VolumeTracing.VolumeTracing.Elemen
 import com.scalableminds.webknossos.datastore.dataformats.wkw.WKWDataFormatHelper
 import com.scalableminds.webknossos.datastore.geometry.NamedBoundingBoxProto
 import com.scalableminds.webknossos.datastore.helpers.{NativeBucketScanner, ProtoGeometryConversions}
-import com.scalableminds.webknossos.datastore.models._
+import com.scalableminds.webknossos.datastore.models.*
 import com.scalableminds.webknossos.datastore.models.datasource.{AdditionalAxis, DataLayer, ElementClass}
 import com.scalableminds.webknossos.datastore.models.requests.DataServiceDataRequest
-import com.scalableminds.webknossos.datastore.services._
+import com.scalableminds.webknossos.datastore.services.*
 import com.scalableminds.webknossos.datastore.services.mesh.{AdHocMeshRequest, AdHocMeshService, AdHocMeshServiceHolder}
 import com.scalableminds.webknossos.tracingstore.files.TsTempFileService
 import com.scalableminds.webknossos.tracingstore.tracings.TracingType.TracingType
-import com.scalableminds.webknossos.tracingstore.tracings._
+import com.scalableminds.webknossos.tracingstore.tracings.*
 import com.scalableminds.webknossos.tracingstore.tracings.volume.VolumeDataZipFormat.VolumeDataZipFormat
 import com.scalableminds.webknossos.tracingstore.{TSRemoteDatastoreClient, TSRemoteWebknossosClient}
 import com.typesafe.scalalogging.LazyLogging
 
-import java.io._
+import java.io.*
 import java.nio.file.Path
 import java.util.Base64
 import java.util.zip.Deflater
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class VolumeTracingService @Inject() (
     tracingDataStore: TracingDataStore,

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeUpdateActions.scala
@@ -11,7 +11,7 @@ import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
 import com.scalableminds.webknossos.datastore.models.{AdditionalCoordinate, BucketPosition}
 import com.scalableminds.webknossos.tracingstore.annotation.{LayerUpdateAction, UpdateAction, UserStateUpdateAction}
 import com.scalableminds.webknossos.tracingstore.tracings.{GroupUtils, MetadataEntry, NamedBoundingBox}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait VolumeUpdateActionHelper {
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Zarr3BucketStreamSink.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/Zarr3BucketStreamSink.scala
@@ -5,7 +5,7 @@ import com.scalableminds.util.io.{NamedFunctionStream, NamedStream}
 import com.scalableminds.util.tools.{ByteUtils, Fox}
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
 import com.scalableminds.webknossos.datastore.dataformats.zarr.Zarr3OutputHelper
-import com.scalableminds.webknossos.datastore.datareaders.zarr3._
+import com.scalableminds.webknossos.datastore.datareaders.zarr3.*
 import com.scalableminds.webknossos.datastore.datareaders.AxisOrder
 import com.scalableminds.webknossos.datastore.helpers.{ProtoGeometryConversions, UPath}
 import com.scalableminds.webknossos.datastore.models.datasource.{


### PR DESCRIPTION
### Summary
- Makes scalafmt more aggressive:
  - Rewrite imports to use "as" for renamings and * as wildcard instead of _
  - rewrite type wildcards to use ? instead of _
  - remove redundant string interpolation braces
- Apart from .scalafmt.conf all changes are purely mechanical, spot-check review should be enough :)
- Couldn’t bring myself to enable control structure rewrite `if x == 1 then println(x)` [instead of](https://docs.scala-lang.org/scala3/book/control-structures.html) the old `if (x == 1) println(x)`. Let’s see if we feel ready for that at some point.

### Steps to test:
- CI should be enough

---
- [x] Needs datastore update after deployment
