### PR TITLE
Fix no-overlap edge case in chunk loading

### DIFF
--- a/unreleased_changes/9800.md
+++ b/unreleased_changes/9800.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where webknossos would attempt to load some chunks outside of the dataset in rare cases, producing permanent errors there.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/MultiArrayUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/MultiArrayUtils.scala
@@ -106,6 +106,7 @@ object MultiArrayUtils extends LazyLogging {
     val targetShape: Array[Int] = target.getShape
     val sourceRanges = new util.ArrayList[Range]
     val targetRanges = new util.ArrayList[Range]
+    var hasOverlap = true
     for (dimension <- offset.indices) {
       val dimOffset = offset(dimension)
       var sourceFirst = 0
@@ -120,16 +121,27 @@ object MultiArrayUtils extends LazyLogging {
       val maxSSteps = sourceShape(dimension) - sourceFirst
       val maxTSteps = targetShape(dimension) - targetFirst
       val maxSteps = Math.min(maxSSteps, maxTSteps)
-      val sourceLast = sourceFirst + maxSteps
-      val targetLast = targetFirst + maxSteps
-      sourceRanges.add(new Range(sourceFirst, sourceLast - 1))
-      targetRanges.add(new Range(targetFirst, targetLast - 1))
+      // A non-positive maxSteps means source and target do not overlap at all in this dimension.
+      // This can happen if the image array does not match the layer bbox exactly.
+      // One legitimate case for this is downsampling pyramids where the in-mag bbox extent is rounded
+      // down in the source data, but wk attempts reading with the rounded-up extent.
+      // There is nothing to copy in that case.
+      if (maxSteps <= 0) {
+        hasOverlap = false
+      } else {
+        val sourceLast = sourceFirst + maxSteps
+        val targetLast = targetFirst + maxSteps
+        sourceRanges.add(new Range(sourceFirst, sourceLast - 1))
+        targetRanges.add(new Range(targetFirst, targetLast - 1))
+      }
     }
-    val sourceRangeIterator = source.getRangeIterator(sourceRanges)
-    val targetRangeIterator = target.getRangeIterator(targetRanges)
-    val elementType = source.getElementType
-    val setter = createValueSetter(elementType)
-    while (sourceRangeIterator.hasNext) setter.set(sourceRangeIterator, targetRangeIterator)
+    if (hasOverlap) {
+      val sourceRangeIterator = source.getRangeIterator(sourceRanges)
+      val targetRangeIterator = target.getRangeIterator(targetRanges)
+      val elementType = source.getElementType
+      val setter = createValueSetter(elementType)
+      while (sourceRangeIterator.hasNext) setter.set(sourceRangeIterator, targetRangeIterator)
+    }
   }
 
   private def createValueSetter(elementType: Class[?]): MultiArrayUtils.ValueSetter =


### PR DESCRIPTION
### Summary

When reading image data, we copy the required range from the source chunk to the output buffer. However, if the requested range is fully outside of the source chunk (no overlap), there was an exception. This PR changes that to silently return black data there.

There is one legitimate-ish case where this edge case can happen: Downsampling pyramids where the in-mag bbox extent is rounded down in the source data, but wk attempts reading with the rounded-up extent, because the layer bbox in wk is always mag1-based and then rounded up.

This happened with a concrete dataset, imported from https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z_dtype_fix.zarr/ – here are the numbers to illustrate this case:

mag1 array: shape z=259, chunks z=125
mag8 array: shape z=32,  chunks z=32

259 / 8 = 32.375 so the pyramid generator rounded down for the mag8 shape in z.

The failing bucket request topleft was at mag1 z=256, so at the mag8 z-coordinate 256/8 = 32. That's one voxel past the end of the mag8 array's real z-extent (valid indices 0..31, chunk shape z=32, exactly one chunk covering the whole axis). webknossos's bounding-box logic (built from the mag1 extent) still considers z=256 “in range” for this mag and issues the bucket read; the request lands exactly on the chunk boundary, producing offsetInChunk z = 32 – a full chunk-width out of bounds.

### Steps to test:
- Import dataset from https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z_dtype_fix.zarr/
- Should load without error logging.

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
