### PR TITLE
Ignore autofill keyboard events while tracking keyboard layout

### DIFF
--- a/frontend/javascripts/viewer/view/keyboard_shortcuts/keyboard_layout_utils.ts
+++ b/frontend/javascripts/viewer/view/keyboard_shortcuts/keyboard_layout_utils.ts
@@ -157,7 +157,7 @@ export async function initializeKeyboardLayoutMap(): Promise<void> {
 // Called from the shortcut recorder modal's keydown handler (all browsers) and the global
 // keydown listener registered above.
 export function registerKeyForLayoutMap(e: KeyboardEvent) {
-  if (e.repeat) {
+  if (e.repeat || e.key == null) {
     // Skip repeated events.
     return;
   }

--- a/unreleased_changes/9860.md
+++ b/unreleased_changes/9860.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a small bug leading to an error toast if the browser autofill feature is used in input fields.


### PR DESCRIPTION
### Summary
Fixes a small keyboard tracking bug.
Explaination: Browser autofill events have `event.key === undefined`. The `registerKeyForLayoutMap` function should just skip such events.

### Steps to test:
- Open an annotation / view a dataset
- Go to teams view
- open the "add team modal" -> in the input use the browser text autofill feature. -> should no longer show an error toast.


### Issues:
- fixes a self noticed bug.

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)