### PR TITLE
Use semantic antd primitives for status colors, fix two DAG view color bugs

### DIFF
--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -34,6 +34,7 @@ import {
   Table,
   Tag,
   Tooltip,
+  Typography,
 } from "antd";
 import LinkButton from "components/link_button";
 import dayjs from "dayjs";
@@ -500,13 +501,14 @@ function UserListView() {
                 </Tooltip>
               ) : (
                 <Tooltip title="Account is not activated">
-                  <CloseCircleOutlined
-                    className="icon-margin-right"
-                    style={{
-                      fontSize: 20,
-                      color: "var(--ant-color-error)",
-                    }}
-                  />
+                  <Typography.Text type="danger">
+                    <CloseCircleOutlined
+                      className="icon-margin-right"
+                      style={{
+                        fontSize: 20,
+                      }}
+                    />
+                  </Typography.Text>
                 </Tooltip>
               );
 
@@ -521,13 +523,14 @@ function UserListView() {
                 </Tooltip>
               ) : (
                 <Tooltip title="Email is not verified">
-                  <MailOutlined
-                    className="icon-margin-right"
-                    style={{
-                      fontSize: 20,
-                      color: "var(--ant-color-error)",
-                    }}
-                  />
+                  <Typography.Text type="danger">
+                    <MailOutlined
+                      className="icon-margin-right"
+                      style={{
+                        fontSize: 20,
+                      }}
+                    />
+                  </Typography.Text>
                 </Tooltip>
               );
 

--- a/frontend/javascripts/admin/voxelytics/dag_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/dag_view.tsx
@@ -1,5 +1,5 @@
 import { ExpandOutlined, MinusOutlined, PlusOutlined } from "@ant-design/icons";
-import { Button } from "antd";
+import { theme as antdTheme, Button } from "antd";
 import ColorHash from "color-hash";
 import dagre from "dagre";
 import { useWkSelector } from "libs/react_hooks";
@@ -94,6 +94,10 @@ function getEdgesAndNodes(
   filteredTasks: Array<VoxelyticsTaskConfigWithName>,
   selectedNodeId: string | null,
   theme: Theme,
+  // React Flow renders parts of the graph via SVG presentation attributes (e.g. the
+  // <rect stroke> behind an edge label), where a `var(--ant-…)` reference is not resolved.
+  // So the border color has to be passed in as an already-resolved value.
+  borderColor: string,
 ) {
   const dagreGraph = new dagre.graphlib.Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
@@ -129,7 +133,7 @@ function getEdgesAndNodes(
   const nodes: Array<FlowNode> = dag.nodes.map((node) => {
     const nodeType = getNodeType(nodeMap.get(node.id) ?? null);
 
-    let color = "var(--ant-color-border)";
+    let color = borderColor;
     let opacity = 100;
 
     const fontColor = colorHasher.hex(
@@ -201,7 +205,7 @@ function getEdgesAndNodes(
       },
       labelBgStyle: {
         fill: theme === "light" ? "white" : "black",
-        stroke: "var(--ant-color-border)",
+        stroke: borderColor,
       },
       labelShowBg: true,
       type: "smoothstep",
@@ -223,6 +227,9 @@ function DAGView({
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const allTaskIds = dag.nodes.map((node) => node.id);
   const theme = useWkSelector((state) => state.uiInformation.theme);
+  // Resolved token values, because React Flow passes these into SVG presentation
+  // attributes where `var(--ant-…)` references are not resolved.
+  const { token } = antdTheme.useToken();
   const reactFlowRef = useRef<ReactFlowInstance | null>(null);
 
   const handleNodeClick = (_event: any, element: FlowNode) => {
@@ -246,7 +253,13 @@ function DAGView({
     }
   };
 
-  const { nodes, edges } = getEdgesAndNodes(dag, filteredTasks, selectedNodeId, theme);
+  const { nodes, edges } = getEdgesAndNodes(
+    dag,
+    filteredTasks,
+    selectedNodeId,
+    theme,
+    token.colorBorder,
+  );
 
   return (
     <ReactFlow
@@ -267,15 +280,15 @@ function DAGView({
       <MiniMap
         nodeStrokeColor={(n) => {
           if (n.style?.borderColor) return n.style.borderColor;
-          return "var(--ant-color-border-secondary)";
+          return token.colorBorderSecondary;
         }}
         nodeColor={(n) => {
           if (n.style?.borderColor) return n.style.borderColor;
-          return "var(--ant-color-bg-container)";
+          return token.colorBgContainer;
         }}
         nodeBorderRadius={2}
       />
-      <Background color="var(--ant-color-border)" gap={16} />
+      <Background color={token.colorBorder} gap={16} />
       <div className="controls">
         <Button
           icon={<PlusOutlined />}

--- a/frontend/javascripts/admin/voxelytics/dag_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/dag_view.tsx
@@ -201,7 +201,7 @@ function getEdgesAndNodes(
       style: { opacity, strokeWidth },
       labelStyle: {
         opacity,
-        fill: (labelFontColor ?? theme === "light") ? "black" : "white",
+        fill: labelFontColor ?? (theme === "light" ? "black" : "white"),
       },
       labelBgStyle: {
         fill: theme === "light" ? "white" : "black",

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -8,7 +8,7 @@ import {
   SettingOutlined,
   TeamOutlined,
 } from "@ant-design/icons";
-import { Alert, Breadcrumb, Button, Form, Layout, Menu, Space, Tooltip } from "antd";
+import { Alert, Breadcrumb, Button, Form, Layout, Menu, Space, Tooltip, Typography } from "antd";
 import type { ItemType } from "antd/es/menu/interface";
 import { useDatasetSettingsContext } from "dashboard/dataset/dataset_settings_context";
 import features from "features";
@@ -118,11 +118,9 @@ const DatasetSettingsView: React.FC = () => {
     isEditingMode || (dataset != null && dataset.dataSource.status == null) ? "Save" : "Import";
   const errorIcon = (
     <Tooltip title="Some fields in this tab require your attention.">
-      <ExclamationCircleOutlined
-        style={{
-          color: "var(--ant-color-error)",
-        }}
-      />
+      <Typography.Text type="danger">
+        <ExclamationCircleOutlined />
+      </Typography.Text>
     </Tooltip>
   );
 

--- a/frontend/javascripts/viewer/view/action_bar/private_links_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/private_links_view.tsx
@@ -32,6 +32,7 @@ import {
   Spin,
   Table,
   Tooltip,
+  Typography,
 } from "antd";
 import type { ColumnsType } from "antd/lib/table";
 import { AsyncButton, AsyncIconButton } from "components/async_clickables";
@@ -271,7 +272,9 @@ function ExpirationDate({ linkItem }: { linkItem: ZarrPrivateLink }) {
   const maybeWarning =
     Date.now() > linkItem.expirationDateTime ? (
       <Tooltip title="This link has expired">
-        <InfoCircleOutlined style={{ color: "var(--ant-color-error)" }} />
+        <Typography.Text type="danger">
+          <InfoCircleOutlined />
+        </Typography.Text>
       </Tooltip>
     ) : null;
 

--- a/frontend/javascripts/viewer/view/action_bar/private_links_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/private_links_view.tsx
@@ -299,8 +299,10 @@ function ExpirationDate({ linkItem }: { linkItem: ZarrPrivateLink }) {
         title="Set an expiration date"
         trigger="click"
       >
-        <EditOutlined style={{ marginLeft: 4 }} />
-        {maybeWarning || <HumanizedDuration expirationDate={expirationDate} />}
+        <Space size="small">
+          <EditOutlined style={{ marginLeft: 4 }} />
+          {maybeWarning || <HumanizedDuration expirationDate={expirationDate} />}
+        </Space>
       </Popover>
     </span>
   );

--- a/frontend/javascripts/viewer/view/context_menu/no_node_context_menu_options.tsx
+++ b/frontend/javascripts/viewer/view/context_menu/no_node_context_menu_options.tsx
@@ -1,5 +1,5 @@
 import { WarningOutlined } from "@ant-design/icons";
-import { App, Empty } from "antd";
+import { App, Empty, Typography } from "antd";
 import type { ItemType, MenuItemType } from "antd/es/menu/interface";
 import FastTooltip from "components/fast_tooltip";
 import { useWkSelector } from "libs/react_hooks";
@@ -357,7 +357,9 @@ export function useNoNodeContextMenuOptions(
                 <span>
                   Import Agglomerate Tree{" "}
                   {!isAgglomerateMappingEnabled.value ? (
-                    <WarningOutlined style={{ color: "var(--ant-color-text-disabled)" }} />
+                    <Typography.Text disabled>
+                      <WarningOutlined />
+                    </Typography.Text>
                   ) : null}{" "}
                   {shortcutBuilder(["Shift", "middleMouse"])}
                 </span>
@@ -462,7 +464,9 @@ export function useNoNodeContextMenuOptions(
         <FastTooltip title={isConnectomeMappingEnabled.reason}>
           Import Synapses{" "}
           {!isConnectomeMappingEnabled.value ? (
-            <WarningOutlined style={{ color: "var(--ant-color-text-disabled)" }} />
+            <Typography.Text disabled>
+              <WarningOutlined />
+            </Typography.Text>
           ) : null}{" "}
         </FastTooltip>
       ),

--- a/frontend/javascripts/viewer/view/left_border_tabs/components/layer_settings_header.tsx
+++ b/frontend/javascripts/viewer/view/left_border_tabs/components/layer_settings_header.tsx
@@ -19,7 +19,7 @@ import {
   findDataPositionForVolumeTracing,
   startComputeSegmentIndexFileJob,
 } from "admin/rest_api";
-import { App, Dropdown, Flex, type MenuProps, Switch } from "antd";
+import { App, Dropdown, Flex, type MenuProps, Switch, Typography } from "antd";
 import type { ItemType } from "antd/es/menu/interface";
 import type { SwitchChangeEventHandler } from "antd/es/switch";
 import FastTooltip from "components/fast_tooltip";
@@ -322,11 +322,9 @@ export default function LayerSettingsHeader({
 
     return (
       <FastTooltip title="This volume tracing does not have data at all magnifications.">
-        <WarningOutlined
-          style={{
-            color: "var(--ant-color-warning)",
-          }}
-        />
+        <Typography.Text type="warning">
+          <WarningOutlined />
+        </Typography.Text>
       </FastTooltip>
     );
   };
@@ -652,11 +650,9 @@ export default function LayerSettingsHeader({
             title={`No data is being rendered for this layer as the minimum and maximum of the range have the same values.
             If you want to hide this layer, you can also disable it with the switch on the left.`}
           >
-            <WarningOutlined
-              style={{
-                color: "var(--ant-color-warning)",
-              }}
-            />
+            <Typography.Text type="warning">
+              <WarningOutlined />
+            </Typography.Text>
           </FastTooltip>
         ) : null}
         {isColorLayer ? null : getOptionalDownsampleVolumeIcon(maybeVolumeTracing)}

--- a/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/load_mesh_menu_item_label.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/segments_tab/load_mesh_menu_item_label.tsx
@@ -1,4 +1,5 @@
 import { WarningOutlined } from "@ant-design/icons";
+import { Typography } from "antd";
 import FastTooltip from "components/fast_tooltip";
 import type { APIMeshFileInfo } from "types/api_types";
 import type { VolumeTracing } from "viewer/store";
@@ -29,7 +30,9 @@ export function LoadMeshMenuItemLabel({ currentMeshFile, volumeTracing }: Props)
       </FastTooltip>
       {showWarning && (
         <FastTooltip title="Warning: The segmentation data has changed since the mesh file was created. The mesh may not match the current data.">
-          <WarningOutlined style={{ color: "var(--ant-color-warning)" }} />
+          <Typography.Text type="warning">
+            <WarningOutlined />
+          </Typography.Text>
         </FastTooltip>
       )}
     </span>

--- a/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/skeleton_tab_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/skeleton_tab/skeleton_tab_view.tsx
@@ -1,5 +1,5 @@
 import { WarningOutlined } from "@ant-design/icons";
-import { Divider, Empty, Modal, Spin, Tooltip } from "antd";
+import { Divider, Empty, Modal, Spin, Tooltip, Typography } from "antd";
 import { useWkSelector } from "libs/react_hooks";
 import messages from "messages";
 import { useRef } from "react";
@@ -20,11 +20,9 @@ function SkeletonsHiddenWarning() {
   }
   return (
     <Tooltip title={messages["tracing.skeletons_are_hidden_warning"]}>
-      <WarningOutlined
-        style={{
-          color: "var(--ant-color-warning)",
-        }}
-      />
+      <Typography.Text type="warning">
+        <WarningOutlined />
+      </Typography.Text>
     </Tooltip>
   );
 }

--- a/frontend/javascripts/viewer/view/statusbar.tsx
+++ b/frontend/javascripts/viewer/view/statusbar.tsx
@@ -267,11 +267,9 @@ function maybeLabelWithSegmentationWarning(isUint64SegmentationVisible: boolean,
     <React.Fragment>
       {label}{" "}
       <FastTooltip title={message["tracing.uint64_segmentation_warning"]}>
-        <WarningOutlined
-          style={{
-            color: "var(--ant-color-warning)",
-          }}
-        />
+        <Typography.Text type="warning">
+          <WarningOutlined />
+        </Typography.Text>
       </FastTooltip>
     </React.Fragment>
   ) : (

--- a/unreleased_changes/9859.md
+++ b/unreleased_changes/9859.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed the background grid and the default node colors of the minimap in the Voxelytics workflow graph not being applied.

--- a/unreleased_changes/9859.md
+++ b/unreleased_changes/9859.md
@@ -1,2 +1,3 @@
 ### Fixed
 - Fixed the background grid and the default node colors of the minimap in the Voxelytics workflow graph not being applied.
+- Fixed the edge labels of a selected task in the Voxelytics workflow graph not being highlighted.


### PR DESCRIPTION
### Summary

Stacked on #9857 (which is stacked on #9850). Second step of the color/theming cleanup: replace hardcoded `var(--ant-*)` status colors with the antd primitive that already carries that meaning, and use `theme.useToken()` for the one place that genuinely needs resolved values.

**1. Status icons → `Typography.Text type=…`** (9 sites)

Antd icons render as `fill: currentColor`, so wrapping them in a `Typography.Text` with a semantic `type` colors them without naming a color at all:

| before | after |
| --- | --- |
| `<WarningOutlined style={{ color: "var(--ant-color-warning)" }} />` | `<Typography.Text type="warning"><WarningOutlined /></Typography.Text>` |
| `<InfoCircleOutlined style={{ color: "var(--ant-color-error)" }} />` | `<Typography.Text type="danger"><InfoCircleOutlined /></Typography.Text>` |
| `<WarningOutlined style={{ color: "var(--ant-color-text-disabled)" }} />` | `<Typography.Text disabled><WarningOutlined /></Typography.Text>` |

**These are exactly color-preserving.** I checked the resolved tokens rather than assuming — `colorWarningText` / `colorErrorText` / `colorSuccessText` come from palette index 9 while `colorWarning` / `colorError` / `colorSuccess` come from index 6, but they resolve to identical values in both themes (`#faad14` / `#ff4d4f` / `#52c41a` light, `#d89614` / `#dc4446` / `#49aa19` dark). `Typography.Text disabled` uses `colorTextDisabled` directly. So no visual change is expected anywhere in this group.

Sites: `statusbar.tsx`, `skeleton_tab_view.tsx`, `load_mesh_menu_item_label.tsx`, `layer_settings_header.tsx` (×2), `private_links_view.tsx`, `dataset_settings_view.tsx`, `user_list_view.tsx` (×2), `no_node_context_menu_options.tsx` (×2).

**2. Voxelytics DAG view → `theme.useToken()` — this one is a bug fix**

`dag_view.tsx` passed `var(--ant-…)` strings into React Flow's `Background color`, `MiniMap nodeColor` and `MiniMap nodeStrokeColor`. React Flow puts those into **SVG presentation attributes** — `<path stroke={color}>` in `index3.js`, `<rect fill={fill} stroke={strokeColor}>` in `index2.js` — and CSS `var()` is not resolved in XML attribute values, only in CSS property values. So the background grid and the minimap's default node fill/stroke were silently never colored. They now come from `theme.useToken().token` as resolved values, which is what that API is for.

The `style`-object cases in the same file (`node.style.borderColor`, `labelBgStyle.stroke`) *did* work, since those become real inline styles — but they feed `n.style.borderColor` back into the minimap, so they're resolved the same way now for consistency.

**3. A second DAG view color bug, in the same function**

```ts
const labelFontColor = isSourceSelected ? "red" : null;
…
fill: (labelFontColor ?? theme === "light") ? "black" : "white",
```

The `??` groups around the comparison instead of around the fallback. `labelFontColor` is the string `"red"` whenever an edge's source node is selected, which is truthy, so the ternary always yielded `"black"` and the intended red highlight never rendered. The unselected case worked, but only by accident. Now `labelFontColor ?? (theme === "light" ? "black" : "white")`.

(`labelStyle` is applied as a real CSS style — `<text style={labelStyle}>` — so unlike the attribute cases above, `fill: "red"` does take effect once the grouping is fixed.)

### Steps to test:
- **Warning icons, both themes:** annotation status bar with a uint64 segmentation loaded; right-hand *Skeleton* tab with skeletons hidden; *Segments* tab → "Load Mesh (precomputed)" when the segmentation changed after the mesh file was built; a layer's settings header for a volume layer without all mags, and for a layer whose intensity range min == max. All should look **unchanged** — amber as before.
- **Danger icons, both themes:** an expired private link (share → private links); dataset settings with a validation error in another tab; admin user list, a non-activated account and an unverified email. Also unchanged — red as before.
- **Disabled icons:** right-click in an annotation without an agglomerate mapping → "Import Agglomerate Tree" / "Import Synapses" warning icons stay dimmed.
- **Voxelytics DAG** (Voxelytics → a workflow → DAG tab): the background dot grid should now actually be visible in the theme's border color, and minimap nodes for tasks in a neutral run state should be filled/stroked instead of falling back to the browser default. Then click a node that has outgoing edges — its edge labels should turn red. This is the one place where a visual **change** is expected — it's the bugs being fixed. Check both themes.

### Issues:
- part of the color/theming cleanup started in #9850


------
- [x] Added changelog entry
- [ ] ~~Added migration guide entry if applicable~~
- [ ] ~~Updated documentation if applicable~~
- [ ] ~~Adapted wk-libs python client~~
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered common edge cases
- [ ] ~~Needs datastore update after deployment~~
