### PR TITLE
Ensure FE Bucket.ensureLoaded terminates in case of a failure status

### DIFF
--- a/frontend/javascripts/test/model/binary/cube.spec.ts
+++ b/frontend/javascripts/test/model/binary/cube.spec.ts
@@ -130,6 +130,28 @@ describe("DataCube", () => {
     expect(cube.buckets.length).toBe(1);
   });
 
+  it<TestContext>("ensureLoaded() should terminate when a bucket request fails", async ({
+    cube,
+  }) => {
+    const bucket = cube.getOrCreateBucket([0, 0, 0, 0, []]);
+    assertNonNullBucket(bucket);
+
+    // Simulate the pull queue having requested the bucket...
+    bucket.markAsRequested();
+    const ensureLoadedPromise = bucket.ensureLoaded();
+
+    // ...and the request failing in a non-missing way (e.g. the datastore reported the
+    // bucket via the failure-bucket-indices header, or the request threw). Such a bucket
+    // falls back to UNREQUESTED and, when it is not dirty, is never re-requested. It used
+    // to leave ensureLoaded() hanging forever; now it must settle. If this regresses, the
+    // await below never resolves and the test fails with a timeout.
+    bucket.markAsFailed(false);
+    await ensureLoadedPromise;
+
+    // The failed bucket is treated like an empty bucket: it holds no data.
+    expect(bucket.hasData()).toBe(false);
+  });
+
   it<TestContext>("Voxel Labeling should request buckets when temporal buckets are created", async ({
     cube,
     pullQueue,

--- a/frontend/javascripts/test/model/binary/cube.spec.ts
+++ b/frontend/javascripts/test/model/binary/cube.spec.ts
@@ -145,7 +145,7 @@ describe("DataCube", () => {
     // falls back to UNREQUESTED and, when it is not dirty, is never re-requested. It used
     // to leave ensureLoaded() hanging forever; now it must settle. If this regresses, the
     // await below never resolves and the test fails with a timeout.
-    bucket.markAsFailed(false);
+    bucket.markAsFailed();
     await ensureLoadedPromise;
 
     // The failed bucket is treated like an empty bucket: it holds no data.

--- a/frontend/javascripts/viewer/model/bucket_data_handling/bucket.ts
+++ b/frontend/javascripts/viewer/model/bucket_data_handling/bucket.ts
@@ -608,9 +608,7 @@ export class DataBucket {
       case BucketStateEnum.REQUESTED: {
         this.state = isMissing ? BucketStateEnum.MISSING : BucketStateEnum.UNREQUESTED;
 
-        if (isMissing) {
-          this.trigger("bucketMissing");
-        }
+        this.trigger(isMissing ? "bucketMissing" : "bucketRequestFailed");
 
         break;
       }
@@ -830,6 +828,9 @@ export class DataBucket {
       await new Promise((resolve) => {
         this.once("bucketLoaded", resolve);
         this.once("bucketMissing", resolve);
+        // Treat failure like missing to not block callers waiting for ensureLoaded to resolve
+        // as a failure not necessarily auto re-requests the bucket from the backend.
+        this.once("bucketRequestFailed", resolve);
       });
     }
 

--- a/frontend/javascripts/viewer/model/bucket_data_handling/bucket.ts
+++ b/frontend/javascripts/viewer/model/bucket_data_handling/bucket.ts
@@ -603,12 +603,30 @@ export class DataBucket {
     }
   }
 
-  markAsFailed(isMissing: boolean): void {
+  // The bucket is not present on the datastore. It transitions to MISSING and stays there.
+  markAsMissing(): void {
+    this.markAsUnavailable(BucketStateEnum.MISSING, "bucketMissing");
+  }
+
+  // The bucket's request could not be read (e.g. transient error or a failure bucket). It
+  // transitions back to UNREQUESTED so that it may be requested again later.
+  markAsFailed(): void {
+    this.markAsUnavailable(BucketStateEnum.UNREQUESTED, "bucketRequestFailed");
+  }
+
+  private markAsUnavailable(
+    nextState: BucketStateEnum.MISSING | BucketStateEnum.UNREQUESTED,
+    event: "bucketMissing" | "bucketRequestFailed",
+  ): void {
     switch (this.state) {
       case BucketStateEnum.REQUESTED: {
-        this.state = isMissing ? BucketStateEnum.MISSING : BucketStateEnum.UNREQUESTED;
+        this.state = nextState;
 
-        this.trigger(isMissing ? "bucketMissing" : "bucketRequestFailed");
+        // Notify awaiters (see ensureLoaded). Emitting an event on both outcomes is
+        // important because a failure bucket falls back to UNREQUESTED and is only
+        // re-requested when it is dirty. Without it, a caller awaiting a non-dirty failure
+        // bucket (e.g. getDataForBoundingBox) would hang forever.
+        this.trigger(event);
 
         break;
       }

--- a/frontend/javascripts/viewer/model/bucket_data_handling/pullqueue.ts
+++ b/frontend/javascripts/viewer/model/bucket_data_handling/pullqueue.ts
@@ -112,7 +112,7 @@ class PullQueue {
                 // Render empty buckets as black (zeroed) data.
                 this.handleBucket(bucket, null);
               } else {
-                bucket.markAsFailed(true);
+                bucket.markAsMissing();
               }
               break;
             }
@@ -140,7 +140,7 @@ class PullQueue {
         const bucket = this.cube.getBucket(bucketAddress);
 
         if (bucket.type === "data") {
-          bucket.markAsFailed(false);
+          bucket.markAsFailed();
 
           if (bucket.dirty) {
             bucket.addToPullQueueWithHighestPriority();

--- a/frontend/javascripts/viewer/model/bucket_data_handling/pullqueue.ts
+++ b/frontend/javascripts/viewer/model/bucket_data_handling/pullqueue.ts
@@ -139,7 +139,11 @@ class PullQueue {
       for (const bucketAddress of failedBucketAddresses) {
         const bucket = this.cube.getBucket(bucketAddress);
 
-        if (bucket.type === "data") {
+        // Only mark the bucket as failed if it is still in the REQUESTED state.
+        // A bucket might have already transitioned to another state (e.g. LOADED
+        // via an earlier result in the same batch), in which case markAsFailed()
+        // would throw. Skipping it lets the loop safely handle the remaining buckets.
+        if (bucket.type === "data" && bucket.isRequested()) {
           bucket.markAsFailed();
 
           if (bucket.dirty) {

--- a/frontend/javascripts/viewer/model/bucket_data_handling/temporal_bucket_manager.ts
+++ b/frontend/javascripts/viewer/model/bucket_data_handling/temporal_bucket_manager.ts
@@ -42,6 +42,8 @@ class TemporalBucketManager {
         return resolve();
       };
 
+      // No "bucketRequestFailed" here: These buckets are dirty, so the pull queue retries
+      // them until the real backend data is read and merged (resolving as empty could lose data).
       bucket.on("bucketLoaded", onLoadedOrMissingHandler);
       bucket.on("bucketMissing", onLoadedOrMissingHandler);
     });

--- a/unreleased_changes/9795.md
+++ b/unreleased_changes/9795.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where requesting data for a bounding box (e.g. when rendering a bounding box as MIP) could hang indefinitely if the datastore reported one of the requested buckets as a failure. Such buckets are now treated as empty instead of leaving the request unresolved.


### PR DESCRIPTION
Do let getDataForBoundingBox of the FE api wait forever if some buckets have status failure.

### Summary
- While debugging the new Maximum Intensity Projection feature I noticed that the `api.data.getDataForBoundingBox` call seems to never terminate if the server responds with some failure buckets. The reason here is that the call hierarchy ends up at `bucket.ensureLoaded` which never terminated as a failure bucket never emitted an event and thus `ensureLoaded` never got notified of the failure. As `ensureLoaded` already treats missing buckets as a non error case (resolving the promise) we do the same for the failure bucket for now.
- Added a test checking that `ensureLoaded` resolves in case of a failure bucket
- Not failure bucket responses aren't easily produced reliable. But https://webknossos.org/datasets/Tissue%20of%20Arabidopsis%20thaliana-64625aa8010000ab008580de/view#934,967,197,0,1.737 reliably has some. Just look into the console when viewing the dataset. Not sure which buckets these are though. When I try to request them via the frontend api, the backend does not reply with a failure.
- `markAsFailed` of bucket was a little hard to understand as its parameters meaning was not clear from the name of the function. I split this up into two functions instead to make the "interface" easier to understand. Just a refactoring here.


### Steps to test:
- I dont suggest testing this. Not worth the time! It took me too much time:
- Add https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z_dtype_fix.zarr/ as a remote dataset
- view it -> should print bucket failures
- Execute the test script:
```javascript
(async function testFailureBucketBBoxRequest() {
  const api = window.webknossos.apiInterface;

  const layerName = "9836832_z_dtype_fix.zarr_2";
  const zoomStep = 3; // index into `mags` below → mag 8-8-8
  const mags = [
    [1, 1, 1],
    [2, 2, 2],
    [4, 4, 4],
    [8, 8, 8],
    [16, 16, 16],
    [32, 32, 32],
  ];
  const BUCKET_WIDTH = 32;

  // Bucket addresses [x, y, z] (at `zoomStep`) that this dataset reliably
  // answers as "failure" buckets.
  const bucketAddresses = [
    [3, 2, 1],
    [2, 3, 1],
    [3, 4, 1],
    [3, 5, 1],
  ];

  const mag = mags[zoomStep];
  // A bucket spans BUCKET_WIDTH voxels in its own mag → BUCKET_WIDTH * mag in mag-1 voxels.
  const bboxForBucket = ([x, y, z]) => {
    const min = [x, y, z].map((c, i) => c * BUCKET_WIDTH * mag[i]);
    const max = min.map((c, i) => c + BUCKET_WIDTH * mag[i]);
    return { min, max };
  };

  console.log(`requesting started (${bucketAddresses.length} buckets, mag ${mag.join("-")})`);

  await Promise.all(
    bucketAddresses.map(async (addr) => {
      const bbox = bboxForBucket(addr);
      const label = `bucket [${addr.join(",")},${zoomStep}] → bbox min [${bbox.min.join(",")}] max [${bbox.max.join(",")}]`;
      console.log(`  → requesting ${label}`);
      const data = await api.data.getDataForBoundingBox(layerName, bbox, zoomStep);
      console.log(`  ✓ finished ${label} — received ${data.length} values`, data);
    }),
  );

  console.log("requesting finished, bucket data received for all buckets ✅");
})();
```
- on master -> `requesting finished, bucket data received for all buckets ✅` will never print
- on this branch `requesting finished, bucket data received for all buckets ✅` will print


### Issues:
- fixes behaviour introduced in #9716

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
