### PR TITLE
Fix error of keystrokes lib if user uses browser auto fill feature in input texts

### DIFF
--- a/frontend/javascripts/libs/input.ts
+++ b/frontend/javascripts/libs/input.ts
@@ -38,9 +38,19 @@ function normalizeDigitKeyEvent(event: BrowserKeyEvent): BrowserKeyEvent {
 setGlobalKeystrokesOptions({
   keyRemap: { " ": "space" },
   onKeyPressed: (handler) =>
-    browserOnKeyPressedBinder((event) => handler(normalizeDigitKeyEvent(event))),
+    browserOnKeyPressedBinder((event) => {
+      if (event.key === undefined) {
+        return;
+      }
+      handler(normalizeDigitKeyEvent(event));
+    }),
   onKeyReleased: (handler) =>
-    browserOnKeyReleasedBinder((event) => handler(normalizeDigitKeyEvent(event))),
+    browserOnKeyReleasedBinder((event) => {
+      if (event.key === undefined) {
+        return;
+      }
+      handler(normalizeDigitKeyEvent(event));
+    }),
 });
 
 // This is the main Input implementation.

--- a/unreleased_changes/9834.md
+++ b/unreleased_changes/9834.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed an error that might occur when using the auto-fill feature of your browser in any input field in WEBKNOSSOS.


### PR DESCRIPTION
### Summary
Fix error of keystrokes lib in case a key event with undefined key is sent

- usually happens when the user uses some browser autofill input text feature



### Steps to test:
- Use chrome (at least on macos this works)
- open the team admin page
- add a team, in the input text for the team name use the browser auto fill feature
- On master an error should be thrown
- on this branch it it caught

### Issues:
- fixes self noticed bug

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)