### PR TITLE
Fix N5 raw compression, S3 uri style handling and zarr v3 codec error reporting

### DIFF
--- a/test/backend/N5HeaderTestSuite.scala
+++ b/test/backend/N5HeaderTestSuite.scala
@@ -119,6 +119,8 @@ class N5HeaderTestSuite extends AsyncWordSpec {
 
     "selecting the compressor from the parsed header" should {
       "resolve the known compression types" in {
+        // "raw" is the N5 spec’s identifier for uncompressed data
+        assert(headerWithCompression("""{"type": "raw"}""").compressorImpl.isInstanceOf[NullCompressor])
         assert(headerWithCompression("""{"type": "null"}""").compressorImpl.isInstanceOf[NullCompressor])
         assert(headerWithCompression("""{"type": "zlib", "level": 6}""").compressorImpl.isInstanceOf[ZlibCompressor])
         assert(headerWithCompression("""{"type": "gzip", "level": 6}""").compressorImpl.isInstanceOf[GzipCompressor])
@@ -138,11 +140,10 @@ class N5HeaderTestSuite extends AsyncWordSpec {
       }
 
       "throw for an unknown compression type" in {
+        // lz4, xz and bzip2 are valid N5 compression types that webknossos does not implement
         assertThrows[IllegalArgumentException](headerWithCompression("""{"type": "lz4"}""").compressorImpl)
+        assertThrows[IllegalArgumentException](headerWithCompression("""{"type": "xz"}""").compressorImpl)
         assertThrows[IllegalArgumentException](headerWithCompression("""{"type": 5}""").compressorImpl)
-        // Pinning current behavior: "raw" is the N5 spec’s identifier for uncompressed data, but the factory
-        // only knows "null", so an attributes.json that states it explicitly throws here.
-        assertThrows[IllegalArgumentException](headerWithCompression("""{"type": "raw"}""").compressorImpl)
       }
     }
 

--- a/test/backend/S3UriUtilsTestSuite.scala
+++ b/test/backend/S3UriUtilsTestSuite.scala
@@ -31,16 +31,28 @@ class S3UriUtilsTestSuite extends AsyncWordSpec {
       "read bucket and object key" in {
         val virtualHosted = uri("https://my-bucket.s3.amazonaws.com/dataset/color/1/.zarray")
         assert(S3UriUtils.hostBucketFromUri(virtualHosted).contains("my-bucket"))
-        // Note: unlike the other two styles, the object key keeps its leading slash here
-        assert(S3UriUtils.objectKeyFromUri(virtualHosted).contains("/dataset/color/1/.zarray"))
+        assert(S3UriUtils.objectKeyFromUri(virtualHosted).contains("dataset/color/1/.zarray"))
       }
 
-      "not read a bucket from a region-qualified virtual hosted uri" in {
-        // Pinning current behavior: only the region-less ".s3.amazonaws.com" suffix is recognised as
-        // virtual hosted style, so "bucket.s3.<region>.amazonaws.com" matches no style at all.
+      "read bucket and object key from a region-qualified host" in {
         val regional = uri("https://my-bucket.s3.us-west-2.amazonaws.com/dataset/color")
-        assert(S3UriUtils.hostBucketFromUri(regional).isEmpty)
-        assert(S3UriUtils.objectKeyFromUri(regional).isEmpty)
+        assert(S3UriUtils.hostBucketFromUri(regional).contains("my-bucket"))
+        assert(S3UriUtils.objectKeyFromUri(regional).contains("dataset/color"))
+      }
+
+      "read bucket and object key from the legacy dash form and from a dualstack host" in {
+        val dashed = uri("https://my-bucket.s3-us-west-2.amazonaws.com/dataset/color")
+        assert(S3UriUtils.hostBucketFromUri(dashed).contains("my-bucket"))
+        assert(S3UriUtils.objectKeyFromUri(dashed).contains("dataset/color"))
+        val dualstack = uri("https://my-bucket.s3.dualstack.us-west-2.amazonaws.com/dataset/color")
+        assert(S3UriUtils.hostBucketFromUri(dualstack).contains("my-bucket"))
+        assert(S3UriUtils.objectKeyFromUri(dualstack).contains("dataset/color"))
+      }
+
+      "read a bucket name containing dots" in {
+        val dottedBucket = uri("https://my.bucket.name.s3.us-west-2.amazonaws.com/dataset/color")
+        assert(S3UriUtils.hostBucketFromUri(dottedBucket).contains("my.bucket.name"))
+        assert(S3UriUtils.objectKeyFromUri(dottedBucket).contains("dataset/color"))
       }
     }
 
@@ -81,21 +93,28 @@ class S3UriUtilsTestSuite extends AsyncWordSpec {
         assert(!S3UriUtils.isNonAmazonHost(uri("s3://my-bucket/key")))
       }
 
-      "recognise localhost as a non-amazon host" in {
-        val local = uri("http://localhost:9000/my-bucket/dataset")
+      "read bucket and object key from localhost" in {
+        val local = uri("s3://localhost:9000/my-bucket/dataset")
         assert(S3UriUtils.isNonAmazonHost(local))
-        // Pinning current behavior: a dot-free host is treated as short style, so the host itself
-        // becomes the bucket and the whole path becomes the object key.
-        assert(S3UriUtils.hostBucketFromUri(local).contains("localhost"))
-        assert(S3UriUtils.objectKeyFromUri(local).contains("my-bucket/dataset"))
+        assert(S3UriUtils.hostBucketFromUri(local).contains("my-bucket"))
+        assert(S3UriUtils.objectKeyFromUri(local).contains("dataset"))
+      }
+
+      "read a dot-free endpoint host that states a port as an endpoint" in {
+        // Bucket names cannot contain a port, so a port disambiguates an endpoint from a bucket
+        val kubernetesService = uri("s3://minio:9000/my-bucket/dataset/color")
+        assert(S3UriUtils.isNonAmazonHost(kubernetesService))
+        assert(S3UriUtils.hostBucketFromUri(kubernetesService).contains("my-bucket"))
+        assert(S3UriUtils.objectKeyFromUri(kubernetesService).contains("dataset/color"))
       }
     }
 
     "the bucket name contains dots" should {
 
-      "classify a short style uri as path style" in {
-        // Pinning current behavior: isShortStyle only matches dot-free hosts, so a dotted bucket in
-        // short form falls through to the path style branch and the first path segment becomes the bucket.
+      "still classify a short style uri as path style" in {
+        // Pinning current behavior: an s3:// uri states either a bucket or an endpoint in its host slot, and a
+        // dotted bucket name is indistinguishable from an endpoint host, so the endpoint reading wins here.
+        // Such buckets can be addressed in virtual hosted style instead, see above.
         val dottedBucket = uri("s3://my.bucket.name/dataset/color")
         assert(S3UriUtils.hostBucketFromUri(dottedBucket).contains("dataset"))
         assert(S3UriUtils.objectKeyFromUri(dottedBucket).contains("color"))
@@ -103,9 +122,26 @@ class S3UriUtilsTestSuite extends AsyncWordSpec {
     }
 
     "the uri has no host at all" should {
-      "yield no bucket" in {
+      "yield no bucket and no object key" in {
         assert(S3UriUtils.hostBucketFromUri(uri("s3:///dataset/color")).isEmpty)
         assert(S3UriUtils.hostBucketFromUri(uri("/dataset/color")).isEmpty)
+        assert(S3UriUtils.objectKeyFromUri(uri("s3:///dataset/color")).isEmpty)
+      }
+    }
+
+    "the key has a trailing slash" should {
+      "keep it, since it is significant as a listing prefix" in {
+        assert(S3UriUtils.objectKeyFromUri(uri("s3://my-bucket/dataset/color/")).contains("dataset/color/"))
+        assert(
+          S3UriUtils
+            .objectKeyFromUri(uri("https://s3.amazonaws.com/my-bucket/dataset/color/"))
+            .contains("dataset/color/")
+        )
+        assert(
+          S3UriUtils
+            .objectKeyFromUri(uri("https://my-bucket.s3.amazonaws.com/dataset/color/"))
+            .contains("dataset/color/")
+        )
       }
     }
 

--- a/test/backend/Zarr3TestSuite.scala
+++ b/test/backend/Zarr3TestSuite.scala
@@ -1,5 +1,6 @@
 package backend
 
+import com.scalableminds.util.box.Failure
 import com.scalableminds.util.tools.JsonHelper
 import com.scalableminds.webknossos.datastore.datareaders.{ArrayDataType, ArrayOrder, DimensionSeparator}
 import com.scalableminds.webknossos.datastore.datareaders.zarr3.{
@@ -22,6 +23,9 @@ class Zarr3TestSuite extends AsyncWordSpec {
 
   private def parseHeader(json: String): Zarr3ArrayHeader =
     JsonHelper.parseAs[Zarr3ArrayHeader](json).get("test execution")
+
+  private def failureChain(failure: Failure): String =
+    (failure.msg :: failure.chain.toList.map(failureChain)).mkString(" <- ")
 
   "Zarr 3" when {
 
@@ -126,7 +130,7 @@ class Zarr3TestSuite extends AsyncWordSpec {
     }
 
     "dimension_names are absent" should {
-      "read an empty array of dimension names" in {
+      "read no dimension names" in {
         // Captured from a webknossos-written 1-dimensional zarr v3 array (a segment statistics attachment),
         // which states neither dimension_names nor a chunk key separator.
         val json =
@@ -139,8 +143,13 @@ class Zarr3TestSuite extends AsyncWordSpec {
                "name":"sharding_indexed"}],
              "data_type":"uint32","fill_value":0,"node_type":"array","shape":[1332],"zarr_format":3}"""
         val header = parseHeader(json)
-        // Note: absent dimension_names become an empty array rather than None
-        assert(header.dimension_names.exists(_.isEmpty))
+        assert(header.dimension_names.isEmpty)
+        // The spec allows null entries in dimension_names, which we cannot model, so the field is ignored then
+        assert(
+          parseHeader(
+            json.replace(""""shape":[1332]""", """"dimension_names":[null],"shape":[1332]""")
+          ).dimension_names.isEmpty
+        )
         assert(header.rank == 1)
         assert(header.chunkShape.sameElements(Array(4096)))
         assert(header.outerChunkShape.sameElements(Array(134217728)))
@@ -291,8 +300,8 @@ class Zarr3TestSuite extends AsyncWordSpec {
         assert(parseHeader(groupJson).assertValid.isEmpty)
       }
 
-      "throw for an unsupported codec name" in {
-        // Note: an unknown codec escapes as an exception instead of a failed Box
+      "reject an unsupported codec name" in {
+        // A codec we cannot read must fail the header, since decoding chunks without it would yield wrong data
         val json = """{
           "shape": [64], "data_type": "uint8", "zarr_format": 3,
           "chunk_grid": {"configuration": {"chunk_shape": [8]}, "name": "regular"},
@@ -301,7 +310,32 @@ class Zarr3TestSuite extends AsyncWordSpec {
                      {"configuration": {"digits": 4}, "name": "quantize"}],
           "node_type": "array"
         }"""
-        assertThrows[UnsupportedOperationException](JsonHelper.parseAs[Zarr3ArrayHeader](json))
+        JsonHelper.parseAs[Zarr3ArrayHeader](json) match {
+          case failure: Failure => assert(failureChain(failure).contains("Codec quantize is not supported"))
+          case other            => fail(s"expected Failure, got $other")
+        }
+      }
+
+      "reject a codec whose configuration cannot be read" in {
+        // Malformed codec configurations used to be dropped silently
+        val json = """{
+          "shape": [64], "data_type": "uint8", "zarr_format": 3,
+          "chunk_grid": {"configuration": {"chunk_shape": [8]}, "name": "regular"},
+          "chunk_key_encoding": {"name": "default"}, "fill_value": 0,
+          "codecs": [{"configuration": {"endian": "little"}, "name": "bytes"},
+                     {"configuration": {"level": "high"}, "name": "gzip"}],
+          "node_type": "array"
+        }"""
+        assert(JsonHelper.parseAs[Zarr3ArrayHeader](json).isEmpty)
+        // A codec entry without a name is rejected as well
+        val noNameJson = """{
+          "shape": [64], "data_type": "uint8", "zarr_format": 3,
+          "chunk_grid": {"configuration": {"chunk_shape": [8]}, "name": "regular"},
+          "chunk_key_encoding": {"name": "default"}, "fill_value": 0,
+          "codecs": [{"configuration": {"endian": "little"}}],
+          "node_type": "array"
+        }"""
+        assert(JsonHelper.parseAs[Zarr3ArrayHeader](noNameJson).isEmpty)
       }
     }
   }

--- a/unreleased_changes/9906.md
+++ b/unreleased_changes/9906.md
@@ -1,0 +1,6 @@
+### Fixed
+- Fixed reading N5 datasets whose `attributes.json` states the compression type `raw`, the N5 identifier for uncompressed data. Such datasets previously failed to load.
+- Fixed adding remote S3 datasets that are addressed in virtual-hosted style (e.g. `https://my-bucket.s3.us-west-2.amazonaws.com/key`). Regional, dualstack and legacy dash hosts were not recognized at all, and object keys were requested with a leading slash, so these datasets could not be read.
+- Fixed reading S3 datasets from a custom endpoint whose host name contains no dot but states a port, e.g. `s3://localhost:9000/my-bucket/key` or `s3://minio:9000/my-bucket/key`. The endpoint host was mistaken for the bucket name.
+- Fixed that directory listings for S3 datasets on a custom endpoint could ignore the trailing slash of the listing prefix.
+- Zarr v3 datasets that use a codec WEBKNOSSOS cannot read now report an error naming the codec, instead of failing with an internal server error. Codecs whose configuration cannot be read are no longer ignored silently, which could previously lead to wrongly decoded data.

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5CompressorFactory.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/n5/N5CompressorFactory.scala
@@ -24,8 +24,9 @@ object N5CompressorFactory {
 
   def create(id: String, properties: Map[String, CompressionSetting]): Compressor =
     id match {
-      case "null" => nullCompressor
-      case "zlib" => new ZlibCompressor(properties)
+      // "raw" is the N5 spec’s identifier for uncompressed data
+      case "raw" | "null" => nullCompressor
+      case "zlib"         => new ZlibCompressor(properties)
       case "gzip" if properties.getOrElse("useZlib", BoolCompressionSetting(false)) == BoolCompressionSetting(true) =>
         new ZlibCompressor(properties)
       case "gzip"  => new GzipCompressor(properties)

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3ArrayHeader.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/datareaders/zarr3/Zarr3ArrayHeader.scala
@@ -188,8 +188,9 @@ object Zarr3ArrayHeader extends JsonImplicits {
         }
         attributes = (json \ "attributes").validate[JsObject].asOpt
         codecsJsValue <- (json \ "codecs").validate[JsValue]
-        codecs = readCodecs(codecsJsValue)
-        dimension_names <- (json \ "dimension_names").validate[Array[String]].orElse(JsSuccess(Array[String]()))
+        codecs <- readCodecs(codecsJsValue)
+        // The spec allows null entries in dimension_names, which we cannot model. Ignore the field in that case.
+        dimension_names = (json \ "dimension_names").validate[Array[String]].asOpt
       } yield Zarr3ArrayHeader(
         zarr_format,
         node_type,
@@ -201,52 +202,51 @@ object Zarr3ArrayHeader extends JsonImplicits {
         attributes,
         codecs,
         storage_transformers = None, // No storage transformers are currently defined
-        Some(dimension_names)
+        dimension_names
       )
 
-    private def readShardingCodecConfiguration(config: JsValue): JsResult[ShardingCodecConfiguration] =
+    private def readShardingCodecConfiguration(config: JsLookupResult): JsResult[ShardingCodecConfiguration] =
       for {
-        chunk_shape <- config("chunk_shape").validate[Array[Int]]
-        codecs = readCodecs(config("codecs"))
-        index_codecs = readCodecs(config("index_codecs"))
+        chunk_shape <- (config \ "chunk_shape").validate[Array[Int]]
+        codecs <- readCodecs((config \ "codecs").toOption.getOrElse(JsArray()))
+        index_codecs <- readCodecs((config \ "index_codecs").toOption.getOrElse(JsArray()))
         index_location = (config \ "index_location")
           .asOpt[IndexLocationSetting.IndexLocationSetting]
           .getOrElse(IndexLocationSetting.end)
       } yield ShardingCodecConfiguration(chunk_shape, codecs, index_codecs, index_location)
 
-    private def readCodecs(value: JsValue): Seq[CodecConfiguration] = {
+    // Note that a codec we cannot read must fail the whole header rather than be skipped, since decoding
+    // chunks without it would silently yield wrong data.
+    private def readCodecs(value: JsValue): JsResult[Seq[CodecConfiguration]] = {
       val rawCodecSpecs: Seq[JsValue] = value match {
         case JsArray(arr) => arr.toSeq
         case _            => Seq()
       }
-      val configurationKey = "configuration"
-      val codecSpecs = rawCodecSpecs.map(c =>
-        for {
-          spec: CodecConfiguration <- c("name") match {
-            // BytesCodec may have no "configuration" key
-            case JsString(BytesCodecConfiguration.name) =>
-              (c \ configurationKey).toOption
-                .map(_.validate[BytesCodecConfiguration])
-                .getOrElse(JsSuccess(BytesCodecConfiguration(None)))
-            case JsString(BytesCodecConfiguration.legacyName) =>
-              (c \ configurationKey).toOption
-                .map(_.validate[BytesCodecConfiguration])
-                .getOrElse(JsSuccess(BytesCodecConfiguration(None)))
-            case JsString(TransposeCodecConfiguration.name) => c(configurationKey).validate[TransposeCodecConfiguration]
-            case JsString(GzipCodecConfiguration.name)      => c(configurationKey).validate[GzipCodecConfiguration]
-            case JsString(BloscCodecConfiguration.name)     => c(configurationKey).validate[BloscCodecConfiguration]
-            case JsString(ZstdCodecConfiguration.name)      => c(configurationKey).validate[ZstdCodecConfiguration]
-            case JsString(Crc32CCodecConfiguration.name)    =>
-              JsSuccess(Crc32CCodecConfiguration) // Crc32 codec has no configuration
-            case JsString(ShardingCodecConfiguration.name) => readShardingCodecConfiguration(c(configurationKey))
-            case JsString(name) => throw new UnsupportedOperationException(s"Codec $name is not supported.")
-            case _              => throw new IllegalArgumentException()
-          }
-        } yield spec
-      )
-      codecSpecs.flatMap(possibleCodecSpec =>
-        possibleCodecSpec.map((s: CodecConfiguration) => Seq(s)).getOrElse(Seq[CodecConfiguration]())
-      )
+      rawCodecSpecs.foldLeft[JsResult[Seq[CodecConfiguration]]](JsSuccess(Seq.empty[CodecConfiguration])) {
+        (readSoFar, codecSpec) =>
+          for {
+            codecs <- readSoFar
+            codec <- readCodec(codecSpec)
+          } yield codecs :+ codec
+      }
+    }
+
+    private def readCodec(codecSpec: JsValue): JsResult[CodecConfiguration] = {
+      val configuration = codecSpec \ "configuration"
+      (codecSpec \ "name").validate[String].flatMap {
+        // BytesCodec may have no "configuration" key
+        case BytesCodecConfiguration.name | BytesCodecConfiguration.legacyName =>
+          configuration.toOption
+            .map(_.validate[BytesCodecConfiguration])
+            .getOrElse(JsSuccess(BytesCodecConfiguration(None)))
+        case TransposeCodecConfiguration.name => configuration.validate[TransposeCodecConfiguration]
+        case GzipCodecConfiguration.name      => configuration.validate[GzipCodecConfiguration]
+        case BloscCodecConfiguration.name     => configuration.validate[BloscCodecConfiguration]
+        case ZstdCodecConfiguration.name      => configuration.validate[ZstdCodecConfiguration]
+        case Crc32CCodecConfiguration.name    => JsSuccess(Crc32CCodecConfiguration) // has no configuration
+        case ShardingCodecConfiguration.name  => readShardingCodecConfiguration(configuration)
+        case name                             => JsError(s"Codec $name is not supported.")
+      }
     }
 
     override def writes(zarrArrayHeader: Zarr3ArrayHeader): JsValue = {

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/S3UriUtils.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/helpers/S3UriUtils.scala
@@ -8,39 +8,67 @@ import java.net.URI
 
 object S3UriUtils {
 
+  sealed private trait S3UriStyle
+
+  // S3://bucket-name/key-name — the host is the bucket
+  private case object ShortStyle extends S3UriStyle
+
+  // https://bucket-name.s3.region-code.amazonaws.com/key-name — the bucket is a prefix of the host
+  private case class VirtualHostedStyle(bucket: String) extends S3UriStyle
+
+  // https://s3.region-code.amazonaws.com/bucket-name/key-name — the host is an endpoint,
+  // the bucket is the first path segment
+  private case object PathStyle extends S3UriStyle
+
+  // Matches bucket-name.s3.amazonaws.com, bucket-name.s3.us-west-2.amazonaws.com,
+  // bucket-name.s3-us-west-2.amazonaws.com and bucket-name.s3.dualstack.us-west-2.amazonaws.com
+  private val virtualHostedStyleHost = """^(.+?)\.s3([.-][\w.-]+)?\.amazonaws\.com$""".r
+
+  // Matches s3.amazonaws.com, s3.us-west-2.amazonaws.com, s3-us-west-2.amazonaws.com
+  private val amazonEndpointHost = """^s3([.-][\w.-]+)?\.amazonaws\.com$""".r
+
+  private def styleOf(uri: URI): Option[S3UriStyle] =
+    Option(uri.getHost).filter(_.nonEmpty).map {
+      case virtualHostedStyleHost(bucket, _) => VirtualHostedStyle(bucket)
+      case host if isEndpointHost(uri, host) => PathStyle
+      case _                                 => ShortStyle
+    }
+
+  /** Telling an endpoint host apart from a bucket name can only be done heuristically, since the host slot of an s3://
+    * uri is used for both (s3://bucket-name/key vs. s3://my-minio.example.com/bucket-name/key). A host is read as an
+    * endpoint if it is an amazon s3 endpoint, if a port is stated (bucket names cannot contain one), if it is
+    * localhost, or if it contains a dot. Note that this leaves a bucket name containing dots indistinguishable from an
+    * endpoint host; such a host is read as an endpoint.
+    */
+  private def isEndpointHost(uri: URI, host: String): Boolean =
+    amazonEndpointHost.matches(host) || uri.getPort >= 0 || host == "localhost" || host.contains(".")
+
+  private def pathWithoutLeadingSlash(uri: URI): String =
+    Option(uri.getPath).getOrElse("").stripPrefix("/")
+
+  // Split the path into its first segment (the bucket, for path style uris) and the remaining key.
+  // A trailing slash is part of the key, since it is significant when the key is used as a listing prefix.
+  private def firstPathSegmentAndRest(uri: URI): (Option[String], String) = {
+    val path = pathWithoutLeadingSlash(uri)
+    val separatorIndex = path.indexOf('/')
+    if (separatorIndex < 0)
+      (Some(path).filter(_.nonEmpty), "")
+    else
+      (Some(path.take(separatorIndex)).filter(_.nonEmpty), path.drop(separatorIndex + 1))
+  }
+
   def hostBucketFromUPath(upath: UPath): Box[String] = for {
     uri <- upath.toRemoteUri
     _ <- checkSchemeIsS3(uri)
     bucket <- Box.fromOption(hostBucketFromUri(uri))
   } yield bucket
 
-  def hostBucketFromUri(uri: URI): Option[String] = {
-    val host = uri.getHost
-    if (host == null) {
-      None
-    } else if (isShortStyle(uri)) { // assume host is omitted from uri, shortcut form s3://bucket/key
-      Some(host)
-    } else if (isVirtualHostedStyle(uri)) {
-      Some(host.substring(0, host.length - ".s3.amazonaws.com".length))
-    } else if (isPathStyle(uri)) {
-      Some(uri.getPath.substring(1).split("/")(0))
-    } else {
-      None
+  def hostBucketFromUri(uri: URI): Option[String] =
+    styleOf(uri).flatMap {
+      case ShortStyle                 => Option(uri.getHost)
+      case VirtualHostedStyle(bucket) => Some(bucket)
+      case PathStyle                  => firstPathSegmentAndRest(uri)._1
     }
-  }
-
-  // https://bucket-name.s3.region-code.amazonaws.com/key-name
-  private def isVirtualHostedStyle(uri: URI): Boolean =
-    uri.getHost.endsWith(".s3.amazonaws.com")
-
-  // https://s3.region-code.amazonaws.com/bucket-name/key-name
-  private def isPathStyle(uri: URI): Boolean =
-    uri.getHost.matches("s3(.[\\w\\-_]+)?.amazonaws.com") ||
-      (!uri.getHost.contains("amazonaws.com") && uri.getHost.contains("."))
-
-  // S3://bucket-name/key-name
-  private def isShortStyle(uri: URI): Boolean =
-    !uri.getHost.contains(".")
 
   def objectKeyFromUPath(upath: UPath): Box[String] = for {
     uri <- upath.toRemoteUri
@@ -49,13 +77,11 @@ object S3UriUtils {
   } yield objectKey
 
   def objectKeyFromUri(uri: URI): Box[String] =
-    if (isVirtualHostedStyle(uri)) {
-      Full(uri.getPath)
-    } else if (isPathStyle(uri)) {
-      Full(uri.getPath.substring(1).split("/").tail.mkString("/"))
-    } else if (isShortStyle(uri)) {
-      Full(uri.getPath.tail)
-    } else Failure(s"Not a valid s3 uri: $uri")
+    styleOf(uri) match {
+      case Some(ShortStyle) | Some(VirtualHostedStyle(_)) => Full(pathWithoutLeadingSlash(uri))
+      case Some(PathStyle)                                => Full(firstPathSegmentAndRest(uri)._2)
+      case None                                           => Failure(s"Not a valid s3 uri: $uri")
+    }
 
   def objectKeyFromVaultPath(vaultPath: VaultPath): Box[String] =
     objectKeyFromUPath(vaultPath.toUPath)
@@ -74,7 +100,7 @@ object S3UriUtils {
     )
 
   def isNonAmazonHost(uri: URI): Boolean =
-    (isPathStyle(uri) && !uri.getHost.endsWith(".amazonaws.com")) || uri.getHost == "localhost"
+    styleOf(uri).contains(PathStyle) && !uri.getHost.endsWith(".amazonaws.com")
 
   private def checkSchemeIsS3(uri: URI): Box[Unit] =
     Box


### PR DESCRIPTION
### Summary

Stacked on #9904 — **please review and merge that one first**, this PR targets its branch so the diff stays small.

#9904 added header parsing tests and, where a behavior looked wrong, pinned it as-is with a `Pinning current behavior` comment rather than changing production code. This PR implements those fixes and flips the pinned assertions to the fixed behavior.

#### N5: `"compression": {"type": "raw"}` no longer throws

`raw` is the N5 spec's identifier for uncompressed data, but `N5CompressorFactory` only knew `null`, so an `attributes.json` stating it explicitly threw `IllegalArgumentException` on the first chunk read. It now resolves to the null compressor.

#### S3: one style classification instead of three overlapping predicates

`hostBucketFromUri` and `objectKeyFromUri` each tested `isShortStyle` / `isVirtualHostedStyle` / `isPathStyle` *in a different order*, and the three overlapped. Replaced by a single `styleOf` returning the style (and the bucket, for virtual hosted). Behavior changes that follow:

- **Virtual hosted style now recognises regional hosts.** `isVirtualHostedStyle` only accepted the region-less `.s3.amazonaws.com` suffix, so `bucket.s3.us-west-2.amazonaws.com` — the form the AWS console hands out — matched *no* style at all: no bucket, and `S3DataVault` threw "Could not parse S3 bucket". Now the region, legacy dash (`s3-us-west-2`) and dualstack forms all work, and a dotted bucket name is read correctly in this style.
- **Object keys no longer keep a leading slash in virtual hosted style.** `objectKeyFromUri` returned `/dataset/color` there while the other two styles returned `dataset/color`. S3 treats those as two different objects, so this addressed the wrong key. Together with the point above, virtual hosted S3 paths were effectively unusable.
- **A dot-free endpoint host that states a port is no longer mistaken for the bucket.** `s3://localhost:9000/my-bucket/key` and `s3://minio:9000/my-bucket/key` returned bucket `localhost`/`minio` and key `my-bucket/key`, even though `isNonAmazonHost` correctly pointed the client at the custom endpoint. A port disambiguates unambiguously — bucket names cannot contain one — so such hosts are now read as endpoints.
- **Trailing slashes are kept for all styles.** Short style kept them, path style dropped them. They are significant when the key is used as a listing prefix (`listDirectory` passes it straight to `ListObjectsV2Request` with delimiter `/`), so the short-style behavior is the correct one to align on.

`isNonAmazonHost` is unchanged for every input it was called with before.

#### Zarr v3: codec read errors are reported, not thrown or swallowed

`Zarr3ArrayHeader.reads` threw `UnsupportedOperationException` from `readCodecs` for a codec name it did not know, and neither `JsonHelper.parseAs` nor `VaultPath.parseAsJson` wraps validation in `tryo` — so exploring an array with, say, a `quantize` codec surfaced as an internal server error instead of a message naming the codec. `readCodecs` now returns `JsResult`, so this becomes a normal `Failure`.

The same loop also *silently dropped* any codec whose configuration failed to validate. That is the more dangerous half: a chunk decoded without a codec it declares yields wrong data rather than an error. Such codecs now fail the header too.

#### Zarr v3: absent `dimension_names` read as `None`

They became `Some(Array())`, which `writes` then emitted as `"dimension_names": []` — invalid per spec, which requires one entry per dimension when the field is present. Malformed values (the spec permits `null` entries, which the `Array[String]` model cannot hold) are still tolerated and ignored rather than failing the header.

### Not fixed: a bucket name containing dots in short form

`s3://my.bucket.name/dataset/color` still reads bucket `dataset`, key `color`. This one is not an oversight but an ambiguity: an `s3://` uri states *either* a bucket *or* an endpoint host in its host slot, and `s3://my.bucket.name/dataset` is syntactically indistinguishable from `s3://my-minio.example.com/bucket`. Resolving it in favour of buckets would break every custom-endpoint dataset. The test stays, with the reasoning in a comment, and such buckets can be addressed in virtual hosted style, which this PR fixes. Happy to add an explicit endpoint field or a configured-endpoint list in a follow-up if we want short-style dotted buckets to work.

### Steps to test:
- `yarn test-backend` — the suites from #9904 now assert the fixed behavior. 5 tests were added or reshaped; nothing was removed.
- The live-cloud tests in `DataVaultTestSuite` exercise real S3 reads, range requests and directory listing through the rewritten `S3UriUtils` and pass.
- Note: `backend.BucketScannerTestSuite` aborts locally on arm64 macOS with `UnsatisfiedLinkError` for `/native/x86_64-darwin/libwebknossosJni0.dylib`. Pre-existing on master, unrelated.

### Issues:
- Contributes to https://github.com/scalableminds/webknossos/issues/8288

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
