### PR TITLE
Remove backend dependency check sbt plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,9 +13,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.0")
 // scala linter
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 
-// check dependencies against published vulnerabilities with sbt dependencyCheck
-addSbtPlugin("net.nmoncho" % "sbt-dependency-check" % "1.9.0")
-
 // protocol buffers
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"
 


### PR DESCRIPTION
Removes backend dependency check sbt plugin. It is currently broken (tries to fetch files that don’t exist) and slows down every sbt load a little. I suggest to instead run the dependency check periodically and add the plugin locally again to do it then, without committing the change.
