### PR TITLE
For custom instances with no local datastore, do not auto-insert pretrained AI models

### DIFF
--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -8,7 +8,6 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
-import com.scalableminds.util.tools.Fox.toFox
 import com.typesafe.scalalogging.LazyLogging
 import models.aimodels.{AiModel, AiModelCategory, AiModelDAO, AiModelService}
 import models.annotation.{TracingStore, TracingStoreDAO}

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -81,7 +81,8 @@ class InitialDataService @Inject() (
   private val defaultUserEmail2 = conf.WebKnossos.SampleOrganization.User.email2
   private val defaultUserPassword = conf.WebKnossos.SampleOrganization.User.password
   private val defaultUserToken = conf.WebKnossos.SampleOrganization.User.token
-  private val additionalInformation = """**Sample Organization**
+  private val additionalInformation =
+    """**Sample Organization**
 
 Sample Street 123
 Sampletown
@@ -535,38 +536,41 @@ Samplecountry
     } else Fox.successful(())
   }
 
-  private def insertDataset(): Fox[Unit] = datasetDAO.findOne(defaultDataset._id).shiftBox.flatMap { maybeDataset =>
-    if (maybeDataset.isEmpty) {
-      for {
-        _ <- datasetDAO.insertOne(defaultDataset)
-        _ <- datasetLayerDAO.updateLayers(defaultDataset._id, defaultDataSource)
-      } yield ()
-    } else Fox.successful(())
-  }
-
-  private def insertRemoteNDDataset(): Fox[Unit] =
-    datasetDAO.findOne(remoteNDZarrDataset._id).shiftBox.flatMap { maybeDataset =>
-      if (maybeDataset.isEmpty) {
-        for {
-          _ <- datasetDAO.insertOne(remoteNDZarrDataset)
-          _ <- datasetLayerDAO.updateLayers(remoteNDZarrDataset._id, remoteNDZarrDataSource)
-        } yield ()
-      } else Fox.successful(())
+  private def insertDataset(): Fox[?] =
+    Fox.runIf(storeModules.localDataStoreEnabled) {
+      datasetDAO.findOne(defaultDataset._id).shiftBox.flatMap { maybeDataset =>
+        if (maybeDataset.isEmpty) {
+          for {
+            _ <- datasetDAO.insertOne(defaultDataset)
+            _ <- datasetLayerDAO.updateLayers(defaultDataset._id, defaultDataSource)
+          } yield ()
+        } else Fox.successful(())
+      }
     }
 
-  private def insertAiModelIfAbsent(model: AiModel): Fox[Unit] =
-    if (storeModules.localDataStoreEnabled) {
+  private def insertRemoteNDDataset(): Fox[?] =
+    Fox.runIf(storeModules.localDataStoreEnabled) {
+      datasetDAO.findOne(remoteNDZarrDataset._id).shiftBox.flatMap { maybeDataset =>
+        if (maybeDataset.isEmpty) {
+          for {
+            _ <- datasetDAO.insertOne(remoteNDZarrDataset)
+            _ <- datasetLayerDAO.updateLayers(remoteNDZarrDataset._id, remoteNDZarrDataSource)
+          } yield ()
+        } else Fox.successful(())
+      }
+    }
+
+  private def insertAiModelIfAbsent(model: AiModel): Fox[?] =
+    // For custom instances with no local datastore the default ai models must be inserted into the DB manually.
+    // Give them the datastore that the worker also has access to.
+    Fox.runIf(storeModules.localDataStoreEnabled) {
       aiModelDAO.findOne(model._id).shiftBox.flatMap {
         case Full(_) => Fox.successful(())
         case _       => aiModelDAO.insertOne(model)
       }
-    } else {
-      // For custom instances with no local datastore the default ai models must be inserted into the DB manually.
-      // Give them the datastore that the worker also has access to.
-      Fox.successful(())
     }
 
-  private def insertCustomAiModel(): Fox[Unit] = insertAiModelIfAbsent(defaultAiModel)
+  private def insertCustomAiModel(): Fox[?] = insertAiModelIfAbsent(defaultAiModel)
 
   private def insertPretrainedAiModels(): Fox[Unit] =
     for {

--- a/app/controllers/InitialDataController.scala
+++ b/app/controllers/InitialDataController.scala
@@ -8,6 +8,7 @@ import com.scalableminds.util.geometry.{BoundingBox, Vec3Double, Vec3Int}
 import com.scalableminds.util.objectid.ObjectId
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
+import com.scalableminds.util.tools.Fox.toFox
 import com.typesafe.scalalogging.LazyLogging
 import models.aimodels.{AiModel, AiModelCategory, AiModelDAO, AiModelService}
 import models.annotation.{TracingStore, TracingStoreDAO}
@@ -34,7 +35,7 @@ import play.api.libs.json.{JsArray, Json}
 import utils.{StoreModules, WkConf}
 
 import javax.inject.Inject
-import models.organization.{Organization, OrganizationDAO, OrganizationService, PricingPlan, AiPlan}
+import models.organization.{AiPlan, Organization, OrganizationDAO, OrganizationService, PricingPlan}
 import play.api.mvc.{Action, AnyContent}
 import security.{Token, TokenDAO, TokenType, WkEnv}
 
@@ -164,6 +165,7 @@ Samplecountry
   )
   private val defaultDataStore =
     DataStore(conf.Datastore.name, conf.Http.uri, conf.Datastore.publicUri.getOrElse(conf.Http.uri), conf.Datastore.key)
+
   private val defaultAiModel = AiModel(
     _id = ObjectId("66544a56d20000af0e42ba0f"),
     _organization = Some(defaultOrganization._id),
@@ -426,7 +428,7 @@ Samplecountry
       _ <- insertPublication()
       _ <- insertDataset()
       _ <- insertRemoteNDDataset()
-      _ <- insertAiModel()
+      _ <- insertCustomAiModel()
 
     } yield ()
 
@@ -553,20 +555,26 @@ Samplecountry
       } else Fox.successful(())
     }
 
-  private def insertModelIfAbsent(model: AiModel): Fox[Unit] =
-    aiModelDAO.findOne(model._id).shiftBox.flatMap {
-      case Full(_) => Fox.successful(())
-      case _       => aiModelDAO.insertOne(model)
+  private def insertAiModelIfAbsent(model: AiModel): Fox[Unit] =
+    if (storeModules.localDataStoreEnabled) {
+      aiModelDAO.findOne(model._id).shiftBox.flatMap {
+        case Full(_) => Fox.successful(())
+        case _       => aiModelDAO.insertOne(model)
+      }
+    } else {
+      // For custom instances with no local datastore the default ai models must be inserted into the DB manually.
+      // Give them the datastore that the worker also has access to.
+      Fox.successful(())
     }
 
-  private def insertAiModel(): Fox[Unit] = insertModelIfAbsent(defaultAiModel)
+  private def insertCustomAiModel(): Fox[Unit] = insertAiModelIfAbsent(defaultAiModel)
 
   private def insertPretrainedAiModels(): Fox[Unit] =
     for {
-      _ <- insertModelIfAbsent(pretrainedNeuronModel)
-      _ <- insertModelIfAbsent(pretrainedMitochondriaModel)
-      _ <- insertModelIfAbsent(pretrainedNucleiModel)
-      _ <- insertModelIfAbsent(pretrainedSomaModel)
+      _ <- insertAiModelIfAbsent(pretrainedNeuronModel)
+      _ <- insertAiModelIfAbsent(pretrainedMitochondriaModel)
+      _ <- insertAiModelIfAbsent(pretrainedNucleiModel)
+      _ <- insertAiModelIfAbsent(pretrainedSomaModel)
     } yield ()
 
   def insertLocalDataStoreIfEnabled(): Fox[Unit] =


### PR DESCRIPTION
The inital data service tries to insert the pretrained ai models for the local datastore. If that doesn’t exist, as is the case for custom setups, that fails with an SQL foreign key constraint.

This PR adapts the code to not attempt to insert the models in this case. Instead, they will need to be inserted manually for the correct datastore that also has the corresponding worker.

Also, the two sample datasets are skipped in this case. This is only relevant for development setup with `sampleOrganization.enabled=true`.

I recommend to review while hiding whitespace changes :-)

### Steps to test:
(I tested locally)
- refresh-schema
- start wk with local datastore disabled (`play.modules.disabled += "com.scalableminds.webknossos.datastore.DataStoreModule"` and `play.http.router = "noDS.Routes"` in `application.conf`)
- no sql error should show up.