### PR TITLE
Fix edge case in dataset deletion if still referenced by deleted annotations

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -674,13 +674,13 @@ class AnnotationDAO @Inject() (sqlClient: SqlClient, annotationLayerDAO: Annotat
       count <- countList.headOption.toFox
     } yield count
 
-  def countAllByDataset(datasetId: ObjectId)(using ctx: DBAccessContext): Fox[Int] =
+  // Counts all annotations in the db that reference this dataset. Independent of isDeleted or user read access
+  // This is used during dataset deletion to prevent foreign key constraints blocking the deletion.
+  def countAllByDatasetIncludingDeleted(datasetId: ObjectId): Fox[Int] =
     for {
-      accessQuery <- readAccessQuery
       countList <- run(q"""SELECT COUNT(*)
-                           FROM $existingCollectionName
-                           WHERE _dataset = $datasetId
-                           AND $accessQuery""".as[Int])
+                           FROM webknossos.annotations
+                           WHERE _dataset = $datasetId""".as[Int])
       count <- countList.headOption.toFox
     } yield count
 

--- a/app/models/dataset/DatasetService.scala
+++ b/app/models/dataset/DatasetService.scala
@@ -758,7 +758,7 @@ class DatasetService @Inject() (
       _ <- existingDatasetBox match {
         case Full(dataset) =>
           for {
-            annotationCount <- annotationDAO.countAllByDataset(dataset._id)(using GlobalAccessContext)
+            annotationCount <- annotationDAO.countAllByDatasetIncludingDeleted(dataset._id)
             _ <- datasetDAO.deleteDataset(dataset._id, onlyMarkAsDeleted = annotationCount > 0)
             _ <- usedStorageService.refreshStorageReportForDataset(dataset)
           } yield ()

--- a/unreleased_changes/9774.md
+++ b/unreleased_changes/9774.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where dataset deletion would fail if task annotations that were already marked as deleted still referenced it.


### PR DESCRIPTION
### Summary
 - Like already on master, the dataset is only marked as deletedByUser, not hard-deleted if still referenced by annotations. This prevents foreign key constraints blocking the delete in SQL.
 - With this change, counting those references is no longer limited to isDeleted status or user read access. We need to actually count all referencing annotations in the whole db.

### Steps to test:
(I tested locally)
- Create a task on this dataset, but no explorative annotations
- delete the task
- deleting the dataset should not fail with sql error, instead the dataset should be marked as deletedByUser.

### Issues:
- fixes https://scm.slack.com/archives/CMBMU5684/p1783515998326539

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
