### PR TITLE
Fix error handling for GoogleCloudStorage reads

### DIFF
--- a/test/backend/DataVaultTestSuite.scala
+++ b/test/backend/DataVaultTestSuite.scala
@@ -109,12 +109,27 @@ class DataVaultTestSuite extends AsyncWordSpec with ParallelTestExecution {
               case _ => fail()
             }
 
-        "return empty box" when {
+        "return empty box, not failure" when {
           "requesting a non-existent object" in
             (vaultPath / s"non-existent-key${UUID.randomUUID}")
               .readBytes()(using globalExecutionContext, emptyTokenContext)
               .futureBox
               .map(assertBoxEmpty)
+
+          "requesting a byte range from an object that does not exist (404)" in {
+            val upath =
+              UPath.fromStringUnsafe("gs://iarpa_microns/minnie/minnie65/seg_m1300/8.0x8.0x40.0/03b1e.shard")
+            val vaultPath = new VaultPath(
+              upath,
+              GoogleCloudDataVault
+                .create(CredentializedUPath(upath, None))
+                .getOrElse(fail("Failed to create GoogleCloudDataVault"))
+            )
+            vaultPath
+              .readBytes(ByteRange.startEndExclusive(0, 1024))(using globalExecutionContext, emptyTokenContext)
+              .futureBox
+              .map(assertBoxEmpty)
+          }
         }
         "return failure" when {
           "requesting invalid range" in
@@ -137,6 +152,23 @@ class DataVaultTestSuite extends AsyncWordSpec with ParallelTestExecution {
               )
             (vaultPath / dataKey)
               .readBytes(ByteRange.startEndExclusive(-10, 10))(using globalExecutionContext, emptyTokenContext)
+              .futureBox
+              .map(assertBoxFailure)
+          }
+
+          "requesting a byte range that extends past the object's actual end" in {
+            val dataKey = "32_32_40/15360-15424_8384-8448_3520-3584"
+            val realObjectSize = 127808
+            val upath = UPath.fromStringUnsafe(s"gs://neuroglancer-fafb-data/fafb_v14/fafb_v14_orig/$dataKey")
+            val vaultPath = new VaultPath(
+              upath,
+              GoogleCloudDataVault
+                .create(CredentializedUPath(upath, None))
+                .getOrElse(fail("Failed to create GoogleCloudDataVault"))
+            )
+            val overreachingRange = ByteRange.startEndExclusive(realObjectSize - 100, realObjectSize + 1000)
+            vaultPath
+              .readBytes(overreachingRange)(using globalExecutionContext, emptyTokenContext)
               .futureBox
               .map(assertBoxFailure)
           }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/NeuroglancerPrecomputedShardingUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/NeuroglancerPrecomputedShardingUtils.scala
@@ -76,11 +76,11 @@ trait NeuroglancerPrecomputedShardingUtils {
      The decoded "minishard index" is a binary string of 24*n bytes, specifying a contiguous C-order array of [3, n]
       uint64le values.
      */
-    val n = bytes.length / 24
-    if (n == 0) {
+    if (bytes.isEmpty) {
       // Minishard with zero chunks
       Array.empty[(Long, Long, Long)]
     } else {
+      val n = bytes.length / 24
       val buf = ByteBuffer.allocate(bytes.length)
       buf.put(bytes)
 

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/NeuroglancerPrecomputedShardingUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/NeuroglancerPrecomputedShardingUtils.scala
@@ -58,11 +58,16 @@ trait NeuroglancerPrecomputedShardingUtils {
   }
 
   private def decodeMinishardIndex(bytes: Array[Byte]) =
-    shardingSpecification.minishard_index_encoding match {
-      case "gzip" => ZipIO.gunzip(bytes)
-      case _      => bytes
-
-    }
+    // An empty minishard index is a legitimate, expected state: cloud-volume/neuroglancer sharded writers skip
+    // writing chunks that are entirely background, so a minishard can genuinely contain zero chunks. Attempting to
+    // gunzip-decode zero bytes would throw (GZIPInputStream reads its header eagerly), so short-circuit here instead
+    // of letting that exception surface as a hard failure below.
+    if (bytes.isEmpty) bytes
+    else
+      shardingSpecification.minishard_index_encoding match {
+        case "gzip" => ZipIO.gunzip(bytes)
+        case _      => bytes
+      }
 
   private def parseMinishardIndex(input: Array[Byte]): Box[Array[(Long, Long, Long)]] = tryo {
     val bytes = decodeMinishardIndex(input)
@@ -72,41 +77,46 @@ trait NeuroglancerPrecomputedShardingUtils {
       uint64le values.
      */
     val n = bytes.length / 24
-    val buf = ByteBuffer.allocate(bytes.length)
-    buf.put(bytes)
+    if (n == 0) {
+      // Minishard with zero chunks
+      Array.empty[(Long, Long, Long)]
+    } else {
+      val buf = ByteBuffer.allocate(bytes.length)
+      buf.put(bytes)
 
-    val longArray = new Array[Long](n * 3)
-    buf.position(0)
-    buf.order(ByteOrder.LITTLE_ENDIAN)
-    buf.asLongBuffer().get(longArray)
-    // longArray is row major / C-order
-    /*
-     From: https://github.com/google/neuroglancer/blob/233fc39b07a0480a8e1c90fc5ca835330a0bf287/src/datasource/precomputed/sharded.md#minishard-index-format
-     Values array[0, 0], ..., array[0, n-1] specify the chunk IDs in the minishard, and are delta encoded, such that
-     array[0, 0] is equal to the ID of the first chunk, and the ID of chunk i is equal to the sum
-     of array[0, 0], ..., array[0, i].
-     */
-    val chunkIds = new Array[Long](n)
-    chunkIds(0) = longArray(0)
-    for (i <- 1 until n)
-      chunkIds(i) = longArray(i) + chunkIds(i - 1)
-    /*
-     From: https://github.com/google/neuroglancer/blob/233fc39b07a0480a8e1c90fc5ca835330a0bf287/src/datasource/precomputed/sharded.md#minishard-index-format
-     The size of the data for chunk i is stored as array[2, i].
-     Values array[1, 0], ..., array[1, n-1] specify the starting offsets in the shard file of the data corresponding to
-     each chunk, and are also delta encoded relative to the end of the prior chunk, such that the starting offset of the
-     first chunk is equal to shard_index_end + array[1, 0], and the starting offset of chunk i is the sum of
-     shard_index_end + array[1, 0], ..., array[1, i] and array[2, 0], ..., array[2, i-1].
-     */
-    val chunkSizes = longArray.slice(2 * n, 3 * n)
-    val chunkStartOffsets = new Array[Long](n)
-    chunkStartOffsets(0) = longArray(n)
-    for (i <- 1 until n) {
-      val startOffsetIndex = i + n
-      chunkStartOffsets(i) = chunkStartOffsets(i - 1) + longArray(startOffsetIndex) + chunkSizes(i - 1)
+      val longArray = new Array[Long](n * 3)
+      buf.position(0)
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.asLongBuffer().get(longArray)
+      // longArray is row major / C-order
+      /*
+       From: https://github.com/google/neuroglancer/blob/233fc39b07a0480a8e1c90fc5ca835330a0bf287/src/datasource/precomputed/sharded.md#minishard-index-format
+       Values array[0, 0], ..., array[0, n-1] specify the chunk IDs in the minishard, and are delta encoded, such that
+       array[0, 0] is equal to the ID of the first chunk, and the ID of chunk i is equal to the sum
+       of array[0, 0], ..., array[0, i].
+       */
+      val chunkIds = new Array[Long](n)
+      chunkIds(0) = longArray(0)
+      for (i <- 1 until n)
+        chunkIds(i) = longArray(i) + chunkIds(i - 1)
+      /*
+       From: https://github.com/google/neuroglancer/blob/233fc39b07a0480a8e1c90fc5ca835330a0bf287/src/datasource/precomputed/sharded.md#minishard-index-format
+       The size of the data for chunk i is stored as array[2, i].
+       Values array[1, 0], ..., array[1, n-1] specify the starting offsets in the shard file of the data corresponding to
+       each chunk, and are also delta encoded relative to the end of the prior chunk, such that the starting offset of the
+       first chunk is equal to shard_index_end + array[1, 0], and the starting offset of chunk i is the sum of
+       shard_index_end + array[1, 0], ..., array[1, i] and array[2, 0], ..., array[2, i-1].
+       */
+      val chunkSizes = longArray.slice(2 * n, 3 * n)
+      val chunkStartOffsets = new Array[Long](n)
+      chunkStartOffsets(0) = longArray(n)
+      for (i <- 1 until n) {
+        val startOffsetIndex = i + n
+        chunkStartOffsets(i) = chunkStartOffsets(i - 1) + longArray(startOffsetIndex) + chunkSizes(i - 1)
+      }
+
+      chunkIds.lazyZip(chunkStartOffsets).lazyZip(chunkSizes).toArray
     }
-
-    chunkIds.lazyZip(chunkStartOffsets).lazyZip(chunkSizes).toArray
   }
 
   def getMinishardIndex(shardPath: VaultPath, minishardNumber: Int)(using
@@ -132,9 +142,10 @@ trait NeuroglancerPrecomputedShardingUtils {
       ec: ExecutionContext
   ): Fox[StartEndExclusiveByteRange] =
     for {
+      // A chunk id absent from an (otherwise successfully read) means fill value, so we use ?->, passing through empty
       chunkSpecification <- minishardIndex
         .find(_._1 == chunkId)
-        .toFox ?~> s"Could not find chunk id $chunkId in minishard index"
+        .toFox ?-> s"Could not find chunk id $chunkId in minishard index"
       chunkStart = (shardIndexRange.end) + chunkSpecification._2
       chunkEnd = (shardIndexRange.end) + chunkSpecification._2 + chunkSpecification._3
     } yield ByteRange.startEndExclusive(chunkStart, chunkEnd)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/precomputed/PrecomputedArray.scala
@@ -97,7 +97,7 @@ class PrecomputedArray(
       chunkRange <- getChunkRange(
         chunkIdentifier,
         minishardIndex
-      ) ?~> s"Could not get chunk range for chunkIndex ${chunkIndex
+      ) ?-> s"Could not get chunk range for chunkIndex ${chunkIndex
           .mkString(",")}  with chunkIdentifier $chunkIdentifier in minishard index."
     } yield (shardPath, chunkRange)
   }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
@@ -51,23 +51,27 @@ class GoogleCloudDataVault(uri: URI, credential: Option[GoogleServiceAccountCred
           range match {
             case r: StartEndExclusiveByteRange =>
               val blobReader = storage.reader(blobId)
-              blobReader.seek(r.start)
-              blobReader.limit(r.end)
-              val bb = ByteBuffer.allocateDirect(r.length)
-              readFully(blobReader, bb)
-              val arr = new Array[Byte](r.length)
-              bb.position(0)
-              bb.get(arr)
-              Fox.successful(arr)
+              try {
+                blobReader.seek(r.start)
+                blobReader.limit(r.end)
+                val bb = ByteBuffer.allocateDirect(r.length)
+                readFully(blobReader, bb)
+                val arr = new Array[Byte](r.length)
+                bb.position(0)
+                bb.get(arr)
+                Fox.successful(arr)
+              } finally blobReader.close()
             case SuffixLengthByteRange(l) =>
               val blobReader = storage.reader(blobId)
-              blobReader.seek(-l)
-              val bb = ByteBuffer.allocateDirect(l)
-              readFully(blobReader, bb)
-              val arr = new Array[Byte](l)
-              bb.position(0)
-              bb.get(arr)
-              Fox.successful(arr)
+              try {
+                blobReader.seek(-l)
+                val bb = ByteBuffer.allocateDirect(l)
+                readFully(blobReader, bb)
+                val arr = new Array[Byte](l)
+                bb.position(0)
+                bb.get(arr)
+                Fox.successful(arr)
+              } finally blobReader.close()
             case CompleteByteRange() =>
               Fox.successful(storage.readAllBytes(bucket, objName, BlobSourceOption.shouldReturnRawInputStream(true)))
           }

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datavault/GoogleCloudDataVault.scala
@@ -4,7 +4,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.storage.Storage.BlobSourceOption
 import com.google.cloud.storage.{BlobId, BlobInfo, Storage, StorageException, StorageOptions}
 import com.scalableminds.util.accesscontext.TokenContext
-import com.scalableminds.util.box.Box
+import com.scalableminds.util.box.{Box, Full}
 import com.scalableminds.util.tools.Fox
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.storage.{CredentializedUPath, GoogleServiceAccountCredential}
@@ -12,9 +12,10 @@ import Box.tryo
 import com.scalableminds.webknossos.datastore.helpers.UPath
 import org.apache.commons.lang3.builder.HashCodeBuilder
 
-import java.io.ByteArrayInputStream
+import java.io.{ByteArrayInputStream, EOFException, IOException}
 import java.net.URI
 import java.nio.ByteBuffer
+import java.nio.channels.ReadableByteChannel
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.{IterableHasAsScala, IteratorHasAsScala}
 
@@ -53,7 +54,7 @@ class GoogleCloudDataVault(uri: URI, credential: Option[GoogleServiceAccountCred
               blobReader.seek(r.start)
               blobReader.limit(r.end)
               val bb = ByteBuffer.allocateDirect(r.length)
-              blobReader.read(bb)
+              readFully(blobReader, bb)
               val arr = new Array[Byte](r.length)
               bb.position(0)
               bb.get(arr)
@@ -62,7 +63,7 @@ class GoogleCloudDataVault(uri: URI, credential: Option[GoogleServiceAccountCred
               val blobReader = storage.reader(blobId)
               blobReader.seek(-l)
               val bb = ByteBuffer.allocateDirect(l)
-              blobReader.read(bb)
+              readFully(blobReader, bb)
               val arr = new Array[Byte](l)
               bb.position(0)
               bb.get(arr)
@@ -71,11 +72,13 @@ class GoogleCloudDataVault(uri: URI, credential: Option[GoogleServiceAccountCred
               Fox.successful(storage.readAllBytes(bucket, objName, BlobSourceOption.shouldReturnRawInputStream(true)))
           }
         catch {
-          case s: StorageException =>
-            if (s.getCode == 404)
-              Fox.empty
-            else Fox.failure(s.getMessage)
-          case t: Throwable => Fox.failure(t.getMessage)
+          case s: StorageException => storageExceptionToFox(s)
+          case e: IOException      =>
+            e.getCause match {
+              case s: StorageException => storageExceptionToFox(s)
+              case _                   => Fox.failure(e.getMessage, Full(e))
+            }
+          case t: Throwable => Fox.failure(t.getMessage, Full(t))
         }
       blobInfo: BlobInfo <- tryo(
         storage.get(
@@ -112,6 +115,18 @@ class GoogleCloudDataVault(uri: URI, credential: Option[GoogleServiceAccountCred
       ) // no currentDirectory(); Do deep recursive listing
       totalSize <- tryo(blobs.iterateAll().iterator().asScala.map(_.getSize).foldLeft(0L)(_ + _))
     } yield totalSize).toFox
+
+  private def readFully(channel: ReadableByteChannel, buffer: ByteBuffer): Unit =
+    while (buffer.hasRemaining) {
+      val bytesRead = channel.read(buffer)
+      if (bytesRead == -1)
+        throw new EOFException(
+          s"Unexpected end of stream while reading from GCS: got ${buffer.position} of ${buffer.capacity} requested bytes"
+        )
+    }
+
+  private def storageExceptionToFox(s: StorageException)(using ec: ExecutionContext): Fox[Array[Byte]] =
+    if (s.getCode == 404) Fox.empty else Fox.failure(s.getMessage, Full(s))
 
   private def getUri = uri
   private def getCredential = credential


### PR DESCRIPTION
### Summary
- Fixes two distinct problems when reading from GCS:
  - matching on `StorageException` to distinguish between Empty and Failure was no longer enough because they are now wrapped in `IOExceptions`. Now we check getCause also.
  - `blobReader.read` was not used correctly. Has to be read with while-hasRemaining-loop. This lead to rare cases of false-positive `EOFException`.
- Adds regression tests for both
- Fixes vaguely related issue: for chunks absent from neuroglancerPrecomputed shards/minishards, we now also propagate Empty rather than Failure.

### Steps to test:
- Import dataset from https://webknossos.org/datasets/microns_minnie65-6a60dd3d9bc23e1845b8b551 locally, check that its segmentation loads correctly, with no error logging in the backend.

### Issues:
- fixes https://scm.slack.com/archives/C02H5T8Q08P/p1786607244178349?thread_ts=1786522381.140529&cid=C02H5T8Q08P

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
