### PR TITLE
Fix too many annotation versions during movement

### DIFF
--- a/frontend/javascripts/viewer/model/sagas/saving/save_queue_filling_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/saving/save_queue_filling_saga.ts
@@ -221,22 +221,34 @@ function performDiffAnnotation(
   prevTdCamera: CameraData,
   tdCamera: CameraData,
 ): Array<UpdateActionWithoutIsolationRequirement> {
-  let actions: Array<UpdateActionWithoutIsolationRequirement> = [];
-
   if (prevFlycam !== flycam) {
-    actions = actions.concat(
+    return [
       updateCameraAnnotation(
         getFlooredPosition(flycam),
         flycam.additionalCoordinates,
         getRotationInDegrees(flycam),
         flycam.zoomStep,
       ),
-    );
+    ];
+  } else if (prevTdCamera !== tdCamera) {
+    // We only emit updateTdCamera actions when the flycam properties did *not* change.
+    // The update action itself doesn't contain any properties (so, nothing is actually
+    // mutated in the database). The action only exists for time tracking (if users
+    // interact with the 3D viewport, this should be time-tracked).
+    // When updateCameraAnnotation is already emitted, an additional updateTdCamera
+    // doesn't provide any value.
+    // Additional background:
+    // The reason why we don't want to emit both actions is that the current compaction
+    // mechanism for update actions (see compact_save_queue.ts) only compacts version
+    // groups where *either* one updateCamera OR one updateTdCamera action exists.
+    // The compaction could be adapted, but as stated before: there is no value in
+    // emitting an additional updateTdCamera action here.
+    // This change became necessary with the introduction of the perspective camera,
+    // with which each movement of the current position (the flycam) also triggers
+    // a subtle update to the 3D camera properties (because of how the perspective
+    // camera is anchored/re-positioned).
+    return [updateTdCamera()];
   }
 
-  if (prevTdCamera !== tdCamera) {
-    actions = actions.concat(updateTdCamera());
-  }
-
-  return actions;
+  return [];
 }

--- a/unreleased_changes/9905.md
+++ b/unreleased_changes/9905.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a regression which caused too many versions to be saved in the annotation history.


### PR DESCRIPTION
### Summary
The current update action compaction mechanism only handled the case where exactly one updateCamera action was in a batch. With #9764, each camera movement also slightly updates the 3D camera. This also caused an updatetTdCamera action in the same version batch. As a result, no compaction was happening and multiple hundreds of annotation versions were produced in a couple of seconds.
This PR fixes this problem by simply not emitting the updatetTdCamera action in the first place if it doesn't provide any value (see code comment).

### Steps to test:
- create a new annotation
- pan the camera for a few seconds
- save
- open the version restore view --> the newest annotation version should be sth like 4 (on master, this can easily be above 200; depending on how long you panned)


### Issues:
- fixes regression from #9764
- context: https://app.letsjelly.com/scalable-minds/conversations/delayed-saving#note_54877

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
