### PR TITLE
Fix 415 Unsupported Media Type when cancelling a dataset upload

### DIFF
--- a/unreleased_changes/9880.md
+++ b/unreleased_changes/9880.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a "415 Unsupported Media Type" error when cancelling a dataset upload. [#9880](https://github.com/scalableminds/webknossos/pull/9880)

--- a/unreleased_changes/9880.md
+++ b/unreleased_changes/9880.md
@@ -1,2 +1,2 @@
 ### Fixed
-- Fixed a "415 Unsupported Media Type" error when cancelling a dataset upload. [#9880](https://github.com/scalableminds/webknossos/pull/9880)
+- Fixed a "415 Unsupported Media Type" error when cancelling a dataset upload.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/UploadController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/UploadController.scala
@@ -10,7 +10,6 @@ import com.scalableminds.webknossos.datastore.services.{
 }
 import com.scalableminds.webknossos.datastore.services.uploading.{
   AttachmentUploadInfo,
-  CancelUploadInformation,
   DatasetUploadInfo,
   MagUploadInfo,
   UploadDomain,
@@ -214,15 +213,15 @@ class UploadController @Inject() (
     }
   }
 
-  def cancelUpload(uploadDomain: String, uploadId: String): Action[CancelUploadInformation] =
-    Action.fox(validateJson[CancelUploadInformation]) { implicit request =>
+  def cancelUpload(uploadDomain: String, uploadId: String): Action[AnyContent] =
+    Action.fox { implicit request =>
       for {
         uploadDomainValidated <- UploadDomain.fromString(uploadDomain).toFox
         _ <- Fox.fromBool(
           uploadDomainValidated == UploadDomain.dataset
         ) ?~> "Cancel upload is only supported for datasets."
         datasetIdFox = uploadService.isKnownUpload(uploadId, uploadDomainValidated).flatMap {
-          case false => Fox.failure(Msg.Dataset.Upload.noSuchUpload(request.body.uploadId, uploadDomain))
+          case false => Fox.failure(Msg.Dataset.Upload.noSuchUpload(uploadId, uploadDomain))
           case true  => uploadService.getDatasetIdByUploadId(uploadId, uploadDomainValidated)
         }
         result <- datasetIdFox.flatMap { datasetId =>

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala
@@ -161,11 +161,6 @@ object LinkedLayerIdentifier {
   implicit val jsonFormat: OFormat[LinkedLayerIdentifier] = Json.format[LinkedLayerIdentifier]
 }
 
-case class CancelUploadInformation(uploadId: String)
-object CancelUploadInformation {
-  implicit val jsonFormat: OFormat[CancelUploadInformation] = Json.format[CancelUploadInformation]
-}
-
 class UploadService @Inject() (
     dataSourceService: DataSourceService,
     datasetUploadMetadataStore: DatasetUploadMetadataStore,


### PR DESCRIPTION
### Summary
`cancelUpload` was declared as `Action[CancelUploadInformation]` with `validateJson`, so Play rejected the frontend's bodyless POST with 415. The `uploadId` already comes from the query string (bound by the route), so the body is unnecessary — the action is now `AnyContent`, mirroring `finishUpload`. The now-unused `CancelUploadInformation` case class was removed.

### Steps to test:
- Start a dataset upload and cancel it before it finishes; the upload is cancelled without an error toast.

------
- [x] Needs datastore update after deployment