### PR TITLE
use own transition style for upload progressbar to fix its long delay

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -542,14 +542,17 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
               <br />
               {isRetrying ? "Retrying to continue the upload …" : null}
               <br />
-              <Progress
-                // Round to 1 digit after the comma, but use floor
-                // to avoid that 100% are displayed even though the progress is lower.
-                percent={Math.floor(uploadProgress * 1000) / 10}
-                status="active"
-              />
             </>
           )}
+          <Progress
+            // Use floor so that 100% is not displayed while the progress is still lower.
+            percent={isFinishing ? 100 : Math.floor(uploadProgress * 100)}
+            status="active"
+            // antd's default easing (0.3s ease-in-out-circ) is very flat at the start, so the bar
+            // lags tens of percent behind the — untransitioned — label whenever the progress
+            // jumps, which it does at the end of every upload (in-flight chunks count as 0%).
+            styles={{ track: { transition: "width 150ms linear" } }}
+          />
         </div>
       </Modal>
     );

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -548,9 +548,7 @@ class DatasetUploadView extends React.Component<PropsWithFormAndRouter, State> {
             // Use floor so that 100% is not displayed while the progress is still lower.
             percent={isFinishing ? 100 : Math.floor(uploadProgress * 100)}
             status="active"
-            // antd's default easing (0.3s ease-in-out-circ) is very flat at the start, so the bar
-            // lags tens of percent behind the — untransitioned — label whenever the progress
-            // jumps, which it does at the end of every upload (in-flight chunks count as 0%).
+            // Fix too slow updating of progress bar via own transition style.
             styles={{ track: { transition: "width 150ms linear" } }}
           />
         </div>

--- a/unreleased_changes/9866.md
+++ b/unreleased_changes/9866.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed the progressbar of an ongoing dataset upload being heavily delayed in its visual progress bar.


### PR DESCRIPTION
### Summary
Simply fixes the progress bar of the upload view. Antd's transition prop has quite the extreme delay. Setting our own keeps the shown percentage and the progress of the bar in sync.


### Steps to test:
No need to test imo. Did this myself already.
- Upload something that takes some time (e.g. throttle connection via dev tools or a upload of ~1gb or so; should take at least 5 secs or so)
- Watch the progressbar. Should be in sync with the shown percentage
- Compare with master -> should have quite the delay


### Issues:
- fixes something that annoyed me for a long time :D

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
