### PR TITLE
Dont allow joining a deleted team via invite link / token

### DIFF
--- a/app/controllers/TeamController.scala
+++ b/app/controllers/TeamController.scala
@@ -4,7 +4,6 @@ import com.scalableminds.util.Msg
 import play.silhouette.api.Silhouette
 import com.scalableminds.util.tools.Fox
 import models.team.*
-import models.user.{InviteDAO, UserDAO}
 import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.WkEnv
@@ -18,13 +17,7 @@ object TeamParameters {
   implicit val jsonFormat: Format[TeamParameters] = Json.format[TeamParameters]
 }
 
-class TeamController @Inject() (
-    teamDAO: TeamDAO,
-    userDAO: UserDAO,
-    inviteDAO: InviteDAO,
-    teamService: TeamService,
-    sil: Silhouette[WkEnv]
-)(implicit
+class TeamController @Inject() (teamDAO: TeamDAO, teamService: TeamService, sil: Silhouette[WkEnv])(implicit
     ec: ExecutionContext,
     playBodyParsers: PlayBodyParsers
 ) extends Controller {
@@ -43,10 +36,7 @@ class TeamController @Inject() (
       team <- teamDAO.findOne(id) ?~> Msg.Team.notFound(id) ~> NOT_FOUND
       _ <- Fox.fromBool(!team.isOrganizationTeam) ?~> Msg.Team.deleteOrganizationTeam ~> FORBIDDEN
       _ <- teamService.assertNoReferences(id) ?~> Msg.Team.deleteInUse ~> FORBIDDEN
-      _ <- teamDAO.deleteOne(id)
-      _ <- userDAO.removeTeamFromAllUsers(id)
-      _ <- inviteDAO.removeTeamFromAllInvites(id)
-      _ <- teamDAO.removeTeamFromAllDatasetsAndFolders(id)
+      _ <- teamDAO.deleteOneWithReferences(id)
     } yield JsonOk(Msg.Team.deleteSuccess)
   }
 

--- a/app/controllers/TeamController.scala
+++ b/app/controllers/TeamController.scala
@@ -4,7 +4,7 @@ import com.scalableminds.util.Msg
 import play.silhouette.api.Silhouette
 import com.scalableminds.util.tools.Fox
 import models.team.*
-import models.user.UserDAO
+import models.user.{InviteDAO, UserDAO}
 import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, PlayBodyParsers}
 import security.WkEnv
@@ -18,8 +18,13 @@ object TeamParameters {
   implicit val jsonFormat: Format[TeamParameters] = Json.format[TeamParameters]
 }
 
-class TeamController @Inject() (teamDAO: TeamDAO, userDAO: UserDAO, teamService: TeamService, sil: Silhouette[WkEnv])(
-    implicit
+class TeamController @Inject() (
+    teamDAO: TeamDAO,
+    userDAO: UserDAO,
+    inviteDAO: InviteDAO,
+    teamService: TeamService,
+    sil: Silhouette[WkEnv]
+)(implicit
     ec: ExecutionContext,
     playBodyParsers: PlayBodyParsers
 ) extends Controller {
@@ -40,6 +45,7 @@ class TeamController @Inject() (teamDAO: TeamDAO, userDAO: UserDAO, teamService:
       _ <- teamService.assertNoReferences(id) ?~> Msg.Team.deleteInUse ~> FORBIDDEN
       _ <- teamDAO.deleteOne(id)
       _ <- userDAO.removeTeamFromAllUsers(id)
+      _ <- inviteDAO.removeTeamFromAllInvites(id)
       _ <- teamDAO.removeTeamFromAllDatasetsAndFolders(id)
     } yield JsonOk(Msg.Team.deleteSuccess)
   }

--- a/app/controllers/TeamController.scala
+++ b/app/controllers/TeamController.scala
@@ -36,7 +36,7 @@ class TeamController @Inject() (teamDAO: TeamDAO, teamService: TeamService, sil:
       team <- teamDAO.findOne(id) ?~> Msg.Team.notFound(id) ~> NOT_FOUND
       _ <- Fox.fromBool(!team.isOrganizationTeam) ?~> Msg.Team.deleteOrganizationTeam ~> FORBIDDEN
       _ <- teamService.assertNoReferences(id) ?~> Msg.Team.deleteInUse ~> FORBIDDEN
-      _ <- teamDAO.deleteOneWithReferences(id)
+      _ <- teamDAO.deleteOne(id)
     } yield JsonOk(Msg.Team.deleteSuccess)
   }
 

--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -14,6 +14,7 @@ import models.project.ProjectDAO
 import models.task.TaskTypeDAO
 import models.user.User
 import play.api.libs.json.*
+import slick.jdbc.PostgresProfile.api.*
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 import com.scalableminds.util.objectid.ObjectId
 
@@ -220,13 +221,26 @@ class TeamDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
     replaceSequentiallyAsTransaction(clearQuery, insertQueries)
   }
 
-  def removeTeamFromAllDatasetsAndFolders(teamId: ObjectId): Fox[Unit] =
-    for {
-      _ <- run(q"DELETE FROM webknossos.dataset_allowedTeams WHERE _team = $teamId".asUpdate)
-      _ <- run(q"DELETE FROM webknossos.folder_allowedTeams WHERE _team = $teamId".asUpdate)
-    } yield ()
-
   override def deleteOne(teamId: ObjectId)(using ctx: DBAccessContext): Fox[Unit] =
     deleteOneWithNameSuffix(teamId)
+
+  /* Marks the team as deleted and removes all references to it (user and invite team roles, allowed teams of
+   * datasets and folders) in a single transaction. Cleaning up in the same transaction as the deletion itself
+   * ensures that a failing cleanup step cannot leave dangling references to an already-deleted team behind.
+   * The references are deleted here rather than in the DAOs owning the respective tables, since they can only
+   * be part of this transaction if they are issued as part of the same query. */
+  def deleteOneWithReferences(teamId: ObjectId)(using ctx: DBAccessContext): Fox[Unit] = {
+    val queries = List(
+      deleteOneWithNameSuffixQuery(teamId),
+      q"DELETE FROM webknossos.user_team_roles WHERE _team = $teamId".asUpdate,
+      q"DELETE FROM webknossos.invite_team_roles WHERE _team = $teamId".asUpdate,
+      q"DELETE FROM webknossos.dataset_allowedTeams WHERE _team = $teamId".asUpdate,
+      q"DELETE FROM webknossos.folder_allowedTeams WHERE _team = $teamId".asUpdate
+    )
+    for {
+      _ <- assertDeleteAccess(teamId)
+      _ <- run(DBIO.sequence(queries).transactionally)
+    } yield ()
+  }
 
 }

--- a/app/models/team/Team.scala
+++ b/app/models/team/Team.scala
@@ -14,7 +14,6 @@ import models.project.ProjectDAO
 import models.task.TaskTypeDAO
 import models.user.User
 import play.api.libs.json.*
-import slick.jdbc.PostgresProfile.api.*
 import utils.sql.{SQLDAO, SqlClient, SqlToken}
 import com.scalableminds.util.objectid.ObjectId
 
@@ -221,25 +220,24 @@ class TeamDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
     replaceSequentiallyAsTransaction(clearQuery, insertQueries)
   }
 
-  override def deleteOne(teamId: ObjectId)(using ctx: DBAccessContext): Fox[Unit] =
-    deleteOneWithNameSuffix(teamId)
-
   /* Marks the team as deleted and removes all references to it (user and invite team roles, allowed teams of
-   * datasets and folders) in a single transaction. Cleaning up in the same transaction as the deletion itself
-   * ensures that a failing cleanup step cannot leave dangling references to an already-deleted team behind.
+   * datasets and folders, shared teams of annotations) in a single transaction. Cleaning up in the same
+   * transaction as the deletion itself ensures that a failing cleanup step cannot leave dangling references to
+   * an already-deleted team behind, and that no reference can be inserted concurrently.
    * The references are deleted here rather than in the DAOs owning the respective tables, since they can only
    * be part of this transaction if they are issued as part of the same query. */
-  def deleteOneWithReferences(teamId: ObjectId)(using ctx: DBAccessContext): Fox[Unit] = {
+  override def deleteOne(teamId: ObjectId)(using ctx: DBAccessContext): Fox[Unit] = {
     val queries = List(
       deleteOneWithNameSuffixQuery(teamId),
       q"DELETE FROM webknossos.user_team_roles WHERE _team = $teamId".asUpdate,
       q"DELETE FROM webknossos.invite_team_roles WHERE _team = $teamId".asUpdate,
+      q"DELETE FROM webknossos.annotation_sharedTeams WHERE _team = $teamId".asUpdate,
       q"DELETE FROM webknossos.dataset_allowedTeams WHERE _team = $teamId".asUpdate,
       q"DELETE FROM webknossos.folder_allowedTeams WHERE _team = $teamId".asUpdate
     )
     for {
       _ <- assertDeleteAccess(teamId)
-      _ <- run(DBIO.sequence(queries).transactionally)
+      _ <- runAsTransaction(queries)
     } yield ()
   }
 

--- a/app/models/user/Invite.scala
+++ b/app/models/user/Invite.scala
@@ -159,12 +159,6 @@ class InviteDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
       parsed = rows.map(row => TeamMembership(row._1, row._2))
     } yield parsed
 
-  // Called on team deletion, so that the team role does not become a dangling reference in pending invites.
-  def removeTeamFromAllInvites(teamId: ObjectId): Fox[Unit] =
-    for {
-      _ <- run(q"DELETE FROM webknossos.invite_team_roles WHERE _team = $teamId".asUpdate)
-    } yield ()
-
   def deleteAllExpired(): Fox[Unit] =
     for {
       _ <- run(q"UPDATE $collectionName SET isDeleted = TRUE WHERE expirationDateTime <= ${Instant.now}".asUpdate)

--- a/app/models/user/Invite.scala
+++ b/app/models/user/Invite.scala
@@ -150,13 +150,12 @@ class InviteDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
     } yield ()
   }
 
-  // Ensure only teams are returned that are not deleted (present in teams_) as teams might be deleted after the invite was created.
   def findTeamMembershipsFor(inviteId: ObjectId): Fox[Seq[TeamMembership]] =
     for {
-      rows <- run(q"""SELECT invite._team, invite.isTeamManager
-                      FROM webknossos.invite_team_roles invite
-                      JOIN webknossos.teams_ t ON t._id = invite._team
-                      WHERE invite._invite = $inviteId""".as[(ObjectId, Boolean)])
+      rows <- run(
+        q"SELECT _team, isTeamManager FROM WEBKNOSSOS.invite_team_roles WHERE _invite = $inviteId"
+          .as[(ObjectId, Boolean)]
+      )
       parsed = rows.map(row => TeamMembership(row._1, row._2))
     } yield parsed
 

--- a/app/models/user/Invite.scala
+++ b/app/models/user/Invite.scala
@@ -150,14 +150,21 @@ class InviteDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
     } yield ()
   }
 
+  // Ensure only teams are returned that are not deleted (present in teams_) as teams might be deleted after the invite was created.
   def findTeamMembershipsFor(inviteId: ObjectId): Fox[Seq[TeamMembership]] =
     for {
-      rows <- run(
-        q"SELECT _team, isTeamManager FROM WEBKNOSSOS.invite_team_roles WHERE _invite = $inviteId"
-          .as[(ObjectId, Boolean)]
-      )
+      rows <- run(q"""SELECT invite._team, invite.isTeamManager
+                      FROM webknossos.invite_team_roles invite
+                      JOIN webknossos.teams_ t ON t._id = invite._team
+                      WHERE invite._invite = $inviteId""".as[(ObjectId, Boolean)])
       parsed = rows.map(row => TeamMembership(row._1, row._2))
     } yield parsed
+
+  // Called on team deletion, so that the team role does not become a dangling reference in pending invites.
+  def removeTeamFromAllInvites(teamId: ObjectId): Fox[Unit] =
+    for {
+      _ <- run(q"DELETE FROM webknossos.invite_team_roles WHERE _team = $teamId".asUpdate)
+    } yield ()
 
   def deleteAllExpired(): Fox[Unit] =
     for {

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -559,8 +559,12 @@ class UserDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
       })
     } yield teamMemberships
 
+  // Re-selecting the team id from teams_ ensures the team is not marked as isDeleted = true.
   private def insertTeamMembershipQuery(userId: ObjectId, teamMembership: TeamMembership) =
-    q"INSERT INTO webknossos.user_team_roles(_user, _team, isTeamManager) VALUES($userId, ${teamMembership.teamId}, ${teamMembership.isTeamManager})".asUpdate
+    q"""INSERT INTO webknossos.user_team_roles(_user, _team, isTeamManager)
+        SELECT $userId, t._id, ${teamMembership.isTeamManager}
+        FROM webknossos.teams_ t
+        WHERE t._id = ${teamMembership.teamId}""".asUpdate
 
   def updateTeamMembershipsForUser(userId: ObjectId, teamMemberships: Seq[TeamMembership])(using
       ctx: DBAccessContext

--- a/app/models/user/User.scala
+++ b/app/models/user/User.scala
@@ -583,11 +583,6 @@ class UserDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContext)
       _ <- run(insertTeamMembershipQuery(userId, teamMembership))
     } yield ()
 
-  def removeTeamFromAllUsers(teamId: ObjectId): Fox[Unit] =
-    for {
-      _ <- run(q"DELETE FROM webknossos.user_team_roles WHERE _team = $teamId".asUpdate)
-    } yield ()
-
   def findTeamMemberDifference(potentialSubteam: ObjectId, superteams: List[ObjectId]): Fox[List[User]] =
     for {
       r <- run(q"""SELECT ${columnsWithPrefix("u.")}

--- a/app/utils/sql/SQLDAO.scala
+++ b/app/utils/sql/SQLDAO.scala
@@ -59,15 +59,17 @@ abstract class SQLDAO[C, R, X <: AbstractTable[R]] @Inject() (sqlClient: SqlClie
       _ <- run(q"UPDATE $collectionName SET isDeleted = TRUE WHERE _id = $id".asUpdate)
     } yield ()
 
+  protected def deleteOneWithNameSuffixQuery(id: ObjectId, nameColumn: String = "name") = {
+    val deletedSuffix = s".deleted.at.${Instant.now.epochMillis}"
+    val collectionToken = collectionName
+    val nameColumnToken = SqlToken.raw(nameColumn)
+    q"UPDATE $collectionToken SET isDeleted = TRUE, $nameColumnToken = CONCAT($nameColumnToken, $deletedSuffix) WHERE _id = $id".asUpdate
+  }
+
   def deleteOneWithNameSuffix(id: ObjectId, nameColumn: String = "name")(using ctx: DBAccessContext): Fox[Unit] =
     for {
       _ <- assertDeleteAccess(id)
-      deletedSuffix = s".deleted.at.${Instant.now.epochMillis}"
-      collectionToken = collectionName
-      nameColumnToken = SqlToken.raw(nameColumn)
-      _ <- run(
-        q"UPDATE $collectionToken SET isDeleted = TRUE, $nameColumnToken = CONCAT($nameColumnToken, $deletedSuffix) WHERE _id = $id".asUpdate
-      )
+      _ <- run(deleteOneWithNameSuffixQuery(id, nameColumn))
     } yield ()
 
 }

--- a/app/utils/sql/SimpleSQLDAO.scala
+++ b/app/utils/sql/SimpleSQLDAO.scala
@@ -70,17 +70,21 @@ class SimpleSQLDAO @Inject() (sqlClient: SqlClient)(implicit ec: ExecutionContex
     new String(os.toByteArray, StandardCharsets.UTF_8)
   }
 
-  def replaceSequentiallyAsTransaction(
-      clearQuery: SqlAction[Int, NoStream, Effect],
-      insertQueries: Seq[SqlAction[Int, NoStream, Effect]]
-  ): Fox[Unit] = {
-    val composedQuery = DBIO.sequence(List(clearQuery) ++ insertQueries)
+  /* Runs the queries in a single serializable transaction, so that either all or none of them are applied.
+   * Serializable isolation also guards against concurrent transactions inserting rows that the queries here
+   * were supposed to remove (or vice versa); such conflicts are reported by postgres and retried. */
+  def runAsTransaction(queries: Seq[SqlAction[Int, NoStream, Effect]]): Fox[Unit] =
     for {
       _ <- run(
-        composedQuery.transactionally.withTransactionIsolation(Serializable),
+        DBIO.sequence(queries.toList).transactionally.withTransactionIsolation(Serializable),
         retryCount = 50,
         retryIfErrorContains = List(transactionSerializationError, cacheLookupFailedForTypeError)
       )
     } yield ()
-  }
+
+  def replaceSequentiallyAsTransaction(
+      clearQuery: SqlAction[Int, NoStream, Effect],
+      insertQueries: Seq[SqlAction[Int, NoStream, Effect]]
+  ): Fox[Unit] =
+    runAsTransaction(List(clearQuery) ++ insertQueries)
 }

--- a/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
@@ -56,7 +56,7 @@ export function NewVolumeLayerSelection({
         placement="right"
       >
         <InfoCircleOutlined />
-      </Tooltip>
+      </Tooltip>{" "}
       <Radio.Group
         onChange={(e) => {
           const index = Number.parseInt(e.target.value, 10);

--- a/unreleased_changes/9827.md
+++ b/unreleased_changes/9827.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that a user could become a member of an already deleted team when joining via an invite link that was created before the team was deleted. Deleting a team now also removes its pending invite roles.


### PR DESCRIPTION
### Summary
On master it is possible to 1. create a team, 2. create an invite via email with a role to that team, 3. delete the team, 4. the user joining yielding it being a member of the deleted team.
This PR fixes this by
1. Auto deleting team invite entries in the db upon team deletion.
2. When a new user's team memberships are fetched filter out the deleted teams by joining with `teams_` which is a view that already filters out the deleted teams


### Steps to test:
0. No need to test imo. Did this myself pretty thourghly
1. create a team, 
2. create an invite via email with a role to that team, 
3. delete the team, 
4. the user joining should not yield it being a member of the deleted team.


### Issues:
- fixes user reported https://scm.slack.com/archives/C0B8TNTN50R/p1785146540392749

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
