### PR TITLE
Fix API v14 largestSegmentId format

### DIFF
--- a/conf/webknossos.versioned.routes
+++ b/conf/webknossos.versioned.routes
@@ -21,6 +21,7 @@
 
 ->       /v15/                                                                webknossos.latest.Routes
 
+# v14: support changes to v15
 GET      /v14/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v14/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v14/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)

--- a/conf/webknossos.versioned.routes
+++ b/conf/webknossos.versioned.routes
@@ -21,6 +21,9 @@
 
 ->       /v15/                                                                webknossos.latest.Routes
 
+GET      /v14/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
+GET      /v14/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
+PATCH    /v14/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)
 ->       /v14/                                                                webknossos.latest.Routes
 
 # v13: support changes to v15


### PR DESCRIPTION
This was only wired to v13 and down, but v14 also needs to write the old format. Only v15 should default to latest for these routes.