### PR TITLE
Wrap schema refresh stamp file creation in try/catch in dbtool

### DIFF
--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -191,8 +191,12 @@ function refreshSchema() {
 }
 
 function updateRefreshStamp() {
-  fs.mkdirSync(path.dirname(refreshStampPath), { recursive: true });
-  fs.writeFileSync(refreshStampPath, `Last schema changes by dbtool.js applied at ${new Date().toISOString()}.\n`);
+  try {
+    fs.mkdirSync(path.dirname(refreshStampPath), { recursive: true });
+    fs.writeFileSync(refreshStampPath, `Last schema changes by dbtool.js applied at ${new Date().toISOString()}.\n`);
+  } catch (e) {
+    console.warn(`Could not write schema refresh stamp file (this is expected in production setups): ${e.message}`);
+  }
 }
 
 function dumpCurrentSchema(databaseUrl, schemaDir, silent = false) {

--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -390,7 +390,6 @@ function applyEvolutions() {
       ]);
     }
     console.log("✨✨ Successfully applied the evolutions");
-    updateRefreshStamp();
   } else {
     console.log("There are no evolutions that can be applied.");
   }

--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -191,12 +191,8 @@ function refreshSchema() {
 }
 
 function updateRefreshStamp() {
-  try {
-    fs.mkdirSync(path.dirname(refreshStampPath), { recursive: true });
-    fs.writeFileSync(refreshStampPath, `Last schema changes by dbtool.js applied at ${new Date().toISOString()}.\n`);
-  } catch (e) {
-    console.warn(`Could not write schema refresh stamp file (this is expected in production setups): ${e.message}`);
-  }
+  fs.mkdirSync(path.dirname(refreshStampPath), { recursive: true });
+  fs.writeFileSync(refreshStampPath, `Last schema changes by dbtool.js applied at ${new Date().toISOString()}.\n`);
 }
 
 function dumpCurrentSchema(databaseUrl, schemaDir, silent = false) {


### PR DESCRIPTION
This stamp file is only relevant for dev setup. In production, the relevant directories may not be writable so this can fail. Since applyEvolutions is mostly used in production, let’s skip this step there. That means that if applyEvolutions is used during development, the slick regeneration may get outdated.