### PR TITLE
Let antd own icon colors instead of hardcoding them inline

### DIFF
--- a/frontend/javascripts/admin/organization/organization_credit_activity_view.tsx
+++ b/frontend/javascripts/admin/organization/organization_credit_activity_view.tsx
@@ -199,11 +199,8 @@ export function OrganizationCreditActivityView() {
                 </Space>
               );
             }}
-            filterIcon={(filtered) => (
-              <CalendarOutlined
-                style={{ color: filtered ? "var(--ant-color-primary" : undefined }}
-              />
-            )}
+            // antd already colors an active filter trigger with colorPrimary.
+            filterIcon={<CalendarOutlined />}
             onFilter={(value, record) => {
               const [startDate, endDate] = parseRangeValue(value as string);
               if (startDate == null || endDate == null) {

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -71,11 +71,7 @@ function NewAnnotationLink({
         className="ant-dropdown-link"
         onClick={() => !isReloading && onShowCreateExplorativeModal()}
       >
-        <EllipsisOutlined
-          style={{
-            color: "var(--ant-color-link)",
-          }}
-        />
+        <EllipsisOutlined />
       </a>
       {isCreateExplorativeModalVisible ? (
         <CreateExplorativeModal datasetId={dataset.id} onClose={onCloseCreateExplorativeModal} />

--- a/frontend/javascripts/dashboard/folders/metadata_table.tsx
+++ b/frontend/javascripts/dashboard/folders/metadata_table.tsx
@@ -438,14 +438,7 @@ export default function MetadataTable({
       <Button
         type="text"
         disabled={isSaving}
-        icon={
-          <CloseOutlined
-            style={{
-              color: "var(--ant-color-text-tertiary)",
-              width: 16,
-            }}
-          />
-        }
+        icon={<CloseOutlined />}
         style={{ width: 16, height: 19 }}
         onClick={() => deleteKey(index)}
       />
@@ -514,12 +507,9 @@ export function InnerMetadataTable({
                 >
                   <Button
                     className="add-property-button"
-                    ghost
+                    type="text"
                     size="small"
-                    style={{ border: "none" }}
-                    icon={
-                      <PlusOutlined size={18} style={{ color: "var(--ant-color-text-tertiary)" }} />
-                    }
+                    icon={<PlusOutlined />}
                   />
                 </Dropdown>
               </FastTooltip>

--- a/frontend/javascripts/viewer/view/left_border_tabs/components/layer_transform_settings_popover.tsx
+++ b/frontend/javascripts/viewer/view/left_border_tabs/components/layer_transform_settings_popover.tsx
@@ -368,9 +368,12 @@ export function LayerTransformSettingsPopover({
       <span>
         <Typography.Title level={4}>Layer Transforms</Typography.Title>
       </span>
-      <CloseOutlined
-        style={{ cursor: "pointer", fontSize: 12, color: "var(--ant-color-text-secondary)" }}
+      <Button
+        type="text"
+        size="small"
+        icon={<CloseOutlined />}
         onClick={onClose}
+        aria-label="Close layer transform settings"
       />
     </Flex>
   );

--- a/frontend/javascripts/viewer/view/right_border_tabs/metadata_table.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/metadata_table.tsx
@@ -59,14 +59,7 @@ function _MetadataTableRows<ItemType extends { metadata: MetadataEntryProto[] }>
         type="text"
         disabled={readOnly}
         style={{ width: 16, height: 19 }}
-        icon={
-          <CloseOutlined
-            style={{
-              color: "var(--ant-color-text-tertiary)",
-              width: 16,
-            }}
-          />
-        }
+        icon={<CloseOutlined />}
         onClick={() => {
           removeMetadataEntryByIndex(item, index);
         }}

--- a/unreleased_changes/9857.md
+++ b/unreleased_changes/9857.md
@@ -1,0 +1,4 @@
+### Fixed
+- Fixed the delete buttons in the dataset and annotation metadata tables not appearing greyed out while a save was in progress or in read-only annotations.
+- Fixed the date filter icon in the organization credit activity table not being highlighted while a filter was active.
+- Fixed the close button of the layer transform settings popover not being reachable via keyboard.


### PR DESCRIPTION
### Summary

Stacked on #9850. Antd icons render their SVG as `fill: currentColor` at `width/height: 1em`, so they inherit the color of whatever parent they sit in. Hardcoding a color inline overrides antd's own hover/active/disabled handling — which turned out to be masking a few real bugs:

- **Both metadata table delete buttons never dimmed when disabled.** The inline `color` on the icon beat the `colorTextDisabled` antd puts on the disabled `Button`, so the icon stayed tertiary-colored while saving / in read-only mode. `width: 16` on the icon was also a no-op for the glyph (it's sized via `fontSize`), it only widened the wrapper box.
- **The credit activity filter icon was never colored at all** — `"var(--ant-color-primary"` is missing its closing paren, so the declaration was invalid. Antd already colors an active filter trigger with `colorPrimary`, so the override was redundant on top of being broken.
- **The "add property" button used `ghost`**, which colors its content `colorBgContainer` (white in the light theme, see `button/style/token.js`), and then compensated with an inline tertiary color *and* a `style={{ border: "none" }}` override. `type="text"` is the primitive that was actually wanted, so all three workarounds go away. The invalid `size={18}` prop on the icon (not an antd icon prop) is gone too.
- **The dataset action `EllipsisOutlined`** restated the `colorLink` it already inherits from its `<a>`. The seven sibling icons in that same file don't set a color, which is what made it clear this was accidental.
- **The layer transform close icon** was a bare `<CloseOutlined>` with `cursor: pointer` and an `onClick` — a button without focus handling or an accessible name. Now a real `Button type="text"` with an `aria-label`.

Net effect: 5 fewer hardcoded `var(--ant-*)` references, and the icons now follow their parent's state.

### Steps to test:
- **Metadata tables** (dashboard folder sidebar → a dataset's metadata, and the annotation right-hand *Segments*/*Bounding Boxes* metadata): the ✕ delete button should visibly dim while a save is in flight and in read-only annotations. Previously it stayed the same shade.
- **Add property button** (same tables, the `+` at the bottom): should look like a borderless text button with a hover background, and the `+` should be legible. Check both light and dark theme.
- **Credit activity** (org admin → credits, `CalendarOutlined` filter on the date column): the icon should turn WK blue while a date filter is active.
- **Dataset action row** (dashboard dataset list, the `…` link): unchanged link-blue, including hover.
- **Layer transform popover** (left sidebar → a layer → transform settings): the ✕ should be tab-focusable and show a hover background; it closes the popover as before.
- All in both light and dark theme.

### Issues:
- part of the color/theming cleanup started in #9850

------
- [x] Added changelog entry
- [ ] ~~Added migration guide entry if applicable~~
- [ ] ~~Updated documentation if applicable~~
- [ ] ~~Adapted wk-libs python client~~
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered common edge cases
- [ ] ~~Needs datastore update after deployment~~
