### PR TITLE
add config options (tenant, user+password) to LokiClient

### DIFF
--- a/app/models/voxelytics/LokiClient.scala
+++ b/app/models/voxelytics/LokiClient.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.mvc.MimeTypes
 import com.scalableminds.util.time.Instant
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
-import com.scalableminds.webknossos.datastore.rpc.RPC
+import com.scalableminds.webknossos.datastore.rpc.{RPC, RPCRequest}
 import com.typesafe.scalalogging.LazyLogging
 import models.voxelytics.VoxelyticsLogLevel.VoxelyticsLogLevel
 import com.scalableminds.util.box.Box.tryo
@@ -27,6 +27,11 @@ class LokiClient @Inject() (wkConf: WkConf, rpc: RPC, val actorSystem: ActorSyst
   private lazy val conf = wkConf.Voxelytics.Loki
   private lazy val enabled = wkConf.Features.voxelyticsEnabled && conf.uri.nonEmpty
 
+  private def withAuth(request: RPCRequest): RPCRequest = {
+    val withTenant = if (conf.tenant.nonEmpty) request.addHttpHeader("X-Scope-OrgID", conf.tenant) else request
+    if (conf.user.nonEmpty || conf.password.nonEmpty) withTenant.withBasicAuth(conf.user, conf.password) else withTenant
+  }
+
   private val POLLING_INTERVAL = 1 second
   private val LOG_TIME_BATCH_INTERVAL = 1 days
   private val LOG_ENTRY_QUERY_BATCH_SIZE = 5000
@@ -48,7 +53,7 @@ class LokiClient @Inject() (wkConf: WkConf, rpc: RPC, val actorSystem: ActorSyst
       } yield ()
 
     for {
-      responseBox <- Fox.fromFuture(rpc(s"${conf.uri}/ready").request.withMethod("GET").execute()).shiftBox
+      responseBox <- Fox.fromFuture(withAuth(rpc(s"${conf.uri}/ready")).request.withMethod("GET").execute()).shiftBox
       isServerAvailable <- responseBox match {
         case Full(response) if Status.isSuccessful(response.status) =>
           Fox.successful(true)
@@ -166,7 +171,7 @@ class LokiClient @Inject() (wkConf: WkConf, rpc: RPC, val actorSystem: ActorSyst
           .mkString("&")
       for {
         _ <- serverStartupFox
-        res <- rpc(s"${conf.uri}/loki/api/v1/query_range?$queryString").silent.getWithJsonResponse[JsValue]
+        res <- withAuth(rpc(s"${conf.uri}/loki/api/v1/query_range?$queryString")).silent.getWithJsonResponse[JsValue]
         logEntries <- tryo(
           (res \ "data" \ "result")
             .as[List[JsValue]]
@@ -253,7 +258,7 @@ class LokiClient @Inject() (wkConf: WkConf, rpc: RPC, val actorSystem: ActorSyst
             "values" -> JsArray(values)
           )
         )
-        _ <- rpc(s"${conf.uri}/loki/api/v1/push").silent
+        _ <- withAuth(rpc(s"${conf.uri}/loki/api/v1/push")).silent
           .addHttpHeader(HeaderNames.CONTENT_TYPE, jsonMimeType)
           .postJson[JsValue](Json.obj("streams" -> streams))
       } yield ()

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -273,6 +273,9 @@ class WkConf @Inject() (configuration: Configuration, certificateValidationServi
 
     object Loki {
       val uri: String = get[String]("voxelytics.loki.uri")
+      val tenant: String = get[String]("voxelytics.loki.tenant")
+      val user: String = get[String]("voxelytics.loki.user")
+      val password: String = get[String]("voxelytics.loki.password")
       val startupTimeout: FiniteDuration = get[FiniteDuration]("voxelytics.loki.startupTimeout")
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -372,6 +372,9 @@ voxelytics {
   staleTimeout = 20 minutes
   loki {
     uri = ""
+    tenant = ""
+    user = ""
+    password = ""
     startupTimeout = 1 minute
   }
 }

--- a/unreleased_changes/9805.md
+++ b/unreleased_changes/9805.md
@@ -1,0 +1,5 @@
+### Added
+- Added configuration for LokiClient (tenant, user, password).
+
+### Migration
+- Added `voxelytics.loki.tenant`, `voxelytics.loki.user` and `voxelytics.loki.password` configuration options to the application.conf.

--- a/unreleased_changes/9805.md
+++ b/unreleased_changes/9805.md
@@ -1,5 +1,3 @@
 ### Added
 - Added configuration for LokiClient (tenant, user, password).
 
-### Migration
-- Added `voxelytics.loki.tenant`, `voxelytics.loki.user` and `voxelytics.loki.password` configuration options to the application.conf.


### PR DESCRIPTION
### Summary
- Added more config options to LokiClient to use a [multi-tenant loki database](https://grafana.com/docs/loki/latest/operations/multi-tenancy/).

### Steps to test:
- Start up a loki (with auth_enabled: true), configure it in application.conf
- Configure tenant, user+password
- Run a voxelytics job with log streaming
- Check workflow report

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Added migration guide entry if applicable (edit the same file as for the changelog)
