### PR TITLE
Mirror uint64 legacy API also for datastore

### DIFF
--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -112,6 +112,24 @@ class LegacyApiController @Inject() (
       } yield adaptedResult
     }
 
+  def reserveUploadToPathsV14(): Action[ReserveDatasetUploadToPathsRequest] =
+    sil.SecuredAction.fox(validateJson[ReserveDatasetUploadToPathsRequest]) { implicit request =>
+      for {
+        result <- Fox.fromFuture(datasetController.reserveUploadToPaths()(request))
+        adaptedResult <- replaceInResult(downgradeLargestSegmentIdsIfSafeFox)(result)
+      } yield adaptedResult
+    }
+
+  def reserveUploadToPathsForPreliminaryV14(
+      datasetId: ObjectId
+  ): Action[ReserveDatasetUploadToPathsForPreliminaryRequest] =
+    sil.SecuredAction.fox(validateJson[ReserveDatasetUploadToPathsForPreliminaryRequest]) { implicit request =>
+      for {
+        result <- Fox.fromFuture(datasetController.reserveUploadToPathsForPreliminary(datasetId)(request))
+        adaptedResult <- replaceInResult(downgradeLargestSegmentIdsIfSafeFox)(result)
+      } yield adaptedResult
+    }
+
   /* provide v12 */
 
   def updatePartialV12(datasetId: ObjectId): Action[DatasetUpdatePartialParameters] =

--- a/conf/webknossos.versioned.routes
+++ b/conf/webknossos.versioned.routes
@@ -4,7 +4,7 @@
 # Note: keep this in sync with the reported version numbers in the com.scalableminds.util.mvc.ApiVersioning trait
 
 # version log
- # changed in v15: largestSegmentId is now written using a bigint envelope (to support the full uint64 range) for /datasets/:datasetId, /datasets and PATCH /datasets/:datasetId/updatePartial. Older API versions keep receiving it as a plain number whenever that does not lose precision.
+ # changed in v15: largestSegmentId is now written using a bigint envelope (to support the full uint64 range) for routes that return datasources. Older API versions keep receiving it as a plain number whenever that does not lose precision.
  # changed in v14: Dataset upload routes and parameters have been refactored, introduced upload domain
  # changed in v13: Attachments not mentioned in the dataSource passed to updatePartial will now be deleted.
  # changed in v12: Dataset upload now expects layersToLink in new format with datasetId instead of orgaId+directoryName
@@ -25,36 +25,48 @@
 GET      /v14/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v14/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v14/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)
+POST     /v14/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v14/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v14/                                                                webknossos.latest.Routes
 
 # v13: support changes to v15
 GET      /v13/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v13/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v13/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)
+POST     /v13/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v13/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v13/                                                                webknossos.latest.Routes
 
 # v12: support changes to v15
 GET      /v12/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v12/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v12/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
+POST     /v12/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v12/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v12/                                                                webknossos.latest.Routes
 
 # v11: support changes to v15
 GET      /v11/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v11/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v11/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
+POST     /v11/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v11/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v11/                                                                webknossos.latest.Routes
 
 # v10: support changes to v15
 GET      /v10/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v10/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v10/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
+POST     /v10/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v10/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v10/                                                                webknossos.latest.Routes
 
 # v9: support changes to v15
 GET      /v9/datasets/:datasetId                                              controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v9/datasets                                                         controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v9/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
+POST     /v9/datasets/reserveUploadToPaths                                    controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v9/datasets/:datasetId/reserveUploadToPathsForPreliminary           controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v9/                                                                 webknossos.latest.Routes
 
 # v8: support changes to v13
@@ -70,6 +82,8 @@ POST     /v8/tasks                                                            co
 GET      /v8/projects/:id/tasks                                               controllers.LegacyApiController.tasksForProjectV8(id: ObjectId, limit: Option[Int], pageNumber: Option[Int], includeTotalCount: Option[Boolean])
 # v8: support changes to v15
 GET      /v8/datasets                                                         controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
+POST     /v8/datasets/reserveUploadToPaths                                    controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v8/datasets/:datasetId/reserveUploadToPathsForPreliminary           controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 
 ->       /v8/                                                                 webknossos.latest.Routes
 
@@ -88,6 +102,10 @@ GET      /v7/projects/:id/tasks                                               co
 # v7: support changes to v8
 GET      /v7/datasets                                                         controllers.LegacyApiController.listDatasetsV7(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationName: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 
+# v7: support changes to v15
+POST     /v7/datasets/reserveUploadToPaths                                    controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v7/datasets/:datasetId/reserveUploadToPathsForPreliminary           controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
+
 ->       /v7/                                                                 webknossos.latest.Routes
 
 # v6: support changes to v13
@@ -104,6 +122,10 @@ GET      /v6/projects/:id/tasks                                               co
 # v6: support changes to v7
 GET      /v6/datasets                                                         controllers.LegacyApiController.listDatasetsV6(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationName: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 GET      /v6/datasets/:organizationName/:datasetName                          controllers.LegacyApiController.readDatasetV6(organizationName: String, datasetName: String, sharingToken: Option[String])
+
+# v6: support changes to v15
+POST     /v6/datasets/reserveUploadToPaths                                    controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v6/datasets/:datasetId/reserveUploadToPathsForPreliminary           controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 
 ->       /v6/                                                                 webknossos.latest.Routes
 
@@ -125,6 +147,10 @@ GET      /v5/datasets/:organizationName/:datasetName                          co
 
 # v5: support changes to v6
 GET      /v5/datasets/:organizationName/:datasetName/isValidNewName           controllers.LegacyApiController.assertValidNewNameV5(organizationName: String, datasetName: String)
+
+# v5: support changes to v15
+POST     /v5/datasets/reserveUploadToPaths                                    controllers.LegacyApiController.reserveUploadToPathsV14()
+POST     /v5/datasets/:datasetId/reserveUploadToPathsForPreliminary           controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 
 ->       /v5/                                                                 webknossos.latest.Routes
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSLegacyApiController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DSLegacyApiController.scala
@@ -4,10 +4,11 @@ import com.scalableminds.util.Msg
 import com.google.inject.Inject
 import com.scalableminds.util.box.Full
 import com.scalableminds.util.objectid.ObjectId
-import com.scalableminds.util.tools.Fox
+import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.DataStoreConfig
 import com.scalableminds.webknossos.datastore.dataformats.zarr.Zarr3OutputHelper
+import com.scalableminds.webknossos.datastore.helpers.UnsignedLong
 import com.scalableminds.webknossos.datastore.models.{
   RawCuboidRequest,
   WebknossosAdHocMeshRequest,
@@ -29,8 +30,9 @@ import com.scalableminds.webknossos.datastore.services.{
   DatasetCache,
   UserAccessRequest
 }
+import play.api.http.HttpEntity
 import play.api.libs.Files
-import play.api.libs.json.{JsObject, Json, OFormat}
+import play.api.libs.json.{JsObject, JsValue, Json, OFormat}
 import play.api.mvc.{Action, AnyContent, MultipartFormData, PlayBodyParsers, RawBuffer, Result}
 
 import java.nio.file.Path
@@ -119,6 +121,7 @@ class DSLegacyApiController @Inject() (
     remoteWebknossosClient: DSRemoteWebknossosClient,
     binaryDataController: BinaryDataController,
     zarrStreamingController: ZarrStreamingController,
+    dataProxyController: DataProxyController,
     meshController: DSMeshController,
     dataSourceController: DataSourceController,
     dataSourceService: DataSourceService,
@@ -131,6 +134,22 @@ class DSLegacyApiController @Inject() (
     with Zarr3OutputHelper {
 
   override def allowRemoteOrigin: Boolean = true
+
+  def proxyDatasourceV14(datasetId: ObjectId): Action[AnyContent] = Action.async { implicit request =>
+    withDowngradedLargestSegmentIds(dataProxyController.proxyDatasource(datasetId)(request))
+  }
+
+  def requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int): Action[AnyContent] = Action.async {
+    implicit request =>
+      withDowngradedLargestSegmentIds(zarrStreamingController.requestDataSource(datasetId, zarrVersion)(request))
+  }
+
+  def dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int): Action[AnyContent] =
+    Action.async { implicit request =>
+      withDowngradedLargestSegmentIds(
+        zarrStreamingController.dataSourceWithAnnotationPrivateLink(accessTokenOrId, zarrVersion)(request)
+      )
+    }
 
   def testChunkV13(resumableChunkNumber: Int, resumableIdentifier: String): Action[AnyContent] =
     uploadController.testChunk(resumableChunkNumber, resumableIdentifier, UploadDomain.dataset.toString)
@@ -467,7 +486,7 @@ class DSLegacyApiController @Inject() (
       zarrVersion: Int
   ): Action[AnyContent] = Action.async { implicit request =>
     withResolvedDatasetId(organizationId, datasetDirectoryName) { datasetId =>
-      zarrStreamingController.requestDataSource(datasetId, zarrVersion)(request)
+      withDowngradedLargestSegmentIds(zarrStreamingController.requestDataSource(datasetId, zarrVersion)(request))
     }
   }
 
@@ -631,4 +650,25 @@ class DSLegacyApiController @Inject() (
           )
       }
     } yield result
+
+  // For API versions <= 14, largestSegmentId must keep being written as a plain JsNumber (rather than the
+  // UnsignedLong bigint envelope) whenever that does not lose precision, for backwards compatibility with
+  // clients that do not understand that newer format (see UnsignedLong.scala). This mirrors the analogous
+  // shim in controllers.LegacyApiController of the webknossos app.
+  private def withDowngradedLargestSegmentIds(result: Future[Result]): Future[Result] =
+    result.map { r =>
+      if (r.header.status == OK) {
+        r.body match {
+          case HttpEntity.Strict(data, _) =>
+            JsonHelper.parseAs[JsValue](data.toArray) match {
+              case Full(jsValue) =>
+                val downgraded =
+                  JsonHelper.patchKeyRecursively(jsValue, "largestSegmentId")(UnsignedLong.downgradeToPlainNumberIfSafe)
+                Ok(downgraded).copy(header = r.header)
+              case _ => r
+            }
+          case _ => r
+        }
+      } else r
+    }
 }

--- a/webknossos-datastore/conf/datastore.versioned.routes
+++ b/webknossos-datastore/conf/datastore.versioned.routes
@@ -3,6 +3,12 @@
 
 ->  /v15/ datastore.latest.Routes
 
+GET           /v14/datasets/:datasetId/proxy/datasource-properties.json                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v14/zarr/:datasetId/datasource-properties.json                                                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v14/zarr3_experimental/:datasetId/datasource-properties.json                                                                              @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v14/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                          @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v14/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
+
 ->  /v14/ datastore.latest.Routes
 
 # Dataset upload
@@ -11,6 +17,12 @@ POST          /v13/datasets                                                     
 POST          /v13/datasets/reserveUpload                                                                                                                @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveDatasetUploadV13()
 GET           /v13/datasets/unfinishedUploads                                                                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.getUnfinishedUploadsV13(organizationName: String)
 POST          /v13/datasets/finishUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.finishUploadV13()
+
+GET           /v13/datasets/:datasetId/proxy/datasource-properties.json                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v13/zarr/:datasetId/datasource-properties.json                                                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v13/zarr3_experimental/:datasetId/datasource-properties.json                                                                              @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v13/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                          @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v13/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
 
 ->  /v13/ datastore.latest.Routes
 
@@ -21,6 +33,12 @@ POST          /v12/datasets/reserveUpload                                       
 GET           /v12/datasets/unfinishedUploads                                                                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.getUnfinishedUploadsV13(organizationName: String)
 POST          /v12/datasets/finishUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.finishUploadV13()
 
+GET           /v12/datasets/:datasetId/proxy/datasource-properties.json                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v12/zarr/:datasetId/datasource-properties.json                                                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v12/zarr3_experimental/:datasetId/datasource-properties.json                                                                              @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v12/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                          @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v12/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
+
 ->  /v12/ datastore.latest.Routes
 
 # Dataset upload
@@ -30,6 +48,12 @@ GET           /v11/datasets/unfinishedUploads                                   
 POST          /v11/datasets/finishUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.finishUploadV13()
 # Dataset upload (v11 and older is separate!)
 POST          /v11/datasets/reserveUpload                                                                                                                @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveUploadV11()
+
+GET           /v11/datasets/:datasetId/proxy/datasource-properties.json                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v11/zarr/:datasetId/datasource-properties.json                                                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v11/zarr3_experimental/:datasetId/datasource-properties.json                                                                              @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v11/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                          @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v11/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
 
 ->  /v11/ datastore.latest.Routes
 
@@ -42,6 +66,12 @@ GET           /v10/datasets/unfinishedUploads                                   
 POST          /v10/datasets/finishUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.finishUploadV13()
 # Dataset upload (v11 and older is separate!)
 POST          /v10/datasets/reserveUpload                                                                                                                @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveUploadV11()
+
+GET           /v10/datasets/:datasetId/proxy/datasource-properties.json                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v10/zarr/:datasetId/datasource-properties.json                                                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v10/zarr3_experimental/:datasetId/datasource-properties.json                                                                              @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v10/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                          @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v10/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                            @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
 
 ->  /v10/ datastore.latest.Routes
 
@@ -95,6 +125,12 @@ GET           /v9/datasets/unfinishedUploads                                    
 POST          /v9/datasets/finishUpload                                                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.finishUploadV13()
 # Dataset upload (v11 and older is separate!)
 POST          /v9/datasets/reserveUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveUploadV11()
+
+GET           /v9/datasets/:datasetId/proxy/datasource-properties.json                                                                                   @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v9/zarr/:datasetId/datasource-properties.json                                                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v9/zarr3_experimental/:datasetId/datasource-properties.json                                                                               @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v9/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                           @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v9/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
 
 ->  /v9/  datastore.latest.Routes
 
@@ -150,6 +186,12 @@ POST          /v8/datasets/finishUpload                                         
 # Dataset upload (v11 and older is separate!)
 POST          /v8/datasets/reserveUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveUploadV11()
 
+GET           /v8/datasets/:datasetId/proxy/datasource-properties.json                                                                                   @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v8/zarr/:datasetId/datasource-properties.json                                                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v8/zarr3_experimental/:datasetId/datasource-properties.json                                                                               @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v8/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                           @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v8/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
+
 ->  /v8/  datastore.latest.Routes
 
 # Read image data
@@ -202,6 +244,12 @@ GET           /v7/datasets/unfinishedUploads                                    
 POST          /v7/datasets/finishUpload                                                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.finishUploadV13()
 # Dataset upload (v11 and older is separate!)
 POST          /v7/datasets/reserveUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveUploadV11()
+
+GET           /v7/datasets/:datasetId/proxy/datasource-properties.json                                                                                   @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v7/zarr/:datasetId/datasource-properties.json                                                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v7/zarr3_experimental/:datasetId/datasource-properties.json                                                                               @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v7/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                           @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v7/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
 
 ->  /v7/  datastore.latest.Routes
 
@@ -256,6 +304,12 @@ POST          /v6/datasets/finishUpload                                         
 # Dataset upload (v11 and older is separate!)
 POST          /v6/datasets/reserveUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveUploadV11()
 
+GET           /v6/datasets/:datasetId/proxy/datasource-properties.json                                                                                   @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v6/zarr/:datasetId/datasource-properties.json                                                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v6/zarr3_experimental/:datasetId/datasource-properties.json                                                                               @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v6/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                           @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v6/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
+
 ->  /v6/  datastore.latest.Routes
 
 # Read image data
@@ -306,6 +360,12 @@ GET           /v5/datasets/unfinishedUploads                                    
 POST          /v5/datasets/finishUpload                                                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.finishUploadV13()
 # Dataset upload (v11 and older is separate!)
 POST          /v5/datasets/reserveUpload                                                                                                                 @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.reserveUploadV11()
+
+GET           /v5/datasets/:datasetId/proxy/datasource-properties.json                                                                                   @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)
+GET           /v5/zarr/:datasetId/datasource-properties.json                                                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 2)
+GET           /v5/zarr3_experimental/:datasetId/datasource-properties.json                                                                               @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.requestDataSourceV14(datasetId: ObjectId, zarrVersion: Int = 3)
+GET           /v5/annotations/zarr/:accessTokenOrId/datasource-properties.json                                                                           @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 2)
+GET           /v5/annotations/zarr3_experimental/:accessTokenOrId/datasource-properties.json                                                             @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.dataSourceWithAnnotationPrivateLinkV14(accessTokenOrId: String, zarrVersion: Int = 3)
 
 ->  /v5/  datastore.latest.Routes
 ->  /     datastore.latest.Routes


### PR DESCRIPTION
Follow-up fix for #9765 – this backwards compatibility adapter was missing for the datastore routes.