### PR TITLE
Avoid full skeleton hierarchy rebuild on non-structural tree mutations

### DIFF
--- a/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/context_menus.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/context_menus.tsx
@@ -40,6 +40,7 @@ import {
   toggleInactiveTreesAction,
 } from "viewer/model/actions/skeletontracing_actions";
 import { TreeMap } from "viewer/model/types/tree_types";
+import Store from "viewer/store";
 import {
   createGroupToTreesMap,
   getExpandedGroups,
@@ -102,8 +103,16 @@ export function useTreeContextMenuBuilder(
           {
             key: "duplicateTree",
             onClick: () => {
-              const copyOfTree = { ...cloneDeep(tree), name: `${tree.name} (copy)` };
-              const treeMap = new TreeMap([[tree.treeId, copyOfTree]]);
+              // Read the tree fresh from the store: the hierarchy node's tree may
+              // be referentially stabilized (see areTreeMapsEqualForHierarchy) and
+              // thus not reflect the latest deep edits (e.g. moved nodes), which
+              // must be included in the duplicate.
+              const freshTree =
+                enforceSkeletonTracing(Store.getState().annotation).trees.getNullable(
+                  tree.treeId,
+                ) ?? tree;
+              const copyOfTree = { ...cloneDeep(freshTree), name: `${freshTree.name} (copy)` };
+              const treeMap = new TreeMap([[freshTree.treeId, copyOfTree]]);
               dispatch(addTreesAndGroupsAction(treeMap, null, undefined, false));
               hideContextMenu();
             },

--- a/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/hierarchy.ts
+++ b/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/hierarchy.ts
@@ -74,6 +74,52 @@ function getSortValue(node: SkeletonUiNode, sortBy: TreeSortBy): string | number
   return sortBy === "name" ? node.group.name : 0;
 }
 
+/*
+ * Equality function for the trees selector that feeds buildSkeletonHierarchy.
+ * The skeleton's TreeMap changes its identity on every store mutation (e.g. each
+ * placed or moved node). This keeps the selected TreeMap referentially stable as
+ * long as none of the fields that the hierarchy (this file) or the tree titles
+ * (node_titles.tsx) render or sort by have changed. That lets the expensive
+ * hierarchy rebuild (recursive orderBy + full node allocation) be skipped for
+ * frequent mutations that don't affect what the tab shows, such as moving a node
+ * or changing a node radius.
+ *
+ * IMPORTANT: every field that the hierarchy or the tree titles render or sort by
+ * must be compared here, otherwise the tab would display stale data. Consumers
+ * that need the full (deep) tree data (nodes/edges) must read it fresh from the
+ * store rather than from the hierarchy node, because the node may carry a
+ * referentially-stabilized (older) tree object (see duplicateTree in
+ * context_menus.tsx).
+ */
+export function areTreeMapsEqualForHierarchy(treesA: TreeMap, treesB: TreeMap): boolean {
+  if (treesA === treesB) {
+    return true;
+  }
+  if (treesA.size() !== treesB.size()) {
+    return false;
+  }
+  for (const treeA of treesA.values()) {
+    const treeB = treesB.getNullable(treeA.treeId);
+    if (
+      treeB == null ||
+      treeA.name !== treeB.name ||
+      treeA.color !== treeB.color ||
+      treeA.isVisible !== treeB.isVisible ||
+      treeA.type !== treeB.type ||
+      treeA.groupId !== treeB.groupId ||
+      treeA.edgesAreVisible !== treeB.edgesAreVisible ||
+      treeA.timestamp !== treeB.timestamp ||
+      treeA.metadata !== treeB.metadata ||
+      // The node count is displayed in the tree title, so a change (e.g. a placed
+      // node) must invalidate. Deeper node changes (e.g. moves) do not.
+      treeA.nodes.size() !== treeB.nodes.size()
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function buildSkeletonHierarchy(
   trees: TreeMap,
   treeGroups: TreeGroup[],

--- a/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/hooks/use_skeleton_hierarchy.ts
+++ b/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/hooks/use_skeleton_hierarchy.ts
@@ -1,7 +1,12 @@
 import { useWkSelector } from "libs/react_hooks";
 import { useMemo } from "react";
 import { enforceSkeletonTracing } from "viewer/model/accessors/skeletontracing_accessor";
-import { buildSkeletonHierarchy, type SkeletonHierarchy, type TreeSortBy } from "../hierarchy";
+import {
+  areTreeMapsEqualForHierarchy,
+  buildSkeletonHierarchy,
+  type SkeletonHierarchy,
+  type TreeSortBy,
+} from "../hierarchy";
 
 function useTreeSortBy(): TreeSortBy {
   return useWkSelector((state) => (state.userConfiguration.sortTreesByName ? "name" : "timestamp"));
@@ -13,7 +18,14 @@ function useTreeSortBy(): TreeSortBy {
  * Must only be used in components that are rendered when a skeleton tracing exists.
  */
 export function useSkeletonHierarchy(): SkeletonHierarchy {
-  const trees = useWkSelector((state) => enforceSkeletonTracing(state.annotation).trees);
+  // The TreeMap changes identity on every skeleton mutation. A custom equality
+  // (see areTreeMapsEqualForHierarchy) keeps the reference stable unless a field
+  // the hierarchy renders/sorts by actually changed, so the memoized rebuild
+  // below is skipped for mutations like node moves.
+  const trees = useWkSelector(
+    (state) => enforceSkeletonTracing(state.annotation).trees,
+    areTreeMapsEqualForHierarchy,
+  );
   const treeGroups = useWkSelector((state) => enforceSkeletonTracing(state.annotation).treeGroups);
   const sortBy = useTreeSortBy();
 


### PR DESCRIPTION
### Summary
The skeleton trees tab derives its antd hierarchy via `useSkeletonHierarchy`, which selected `trees` with default reference equality. Since the TreeMap changes identity on every skeleton mutation, buildSkeletonHierarchy (recursive orderBy + full TreeUiNode allocation) reran on every node edit while the tab was open.

Add a custom selector equality (`areTreeMapsEqualForHierarchy`) that compares only the fields the hierarchy and tree titles actually render/sort by (name, color, isVisible, type, groupId, edgesAreVisible, timestamp, metadata and the node count). Mutations that don't change any of these (e.g. moving a node or changing a node radius) now keep the selection referentially stable and skip the rebuild. This mirrors the existing comment-tab blueprint (`areTreesWithCommentsEqual`).

Downside: Because the hierarchy node may now carry a referentially-stabilized (older) tree object, duplicateTree reads the tree fresh from the store before cloning so the duplicate always includes the latest node/edge edits.

### Steps to test:
- Open React Dev Tools. Enable "Highlight component" updates.
- Do some work in WK while Skeleton tab is open, e.g. move camera. --> No React updates / stable reference
- Do some skeleton stuff (e.g. place new nodes, split skeleton) --> Correct React updates / UI refresh
<img width="1153" height="622" alt="Screenshot 2026-07-21 at 15-59-07" src="https://github.com/user-attachments/assets/9fadf79e-4ad3-49be-9af1-4055ff22e013" />


### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
