### PR TITLE
Add support for old registerKeyHandler api interface

### DIFF
--- a/frontend/javascripts/viewer/api/api_latest.ts
+++ b/frontend/javascripts/viewer/api/api_latest.ts
@@ -3146,7 +3146,13 @@ class UtilsApi {
   /**
    * Sets a custom handler function for a keyboard shortcut.
    */
-  registerKeyHandler(key: string, handler: KeyboardNoLoopHandler): UnregisterHandler {
+  registerKeyHandler(
+    key: string,
+    handler: KeyboardNoLoopHandler | (() => void),
+  ): UnregisterHandler {
+    if (handler instanceof Function) {
+      handler = { onPressed: handler, onReleased: () => {} };
+    }
     const keyboard = new InputKeyboard({
       [key]: handler,
     });

--- a/frontend/javascripts/viewer/api/api_latest.ts
+++ b/frontend/javascripts/viewer/api/api_latest.ts
@@ -3167,7 +3167,7 @@ class UtilsApi {
     key: string,
     handler: KeyboardNoLoopHandler | (() => void),
   ): UnregisterHandler {
-    if (handler instanceof Function) {
+    if (typeof handler === "function") {
       handler = { onPressed: handler, onReleased: () => {} };
     }
     const keyboard = new InputKeyboard({

--- a/frontend/javascripts/viewer/api/api_latest.ts
+++ b/frontend/javascripts/viewer/api/api_latest.ts
@@ -3145,6 +3145,23 @@ class UtilsApi {
 
   /**
    * Sets a custom handler function for a keyboard shortcut.
+   *
+   * @param key - The key combo to bind, using the `@rwh/keystrokes` syntax
+   *   (e.g. `"a"`, `"shift + a"`, `"control > y, r"`). See the keystrokes
+   *   docs/InputKeyboard usages in this codebase for more syntax examples.
+   * @param handler - Either a plain function, which is invoked once when the
+   *   key combo is pressed (there is no release callback in that case), or a
+   *   `{ onPressed, onReleased? }` object if you also need to react when the
+   *   key combo is released.
+   * @returns An object with an `unregister()` method that removes the handler
+   *   again.
+   *
+   * @example
+   * const handler = api.utils.registerKeyHandler("g", () => {
+   *   console.log("g was pressed");
+   * });
+   * // later
+   * handler.unregister();
    */
   registerKeyHandler(
     key: string,

--- a/unreleased_changes/9783.md
+++ b/unreleased_changes/9783.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where old registerKeyHandler frontend api calls failed due to lacking backwards compatibility to the old interface. The old format is now supported again.


### PR DESCRIPTION
### Summary
- The old interface worked via simply passing a function as a handler.
- Now the new one allows to also register a onRelease handler if a handler object is passed. But the support for the old format was accidentally dropped in #9081.
- This PR readds the support by converting a function into a matching handler object.

### Steps to test:
- open an annotation
- run `window.webknossos.apiInterface.utils.registerKeyHandler("8", () => console.log("Test")). in the console.
- Press 8 -> should print "Test" in the console
- Previously an error was printed.


### Issues:
- fixes reported bug https://scm.slack.com/archives/C0B8TNTN50R/p1783934086542309

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)