### PR TITLE
Ensure user is attentive to control toast duration

### DIFF
--- a/frontend/javascripts/libs/toast.tsx
+++ b/frontend/javascripts/libs/toast.tsx
@@ -142,12 +142,8 @@ const Toast = {
       this.closePendingToastsEarlyMap[key]?.();
       let cancelledTimeout = false;
       const timeoutToastManually = async () => {
-        const splitTimeout = timeout / 2;
         await ensureUserIsAttentive();
-        await sleep(splitTimeout);
-        await ensureUserIsAttentive();
-        // If the user was not attentive, show the toast again so that the user doesn't just see the toast disappear.
-        await sleep(splitTimeout);
+        await sleep(timeout);
         if (cancelledTimeout) {
           // If the toast has been closed early, don't close it again.
           return;

--- a/frontend/javascripts/libs/toast.tsx
+++ b/frontend/javascripts/libs/toast.tsx
@@ -2,7 +2,7 @@ import { Collapse, notification } from "antd";
 import debounce from "lodash-es/debounce";
 import type React from "react";
 import { useEffect } from "react";
-import { animationFrame, sleep } from "./utils";
+import { ensureUserIsAttentive, sleep } from "./utils";
 
 export type ToastStyle = "info" | "warning" | "success" | "error";
 export type Message = {
@@ -135,18 +135,18 @@ const Toast = {
       actions: config.customFooter,
     };
 
-    // Make sure that toasts don't just disappear while the user has WK in a background tab (e.g. while uploading large dataset).
-    // Most browsers pause requestAnimationFrame() if the current tab is not active, but Firefox does not seem to do that.
+    // Make sure that toasts don't just disappear while the user is not attentive (e.g. the tab is
+    // in the background, or another OS window covers WK, while uploading a large dataset).
     if (useManualTimeout) {
       // In case a toast with the same key is already open, close it first.
       this.closePendingToastsEarlyMap[key]?.();
       let cancelledTimeout = false;
       const timeoutToastManually = async () => {
         const splitTimeout = timeout / 2;
-        await animationFrame(); // ensure tab is active
+        await ensureUserIsAttentive();
         await sleep(splitTimeout);
-        await animationFrame();
-        // If the user has switched the tab, show the toast again so that the user doesn't just see the toast disappear.
+        await ensureUserIsAttentive();
+        // If the user was not attentive, show the toast again so that the user doesn't just see the toast disappear.
         await sleep(splitTimeout);
         if (cancelledTimeout) {
           // If the toast has been closed early, don't close it again.

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -534,6 +534,27 @@ export function animationFrame(maxTimeout?: number): Promise<number | undefined>
   return Promise.race([rafPromise, timeoutPromise]);
 }
 
+// Waits until the user is actually attentive, i.e., they moved the mouse or pressed a key.
+// This is more reliable than the Page Visibility API, which can still report the page as visible
+// even when another OS window fully covers it.
+// On touch devices, mouse/keyboard events don't occur, so an animation frame is used as a fallback.
+export function ensureUserIsAttentive(): Promise<void> {
+  const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  if (isTouchDevice) {
+    return animationFrame().then(() => {});
+  }
+
+  return new Promise((resolve) => {
+    const onUserActivity = () => {
+      window.removeEventListener("mousemove", onUserActivity);
+      window.removeEventListener("keydown", onUserActivity);
+      resolve();
+    };
+    window.addEventListener("mousemove", onUserActivity);
+    window.addEventListener("keydown", onUserActivity);
+  });
+}
+
 export function diffArrays<T>(
   stateA: Array<T>,
   stateB: Array<T>,

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -555,7 +555,6 @@ export function ensureUserIsAttentive(): Promise<void> {
     window.addEventListener("keydown", onUserActivity);
     window.addEventListener("wheel", onUserActivity);
   });
-
 }
 
 export function diffArrays<T>(

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -519,12 +519,10 @@ function _busyWaitDevHelper(time: number) {
   }
 }
 
-export function animationFrame(maxTimeout?: number): Promise<number | undefined> {
-  const rafPromise: Promise<ReturnType<typeof window.requestAnimationFrame>> = new Promise(
-    (resolve) => {
-      window.requestAnimationFrame(resolve);
-    },
-  );
+export function animationFrame(maxTimeout?: number): Promise<undefined> {
+  const rafPromise = new Promise<undefined>((resolve) => {
+    window.requestAnimationFrame(() => resolve(undefined));
+  });
 
   if (maxTimeout == null) {
     return rafPromise;
@@ -537,22 +535,27 @@ export function animationFrame(maxTimeout?: number): Promise<number | undefined>
 // Waits until the user is actually attentive, i.e., they moved the mouse or pressed a key.
 // This is more reliable than the Page Visibility API, which can still report the page as visible
 // even when another OS window fully covers it.
-// On touch devices, mouse/keyboard events don't occur, so an animation frame is used as a fallback.
+// Devices without a mouse/trackpad (e.g. tablets) never fire mousemove, so an animation frame is
+// used as a fallback there. This is checked via "any-pointer: fine" rather than touch support, since
+// convertible devices (e.g. 2-in-1 laptops) can have both a touchscreen and a mouse attached.
 export function ensureUserIsAttentive(): Promise<void> {
-  const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
-  if (isTouchDevice) {
-    return animationFrame().then(() => {});
+  const hasFinePointer = window.matchMedia?.("(any-pointer: fine)").matches ?? true;
+  if (!hasFinePointer) {
+    return animationFrame();
   }
 
   return new Promise((resolve) => {
     const onUserActivity = () => {
       window.removeEventListener("mousemove", onUserActivity);
       window.removeEventListener("keydown", onUserActivity);
+      window.removeEventListener("wheel", onUserActivity);
       resolve();
     };
     window.addEventListener("mousemove", onUserActivity);
     window.addEventListener("keydown", onUserActivity);
+    window.addEventListener("wheel", onUserActivity);
   });
+
 }
 
 export function diffArrays<T>(

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -130,7 +130,7 @@ async function initApp() {
     // todop: remove again
     sleep(2000).then(async () => {
       Toast.error("you should see this error for 3 s", {
-        timeout: 3000
+        timeout: 3000,
       });
     });
 

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -32,8 +32,6 @@ import { checkAnyOrganizationExists, getOrganization } from "admin/api/organizat
 import { CheckCertificateModal } from "components/check_certificate_modal";
 import DisableGenericDnd from "components/disable_generic_dnd";
 import { CheckTermsOfServices } from "components/terms_of_services_check";
-import Toast from "libs/toast";
-import { sleep } from "libs/utils";
 import { RouterProvider } from "react-router-dom";
 import router from "router/router";
 import { getThemeFromUser } from "theme";
@@ -126,13 +124,6 @@ async function initApp() {
       loadHasOrganizations(),
     ]);
     await loadOrganization();
-
-    // todop: remove again
-    sleep(2000).then(async () => {
-      Toast.error("you should see this error for 3 s", {
-        timeout: 3000,
-      });
-    });
 
     // In dev setup the original title indicates loading. That’s done now.
     // Note that this doesn’t use the TabTitle component so that we avoid having multiple ones at once.

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -32,6 +32,8 @@ import { checkAnyOrganizationExists, getOrganization } from "admin/api/organizat
 import { CheckCertificateModal } from "components/check_certificate_modal";
 import DisableGenericDnd from "components/disable_generic_dnd";
 import { CheckTermsOfServices } from "components/terms_of_services_check";
+import Toast from "libs/toast";
+import { sleep } from "libs/utils";
 import { RouterProvider } from "react-router-dom";
 import router from "router/router";
 import { getThemeFromUser } from "theme";
@@ -124,6 +126,13 @@ async function initApp() {
       loadHasOrganizations(),
     ]);
     await loadOrganization();
+
+    // todop: remove again
+    sleep(2000).then(async () => {
+      Toast.error("you should see this error for 3 s", {
+        timeout: 3000
+      });
+    });
 
     // In dev setup the original title indicates loading. That’s done now.
     // Note that this doesn’t use the TabTitle component so that we avoid having multiple ones at once.

--- a/unreleased_changes/9887.md
+++ b/unreleased_changes/9887.md
@@ -1,0 +1,2 @@
+### Changed
+- Improved that user notifications don't auto-close anymore when the user is not active on the WEBKNOSSOS page.


### PR DESCRIPTION
### Summary
Most notifications to the user ("toasts") auto-close after a certain duration. If the WK tab was in the background that duration was increased by using requestAnimationFrame (because browsers typically pause these when a tab is in the background). However, the window might as well be minimized, covered by another window or the user might get some coffee and can miss the notification for that reason.
This PR changes the code so that it is ensured that the user is "attentive". This is done by waiting for a mouse or keyboard event. Only afterwards, the auto-close duration is started. On touch devices the old requestAnimationFrame method is used.

### Steps to test:
- for testing I added a simple toast to all pages
- open wk
- switch to another tab or focus another window
- wait for a few seconds
- switch back to WK --> the toast should be visible for 3 seconds


### Issues:
- #4719

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
