### PR TITLE
Fix user-supplied credentials for attachments

### DIFF
--- a/app/models/dataset/Dataset.scala
+++ b/app/models/dataset/Dataset.scala
@@ -1370,7 +1370,7 @@ class DatasetLayerAttachmentDAO @Inject() (sqlClient: SqlClient)(implicit ec: Ex
       dataFormat <- LayerAttachmentDataformat.fromString(row.dataformat).toFox ?~> "Could not parse data format"
       realPathWithFallback = if (useRealPaths) row.realpath.getOrElse(row.path) else row.path
       path <- UPath.fromString(realPathWithFallback).toFox
-    } yield LayerAttachment(row.name, path, dataFormat)
+    } yield LayerAttachment(row.name, path, dataFormat, row.credentialid)
 
   private def parseAttachments(rows: List[DatasetLayerAttachmentsRow], useRealPaths: Boolean): Fox[AttachmentWrapper] =
     for {
@@ -1403,7 +1403,7 @@ class DatasetLayerAttachmentDAO @Inject() (sqlClient: SqlClient)(implicit ec: Ex
   ): Fox[AttachmentWrapper] =
     for {
       rows <- run(
-        q"""SELECT _dataset, layerName, name, path, realpath, hasLocalData, type, dataFormat, uploadToPathIsPending, uploadIsPending
+        q"""SELECT _dataset, layerName, name, path, realpath, hasLocalData, type, dataFormat, credentialId, uploadToPathIsPending, uploadIsPending
                 FROM webknossos.dataset_layer_attachments
                 WHERE _dataset = $datasetId
                 AND layerName = $layerName
@@ -1416,9 +1416,9 @@ class DatasetLayerAttachmentDAO @Inject() (sqlClient: SqlClient)(implicit ec: Ex
   def updateAttachments(datasetId: ObjectId, dataLayers: List[StaticLayer]): Fox[Unit] = {
     def insertQuery(attachment: LayerAttachment, layerName: String, attachmentType: LayerAttachmentType.Value) = {
       val query =
-        q"""INSERT INTO webknossos.dataset_layer_attachments(_dataset, layerName, name, path, type, dataFormat, uploadToPathIsPending, uploadIsPending)
+        q"""INSERT INTO webknossos.dataset_layer_attachments(_dataset, layerName, name, path, type, dataFormat, credentialId, uploadToPathIsPending, uploadIsPending)
           VALUES($datasetId, $layerName, ${attachment.name}, ${attachment.path}, $attachmentType::webknossos.LAYER_ATTACHMENT_TYPE,
-          ${attachment.dataFormat}::webknossos.LAYER_ATTACHMENT_DATAFORMAT, ${false}, ${false})"""
+          ${attachment.dataFormat}::webknossos.LAYER_ATTACHMENT_DATAFORMAT, ${attachment.credentialId}, ${false}, ${false})"""
       query.asUpdate
     }
 
@@ -1537,7 +1537,7 @@ class DatasetLayerAttachmentDAO @Inject() (sqlClient: SqlClient)(implicit ec: Ex
   ): Fox[LayerAttachment] =
     for {
       rows <- run(
-        q"""SELECT _dataset, layerName, name, path, realpath, hasLocalData, type, dataFormat, uploadToPathIsPending, uploadIsPending
+        q"""SELECT _dataset, layerName, name, path, realpath, hasLocalData, type, dataFormat, credentialId, uploadToPathIsPending, uploadIsPending
                       FROM webknossos.dataset_layer_attachments
                       WHERE _dataset = $datasetId
                       AND layerName = $layerName
@@ -1558,7 +1558,7 @@ class DatasetLayerAttachmentDAO @Inject() (sqlClient: SqlClient)(implicit ec: Ex
   ): Fox[LayerAttachment] =
     for {
       rows <- run(
-        q"""SELECT _dataset, layerName, name, path, realpath, hasLocalData, type, dataFormat, uploadToPathIsPending, uploadIsPending
+        q"""SELECT _dataset, layerName, name, path, realpath, hasLocalData, type, dataFormat, credentialId, uploadToPathIsPending, uploadIsPending
                       FROM webknossos.dataset_layer_attachments
                       WHERE _dataset = $datasetId
                       AND layerName = $layerName

--- a/schema/evolutions/177-attachment-credential-id.sql
+++ b/schema/evolutions/177-attachment-credential-id.sql
@@ -1,0 +1,9 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 176 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+ALTER TABLE webknossos.dataset_layer_attachments ADD COLUMN credentialId TEXT;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 177;
+
+COMMIT TRANSACTION;

--- a/schema/evolutions/reversions/177-attachment-credential-id.sql
+++ b/schema/evolutions/reversions/177-attachment-credential-id.sql
@@ -1,0 +1,9 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 177 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+ALTER TABLE webknossos.dataset_layer_attachments DROP COLUMN credentialId;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 176;
+
+COMMIT TRANSACTION;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
 
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(176);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(177);
 COMMIT TRANSACTION;
 
 
@@ -190,6 +190,7 @@ CREATE TABLE webknossos.dataset_layer_attachments(
   hasLocalData BOOLEAN NOT NULL DEFAULT FALSE,
   type webknossos.LAYER_ATTACHMENT_TYPE NOT NULL,
   dataFormat webknossos.LAYER_ATTACHMENT_DATAFORMAT NOT NULL,
+  credentialId TEXT,
   uploadToPathIsPending BOOLEAN NOT NULL DEFAULT FALSE,
   uploadIsPending BOOLEAN NOT NULL DEFAULT FALSE,
   PRIMARY KEY(_dataset, layerName, name, type)

--- a/unreleased_changes/9873.md
+++ b/unreleased_changes/9873.md
@@ -1,0 +1,5 @@
+### Fixed
+- Fixed loading attachments like mesh files for remote datasets with user-supplied credentials. Existing datasets may need to be re-imported for this fix to reach them.
+
+### Postgres Evolutions
+- [177-attachment-credential-id.sql](schema/evolutions/177-attachment-credential-id.sql)


### PR DESCRIPTION
### Summary
Fixes loading attachments like mesh files for remote datasets with user-supplied credentials. Existing datasets may need to be re-imported for this fix to reach them.

The explore code already correctly added the credentialId for the attachments, but when persisting it to the database, this was dropped.

### Steps to test:
(I already tested locally)
- Explore remote segmentation with user-supplied credentials (compare https://scm.slack.com/archives/C02H5T8Q08P/p1786006863565009 )
- Should be able to load precomputed meshes

### Issues:
- fixes #9872

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Added migration guide entry if applicable (edit the same file as for the changelog)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
