### PR TITLE
Add "Oldy but Goldy" videos to docs

### DIFF
--- a/docs/automation/animations.md
+++ b/docs/automation/animations.md
@@ -2,7 +2,8 @@
 
 A picture is worth a thousand words. In this spirit, you can use WEBKNOSSOS to create eye-catching animations of your datasets as a video clip. You can use these short movies as part of a presentation, website, for social media or to promote a publication.
 
-![type:video](https://static.webknossos.org/assets/docs/webknossos_animation_example.mp4){: autoplay loop muted}
+Watch this short video on how to create an animation:
+![youtube-video](https://www.youtube.com/embed/K0ToMhFlE-Y)
 
 ## Creating an Animation
 

--- a/docs/meshes/working_with_meshes.md
+++ b/docs/meshes/working_with_meshes.md
@@ -2,6 +2,9 @@
 
 Any meshes listed in the `Segments` tab can be downloaded as an industry-standard STL file for further rendering/animation, e.g., in Blender ([Read more in this blog series](https://medium.com/scalableminds/how-to-make-great-videos-for-biomedical-microscopy-data-51218ffa2421)). Hover over the list entry for the desired mesh to reveal a shortcut menu for downloading, reloading, and unloading/removing meshes.
 
+Watch this short walkthrough of working with meshes in WEBKNOSSOS:
+![youtube-video](https://www.youtube.com/embed/ErRCAOd854w)
+
 Mesh visibility can also be toggled from the `Segments` tab using the visibility checkbox next to each segment entry.
 
 ++shift++ + Click on any mesh in the 3D viewport will navigate WEBKNOSSOS to that position.

--- a/docs/ui/object_info.md
+++ b/docs/ui/object_info.md
@@ -44,6 +44,9 @@ The `Segments` tab is for managing volume annotations. It lists all the segments
 
 The `BBoxes` tab lists all the bounding boxes in the annotation and is the central place to manage them. It provides an alternative to drawing boxes with the `Bounding Box` tool from the [toolbar](./toolbar.md).
 
+Watch this short video for an overview of the bounding box tool:
+![youtube-video](https://www.youtube.com/embed/2mgqDvUZ9Dk)
+
 ### Creating Bounding Boxes
 
 The buttons at the top of the tab let you:

--- a/docs/volume_annotation/segments_list.md
+++ b/docs/volume_annotation/segments_list.md
@@ -13,10 +13,10 @@ The following functionality is available for each segment:
 - activating the segment id (so that you can annotate with that id)
 - organizing your segments in groups
 
-![youtube-video](https://www.youtube.com/embed/BJ7lblTSVKY)
+Watch this short video for an overview of the segments list:
+![youtube-video](https://www.youtube.com/embed/3QYBQjL1fls)
 
 Working with groups allows you to perform batch actions on a whole group of segments (e.g. changing the color, loading meshes, ...)
-![youtube-video](https://www.youtube.com/embed/lz-3kFWQ2H8)
 
 ## Segment Groups
 


### PR DESCRIPTION
Embed YouTube videos on the bounding box tool, working with meshes, the segments list (replacing two older clips), and animations (replacing the demo mp4).