### PR TITLE
Restrict mip bbox to layer bounds

### DIFF
--- a/frontend/javascripts/viewer/api/api_latest.ts
+++ b/frontend/javascripts/viewer/api/api_latest.ts
@@ -2077,11 +2077,15 @@ class DataApi {
     }
 
     const mags = magInfo.getDenseMags();
+    // Restrict the requested buckets to the layer's bounding box so that buckets
+    // outside the layer are never requested. Data outside the layer bounds does
+    // not exist, so the returned cuboid is unchanged (those regions stay zero).
     const bucketAddresses = this.getBucketAddressesInCuboid(
       mag1Bbox,
       mags,
       zoomStep,
       additionalCoordinates,
+      BoundingBox.fromBoundBoxObject(layer.boundingBox).toBoundingBoxMinMaxType(),
     );
 
     if (bucketAddresses.length > 15000) {
@@ -2171,11 +2175,23 @@ class DataApi {
     magnifications: Array<Vector3>,
     zoomStep: number,
     additionalCoordinates: AdditionalCoordinate[] | null,
+    // When provided, the iteration is restricted to buckets that intersect this
+    // bounding box.
+    restrictToBoundingBox?: BoundingBoxMinMaxType | null,
   ): Array<BucketAddress> {
-    const buckets = [];
-    const bottomRight = bbox.max;
+    const buckets: Array<BucketAddress> = [];
+    const effectiveBbox =
+      restrictToBoundingBox != null
+        ? new BoundingBox(bbox).intersectedWith(new BoundingBox(restrictToBoundingBox))
+        : new BoundingBox(bbox);
+
+    if (effectiveBbox.getVolume() === 0) {
+      return buckets;
+    }
+
+    const bottomRight = effectiveBbox.max;
     const minBucket = globalPositionToBucketPosition(
-      bbox.min,
+      effectiveBbox.min,
       magnifications,
       zoomStep,
       additionalCoordinates,

--- a/frontend/javascripts/viewer/model/sagas/mip_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/mip_saga.ts
@@ -14,6 +14,8 @@ import { call, select } from "viewer/model/sagas/effect_generators";
 import { api } from "viewer/singletons";
 import type { MipLayerConfig, UserBoundingBox } from "viewer/store";
 import { ensureSceneControllerInitialized } from "./ready_sagas";
+import BoundingBox from "../bucket_data_handling/bounding_box";
+import { getLayerByName } from "../accessors/dataset_accessor";
 
 // Maximum number of MIP layer downloads that run concurrently.
 // Queued requests wait for a slot before starting their HTTP fetch.
@@ -35,18 +37,23 @@ function* runMipDownload(
     yield* put(setMipForBBoxAction(bboxId, { ...config, isLoading: true }));
     const dataset = yield* select((state) => state.dataset);
 
-    const mag1Bbox = { min: bbox.boundingBox.min, max: bbox.boundingBox.max };
+    const mag1BBox = new BoundingBox(bbox.boundingBox);
+    const mag1BBoxClampedToLayerBounds = BoundingBox.fromBoundBoxObject(
+      getLayerByName(dataset, config.layerName).boundingBox,
+    )
+      .intersectedWith(mag1BBox)
+      .toBoundingBoxMinMaxType();
     const { actualZoomStep, textureDims, elementClass } = resolveMipLayerSource(
       dataset,
       config.layerName,
-      mag1Bbox,
+      mag1BBoxClampedToLayerBounds,
       config.zoomStep,
     );
 
     const rawDataTyped = yield* call(
       [api.data, api.data.getDataForBoundingBox],
       config.layerName,
-      mag1Bbox,
+      mag1BBoxClampedToLayerBounds,
       actualZoomStep,
       null,
       abortController.signal,

--- a/frontend/javascripts/viewer/model/sagas/mip_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/mip_saga.ts
@@ -13,9 +13,9 @@ import type { Saga } from "viewer/model/sagas/effect_generators";
 import { call, select } from "viewer/model/sagas/effect_generators";
 import { api } from "viewer/singletons";
 import type { MipLayerConfig, UserBoundingBox } from "viewer/store";
-import { ensureSceneControllerInitialized } from "./ready_sagas";
-import BoundingBox from "../bucket_data_handling/bounding_box";
 import { getLayerByName } from "../accessors/dataset_accessor";
+import BoundingBox from "../bucket_data_handling/bounding_box";
+import { ensureSceneControllerInitialized } from "./ready_sagas";
 
 // Maximum number of MIP layer downloads that run concurrently.
 // Queued requests wait for a slot before starting their HTTP fetch.

--- a/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
+++ b/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
@@ -61,8 +61,8 @@ export function useMipContextMenuItems(
       let bestSize = -1;
       let fallbackZoomStep: number | null = null;
       let fallbackSize = Number.MAX_SAFE_INTEGER;
+      const [bboxW, bboxH, bboxD] = bBoxClampedToLayerBounds[layer.name].getSize();
       for (const [zoomStep, mag] of mags) {
-        const [bboxW, bboxH, bboxD] = bBoxClampedToLayerBounds[layer.name].getSize();
         const voxels =
           Math.ceil(bboxW / mag[0]) * Math.ceil(bboxH / mag[1]) * Math.ceil(bboxD / mag[2]);
         const size = voxels * bytesPerVoxel;

--- a/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
+++ b/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
@@ -44,8 +44,8 @@ export function useMipContextMenuItems(
   const bBoxClampedToLayerBounds = useMemo(
     () =>
       Object.fromEntries(
-        Object.entries(colorLayers).map(([layerName, layer]) => [
-          layerName,
+        colorLayers.map((layer) => [
+          layer.name,
           BoundingBox.fromBoundBoxObject(layer.boundingBox).intersectedWith(bboxFromProps),
         ]),
       ),

--- a/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
+++ b/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
@@ -3,6 +3,8 @@ import MipIcon from "@images/icons/icon-mip.svg?react";
 import { Dropdown, type MenuProps } from "antd";
 import { formatBytes } from "libs/format_utils";
 import { useWkSelector } from "libs/react_hooks";
+import { computeBoundingBoxFromArray } from "libs/utils";
+import { useMemo } from "react";
 import { useDispatch } from "react-redux";
 import type { Vector6 } from "viewer/constants";
 import {
@@ -15,10 +17,8 @@ import {
   removeMipLayerForBBoxAction,
   setMipForBBoxAction,
 } from "viewer/model/actions/annotation_actions";
-import ButtonComponent from "../../components/button_component";
 import BoundingBox from "viewer/model/bucket_data_handling/bounding_box";
-import { computeBoundingBoxFromArray } from "libs/utils";
-import { useMemo } from "react";
+import ButtonComponent from "../../components/button_component";
 
 const RECOMMENDED_MIP_THRESHOLD_IN_BYTES = 50 * 1024 * 1024; // 50 MB
 

--- a/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
+++ b/frontend/javascripts/viewer/view/left_border_tabs/components/mip_menu_helpers.tsx
@@ -16,6 +16,9 @@ import {
   setMipForBBoxAction,
 } from "viewer/model/actions/annotation_actions";
 import ButtonComponent from "../../components/button_component";
+import BoundingBox from "viewer/model/bucket_data_handling/bounding_box";
+import { computeBoundingBoxFromArray } from "libs/utils";
+import { useMemo } from "react";
 
 const RECOMMENDED_MIP_THRESHOLD_IN_BYTES = 50 * 1024 * 1024; // 50 MB
 
@@ -34,17 +37,32 @@ export function useMipContextMenuItems(
 
   const activeMipLayerNames = new Set(mipLayers?.map((l) => l.layerName) ?? []);
   const availableColorLayers = colorLayers.filter((l) => !activeMipLayerNames.has(l.name));
-  const [, , , bboxW, bboxH, bboxD] = propValue;
+  const bboxFromProps = useMemo(
+    () => new BoundingBox(computeBoundingBoxFromArray(propValue)),
+    [propValue],
+  );
+  const bBoxClampedToLayerBounds = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(colorLayers).map(([layerName, layer]) => [
+          layerName,
+          BoundingBox.fromBoundBoxObject(layer.boundingBox).intersectedWith(bboxFromProps),
+        ]),
+      ),
+    [bboxFromProps, colorLayers],
+  );
 
   const buildAutoSelectHandler = (layers: typeof colorLayers) => () => {
     for (const layer of layers) {
       const mags = magInfoByLayer[layer.name]?.getMagsWithIndices() ?? [];
       const bytesPerVoxel = getByteCountFromLayer(layer);
+
       let bestZoomStep: number | null = null;
       let bestSize = -1;
       let fallbackZoomStep: number | null = null;
       let fallbackSize = Number.MAX_SAFE_INTEGER;
       for (const [zoomStep, mag] of mags) {
+        const [bboxW, bboxH, bboxD] = bBoxClampedToLayerBounds[layer.name].getSize();
         const voxels =
           Math.ceil(bboxW / mag[0]) * Math.ceil(bboxH / mag[1]) * Math.ceil(bboxD / mag[2]);
         const size = voxels * bytesPerVoxel;
@@ -78,6 +96,7 @@ export function useMipContextMenuItems(
         key: `mip-${layer.name}`,
         label: layer.name,
         children: mags.map(([zoomStep, mag]) => {
+          const [bboxW, bboxH, bboxD] = bBoxClampedToLayerBounds[layer.name].getSize();
           const voxels =
             Math.ceil(bboxW / mag[0]) * Math.ceil(bboxH / mag[1]) * Math.ceil(bboxD / mag[2]);
           return {

--- a/unreleased_changes/9796.md
+++ b/unreleased_changes/9796.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug in the Maximum Intensity Projection (MIP) feature where the projection and its estimated download size could extend beyond a layer's bounding box. MIP is now restricted to the layer's actual data extent.


### PR DESCRIPTION
### Summary

The recently merged Maximum Intensity Projection (MIP) feature (#9584) could request and render data outside a layer's bounding box when the selected bounding box extended beyond the layer. This PR restricts MIP to the layer's actual data extent and adds a root-level guard so the same class of issue cannot reappear:

- **MIP saga & menu:** the MIP bounding box is now clamped to the layer's bounds before the texture dimensions, the estimated download size, and the data request are computed. The rendered projection and its size estimate are therefore restricted to the layer's data.
- **Root-level guard in `getDataForBoundingBox`:** `getBucketAddressesInCuboid` gained an optional `restrictToBoundingBox` parameter, and `getDataForBoundingBox` now always passes the requested layer's bounding box. This prevents bucket addresses outside the layer from being generated for any current or future caller. `cutOutCuboid` still sizes its output from the originally requested bounding box, so regions outside the layer simply remain zero-initialized — the returned data is byte-for-byte unchanged.

Note: the data cube already prevented actual network requests for buckets fully outside the layer (they resolve to `NULL_BUCKET` without a fetch). The guard's benefit is therefore avoiding the generation/iteration of pointless bucket addresses (and the misleading "> 15000 buckets" warning), plus defense-in-depth for future callers of this API.

### Steps to test:
- Open a dataset and create a bounding box that extends beyond a color layer's bounding box (i.e. partly outside the layer's data).
- Right-click the bounding box and choose "Render as MIP" for that layer.
- Verify the MIP renders correctly and is restricted to the layer's data extent, and that the estimated download size shown in the context menu reflects only the in-layer portion.
- Regression check: render MIP for a bounding box that lies fully inside the layer and confirm the result is unchanged.

### Issues:
- Follow-up to #9584

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
