### PR TITLE
Scroll to top after using pagination

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,2 +1,2 @@
 #! /usr/bin/env bash
-echo '.husky/post-checkout: Deleting auto-generated typescript files...' && rm -f frontend/javascripts/test/snapshots/type-check/*.ts
+echo '.husky/post-checkout: Deleting auto-generated typescript files...' && rm -f frontend/javascripts/test/snapshots/type-check/*.ts && rm -f frontend/javascripts/test/snapshots/type_check/*.ts

--- a/frontend/javascripts/admin/auth/passkeys_view.tsx
+++ b/frontend/javascripts/admin/auth/passkeys_view.tsx
@@ -7,6 +7,7 @@ import {
 } from "admin/api/webauthn";
 import { Button, Input, Modal, Table } from "antd";
 import Toast from "libs/toast";
+import { scrollToTop } from "libs/utils";
 import { useEffect, useState } from "react";
 
 function PasskeysView() {
@@ -78,6 +79,7 @@ function PasskeysView() {
         rowKey="id"
         pagination={{
           hideOnSinglePage: true,
+          onChange: scrollToTop,
         }}
         showHeader={false}
       />

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -24,7 +24,13 @@ import { formatMilliCreditsString, formatWkLibsNdBBox } from "libs/format_utils"
 import Persistence from "libs/persistence";
 import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
-import { compareBy, filterWithSearchQueryAND, localeCompareBy, pluralize } from "libs/utils";
+import {
+  compareBy,
+  filterWithSearchQueryAND,
+  localeCompareBy,
+  pluralize,
+  scrollToTop,
+} from "libs/utils";
 import capitalize from "lodash-es/capitalize";
 import type * as React from "react";
 import { useEffect, useState } from "react";
@@ -544,6 +550,7 @@ function JobListView() {
           rowKey="id"
           pagination={{
             defaultPageSize: 50,
+            onChange: scrollToTop,
           }}
         >
           <Column

--- a/frontend/javascripts/admin/organization/organization_credit_activity_view.tsx
+++ b/frontend/javascripts/admin/organization/organization_credit_activity_view.tsx
@@ -10,6 +10,7 @@ import FormattedId from "components/formatted_id";
 import dayjs from "dayjs";
 import { formatMilliCreditsString } from "libs/format_utils";
 import { useWkSelector } from "libs/react_hooks";
+import { scrollToTop } from "libs/utils";
 import { useMemo } from "react";
 import type { APICreditTransaction, APIJob } from "types/api_types";
 import { enforceActiveOrganization } from "viewer/model/accessors/organization_accessors";
@@ -143,7 +144,7 @@ export function OrganizationCreditActivityView() {
         <Table
           dataSource={organizationTransactions}
           rowKey="id"
-          pagination={{ defaultPageSize: 50 }}
+          pagination={{ defaultPageSize: 50, onChange: scrollToTop }}
           locale={{ emptyText: "No credit activity recorded yet." }}
           style={{ marginTop: 16 }}
           summary={(pageData) => {

--- a/frontend/javascripts/admin/organization/organization_plan_activity_view.tsx
+++ b/frontend/javascripts/admin/organization/organization_plan_activity_view.tsx
@@ -6,6 +6,7 @@ import type { ColumnsType } from "antd/lib/table";
 import FormattedDate from "components/formatted_date";
 import { formatCountToDataAmountUnit } from "libs/format_utils";
 import { useWkSelector } from "libs/react_hooks";
+import { scrollToTop } from "libs/utils";
 import { useMemo } from "react";
 import type { APIOrganizationPricingPlanUpdate } from "types/api_types";
 import { enforceActiveOrganization } from "viewer/model/accessors/organization_accessors";
@@ -126,7 +127,7 @@ export function OrganizationPlanActivityView() {
         loading={isFetching}
         dataSource={tableData}
         columns={columns}
-        pagination={{ pageSize: 10, hideOnSinglePage: true }}
+        pagination={{ pageSize: 10, hideOnSinglePage: true, onChange: scrollToTop }}
         locale={{
           emptyText: <Text type="secondary">No recent subscription changes found.</Text>,
         }}

--- a/frontend/javascripts/admin/project/project_list_view.tsx
+++ b/frontend/javascripts/admin/project/project_list_view.tsx
@@ -37,6 +37,7 @@ import {
   filterWithSearchQueryAND,
   localeCompareBy,
   millisecondsToHours,
+  scrollToTop,
 } from "libs/utils";
 import partial from "lodash-es/partial";
 import uniqBy from "lodash-es/uniqBy";
@@ -246,6 +247,7 @@ function ProjectListView() {
           rowKey="id"
           pagination={{
             defaultPageSize: 50,
+            onChange: scrollToTop,
           }}
           locale={{
             emptyText: renderPlaceholder(),

--- a/frontend/javascripts/admin/scripts/script_list_view.tsx
+++ b/frontend/javascripts/admin/scripts/script_list_view.tsx
@@ -7,7 +7,7 @@ import FormattedId from "components/formatted_id";
 import LinkButton from "components/link_button";
 import { handleGenericError } from "libs/error_handling";
 import Persistence from "libs/persistence";
-import { filterWithSearchQueryAND, localeCompareBy } from "libs/utils";
+import { filterWithSearchQueryAND, localeCompareBy, scrollToTop } from "libs/utils";
 import partial from "lodash-es/partial";
 import messages from "messages";
 import type React from "react";
@@ -111,6 +111,7 @@ function ScriptListView() {
           rowKey="id"
           pagination={{
             defaultPageSize: 50,
+            onChange: scrollToTop,
           }}
           locale={{
             emptyText: renderPlaceholder(),

--- a/frontend/javascripts/admin/statistic/available_tasks_report_view.tsx
+++ b/frontend/javascripts/admin/statistic/available_tasks_report_view.tsx
@@ -4,7 +4,7 @@ import { getAvailableTasksReport } from "admin/rest_api";
 import { Spin, Table, Tag, Tooltip } from "antd";
 import TeamSelectionComponent from "dashboard/dataset/team_selection_component";
 import { useQueryWithErrorHandling } from "libs/react_hooks";
-import { compareBy, localeCompareBy } from "libs/utils";
+import { compareBy, localeCompareBy, scrollToTop } from "libs/utils";
 import { useState } from "react";
 import type { APIAvailableTasksReport } from "types/api_types";
 
@@ -49,6 +49,7 @@ function AvailableTasksReportView() {
           dataSource={data}
           pagination={{
             defaultPageSize: 500,
+            onChange: scrollToTop,
           }}
           rowKey="id"
           size="small"

--- a/frontend/javascripts/admin/statistic/project_progress_report_view.tsx
+++ b/frontend/javascripts/admin/statistic/project_progress_report_view.tsx
@@ -6,7 +6,7 @@ import FormattedDate from "components/formatted_date";
 import StackedBarChart, { colors } from "components/stacked_bar_chart";
 import TeamSelectionComponent from "dashboard/dataset/team_selection_component";
 import { useQueryWithErrorHandling } from "libs/react_hooks";
-import { compareBy, localeCompareBy, millisecondsToHours } from "libs/utils";
+import { compareBy, localeCompareBy, millisecondsToHours, scrollToTop } from "libs/utils";
 import messages from "messages";
 import { useState } from "react";
 import type { APIProjectProgressReport, APITeam } from "types/api_types";
@@ -90,6 +90,7 @@ function ProjectProgressReportView() {
           dataSource={data}
           pagination={{
             defaultPageSize: 100,
+            onChange: scrollToTop,
           }}
           rowKey="projectName"
           size="small"

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -43,6 +43,7 @@ import {
   getUrlParamValue,
   hasUrlParam,
   localeCompareBy,
+  scrollToTop,
 } from "libs/utils";
 import isEmpty from "lodash-es/isEmpty";
 import partial from "lodash-es/partial";
@@ -449,6 +450,7 @@ function TaskListView({ initialFieldValues }: Props) {
           columns={columns}
           pagination={{
             defaultPageSize: 50,
+            onChange: scrollToTop,
           }}
           expandable={{
             expandedRowRender: (task) => <TaskAnnotationView task={task} />,

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
@@ -23,7 +23,7 @@ import { handleGenericError } from "libs/error_handling";
 import Markdown from "libs/markdown_adapter";
 import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling } from "libs/react_hooks";
-import { filterWithSearchQueryAND, localeCompareBy } from "libs/utils";
+import { filterWithSearchQueryAND, localeCompareBy, scrollToTop } from "libs/utils";
 import partial from "lodash-es/partial";
 import messages from "messages";
 import type React from "react";
@@ -128,6 +128,7 @@ function TaskTypeListView() {
           rowKey="id"
           pagination={{
             defaultPageSize: 50,
+            onChange: scrollToTop,
           }}
           locale={{
             emptyText: renderPlaceholder(),

--- a/frontend/javascripts/admin/team/team_list_view.tsx
+++ b/frontend/javascripts/admin/team/team_list_view.tsx
@@ -10,7 +10,7 @@ import { handleGenericError } from "libs/error_handling";
 import { stringToColor } from "libs/format_utils";
 import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling } from "libs/react_hooks";
-import { filterWithSearchQueryAND, localeCompareBy } from "libs/utils";
+import { filterWithSearchQueryAND, localeCompareBy, scrollToTop } from "libs/utils";
 import messages from "messages";
 import type React from "react";
 import { useState } from "react";
@@ -159,6 +159,7 @@ function TeamListView() {
           rowKey="id"
           pagination={{
             defaultPageSize: 50,
+            onChange: scrollToTop,
           }}
           expandable={{
             expandedRowRender: (team) => <TeamMembersRow team={team} users={users} />,

--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -41,7 +41,7 @@ import features from "features";
 import { copyToClipboard } from "libs/clipboard";
 import Persistence from "libs/persistence";
 import { useQueryWithErrorHandling, useWkSelector } from "libs/react_hooks";
-import { filterWithSearchQueryAND, localeCompareBy } from "libs/utils";
+import { filterWithSearchQueryAND, localeCompareBy, scrollToTop } from "libs/utils";
 import { location } from "libs/window";
 import keyBy from "lodash-es/keyBy";
 import React, { type Key, useState } from "react";
@@ -365,6 +365,7 @@ function UserListView() {
           rowSelection={rowSelection}
           pagination={{
             defaultPageSize: 50,
+            onChange: scrollToTop,
           }}
           onChange={(_pagination, filters) => {
             // @ts-expect-error ts-migrate(2322) FIXME: Type 'FilterValue' is not assignable to type '("tr... Remove this comment to see the full error(message)

--- a/frontend/javascripts/admin/voxelytics/ai_model_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/ai_model_list_view.tsx
@@ -26,7 +26,7 @@ import Markdown from "libs/markdown_adapter";
 import { useFetch } from "libs/react_helpers";
 import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
-import { filterWithSearchQueryAND } from "libs/utils";
+import { filterWithSearchQueryAND, scrollToTop } from "libs/utils";
 import uniq from "lodash-es/uniq";
 import type { Key } from "react";
 import { useState } from "react";
@@ -144,7 +144,7 @@ export default function AiModelListView() {
         <Spin spinning={isFetching} size="large">
           <Table
             rowKey={(run: AiModel) => `${run.id}`}
-            pagination={{ pageSize: 100 }}
+            pagination={{ pageSize: 100, onChange: scrollToTop }}
             columns={columns}
             dataSource={filterWithSearchQueryAND(
               aiModels,

--- a/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
@@ -7,7 +7,7 @@ import { Button, Input, Progress, Spin, Table, Tooltip } from "antd";
 import { formatCountToDataAmountUnit, formatDateMedium, formatNumber } from "libs/format_utils";
 import Persistence from "libs/persistence";
 import Toast from "libs/toast";
-import { filterWithSearchQueryAND } from "libs/utils";
+import { filterWithSearchQueryAND, scrollToTop } from "libs/utils";
 import type React from "react";
 import { type Key, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
@@ -185,7 +185,7 @@ export default function WorkflowListView() {
         <Table
           bordered
           rowKey={(run: RenderRunInfo) => `${run.id}-${run.workflowHash}`}
-          pagination={{ pageSize: 100 }}
+          pagination={{ pageSize: 100, onChange: scrollToTop }}
           columns={[
             {
               title: "Workflow",

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -37,7 +37,7 @@ import { diceCoefficient as dice } from "dice-coefficient";
 import { formatCountToDataAmountUnit, stringToColor } from "libs/format_utils";
 import { useWkSelector } from "libs/react_hooks";
 import Shortcut from "libs/shortcut_component";
-import { compareBy, localeCompareBy } from "libs/utils";
+import { compareBy, localeCompareBy, scrollContainerToTop } from "libs/utils";
 import difference from "lodash-es/difference";
 import keyBy from "lodash-es/keyBy";
 import minBy from "lodash-es/minBy";
@@ -83,6 +83,10 @@ type Props = {
   onSelectFolder: (folder: FolderItem | null) => void;
   selectedDatasets: APIDatasetCompact[];
   context: DatasetCollectionContextValue;
+  // The table is rendered inside a scrolling container that isn't the window
+  // (see dataset_folder_view.tsx). Passed through so pagination changes can
+  // scroll that container back to the top instead of the (non-scrolling) window.
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
 };
 
 type State = {
@@ -691,6 +695,7 @@ class DatasetTable extends PureComponent<Props, State> {
           components={components}
           pagination={{
             defaultPageSize: 50,
+            onChange: () => scrollContainerToTop(this.props.scrollContainerRef?.current),
           }}
           styles={{
             // hide/offset the first column containing the checkbox for row selection

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -23,7 +23,7 @@ import Markdown from "libs/markdown_adapter";
 import Persistence from "libs/persistence";
 import Request from "libs/request";
 import Toast from "libs/toast";
-import { compareBy } from "libs/utils";
+import { compareBy, scrollToTop } from "libs/utils";
 import messages from "messages";
 import { PureComponent, useContext } from "react";
 import { connect } from "react-redux";
@@ -490,6 +490,7 @@ class DashboardTaskListView extends PureComponent<Props, State> {
         dataSource={tasks}
         pagination={{
           defaultPageSize: 50,
+          onChange: scrollToTop,
         }}
         loading={this.state.isLoading}
         renderItem={TaskCard}

--- a/frontend/javascripts/dashboard/dataset_folder_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_folder_view.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Col, Flex, Row } from "antd";
 import features, { getDemoDatasetUrl } from "features";
 import { filterNullValues, isUserAdminOrDatasetManager, isUserTeamManager } from "libs/utils";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import type { APIDatasetCompact, APIUser, FolderItem } from "types/api_types";
 import { RenderToPortal } from "viewer/view/layouting/portal_utils";
@@ -30,6 +30,7 @@ function DatasetFolderViewInner(props: Props) {
   const context = useDatasetCollectionContext();
   const { selectedDatasets, setSelectedDatasets, folderModalState, setFolderModalState } = context;
   const { data: hierarchy } = useFolderHierarchyQuery();
+  const mainRef = useRef<HTMLElement>(null);
 
   const setSelectedDataset = (ds: APIDatasetCompact | null, multiSelect?: boolean) => {
     if (!ds) {
@@ -217,13 +218,14 @@ function DatasetFolderViewInner(props: Props) {
       >
         <FolderTreeSidebar />
       </div>
-      <main style={{ gridColumn: "2 / 3", overflow: "auto", paddingRight: 4 }}>
+      <main ref={mainRef} style={{ gridColumn: "2 / 3", overflow: "auto", paddingRight: 4 }}>
         <DatasetView
           user={props.user}
           onSelectDataset={setSelectedDataset}
           onSelectFolder={setSelectedFolder}
           selectedDatasets={selectedDatasets}
           context={context}
+          scrollContainerRef={mainRef}
         />
       </main>
       <div

--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -67,6 +67,7 @@ type Props = {
   onSelectDataset: (dataset: APIDatasetCompact | null, multiSelect?: boolean) => void;
   onSelectFolder: (folder: FolderItem | null) => void;
   selectedDatasets: APIDatasetCompact[];
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
 };
 export type DatasetFilteringMode = "showAllDatasets" | "onlyShowReported" | "onlyShowUnreported";
 type PersistenceState = {
@@ -102,7 +103,14 @@ const refreshMenuItems: ItemType[] = [
   },
 ];
 
-function DatasetView({ user, context, onSelectDataset, selectedDatasets, onSelectFolder }: Props) {
+function DatasetView({
+  user,
+  context,
+  onSelectDataset,
+  selectedDatasets,
+  onSelectFolder,
+  scrollContainerRef,
+}: Props) {
   const searchQuery = context.globalSearchQuery;
   const setSearchQuery = context.setGlobalSearchQuery;
   const [searchTags, setSearchTags] = useState<string[]>([]);
@@ -182,6 +190,7 @@ function DatasetView({ user, context, onSelectDataset, selectedDatasets, onSelec
         updateDataset={context.updateCachedDataset}
         reloadDataset={context.reloadDataset}
         addTagToSearch={addTagToSearch}
+        scrollContainerRef={scrollContainerRef}
       />
     );
   }

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -34,7 +34,7 @@ import { handleGenericError } from "libs/error_handling";
 import { stringToColor } from "libs/format_utils";
 import Persistence from "libs/persistence";
 import Toast from "libs/toast";
-import { compareBy, filterWithSearchQueryAND, localeCompareBy } from "libs/utils";
+import { compareBy, filterWithSearchQueryAND, localeCompareBy, scrollToTop } from "libs/utils";
 import compact from "lodash-es/compact";
 import intersection from "lodash-es/intersection";
 import keyBy from "lodash-es/keyBy";
@@ -708,6 +708,7 @@ class ExplorativeAnnotationsView extends PureComponent<Props, State> {
         rowKey="id"
         pagination={{
           defaultPageSize: 50,
+          onChange: scrollToTop,
         }}
         className="large-table"
         scroll={{

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -152,6 +152,19 @@ export function jsonStringify(json: Record<string, any>) {
   return JSON.stringify(json, null, "  ");
 }
 
+export function scrollToTop(): void {
+  scrollContainerToTop(null);
+}
+
+/**
+ * Smoothly scrolls the given container to the top (falling back to the
+ * window if the ref isn't set yet). For pages whose content scrolls inside a
+ * fixed-height, `overflow: auto` container rather than the window.
+ */
+export function scrollContainerToTop(container: HTMLElement | null | undefined): void {
+  (container ?? window).scrollTo({ top: 0, behavior: "smooth" });
+}
+
 export function clamp(min: number, value: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }

--- a/unreleased_changes/9791.md
+++ b/unreleased_changes/9791.md
@@ -1,0 +1,2 @@
+### Added
+- When switching the page in paginated tables, the view now scrolls back to the top.


### PR DESCRIPTION
### Summary
Scroll window up to top after turning the page on paginated tables. In case of dataset list, the parent with `overflow: auto` is scrolled instead of window.

### Steps to test:
- Fill your tables, switch pages, should scroll up. (might make sense to reduce defaultPageSize e.g. in dataset_table.tsx to reach pagination with fewer entries)

### Issues:
- fixes #4241

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
