### PR TITLE
Disallow rm command for claude on OSX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,6 @@ Code Verification:
 ## Pull Requests
 - run all the appropriate checks above
 - use the PR template at `.github/PULL_REQUEST_TEMPLATE.md
+
+# Scripting & Command Permissions
+- Never ever use `rm` commands on OSX platforms. Instead use the saver `trash` command. This prevents accidental permanent deletion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,5 +24,6 @@ Code Verification:
 - run all the appropriate checks above
 - use the PR template at `.github/PULL_REQUEST_TEMPLATE.md
 
+
 # Scripting & Command Permissions
-- Never ever use `rm` commands on OSX platforms. Instead use the saver `trash` command. This prevents accidental permanent deletion.
+- Never ever use `rm` commands on OSX platforms. Instead use the safer `trash` command. This prevents accidental permanent deletion.


### PR DESCRIPTION
### This PR is a suggestion

### Summary
This adds a note to the claude "config" file to never use `rm` on OSX platforms to avoid accidental deletions. Instead the `trash` command should be used.
Idea: When running claude in `auto` mode, it can happen that claude goes very wild (heard story about unrecoverable linux systems due to that) -> To avoid this / make things easiert recoverable, only allow trash command for OSX!

### Steps to test:
- Nothing


### Issues:
- Nothing, just want to prevent big whoopsies made by claude
