### PR TITLE
Disallow skeleton on click action in case the skeleton layer is disabled

### DIFF
--- a/frontend/javascripts/viewer/controller/combinations/tool_controls.ts
+++ b/frontend/javascripts/viewer/controller/combinations/tool_controls.ts
@@ -423,6 +423,11 @@ export class SkeletonToolController extends ToolController {
     allowNodeCreation: boolean = true,
   ): void {
     const { useLegacyBindings, continuousNodeCreation } = Store.getState().userConfiguration;
+    const showSkeleton = Store.getState().annotation.skeleton?.showSkeletons ?? false;
+    if (!showSkeleton) {
+      // Don't do anything in case the skeleton layer is disabled or does not exist.
+      return;
+    }
 
     if (continuousNodeCreation && allowNodeCreation && !useLegacyBindings) {
       handleCreateNodeFromEvent(position, ctrlPressed);

--- a/unreleased_changes/9792.md
+++ b/unreleased_changes/9792.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where clicking in the 3D viewport could jump the position to a skeleton node even though the skeleton layer was disabled and no nodes were visible.


### PR DESCRIPTION
### Summary

Fixes a bug where clicking in the 3D viewport (TD view) would jump the position to a skeleton node even though the skeleton layer was disabled (all trees hidden) and no node was visible at the clicked position.

**Why this happened:** `SkeletonToolController.onLeftClick` is invoked from the TD view's mouse controls (`td_controller.tsx`) on every left click in the 3D viewport, regardless of whether the skeleton layer is actually shown. It would go on to call `handleSelectNode`, which does a hit-test against the 3D scene to find the closest node to the click and, if found, jumps the position/camera to it. Because hidden nodes aren't necessarily excluded from this hit-test, a click could land on a node that belongs to a hidden skeleton layer, causing wk to jump there even though nothing was visibly rendered at that location.

**The fix:** `SkeletonToolController.onLeftClick` now reads `annotation.skeleton?.showSkeletons` from the store right at the start and returns early if it's `false` (or there is no skeleton tracing at all). This skips all further click handling (node selection, node creation, merge/delete edge) whenever the skeleton layer is toggled off, so clicking in the 3D viewport can no longer select or jump to a node that isn't actually visible.

### Steps to test

- Open an annotation with a skeleton layer, e.g. https://webknossos.org/annotations/641d70d30100009e014df263#1910,4788,4662,0,5.169,5606
- Disable the skeleton layer (hide all trees / turn off "Show Skeletons")
- In the 3D viewport, click on a position where a (now hidden) skeleton node is located
- Before the fix: wk jumps the position to that hidden node
- After the fix: the click has no effect

### Issues:
- fixes #7866

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)