### PR TITLE
Re-enable volume editing in case highest possible mag of volume layer matches the dataset wide highest mag

### DIFF
--- a/frontend/javascripts/test/sagas/annotation_tool_disabled_info.spec.ts
+++ b/frontend/javascripts/test/sagas/annotation_tool_disabled_info.spec.ts
@@ -52,6 +52,44 @@ const zoomedOutState = update(initialState, {
   },
 });
 
+// No layer has mag 1-1-1. When zooming in far, the finest existing mag (2-2-1)
+// is rendered for all layers and should be annotatable.
+const zoomedInStateWithoutMag1 = update(zoomedInInitialState, {
+  dataset: {
+    dataSource: {
+      dataLayers: {
+        [0]: {
+          mags: {
+            $set: [{ mag: [2, 2, 1] }, { mag: [4, 4, 4] }],
+          },
+        },
+        [1]: {
+          mags: {
+            $set: [{ mag: [2, 2, 1] }, { mag: [4, 4, 1] }],
+          },
+        },
+      },
+    },
+  },
+});
+
+// Mag 1-1-1 is missing for the volume layer (e.g., due to mag restrictions),
+// but exists in the color layer. Annotating while that mag is rendered should
+// be disabled.
+const zoomedInStateWithRestrictedVolumeMags = update(zoomedInInitialState, {
+  dataset: {
+    dataSource: {
+      dataLayers: {
+        [0]: {
+          mags: {
+            $set: [{ mag: [2, 2, 1] }, { mag: [4, 4, 4] }],
+          },
+        },
+      },
+    },
+  },
+});
+
 const coordinateTransformations: CoordinateTransformation[] = [
   {
     type: "affine",
@@ -134,6 +172,33 @@ describe("Annotation Tool Disabled Info", () => {
 
   it("Volume tools should be disabled when zoomed out.", () => {
     const disabledInfo = getDisabledInfoForTools(zoomedOutState);
+
+    for (const tool of Object.values(AnnotationTool)) {
+      if (
+        tool === AnnotationTool.PROOFREAD ||
+        zoomSensitiveVolumeTools.includes(tool as AnnotationTool)
+      ) {
+        expect(disabledInfo[tool.id]?.isDisabled).toBe(true);
+      } else {
+        expect(disabledInfo[tool.id]?.isDisabled).toBe(false);
+      }
+    }
+  });
+
+  it("Volume tools should be enabled when zoomed in although mag 1-1-1 does not exist in any layer.", () => {
+    const disabledInfo = getDisabledInfoForTools(zoomedInStateWithoutMag1);
+
+    for (const tool of Object.values(AnnotationTool)) {
+      if (tool === AnnotationTool.PROOFREAD) {
+        expect(disabledInfo[tool.id]?.isDisabled).toBe(true);
+      } else {
+        expect(disabledInfo[tool.id]?.isDisabled).toBe(false);
+      }
+    }
+  });
+
+  it("Volume tools should be disabled when the zoomed-in mag is missing for the volume layer but exists in another layer.", () => {
+    const disabledInfo = getDisabledInfoForTools(zoomedInStateWithRestrictedVolumeMags);
 
     for (const tool of Object.values(AnnotationTool)) {
       if (

--- a/frontend/javascripts/viewer/model/accessors/dataset_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/dataset_accessor.ts
@@ -115,16 +115,13 @@ export function getWidestMags(dataset: APIDataset): Vector3[] {
   return maxBy(allLayerMags, (mags) => mags.length) || [];
 }
 
-export const getSomeMagInfoForDataset = memoizeOne((dataset: APIDataset): MagInfo => {
-  const magUnion = getMagnificationUnion(dataset);
-  const areMagsDistinct = magUnion.every((mags) => mags.length <= 1);
-
-  if (areMagsDistinct) {
-    return new MagInfo(magUnion.map((mags) => mags[0]));
-  } else {
-    return new MagInfo(getWidestMags(dataset));
-  }
-});
+export const getSomeMagInfoForDataset = memoizeOne(
+  (dataset: APIDataset): MagInfo =>
+    // Use one representative (real) mag per existing mag level. This never
+    // synthesizes non-existent mags (unlike dense mags), so index queries such
+    // as getFinestMagIndex reflect the actually available mags of the dataset.
+    new MagInfo(getMagnificationUnion(dataset).map((mags) => mags[0])),
+);
 
 function _getMaxZoomStep(dataset: APIDataset | null | undefined): number {
   const minimumZoomStepCount = 1;

--- a/frontend/javascripts/viewer/model/accessors/volumetracing_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/volumetracing_accessor.ts
@@ -25,10 +25,10 @@ import {
   getDataLayers,
   getLayerByName,
   getMagInfo,
-  getMagInfoByLayer,
   getMappingInfo,
   getSegmentationLayerByName,
   getSegmentationLayers,
+  getSomeMagInfoForDataset,
   getVisibleOrLastSegmentationLayer,
   getVisibleSegmentationLayer,
 } from "viewer/model/accessors/dataset_accessor";
@@ -292,9 +292,7 @@ export function isVolumeAnnotationDisallowedForZoom(
   // would theoretically allow mag 1-1-1). Use the effectively rendered mag index
   // for the check below so that editing is only disabled when another layer actually
   // renders a mag that is missing in the volume layer (e.g., due to mag restrictions).
-  const finestDatasetMagIndex = Math.min(
-    ...Object.values(getMagInfoByLayer(state.dataset)).map((info) => info.getFinestMagIndex()),
-  );
+  const finestDatasetMagIndex = getSomeMagInfoForDataset(state.dataset).getFinestMagIndex();
   const effectiveMagIndex = Math.max(rawMagIndex, finestDatasetMagIndex);
   if (!volumeMags.hasIndex(effectiveMagIndex)) {
     // The current zoom corresponds to a mag that was excluded for this volume layer

--- a/frontend/javascripts/viewer/model/accessors/volumetracing_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/volumetracing_accessor.ts
@@ -25,6 +25,7 @@ import {
   getDataLayers,
   getLayerByName,
   getMagInfo,
+  getMagInfoByLayer,
   getMappingInfo,
   getSegmentationLayerByName,
   getSegmentationLayers,
@@ -285,14 +286,24 @@ export function isVolumeAnnotationDisallowedForZoom(
   const finestExistingMagIndex = volumeMags.getFinestMagIndex();
 
   const rawMagIndex = getRawActiveMagIndexForLayer(state, activeSegmentation.tracingId);
-  if (!volumeMags.hasIndex(rawMagIndex)) {
+  // If the zoom step corresponds to a mag that is finer than every mag of the dataset,
+  // no layer renders that mag. Instead, the finest dataset-wide mag is rendered
+  // (e.g., a dataset whose finest mag is 2-2-1 renders 2-2-1 even when the zoom
+  // would theoretically allow mag 1-1-1). Use the effectively rendered mag index
+  // for the check below so that editing is only disabled when another layer actually
+  // renders a mag that is missing in the volume layer (e.g., due to mag restrictions).
+  const finestDatasetMagIndex = Math.min(
+    ...Object.values(getMagInfoByLayer(state.dataset)).map((info) => info.getFinestMagIndex()),
+  );
+  const effectiveMagIndex = Math.max(rawMagIndex, finestDatasetMagIndex);
+  if (!volumeMags.hasIndex(effectiveMagIndex)) {
     // The current zoom corresponds to a mag that was excluded for this volume layer
     // (e.g., to avoid performance issues when annotating large structures in a coarse
     // mag). Annotating in such a mag doesn't make sense, since it is not actually
     // rendered/labeled, so the tool is disabled.
     return {
       isDisabled: true,
-      reason: finestExistingMagIndex < rawMagIndex ? "needs_zoom_in" : "needs_zoom_out",
+      reason: finestExistingMagIndex < effectiveMagIndex ? "needs_zoom_in" : "needs_zoom_out",
     };
   }
 

--- a/unreleased_changes/9781.md
+++ b/unreleased_changes/9781.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that volume annotation was disabled when zooming in beyond the finest magnification of the dataset. Now when the finest existing magnification is rendered and equals the dataset wide finest mag, the user can still annotate.


### PR DESCRIPTION
### Summary
#9747 disabled volume annotation when the mag corresponding to the current zoom step does not exist in the volume tracing layer. However, the check used the raw, zoom-derived mag index, which also fired when the user zoomed in past the finest mag of the entire dataset. For example, in a dataset whose finest mag is 2-2-1 (no 1-1-1 anywhere), zooming far in disabled the volume tools — even though 2-2-1 is actually rendered for all layers and is perfectly editable.

This PR clamps the raw mag index by the finest mag index that exists in any layer of the dataset before the missing-mag check. This way, volume editing stays enabled when the finest dataset-wide mag is rendered, while the behavior from #9747 is preserved: if the current mag is missing only from the volume layer (e.g., due to "Restrict magnifications") while another layer still renders it, the tools remain disabled with the appropriate zoom hint.

Also adds unit tests for both scenarios.

### Steps to test:
- I already tested locally throughly
- Open a dataset whose finest mag is coarser than 1-1-1 (e.g., 2-2-1 -> create manually) with a volume annotation and zoom in as far as possible → brush/trace/fill should stay enabled (before this PR they were disabled).
- Create an annotation with "Restrict magnifications" (excluding the finer mags) on a dataset that has those mags → the volume tools should still be disabled when zoomed into the excluded mags, with the "zoom out" hint (behavior of #9747).

### Issues:
- fixes the regression of #9410 / #9747 for datasets whose finest mag is coarser than 1-1-1

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)