### PR TITLE
Fix viewport out of sync

### DIFF
--- a/frontend/javascripts/viewer/geometries/plane.ts
+++ b/frontend/javascripts/viewer/geometries/plane.ts
@@ -1,5 +1,4 @@
 import { V3 } from "libs/mjs";
-import memoize from "lodash-es/memoize";
 import {
   BufferAttribute,
   BufferGeometry,
@@ -51,9 +50,9 @@ class Plane {
   baseRotationMatrix = new Matrix4();
   flycamRotationMatrix = new Matrix4();
 
-  // Keeps track of the materials created by getLineBasicMaterial so that
-  // they can be disposed in destroy().
-  private lineMaterials: LineBasicMaterial[] = [];
+  // Caches the materials handed out by getLineBasicMaterial, so that identical
+  // materials are shared and all of them can be disposed in destroy().
+  private lineMaterialByKey: Map<string, LineBasicMaterial> = new Map();
 
   constructor(planeID: OrthoView) {
     this.planeID = planeID;
@@ -120,17 +119,20 @@ class Plane {
     this.displayCrosshair = value;
   };
 
-  getLineBasicMaterial = memoize(
-    (color: number, linewidth: number) => {
-      const material = new LineBasicMaterial({
+  getLineBasicMaterial = (color: number, linewidth: number): LineBasicMaterial => {
+    const key = `${color}_${linewidth}`;
+    let material = this.lineMaterialByKey.get(key);
+
+    if (material == null) {
+      material = new LineBasicMaterial({
         color,
         linewidth,
       });
-      this.lineMaterials.push(material);
-      return material;
-    },
-    (color: number, linewidth: number) => `${color}_${linewidth}`,
-  );
+      this.lineMaterialByKey.set(key, material);
+    }
+
+    return material;
+  };
 
   setOriginalCrosshairColor = (): void => {
     [0, 1].forEach((i) => {
@@ -214,10 +216,10 @@ class Plane {
     for (const mesh of this.getMeshes()) {
       mesh.geometry.dispose();
     }
-    for (const material of this.lineMaterials) {
+    for (const material of this.lineMaterialByKey.values()) {
       material.dispose();
     }
-    this.lineMaterials = [];
+    this.lineMaterialByKey.clear();
   }
 
   bindToEvents(): void {

--- a/frontend/javascripts/viewer/view/arbitrary_view.ts
+++ b/frontend/javascripts/viewer/view/arbitrary_view.ts
@@ -40,6 +40,7 @@ class FlightModeView {
   plane: FlightModePlane;
   setClippingDistance: (value: number) => void;
   needsRerender: boolean;
+  private isRerenderScheduled: boolean = false;
   additionalInfo: string = "";
   isRunning: boolean = false;
   animationRequestId: number | null | undefined = null;
@@ -102,11 +103,7 @@ class FlightModeView {
       );
       this.unsubscribeFunctions.push(
         Store.subscribe(() => {
-          // Only set the flag here (without scheduling a requestAnimationFrame
-          // per action which would queue many redundant callbacks for
-          // high-frequency actions). The animate() loop picks the flag up in
-          // the next frame, i.e. after the change propagated everywhere.
-          this.needsRerender = true;
+          this.scheduleRerender();
         }),
       );
 
@@ -174,6 +171,19 @@ class FlightModeView {
 
     this.renderFunction();
     this.animationRequestId = window.requestAnimationFrame(() => this.animate());
+  }
+
+  // Sets needsRerender in the next animation frame. At most one callback is
+  // queued at a time, so high-frequency callers don't pile up closures.
+  scheduleRerender(): void {
+    if (this.isRerenderScheduled) {
+      return;
+    }
+    this.isRerenderScheduled = true;
+    window.requestAnimationFrame(() => {
+      this.isRerenderScheduled = false;
+      this.needsRerender = true;
+    });
   }
 
   renderFunction() {

--- a/frontend/javascripts/viewer/view/plane_view.ts
+++ b/frontend/javascripts/viewer/view/plane_view.ts
@@ -73,6 +73,7 @@ class PlaneView {
   cameras: OrthoViewMap<OrthographicCamera>;
   isRunning: boolean = false;
   needsRerender: boolean;
+  private isRerenderScheduled: boolean = false;
   unsubscribeFunctions: Array<() => void> = [];
 
   constructor() {
@@ -115,6 +116,19 @@ class PlaneView {
 
     this.renderFunction();
     window.requestAnimationFrame(() => this.animate());
+  }
+
+  // Sets needsRerender in the next animation frame. At most one callback is
+  // queued at a time, so high-frequency callers don't pile up closures.
+  scheduleRerender(): void {
+    if (this.isRerenderScheduled) {
+      return;
+    }
+    this.isRerenderScheduled = true;
+    window.requestAnimationFrame(() => {
+      this.isRerenderScheduled = false;
+      this.needsRerender = true;
+    });
   }
 
   renderFunction(forceRender: boolean = false): void {
@@ -366,11 +380,7 @@ class PlaneView {
 
     this.unsubscribeFunctions.push(
       Store.subscribe(() => {
-        // Only set the flag here (without scheduling a requestAnimationFrame
-        // per action which would queue many redundant callbacks for
-        // high-frequency actions). The animate() loop picks the flag up in
-        // the next frame, i.e. after the change propagated everywhere.
-        this.needsRerender = true;
+        this.scheduleRerender();
       }),
     );
 

--- a/unreleased_changes/9835.md
+++ b/unreleased_changes/9835.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that the visibility state of trees shown in the viewport were maybe out of sync with the visibility setting in the trees tab.

--- a/unreleased_changes/9835.md
+++ b/unreleased_changes/9835.md
@@ -1,2 +1,2 @@
 ### Fixed
-- Fixed that the visibility state of trees shown in the viewport were maybe out of sync with the visibility setting in the trees tab.
+- Fixed an issue where tree visibility in the viewports could become out of sync with the visibility setting in the Trees tab.


### PR DESCRIPTION
### Summary

**TL;DR** — two regressions from #9799:

- #9799 made `PlaneView`/`ArbitraryView` set `needsRerender = true` synchronously on every store action instead of one `requestAnimationFrame` later. `Skeleton` applies its changes via `throttled_store`, i.e. one frame late — so `animate()` consumed and reset the flag *before* the tree color texture was updated, and the next frame skipped rendering. Result: toggling tree visibility left the viewports stale until a mouse move.
- Fixed by scheduling the flag one frame later again, but coalesced to at most one pending rAF, so #9799's perf intent is kept.
- Also cleans up `Plane.getLineBasicMaterial`: #9799 left a `lineMaterials` array next to the never-cleared `memoize` cache. Both are replaced by one `Map` that is cache *and* disposal list.

<details>
<summary><b>1. Viewports going out of sync with the skeleton visibility state</b> — full reasoning</summary>

Toggling a tree's visibility in the skeleton tab sometimes did not update the viewports. The internal state was always correct — only the rendering was stale, and any mouse move over a viewport forced a rerender that brought them back in sync.

**Where it came from**

#9799 changed the `Store.subscribe` handlers in `PlaneView`/`ArbitraryView` to set `needsRerender = true` *synchronously* instead of scheduling a `requestAnimationFrame`, with the goal of not queueing one redundant rAF closure per store action.

**Why that breaks**

`Skeleton` does not listen to the real store — it subscribes via `viewer/throttled_store`, which fans out to its listeners from inside `await animationFrame(...)`, i.e. from **within a rAF callback**, one frame after the dispatch. So `Skeleton.refresh()` → `updateTreeColor()` → `treeColorTexture.needsUpdate = true` happens a frame late.

`PlaneView.animate()` re-registers its own rAF at the end of every frame, so it is always the **first** callback of the next frame. And `renderFunction()` resets `needsRerender = false` after rendering. That gives the following ordering for the frame after a visibility toggle:

Before #9799:

| # | callback | effect |
|---|---|---|
| 1 | `animate()` | renders, `needsRerender = false` |
| 2 | `PlaneView`'s rAF (scheduled during the dispatch) | `needsRerender = true` |
| 3 | throttled-store rAF | `Skeleton` updates the tree color texture |

→ the next frame renders the new state. ✅

After #9799:

| # | callback | effect |
|---|---|---|
| 1 | `animate()` | sees the flag that was set during the dispatch, renders the **old** texture, `needsRerender = false` |
| 2 | throttled-store rAF | `Skeleton` updates the texture — nobody requests a render |

→ the next frame skips rendering entirely. The change sits on the GPU unrendered until something else sets the flag. ❌

This is also why it was intermittent: any *further* dispatch after step 2 (save-queue push, active-tree change, hover) re-arms the flag and masks the bug.

In other words, the `requestAnimationFrame` wrapper was never about "propagation" in the vague sense the old comment suggested — it was load-bearing for exactly one thing: setting the flag *after* the deferred consumers had their turn.

**The fix**

Reintroduce the rAF, but coalesce it so that at most one callback is queued at a time. That keeps #9799's actual intent (no pile-up of one closure per action for high-frequency actions) while restoring the ordering guarantee:

```ts
scheduleRerender(): void {
  if (this.isRerenderScheduled) return;
  this.isRerenderScheduled = true;
  window.requestAnimationFrame(() => {
    this.isRerenderScheduled = false;
    this.needsRerender = true;
  });
}
```

Applied to both `PlaneView` and `ArbitraryView` — flight mode renders skeletons too and had the identical regression.

Note that `Skeleton` is the only scene consumer that mutates three.js state without also emitting `app.vent.emit("rerender")`. Every other deferred mutation announces itself — `TextureBucketManager`'s rAF writer queue, the throttled `recomputeShaders`, the mesh fade-in tweens — which is why they were unaffected by #9799.

</details>

<details>
<summary><b>2. Cleanup of the line material memoization in <code>plane.ts</code></b> — full reasoning</summary>

#9799 added a `lineMaterials` array *alongside* the existing `memoize` cache on `Plane.getLineBasicMaterial`, so that the materials could be disposed in `destroy()`. That left two structures tracking the same objects, and the memoize cache was never cleared — so after `destroy()` it could still hand back a disposed material.

Both are now replaced by a single `Map` that is simultaneously the cache and the disposal list. (Keeping `memoize` is not an option here: its `MapCache` can be cleared but not iterated, so it cannot serve as the disposal list on its own and the parallel array would have to stay.)

The map stays small by construction: `getLineBasicMaterial` is `Plane`-private (four call sites, all in `plane.ts`), `linewidth` is always the literal `1`, and the colors are compile-time constants from `viewer/constants` (`OrthoViewCrosshairColors`, `OrthoViewColors`, `OrthoViewGrayCrosshairColor`). That is at most 4 entries per `Plane` and at most 15 across the four `Plane` instances, all reached within the first frame — nothing user- or data-driven can grow it.

</details>

### Steps to test:
- Create an annotation, add a tree group with a few trees whose nodes all sit next to each other so that they are visible in the viewports at once.
- Toggle the tree visibility via the skeleton tab (repeatedly, and for individual trees as well as the group).
- The viewports must stay in sync with the visibility state without requiring a mouse move over a viewport. On `master` they go out of sync intermittently.
- Repeat the same in flight mode (`ArbitraryView`).

### Issues:
- Regression from #9799 (no separate issue)

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)