### PR TITLE
Add creation time for Folders

### DIFF
--- a/app/models/folder/Folder.scala
+++ b/app/models/folder/Folder.scala
@@ -2,6 +2,7 @@ package models.folder
 
 import com.scalableminds.util.Msg
 import com.scalableminds.util.accesscontext.DBAccessContext
+import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.schema.Tables.{Folders, FoldersRow, GetResultFoldersRow}
@@ -10,6 +11,7 @@ import models.organization.{Organization, OrganizationDAO}
 import models.team.{TeamDAO, TeamService}
 import models.user.User
 import play.api.libs.json.{JsArray, JsObject, Json, OFormat}
+import slick.jdbc.GetResult
 import slick.jdbc.PostgresProfile.api.*
 import slick.sql.SqlAction
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
@@ -19,9 +21,13 @@ import javax.inject.Inject
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 
-case class Folder(_id: ObjectId, name: String, metadata: JsArray)
+case class Folder(_id: ObjectId, name: String, metadata: JsArray, created: Option[Instant] = Some(Instant.now))
 
-case class FolderWithParent(_id: ObjectId, name: String, metadata: JsArray, _parent: Option[ObjectId])
+case class FolderWithParent(_id: ObjectId,
+                             name: String,
+                             metadata: JsArray,
+                             _parent: Option[ObjectId],
+                             created: Option[Instant] = Some(Instant.now))
 
 case class FolderParameters(name: String, allowedTeams: List[ObjectId], metadata: JsArray)
 object FolderParameters {
@@ -57,6 +63,7 @@ class FolderService @Inject() (
       "id" -> folder._id,
       "name" -> folder.name,
       "metadata" -> folder.metadata,
+      "created" -> folder.created,
       "allowedTeams" -> teamsJs,
       "allowedTeamsCumulative" -> teamsCumulativeJs,
       "isEditable" -> isEditable
@@ -68,6 +75,7 @@ class FolderService @Inject() (
       "name" -> folderWithParent.name,
       "parent" -> folderWithParent._parent,
       "metadata" -> folderWithParent.metadata,
+      "created" -> folderWithParent.created,
       "isEditable" -> allEditableIds.contains(folderWithParent._id)
     )
 
@@ -149,12 +157,12 @@ class FolderDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
   protected def parse(r: FoldersRow): Fox[Folder] =
     for {
       metadata <- parseMetadata(r.metadata)
-    } yield Folder(ObjectId(r._id), r.name, metadata)
+    } yield Folder(ObjectId(r._id), r.name, metadata, r.created.map(Instant.fromSql))
 
-  private def parseWithParent(t: (String, String, String, Option[String])): Fox[FolderWithParent] =
+  private def parseWithParent(t: (String, String, String, Option[String], Option[Instant])): Fox[FolderWithParent] =
     for {
       metadata <- parseMetadata(t._3)
-      folderWithParent = FolderWithParent(ObjectId(t._1), t._2, metadata, t._4.map(ObjectId(_)))
+      folderWithParent = FolderWithParent(ObjectId(t._1), t._2, metadata, t._4.map(ObjectId(_)), t._5)
     } yield folderWithParent
 
   private def parseMetadata(literal: String): Fox[JsArray] =
@@ -286,11 +294,13 @@ class FolderDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
       result <- rows.headOption.toFox
     } yield result
 
-  def findTreeOf(folderId: ObjectId)(using ctx: DBAccessContext): Fox[List[FolderWithParent]] =
+  def findTreeOf(folderId: ObjectId)(using ctx: DBAccessContext): Fox[List[FolderWithParent]] = {
+    implicit val gr: GetResult[(String, String, String, Option[String], Option[Instant])] =
+      r => (r.nextString(), r.nextString(), r.nextString(), r.nextStringOption(), GetInstantOpt(r))
     for {
       accessQueryWithPrefix <- accessQueryFromAccessQWithPrefix(readAccessQWithPrefix, prefix = q"f.")
       accessQuery <- readAccessQuery
-      rows <- run(q"""SELECT f._id, f.name, f.metadata, fp._ancestor
+      rows <- run(q"""SELECT f._id, f.name, f.metadata, fp._ancestor, f.created
               FROM webknossos.folders_ f
               JOIN webknossos.folder_paths fp -- join to find immediate parent, this will also kick out self
               ON f._id = fp._descendant
@@ -299,13 +309,14 @@ class FolderDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
               FROM webknossos.folder_paths
               WHERE _ancestor = $folderId)
               AND $accessQueryWithPrefix
-              UNION ALL SELECT _id, name, metadata, NULL -- find self again, with no parent
+              UNION ALL SELECT _id, name, metadata, NULL, created -- find self again, with no parent
               FROM webknossos.folders_
               WHERE _id = $folderId
               AND $accessQuery
-              """.as[(String, String, String, Option[String])])
+              """.as[(String, String, String, Option[String], Option[Instant])])
       parsed <- Fox.combined(rows.toList.map(parseWithParent))
     } yield parsed
+  }
 
   def insertAsChild(parentId: ObjectId, f: Folder)(using ctx: DBAccessContext): Fox[Unit] = {
     val insertPathQuery =
@@ -354,6 +365,6 @@ class FolderDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
   }
 
   private def insertFolderQuery(f: Folder): SqlAction[Int, NoStream, Effect] =
-    q"INSERT INTO webknossos.folders(_id, name) VALUES (${f._id}, ${f.name})".asUpdate
+    q"INSERT INTO webknossos.folders(_id, name, created) VALUES (${f._id}, ${f.name}, ${f.created})".asUpdate
 
 }

--- a/app/models/folder/Folder.scala
+++ b/app/models/folder/Folder.scala
@@ -11,7 +11,6 @@ import models.organization.{Organization, OrganizationDAO}
 import models.team.{TeamDAO, TeamService}
 import models.user.User
 import play.api.libs.json.{JsArray, JsObject, Json, OFormat}
-import slick.jdbc.GetResult
 import slick.jdbc.PostgresProfile.api.*
 import slick.sql.SqlAction
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
@@ -23,11 +22,13 @@ import scala.concurrent.ExecutionContext
 
 case class Folder(_id: ObjectId, name: String, metadata: JsArray, created: Option[Instant] = Some(Instant.now))
 
-case class FolderWithParent(_id: ObjectId,
-                             name: String,
-                             metadata: JsArray,
-                             _parent: Option[ObjectId],
-                             created: Option[Instant] = Some(Instant.now))
+case class FolderWithParent(
+    _id: ObjectId,
+    name: String,
+    metadata: JsArray,
+    _parent: Option[ObjectId],
+    created: Option[Instant] = Some(Instant.now)
+)
 
 case class FolderParameters(name: String, allowedTeams: List[ObjectId], metadata: JsArray)
 object FolderParameters {
@@ -294,9 +295,7 @@ class FolderDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
       result <- rows.headOption.toFox
     } yield result
 
-  def findTreeOf(folderId: ObjectId)(using ctx: DBAccessContext): Fox[List[FolderWithParent]] = {
-    implicit val gr: GetResult[(String, String, String, Option[String], Option[Instant])] =
-      r => (r.nextString(), r.nextString(), r.nextString(), r.nextStringOption(), GetInstantOpt(r))
+  def findTreeOf(folderId: ObjectId)(using ctx: DBAccessContext): Fox[List[FolderWithParent]] =
     for {
       accessQueryWithPrefix <- accessQueryFromAccessQWithPrefix(readAccessQWithPrefix, prefix = q"f.")
       accessQuery <- readAccessQuery
@@ -316,7 +315,6 @@ class FolderDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
               """.as[(String, String, String, Option[String], Option[Instant])])
       parsed <- Fox.combined(rows.toList.map(parseWithParent))
     } yield parsed
-  }
 
   def insertAsChild(parentId: ObjectId, f: Folder)(using ctx: DBAccessContext): Fox[Unit] = {
     val insertPathQuery =

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -430,7 +430,7 @@ class FolderRenderer {
     return null;
   }
   renderCreationDateColumn(): React.ReactNode {
-    return null;
+    return this.data.created != null ? <FormattedDate timestamp={this.data.created} /> : null;
   }
   renderActionsColumn(): React.ReactNode {
     return this.datasetTable.getFolderSettingsActions(this.data);

--- a/frontend/javascripts/dashboard/dataset/queries.tsx
+++ b/frontend/javascripts/dashboard/dataset/queries.tsx
@@ -576,6 +576,7 @@ function getFolderHierarchy(folderTree: FlatFolderTreeItem[]): FolderHierarchy {
       isEditable: folderTreeItem.isEditable,
       parent: folderTreeItem.parent,
       metadata: folderTreeItem.metadata,
+      created: folderTreeItem.created,
       children: [],
     };
     if (folderTreeItem.parent == null) {

--- a/frontend/javascripts/test/backend_snapshot_tests/__snapshots__/folders.e2e.ts.snap
+++ b/frontend/javascripts/test/backend_snapshot_tests/__snapshots__/folders.e2e.ts.snap
@@ -18,6 +18,7 @@ exports[`Folder API (E2E) > addAllowedTeamToFolder 1`] = `
       "organization": "Organization_X",
     },
   ],
+  "created": null,
   "id": "570b9f4e4bb848d08880712a",
   "isEditable": true,
   "metadata": [
@@ -49,6 +50,7 @@ exports[`Folder API (E2E) > addAllowedTeamToFolder 2`] = `
       "organization": "Organization_X",
     },
   ],
+  "created": null,
   "id": "570b9f4e4bb848d08880712a",
   "isEditable": false,
   "metadata": [
@@ -66,6 +68,7 @@ exports[`Folder API (E2E) > createFolder 1`] = `
 {
   "allowedTeams": [],
   "allowedTeamsCumulative": [],
+  "created": "created",
   "id": "id",
   "isEditable": true,
   "metadata": [],
@@ -77,6 +80,7 @@ exports[`Folder API (E2E) > getFolder 1`] = `
 {
   "allowedTeams": [],
   "allowedTeamsCumulative": [],
+  "created": null,
   "id": "570b9f4e4bb848d0885ea917",
   "isEditable": true,
   "metadata": [
@@ -93,6 +97,7 @@ exports[`Folder API (E2E) > getFolder 1`] = `
 exports[`Folder API (E2E) > getFolderTree 1`] = `
 [
   {
+    "created": null,
     "id": "570b9f4e4bb848d08880712a",
     "isEditable": true,
     "metadata": [],
@@ -100,6 +105,7 @@ exports[`Folder API (E2E) > getFolderTree 1`] = `
     "parent": "570b9f4e4bb848d0885ea917",
   },
   {
+    "created": null,
     "id": "570b9f4e4bb848d08880712b",
     "isEditable": true,
     "metadata": [],
@@ -107,6 +113,7 @@ exports[`Folder API (E2E) > getFolderTree 1`] = `
     "parent": "570b9f4e4bb848d0885ea917",
   },
   {
+    "created": null,
     "id": "570b9f4e4bb848d0885ea917",
     "isEditable": true,
     "metadata": [
@@ -126,6 +133,7 @@ exports[`Folder API (E2E) > updateFolder 1`] = `
 {
   "allowedTeams": [],
   "allowedTeamsCumulative": [],
+  "created": null,
   "id": "570b9f4e4bb848d0885ea917",
   "isEditable": true,
   "metadata": [],

--- a/frontend/javascripts/types/api_types.ts
+++ b/frontend/javascripts/types/api_types.ts
@@ -1316,6 +1316,7 @@ export type FlatFolderTreeItem = {
   parent: string | null;
   metadata: APIMetadataEntry[];
   isEditable: boolean;
+  created?: number | null;
 };
 
 // Frontend type of FlatFolderTreeItem with inferred nested structure.
@@ -1326,6 +1327,7 @@ export type FolderItem = {
   children: FolderItem[];
   isEditable: boolean;
   metadata: APIMetadataEntry[];
+  created?: number | null;
   // Can be set so that the antd tree component can disable
   // individual folder items.
   disabled?: boolean;
@@ -1338,6 +1340,7 @@ export type Folder = {
   allowedTeamsCumulative: APITeam[];
   metadata: APIMetadataEntry[];
   isEditable: boolean;
+  created?: number | null;
 };
 
 export type FolderUpdater = {

--- a/schema/evolutions/174-add-created-to-folders.sql
+++ b/schema/evolutions/174-add-created-to-folders.sql
@@ -1,0 +1,13 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 173 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+DROP VIEW webknossos.folders_;
+
+ALTER TABLE webknossos.folders ADD COLUMN created TIMESTAMPTZ DEFAULT NOW();
+
+CREATE VIEW webknossos.folders_ AS SELECT * FROM webknossos.folders WHERE NOT isDeleted;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 174;
+
+COMMIT TRANSACTION;

--- a/schema/evolutions/reversions/174-add-created-to-folders.sql
+++ b/schema/evolutions/reversions/174-add-created-to-folders.sql
@@ -1,0 +1,13 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 174 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+DROP VIEW webknossos.folders_;
+
+ALTER TABLE webknossos.folders DROP COLUMN created;
+
+CREATE VIEW webknossos.folders_ AS SELECT * FROM webknossos.folders WHERE NOT isDeleted;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 173;
+
+COMMIT TRANSACTION;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
 
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(173);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(174);
 COMMIT TRANSACTION;
 
 
@@ -664,6 +664,7 @@ CREATE TABLE webknossos.credentials(
 CREATE TABLE webknossos.folders(
     _id TEXT CONSTRAINT _id_objectId CHECK (_id ~ '^[0-9a-f]{24}$') PRIMARY KEY,
     name TEXT NOT NULL CHECK (name !~ '/'),
+    created TIMESTAMPTZ DEFAULT NOW(),
     isDeleted BOOLEAN NOT NULL DEFAULT FALSE,
     metadata JSONB  NOT NULL DEFAULT '[]',
     CONSTRAINT metadataIsJsonArray CHECK(jsonb_typeof(metadata) = 'array')

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -664,9 +664,9 @@ CREATE TABLE webknossos.credentials(
 CREATE TABLE webknossos.folders(
     _id TEXT CONSTRAINT _id_objectId CHECK (_id ~ '^[0-9a-f]{24}$') PRIMARY KEY,
     name TEXT NOT NULL CHECK (name !~ '/'),
+    metadata JSONB  NOT NULL DEFAULT '[]',
     created TIMESTAMPTZ DEFAULT NOW(),
     isDeleted BOOLEAN NOT NULL DEFAULT FALSE,
-    metadata JSONB  NOT NULL DEFAULT '[]',
     CONSTRAINT metadataIsJsonArray CHECK(jsonb_typeof(metadata) = 'array')
 );
 

--- a/test/db/folders.csv
+++ b/test/db/folders.csv
@@ -1,6 +1,6 @@
-_id,name,isDeleted,metadata
-'570b9f4e4bb848d0885ea917','Organization_X',f,'[{"key": "key","type": "number","value": 10}]'
-'570b9f4e4bb848d08880712a','A subfolder!',f,'[]'
-'570b9f4e4bb848d08880712b','Another subfolder!',f,'[]'
-'570b9f4e4bb848d088a83aef','Organization_Y',f,'[]'
-'570b9f4e4bb848d088a83aff','Organization_Z',f,'[]'
+_id,name,metadata,created,isDeleted
+'570b9f4e4bb848d0885ea917','Organization_X','[{"key": "key","type": "number","value": 10}]',,f
+'570b9f4e4bb848d08880712a','A subfolder!','[]',,f
+'570b9f4e4bb848d08880712b','Another subfolder!','[]',,f
+'570b9f4e4bb848d088a83aef','Organization_Y','[]',,f
+'570b9f4e4bb848d088a83aff','Organization_Z','[]',,f

--- a/unreleased_changes/9789.md
+++ b/unreleased_changes/9789.md
@@ -1,0 +1,5 @@
+### Added
+- Folders now store their creation time.
+
+### Postgres Evolutions
+- [174-add-created-to-folders.sql](schema/evolutions/174-add-created-to-folders.sql)


### PR DESCRIPTION
### Summary
Folders now store their creation time. Shown in dashboard. The value is optional, old folders keep NULL.

### Steps to test:
(I tested locally)
- create new folder, see in dashboard list view

### Issues:
- fixes #8968 

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)