### PR TITLE
Upgrade Biome from 2.3.13 to 2.5.8

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,7 +34,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "useBlockStatements": "off",
         "noNegationElse": "off",
@@ -83,7 +83,8 @@
         "useIframeTitle": "off",
         "noAriaHiddenOnFocusable": "off",
         "noLabelWithoutControl": "off",
-        "noStaticElementInteractions": "off"
+        "noStaticElementInteractions": "off",
+        "noAmbiguousAnchorText": "off"
       },
       "performance": {
         "noDelete": "off",
@@ -110,9 +111,7 @@
         "noRedeclare": "off",
         "noFallthroughSwitchClause": "off",
         "noFocusedTests": "error",
-        "noAssignInExpressions": "off"
-      },
-      "nursery": {
+        "noAssignInExpressions": "off",
         "noReactForwardRef": "error"
       }
     }

--- a/frontend/javascripts/admin/dataset/dataset_components.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_components.tsx
@@ -54,7 +54,7 @@ const sharedRules = [
   },
   {
     validator: syncValidator(
-      (value: string | null) => !value || !value.startsWith("."),
+      (value: string | null) => !value?.startsWith("."),
       "The name must not start with a dot.",
     ),
   },

--- a/frontend/javascripts/components/terms_of_services_check.tsx
+++ b/frontend/javascripts/components/terms_of_services_check.tsx
@@ -44,7 +44,7 @@ export function CheckTermsOfServices() {
   useEffect(() => {
     // Show ToS modal when the acceptance is needed and it wasn't snoozed
     // (unless the deadline is exceeded).
-    if (!acceptanceInfo || !acceptanceInfo.acceptanceNeeded) {
+    if (!acceptanceInfo?.acceptanceNeeded) {
       return;
     }
     if (acceptanceInfo.acceptanceNeeded && acceptanceInfo.acceptanceDeadlinePassed) {

--- a/frontend/javascripts/libs/mjs.ts
+++ b/frontend/javascripts/libs/mjs.ts
@@ -372,4 +372,4 @@ const V4 = {
   },
 };
 
-export { M4x4, V2, V3, V4, type Matrix4x4 };
+export { M4x4, type Matrix4x4, V2, V3, V4 };

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -1279,7 +1279,7 @@ export function getAdaptToTypeFunction(mapping: Mapping | null | undefined) {
 export function getAdaptToTypeFunctionFromList<T extends number | bigint>(
   list: Array<T>,
 ): (el: bigint) => NumberLike {
-  return list[0] == null || Boolean(typeof list[0] === "number")
+  return list[0] == null || typeof list[0] === "number"
     ? (el: bigint) => Number(el)
     : (el: bigint) => el;
 }

--- a/frontend/javascripts/test/browser/dataset_rendering.screenshot.ts
+++ b/frontend/javascripts/test/browser/dataset_rendering.screenshot.ts
@@ -198,129 +198,121 @@ describe("Dataset Rendering", () => {
     },
   );
 
-  it.sequential<ScreenshotTestContext>(
-    "should render a dataset with mappings correctly",
-    { retry: 3 },
-    async ({ browser }) => {
-      const datasetName = "ROI2017_wkw";
-      const mappingName = "astrocyte";
+  it.sequential<ScreenshotTestContext>("should render a dataset with mappings correctly", {
+    retry: 3,
+  }, async ({ browser }) => {
+    const datasetName = "ROI2017_wkw";
+    const mappingName = "astrocyte";
 
-      const page = await getNewPage(browser);
+    const page = await getNewPage(browser);
 
-      const { screenshot, width, height } = await screenshotDatasetWithMapping(
-        page,
-        URL,
-        datasetNameToId[datasetName],
-        mappingName,
-      );
+    const { screenshot, width, height } = await screenshotDatasetWithMapping(
+      page,
+      URL,
+      datasetNameToId[datasetName],
+      mappingName,
+    );
 
-      const changedPixels = await compareScreenshot(
-        screenshot,
-        width,
-        height,
-        SCREENSHOTS_PATH,
-        `${datasetName}_with_mapping_${mappingName}`,
-      );
-      await page.close();
+    const changedPixels = await compareScreenshot(
+      screenshot,
+      width,
+      height,
+      SCREENSHOTS_PATH,
+      `${datasetName}_with_mapping_${mappingName}`,
+    );
+    await page.close();
 
-      expect(
-        isPixelEquivalent(changedPixels, width, height),
-        `Dataset with name: "${datasetName}" and mapping: "${mappingName}" does not look the same.`,
-      ).toBe(true);
-    },
-  );
+    expect(
+      isPixelEquivalent(changedPixels, width, height),
+      `Dataset with name: "${datasetName}" and mapping: "${mappingName}" does not look the same.`,
+    ).toBe(true);
+  });
 
-  it.sequential<ScreenshotTestContext>(
-    "should render a dataset linked to with an active mapping and agglomerate tree correctly",
-    { retry: 3 },
-    async ({ browser }) => {
-      const datasetName = "test-agglomerate-file";
-      const viewOverride = viewOverrides[datasetName];
+  it.sequential<ScreenshotTestContext>("should render a dataset linked to with an active mapping and agglomerate tree correctly", {
+    retry: 3,
+  }, async ({ browser }) => {
+    const datasetName = "test-agglomerate-file";
+    const viewOverride = viewOverrides[datasetName];
 
-      const page = await getNewPage(browser);
+    const page = await getNewPage(browser);
 
-      const { screenshot, width, height } = await screenshotDatasetWithMappingLink(
-        page,
-        URL,
-        datasetNameToId[datasetName],
-        viewOverride,
-      );
+    const { screenshot, width, height } = await screenshotDatasetWithMappingLink(
+      page,
+      URL,
+      datasetNameToId[datasetName],
+      viewOverride,
+    );
 
-      const changedPixels = await compareScreenshot(
-        screenshot,
-        width,
-        height,
-        SCREENSHOTS_PATH,
-        `${datasetName}_with_mapping_link`,
-      );
-      await page.close();
+    const changedPixels = await compareScreenshot(
+      screenshot,
+      width,
+      height,
+      SCREENSHOTS_PATH,
+      `${datasetName}_with_mapping_link`,
+    );
+    await page.close();
 
-      expect(
-        isPixelEquivalent(changedPixels, width, height),
-        `Dataset with name: "${datasetName}", mapping link and loaded agglomerate tree does not look the same.`,
-      ).toBe(true);
-    },
-  );
+    expect(
+      isPixelEquivalent(changedPixels, width, height),
+      `Dataset with name: "${datasetName}", mapping link and loaded agglomerate tree does not look the same.`,
+    ).toBe(true);
+  });
 
-  it.sequential<ScreenshotTestContext>(
-    "should render a dataset sandbox linked to with an active mapping and agglomerate tree correctly",
-    { retry: 3 },
-    async ({ browser }) => {
-      const datasetName = "test-agglomerate-file";
-      const viewOverride = viewOverrides[datasetName];
+  it.sequential<ScreenshotTestContext>("should render a dataset sandbox linked to with an active mapping and agglomerate tree correctly", {
+    retry: 3,
+  }, async ({ browser }) => {
+    const datasetName = "test-agglomerate-file";
+    const viewOverride = viewOverrides[datasetName];
 
-      const page = await getNewPage(browser);
-      const { screenshot, width, height } = await screenshotSandboxWithMappingLink(
-        page,
-        URL,
-        datasetNameToId[datasetName],
-        viewOverride,
-      );
-      // Should look the same as an explorative tracing on the same dataset with the same mapping link
-      const changedPixels = await compareScreenshot(
-        screenshot,
-        width,
-        height,
-        SCREENSHOTS_PATH,
-        `${datasetName}_with_mapping_link`,
-      );
-      await page.close();
-      expect(
-        isPixelEquivalent(changedPixels, width, height),
-        `Sandbox of dataset with name: "${datasetName}", mapping link and loaded agglomerate tree does not look the same.`,
-      ).toBe(true);
-    },
-  );
+    const page = await getNewPage(browser);
+    const { screenshot, width, height } = await screenshotSandboxWithMappingLink(
+      page,
+      URL,
+      datasetNameToId[datasetName],
+      viewOverride,
+    );
+    // Should look the same as an explorative tracing on the same dataset with the same mapping link
+    const changedPixels = await compareScreenshot(
+      screenshot,
+      width,
+      height,
+      SCREENSHOTS_PATH,
+      `${datasetName}_with_mapping_link`,
+    );
+    await page.close();
+    expect(
+      isPixelEquivalent(changedPixels, width, height),
+      `Sandbox of dataset with name: "${datasetName}", mapping link and loaded agglomerate tree does not look the same.`,
+    ).toBe(true);
+  });
 
-  it.sequential<ScreenshotTestContext>(
-    "should render a dataset linked to with ad-hoc and precomputed meshes correctly",
-    { retry: 3 },
-    async ({ browser }) => {
-      const datasetName = "test-agglomerate-file";
-      const viewOverride = viewOverrides["test-agglomerate-file-with-meshes"];
+  it.sequential<ScreenshotTestContext>("should render a dataset linked to with ad-hoc and precomputed meshes correctly", {
+    retry: 3,
+  }, async ({ browser }) => {
+    const datasetName = "test-agglomerate-file";
+    const viewOverride = viewOverrides["test-agglomerate-file-with-meshes"];
 
-      const page = await getNewPage(browser);
-      const { screenshot, width, height } = await screenshotDataset(
-        page,
-        URL,
-        datasetNameToId[datasetName],
-        undefined,
-        {
-          viewOverride: viewOverride,
-        },
-      );
-      const changedPixels = await compareScreenshot(
-        screenshot,
-        width,
-        height,
-        SCREENSHOTS_PATH,
-        `${datasetName}_with_meshes_link`,
-      );
-      await page.close();
-      expect(
-        isPixelEquivalent(changedPixels, width, height),
-        `Dataset with name: "${datasetName}", ad-hoc and precomputed meshes does not look the same.`,
-      ).toBe(true);
-    },
-  );
+    const page = await getNewPage(browser);
+    const { screenshot, width, height } = await screenshotDataset(
+      page,
+      URL,
+      datasetNameToId[datasetName],
+      undefined,
+      {
+        viewOverride: viewOverride,
+      },
+    );
+    const changedPixels = await compareScreenshot(
+      screenshot,
+      width,
+      height,
+      SCREENSHOTS_PATH,
+      `${datasetName}_with_meshes_link`,
+    );
+    await page.close();
+    expect(
+      isPixelEquivalent(changedPixels, width, height),
+      `Dataset with name: "${datasetName}", ad-hoc and precomputed meshes does not look the same.`,
+    ).toBe(true);
+  });
 });

--- a/frontend/javascripts/test/browser/dataset_rendering.wkorg_screenshot.ts
+++ b/frontend/javascripts/test/browser/dataset_rendering.wkorg_screenshot.ts
@@ -104,41 +104,39 @@ describe("webknossos.org Dataset Rendering", () => {
     await setupAfterEach(context);
   });
 
-  it<ScreenshotTestContext>(
-    `should render dataset ${demoDatasetName} correctly`,
-    { retry: 3 },
-    async ({ browser }) => {
-      const response = await fetch(
-        `${URL}/api/datasets/disambiguate/${owningOrganization}/${demoDatasetName}/toId`,
-      );
-      const { id: datasetId } = await response.json();
+  it<ScreenshotTestContext>(`should render dataset ${demoDatasetName} correctly`, {
+    retry: 3,
+  }, async ({ browser }) => {
+    const response = await fetch(
+      `${URL}/api/datasets/disambiguate/${owningOrganization}/${demoDatasetName}/toId`,
+    );
+    const { id: datasetId } = await response.json();
 
-      await updateDatasetDefaultConfiguration(
-        datasetId,
-        datasetConfiguration,
-        getDefaultRequestOptions(URL),
-      );
+    await updateDatasetDefaultConfiguration(
+      datasetId,
+      datasetConfiguration,
+      getDefaultRequestOptions(URL),
+    );
 
-      const page = await getNewPage(browser);
-      const { screenshot, width, height } = await screenshotDatasetView(
-        page,
-        URL,
-        datasetId,
-        viewOverrides[demoDatasetName],
-      );
-      const changedPixels = await compareScreenshot(
-        screenshot,
-        width,
-        height,
-        SCREENSHOTS_PATH,
-        demoDatasetName,
-      );
-      await page.close();
+    const page = await getNewPage(browser);
+    const { screenshot, width, height } = await screenshotDatasetView(
+      page,
+      URL,
+      datasetId,
+      viewOverrides[demoDatasetName],
+    );
+    const changedPixels = await compareScreenshot(
+      screenshot,
+      width,
+      height,
+      SCREENSHOTS_PATH,
+      demoDatasetName,
+    );
+    await page.close();
 
-      expect(
-        isPixelEquivalent(changedPixels, width, height),
-        `Dataset with name: "${demoDatasetName}" does not look the same, see ${demoDatasetName}.diff.png for the difference and ${demoDatasetName}.new.png for the new screenshot.`,
-      ).toBe(true);
-    },
-  );
+    expect(
+      isPixelEquivalent(changedPixels, width, height),
+      `Dataset with name: "${demoDatasetName}" does not look the same, see ${demoDatasetName}.diff.png for the difference and ${demoDatasetName}.new.png for the new screenshot.`,
+    ).toBe(true);
+  });
 });

--- a/frontend/javascripts/test/e2e_setup.ts
+++ b/frontend/javascripts/test/e2e_setup.ts
@@ -167,6 +167,8 @@ export function resetDatabase() {
   shell.exec("tools/postgres/dbtool.js prepare-test-db-no-schema-refresh", { silent: true });
 }
 export {
+  idUserA,
+  setUserAuthToken,
   tokenUserA,
   tokenUserB,
   tokenUserC,
@@ -176,6 +178,4 @@ export {
   tokenUserF,
   tokenUserFInOrgaX,
   tokenUserFInOrgaY,
-  setUserAuthToken,
-  idUserA,
 };

--- a/frontend/javascripts/test/fixtures/segment_merging_fixtures.ts
+++ b/frontend/javascripts/test/fixtures/segment_merging_fixtures.ts
@@ -19,6 +19,7 @@ export const createAction = (id: bigint, properties: Partial<Segment>) =>
   );
 
 const [id1, id2, id3] = [1n, 2n, 3n];
+
 export { id1, id2, id3 };
 export const createSegment1 = createAction(id1, {
   name: "Name 1",

--- a/frontend/javascripts/test/reducers/update_action_application/skeleton.spec.ts
+++ b/frontend/javascripts/test/reducers/update_action_application/skeleton.spec.ts
@@ -177,85 +177,86 @@ describe("Update Action Application for SkeletonTracing", () => {
       ? [hardcodedBeforeVersionIndex]
       : range(0, userActions.length);
 
-  describe.each(
-    compactionModes,
-  )("[Compaction=%s]: should re-apply update actions from complex diff and get same state", (withCompaction) => {
-    describe.each(beforeVersionIndices)("From v=%i", (beforeVersionIndex: number) => {
-      const afterVersionIndices =
-        hardcodedAfterVersionIndex != null
-          ? [hardcodedAfterVersionIndex]
-          : range(beforeVersionIndex, userActions.length + 1);
+  describe.each(compactionModes)(
+    "[Compaction=%s]: should re-apply update actions from complex diff and get same state",
+    (withCompaction) => {
+      describe.each(beforeVersionIndices)("From v=%i", (beforeVersionIndex: number) => {
+        const afterVersionIndices =
+          hardcodedAfterVersionIndex != null
+            ? [hardcodedAfterVersionIndex]
+            : range(beforeVersionIndex, userActions.length + 1);
 
-      test.each(afterVersionIndices)("To v=%i", (afterVersionIndex: number) => {
-        const state2WithActiveTree = applyActions(
-          initialState,
-          userActions.slice(0, beforeVersionIndex),
-        );
-
-        // The active user bounding box and the active group are user-local state
-        // that is not tracked via update actions. Reset them in both state
-        // variants so that the whole-state comparison below is not affected.
-        const normalizationActions = [
-          setActiveUserBoundingBoxId(null),
-          deselectActiveTreeGroupAction(),
-        ];
-        const state2WithoutLocalState = applyActions(state2WithActiveTree, normalizationActions);
-
-        const actionsToApply = userActions.slice(beforeVersionIndex, afterVersionIndex + 1);
-        const state3 = applyActions(
-          state2WithActiveTree,
-          actionsToApply.concat(normalizationActions),
-        );
-        expect(state2WithoutLocalState !== state3).toBeTruthy();
-
-        const skeletonTracing2 = enforceSkeletonTracing(state2WithoutLocalState.annotation);
-        const skeletonTracing3 = enforceSkeletonTracing(state3.annotation);
-
-        const updateActionsBeforeCompaction = Array.from(
-          diffSkeletonTracing(skeletonTracing2, skeletonTracing3),
-        );
-        const maybeCompact = withCompaction
-          ? compactUpdateActions
-          : (updateActions: UpdateActionWithoutIsolationRequirement[]) => updateActions;
-
-        const updateActions = addMissingTimestampProp(
-          maybeCompact(updateActionsBeforeCompaction, skeletonTracing2, skeletonTracing3),
-        );
-
-        for (const action of updateActions) {
-          seenActionTypes.add(action.name);
-        }
-
-        const reappliedNewState = transformStateAsReadOnly(state2WithoutLocalState, (state) =>
-          applyActions(state, [
-            applySkeletonUpdateActionsFromServerAction(updateActions),
-            setActiveUserBoundingBoxId(null),
-          ]),
-        );
-
-        if (skeletonTracing3.activeNodeId != null) {
-          // If an active node exists, the user-local activeTreeId must be
-          // consistent with it (it is re-derived from the active node while
-          // applying an updateActiveNode action).
-          expect(reappliedNewState.localSkeletonState.activeTreeId).toBe(
-            state3.localSkeletonState.activeTreeId,
+        test.each(afterVersionIndices)("To v=%i", (afterVersionIndex: number) => {
+          const state2WithActiveTree = applyActions(
+            initialState,
+            userActions.slice(0, beforeVersionIndex),
           );
-        }
 
-        // The activeTreeId is user-local state that is not tracked via update
-        // actions. During a real rebase it is not rewound (localSkeletonState is
-        // not part of the snapshot), so it is masked in the comparison below.
-        // Without an active node that anchors it, the replay cannot (and does
-        // not need to) restore it.
-        const stateWithRevertedActiveTreeChange = update(state3, {
-          localSkeletonState: {
-            activeTreeId: { $set: reappliedNewState.localSkeletonState.activeTreeId },
-          },
+          // The active user bounding box and the active group are user-local state
+          // that is not tracked via update actions. Reset them in both state
+          // variants so that the whole-state comparison below is not affected.
+          const normalizationActions = [
+            setActiveUserBoundingBoxId(null),
+            deselectActiveTreeGroupAction(),
+          ];
+          const state2WithoutLocalState = applyActions(state2WithActiveTree, normalizationActions);
+
+          const actionsToApply = userActions.slice(beforeVersionIndex, afterVersionIndex + 1);
+          const state3 = applyActions(
+            state2WithActiveTree,
+            actionsToApply.concat(normalizationActions),
+          );
+          expect(state2WithoutLocalState !== state3).toBeTruthy();
+
+          const skeletonTracing2 = enforceSkeletonTracing(state2WithoutLocalState.annotation);
+          const skeletonTracing3 = enforceSkeletonTracing(state3.annotation);
+
+          const updateActionsBeforeCompaction = Array.from(
+            diffSkeletonTracing(skeletonTracing2, skeletonTracing3),
+          );
+          const maybeCompact = withCompaction
+            ? compactUpdateActions
+            : (updateActions: UpdateActionWithoutIsolationRequirement[]) => updateActions;
+
+          const updateActions = addMissingTimestampProp(
+            maybeCompact(updateActionsBeforeCompaction, skeletonTracing2, skeletonTracing3),
+          );
+
+          for (const action of updateActions) {
+            seenActionTypes.add(action.name);
+          }
+
+          const reappliedNewState = transformStateAsReadOnly(state2WithoutLocalState, (state) =>
+            applyActions(state, [
+              applySkeletonUpdateActionsFromServerAction(updateActions),
+              setActiveUserBoundingBoxId(null),
+            ]),
+          );
+
+          if (skeletonTracing3.activeNodeId != null) {
+            // If an active node exists, the user-local activeTreeId must be
+            // consistent with it (it is re-derived from the active node while
+            // applying an updateActiveNode action).
+            expect(reappliedNewState.localSkeletonState.activeTreeId).toBe(
+              state3.localSkeletonState.activeTreeId,
+            );
+          }
+
+          // The activeTreeId is user-local state that is not tracked via update
+          // actions. During a real rebase it is not rewound (localSkeletonState is
+          // not part of the snapshot), so it is masked in the comparison below.
+          // Without an active node that anchors it, the replay cannot (and does
+          // not need to) restore it.
+          const stateWithRevertedActiveTreeChange = update(state3, {
+            localSkeletonState: {
+              activeTreeId: { $set: reappliedNewState.localSkeletonState.activeTreeId },
+            },
+          });
+          expect(reappliedNewState).toEqual(stateWithRevertedActiveTreeChange);
         });
-        expect(reappliedNewState).toEqual(stateWithRevertedActiveTreeChange);
       });
-    });
-  });
+    },
+  );
 
   it("should clear the active node if it was deleted", () => {
     const createNode = createNodeAction(position, null, rotation, viewport, mag);

--- a/frontend/javascripts/test/reducers/update_action_application/volume.spec.ts
+++ b/frontend/javascripts/test/reducers/update_action_application/volume.spec.ts
@@ -206,76 +206,77 @@ describe("Update Action Application for VolumeTracing", () => {
       ? [hardcodedBeforeVersionIndex]
       : range(0, userActions.length);
 
-  describe.each(
-    compactionModes,
-  )("[Compaction=%s]: should re-apply update actions from complex diff and get same state", (withCompaction) => {
-    describe.each(beforeVersionIndices)("From v=%i", (beforeVersionIndex: number) => {
-      const afterVersionIndices =
-        hardcodedAfterVersionIndex != null
-          ? [hardcodedAfterVersionIndex]
-          : range(beforeVersionIndex, userActions.length + 1);
+  describe.each(compactionModes)(
+    "[Compaction=%s]: should re-apply update actions from complex diff and get same state",
+    (withCompaction) => {
+      describe.each(beforeVersionIndices)("From v=%i", (beforeVersionIndex: number) => {
+        const afterVersionIndices =
+          hardcodedAfterVersionIndex != null
+            ? [hardcodedAfterVersionIndex]
+            : range(beforeVersionIndex, userActions.length + 1);
 
-      test.each(afterVersionIndices)("To v=%i", (afterVersionIndex: number) => {
-        // The update actions are applied on the initialState which produces new states.
-        // The "timeline" is as follows:
-        //         initialState
-        //              ↓
-        // [actions until beforeVersionIndex]
-        //              ↓
-        //            state2
-        //              ↓
-        // [actions between before and afterVersionIndex]
-        //              ↓
-        //            state3
-        //
-        // state2 and state3 are diffed and that diff is applied again on state2.
-        // The result is compared against state3 again.
-        const state2WithActiveCell = applyActions(
-          initialState,
-          userActions.slice(0, beforeVersionIndex),
-        );
+        test.each(afterVersionIndices)("To v=%i", (afterVersionIndex: number) => {
+          // The update actions are applied on the initialState which produces new states.
+          // The "timeline" is as follows:
+          //         initialState
+          //              ↓
+          // [actions until beforeVersionIndex]
+          //              ↓
+          //            state2
+          //              ↓
+          // [actions between before and afterVersionIndex]
+          //              ↓
+          //            state3
+          //
+          // state2 and state3 are diffed and that diff is applied again on state2.
+          // The result is compared against state3 again.
+          const state2WithActiveCell = applyActions(
+            initialState,
+            userActions.slice(0, beforeVersionIndex),
+          );
 
-        const state2WithoutActiveBoundingBox = applyActions(state2WithActiveCell, [
-          setActiveUserBoundingBoxId(null),
-        ]);
+          const state2WithoutActiveBoundingBox = applyActions(state2WithActiveCell, [
+            setActiveUserBoundingBoxId(null),
+          ]);
 
-        const actionsToApply = userActions.slice(beforeVersionIndex, afterVersionIndex + 1);
-        let state3 = applyActions(
-          state2WithActiveCell,
-          actionsToApply.concat([setActiveUserBoundingBoxId(null)]),
-        );
-        expect(state2WithoutActiveBoundingBox !== state3).toBeTruthy();
+          const actionsToApply = userActions.slice(beforeVersionIndex, afterVersionIndex + 1);
+          let state3 = applyActions(
+            state2WithActiveCell,
+            actionsToApply.concat([setActiveUserBoundingBoxId(null)]),
+          );
+          expect(state2WithoutActiveBoundingBox !== state3).toBeTruthy();
 
-        const volumeTracing2 = enforceVolumeTracing(state2WithoutActiveBoundingBox);
-        const volumeTracing3 = enforceVolumeTracing(state3);
+          const volumeTracing2 = enforceVolumeTracing(state2WithoutActiveBoundingBox);
+          const volumeTracing3 = enforceVolumeTracing(state3);
 
-        const updateActionsBeforeCompaction = Array.from(
-          diffVolumeTracing(volumeTracing2, volumeTracing3),
-        );
-        const maybeCompact = withCompaction
-          ? compactUpdateActions
-          : (updateActions: UpdateActionWithoutIsolationRequirement[]) => updateActions;
-        const updateActions = addMissingTimestampProp(
-          maybeCompact(updateActionsBeforeCompaction, volumeTracing2, volumeTracing3),
-        );
+          const updateActionsBeforeCompaction = Array.from(
+            diffVolumeTracing(volumeTracing2, volumeTracing3),
+          );
+          const maybeCompact = withCompaction
+            ? compactUpdateActions
+            : (updateActions: UpdateActionWithoutIsolationRequirement[]) => updateActions;
+          const updateActions = addMissingTimestampProp(
+            maybeCompact(updateActionsBeforeCompaction, volumeTracing2, volumeTracing3),
+          );
 
-        for (const action of updateActions) {
-          seenActionTypes.add(action.name);
-        }
+          for (const action of updateActions) {
+            seenActionTypes.add(action.name);
+          }
 
-        const reappliedNewState = transformStateAsReadOnly(
-          state2WithoutActiveBoundingBox,
-          (state) =>
-            applyActions(state, [
-              applyVolumeUpdateActionsFromServerAction(updateActions),
-              setActiveUserBoundingBoxId(null),
-            ]),
-        );
+          const reappliedNewState = transformStateAsReadOnly(
+            state2WithoutActiveBoundingBox,
+            (state) =>
+              applyActions(state, [
+                applyVolumeUpdateActionsFromServerAction(updateActions),
+                setActiveUserBoundingBoxId(null),
+              ]),
+          );
 
-        expect(reappliedNewState.annotation.volumes[0]).toEqual(state3.annotation.volumes[0]);
+          expect(reappliedNewState.annotation.volumes[0]).toEqual(state3.annotation.volumes[0]);
+        });
       });
-    });
-  });
+    },
+  );
 
   it("should be able to apply basic group editing actions", () => {
     const state1 = applyActions(initialState, [setSegmentGroupsAction(SEGMENT_GROUPS, tracingId)]);

--- a/frontend/javascripts/test/sagas/bounding_box_saving.spec.ts
+++ b/frontend/javascripts/test/sagas/bounding_box_saving.spec.ts
@@ -262,7 +262,7 @@ describe("Bounding box diffing and compaction", () => {
     expect(volumeActionBatch.actions[0].name).toBe("updateUserBoundingBoxInVolumeTracing");
 
     const volumeActionValue = (
-      volumeActionBatch?.actions[0] as UpdateUserBoundingBoxInVolumeTracingAction
+      volumeActionBatch.actions[0] as UpdateUserBoundingBoxInVolumeTracingAction
     ).value;
     expect(volumeActionValue).not.toBeNull();
     if (volumeActionValue == null) {
@@ -277,7 +277,7 @@ describe("Bounding box diffing and compaction", () => {
     });
 
     const skeletonActionValue = (
-      skeletonActionBatch?.actions[0] as UpdateUserBoundingBoxInSkeletonTracingAction
+      skeletonActionBatch.actions[0] as UpdateUserBoundingBoxInSkeletonTracingAction
     ).value;
     expect(skeletonActionValue).not.toBeNull();
     if (skeletonActionValue == null) {

--- a/frontend/javascripts/test/sagas/id_reservation.spec.ts
+++ b/frontend/javascripts/test/sagas/id_reservation.spec.ts
@@ -138,75 +138,75 @@ describe("ID reservation saga (concurrent collaboration mode)", () => {
     await task.toPromise();
   });
 
-  it.for([
-    [0],
-    [20],
-  ])("should replenish the buffer after an ID is returned when the remaining count falls below the threshold (delay=%i)", async ([
-    // We use an artificial delay to also test whether dispatchGetNewIdAsync correctly
-    // awaits ongoing replenishment requests
-    delay,
-  ], context: TestContext) => {
-    const { mocks } = context as WebknossosTestContext;
-    const { tracingId } = Store.getState().annotation.volumes[0];
+  it.for([[0], [20]])(
+    "should replenish the buffer after an ID is returned when the remaining count falls below the threshold (delay=%i)",
+    async ([
+      // We use an artificial delay to also test whether dispatchGetNewIdAsync correctly
+      // awaits ongoing replenishment requests
+      delay,
+    ], context: TestContext) => {
+      const { mocks } = context as WebknossosTestContext;
+      const { tracingId } = Store.getState().annotation.volumes[0];
 
-    // 2 usable reservations: 2 < IDEAL_ID_BUFFER_SIZE / 2 (2.5), so replenishment fires after the
-    // first use. But replenishment is async — it runs concurrently with the next request.
-    Store.dispatch(
-      setIdReservationsAction(tracingId, "SegmentGroup", [
-        { id: 199, used: true },
-        { id: 200, used: false },
-        { id: 201, used: false },
-      ]),
-    );
-
-    mockReserveIdsEndpoint(mocks, [300, 301, 302, 303], delay);
-
-    const task = startSaga(function* task() {
-      const id1 = yield call(() =>
-        dispatchGetNewIdAsync(Store.dispatch, tracingId, "SegmentGroup"),
+      // 2 usable reservations: 2 < IDEAL_ID_BUFFER_SIZE / 2 (2.5), so replenishment fires after the
+      // first use. But replenishment is async — it runs concurrently with the next request.
+      Store.dispatch(
+        setIdReservationsAction(tracingId, "SegmentGroup", [
+          { id: 199, used: true },
+          { id: 200, used: false },
+          { id: 201, used: false },
+        ]),
       );
-      expect(id1).toBe(200);
 
-      const id2 = yield call(() =>
-        dispatchGetNewIdAsync(Store.dispatch, tracingId, "SegmentGroup"),
-      );
-      expect(id2).toBe(201);
+      mockReserveIdsEndpoint(mocks, [300, 301, 302, 303], delay);
 
-      // Buffer is now empty; this request must wait for the replenishment saga to complete.
-      // After it returns, we are guaranteed that the replenishment has finished.
-      const id3 = yield call(() =>
-        dispatchGetNewIdAsync(Store.dispatch, tracingId, "SegmentGroup"),
-      );
-      expect(id3).toBe(300);
-
-      const reservations = getIdReservationsForSegmentationLayer(
-        Store.getState(),
-        tracingId,
-      ).SegmentGroup;
-      expect(reservations).toEqual([
-        { id: 201, used: true },
-        { id: 300, used: true },
-        { id: 301, used: false },
-        { id: 302, used: false },
-        { id: 303, used: false },
-      ]);
-
-      const reserveIdsCalls = vi
-        .mocked(mocks.Request.sendJSONReceiveJSON)
-        .mock.calls.filter(([url]) => url.includes("/reserveIds"));
-      expect(reserveIdsCalls).toHaveLength(1);
-
-      const allReleasedIds = vi
-        .mocked(mocks.Request.sendJSONReceiveJSON)
-        .mock.calls.filter(([url]) => url.includes("/reserveIds"))
-        .flatMap(
-          ([, options]) => (options.data as Record<string, unknown>).idsToRelease as number[],
+      const task = startSaga(function* task() {
+        const id1 = yield call(() =>
+          dispatchGetNewIdAsync(Store.dispatch, tracingId, "SegmentGroup"),
         );
-      expect(allReleasedIds).toEqual([199, 200]);
-    });
+        expect(id1).toBe(200);
 
-    await task.toPromise();
-  });
+        const id2 = yield call(() =>
+          dispatchGetNewIdAsync(Store.dispatch, tracingId, "SegmentGroup"),
+        );
+        expect(id2).toBe(201);
+
+        // Buffer is now empty; this request must wait for the replenishment saga to complete.
+        // After it returns, we are guaranteed that the replenishment has finished.
+        const id3 = yield call(() =>
+          dispatchGetNewIdAsync(Store.dispatch, tracingId, "SegmentGroup"),
+        );
+        expect(id3).toBe(300);
+
+        const reservations = getIdReservationsForSegmentationLayer(
+          Store.getState(),
+          tracingId,
+        ).SegmentGroup;
+        expect(reservations).toEqual([
+          { id: 201, used: true },
+          { id: 300, used: true },
+          { id: 301, used: false },
+          { id: 302, used: false },
+          { id: 303, used: false },
+        ]);
+
+        const reserveIdsCalls = vi
+          .mocked(mocks.Request.sendJSONReceiveJSON)
+          .mock.calls.filter(([url]) => url.includes("/reserveIds"));
+        expect(reserveIdsCalls).toHaveLength(1);
+
+        const allReleasedIds = vi
+          .mocked(mocks.Request.sendJSONReceiveJSON)
+          .mock.calls.filter(([url]) => url.includes("/reserveIds"))
+          .flatMap(
+            ([, options]) => (options.data as Record<string, unknown>).idsToRelease as number[],
+          );
+        expect(allReleasedIds).toEqual([199, 200]);
+      });
+
+      await task.toPromise();
+    },
+  );
 
   it("should include pre-existing used IDs in idsToRelease", async (context: WebknossosTestContext) => {
     const { mocks } = context;

--- a/frontend/javascripts/test/sagas/proofreading/proofreading_agglomerate_trees_interaction.spec.ts
+++ b/frontend/javascripts/test/sagas/proofreading/proofreading_agglomerate_trees_interaction.spec.ts
@@ -164,60 +164,60 @@ describe("Proofreading (With Agglomerate Tree interactions)", () => {
     await task.toPromise();
   });
 
-  describe.each([
-    false,
-    true,
-  ])("With shouldSaveAfterLoadingTrees=%s", (shouldSaveAfterLoadingTrees: boolean) => {
-    it("should merge two agglomerate trees optimistically, perform the merge proofreading action and incorporate a new merge action from backend", async (context: WebknossosTestContext) => {
-      const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());
-      backendMock.planMultipleVersionInjections(9, mergeSegment5And6WithAgglomerateTree1And4);
+  describe.each([false, true])(
+    "With shouldSaveAfterLoadingTrees=%s",
+    (shouldSaveAfterLoadingTrees: boolean) => {
+      it("should merge two agglomerate trees optimistically, perform the merge proofreading action and incorporate a new merge action from backend", async (context: WebknossosTestContext) => {
+        const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());
+        backendMock.planMultipleVersionInjections(9, mergeSegment5And6WithAgglomerateTree1And4);
 
-      const { annotation } = Store.getState();
-      const { tracingId } = annotation.volumes[0];
+        const { annotation } = Store.getState();
+        const { tracingId } = annotation.volumes[0];
 
-      const task = startSaga(function* task() {
-        yield performMergeTreesProofreading(context, shouldSaveAfterLoadingTrees, false);
-        const injectedMergeUpdates = context.receivedDataPerSaveRequest.slice(4, 8);
-        assertUpdatesMatchInjectedUpdates(
-          injectedMergeUpdates,
-          mergeSegment5And6WithAgglomerateTree1And4,
-          9,
-        );
+        const task = startSaga(function* task() {
+          yield performMergeTreesProofreading(context, shouldSaveAfterLoadingTrees, false);
+          const injectedMergeUpdates = context.receivedDataPerSaveRequest.slice(4, 8);
+          assertUpdatesMatchInjectedUpdates(
+            injectedMergeUpdates,
+            mergeSegment5And6WithAgglomerateTree1And4,
+            9,
+          );
 
-        const latestUpdateActionRequestPayload = getNestedUpdateActions(context).slice(-4)!;
-        yield expect(latestUpdateActionRequestPayload).toMatchFileSnapshot(
-          "./__snapshots__/proofreading_agglomerate_trees_interaction.spec.ts/merge_trees_simple.json",
-        );
+          const latestUpdateActionRequestPayload = getNestedUpdateActions(context).slice(-4)!;
+          yield expect(latestUpdateActionRequestPayload).toMatchFileSnapshot(
+            "./__snapshots__/proofreading_agglomerate_trees_interaction.spec.ts/merge_trees_simple.json",
+          );
 
-        yield expectSegmentList(tracingId, [
-          {
-            id: 1n,
+          yield expectSegmentList(tracingId, [
+            {
+              id: 1n,
 
-            anchorPosition: [3, 3, 3],
-          },
-        ]);
+              anchorPosition: [3, 3, 3],
+            },
+          ]);
 
-        const finalMapping = yield* select(
-          (state) =>
-            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-        );
+          const finalMapping = yield* select(
+            (state) =>
+              getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+          );
 
-        expect(finalMapping).toEqual(
-          new Map([
-            [1n, 1n],
-            [2n, 1n],
-            [3n, 1n],
-            [4n, 1n],
-            [5n, 1n],
-            [6n, 1n],
-            [7n, 1n],
-          ]),
-        );
+          expect(finalMapping).toEqual(
+            new Map([
+              [1n, 1n],
+              [2n, 1n],
+              [3n, 1n],
+              [4n, 1n],
+              [5n, 1n],
+              [6n, 1n],
+              [7n, 1n],
+            ]),
+          );
+        });
+
+        await task.toPromise();
       });
-
-      await task.toPromise();
-    });
-  });
+    },
+  );
 
   it("should not merge two agglomerate trees if interfering merge makes it a no-op.", async (context: WebknossosTestContext) => {
     const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());

--- a/frontend/javascripts/test/sagas/proofreading/proofreading_auxiliary_mesh_loading.spec.ts
+++ b/frontend/javascripts/test/sagas/proofreading/proofreading_auxiliary_mesh_loading.spec.ts
@@ -152,66 +152,64 @@ describe("Proofreading (with auxiliary mesh loading enabled)", () => {
       await task.toPromise();
     });
 
-    it(
-      "should reload auxiliary meshes after merge",
-      { retry: { count: 3, delay: 10 } },
-      async (context: WebknossosTestContext) => {
-        const _backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());
+    it("should reload auxiliary meshes after merge", {
+      retry: { count: 3, delay: 10 },
+    }, async (context: WebknossosTestContext) => {
+      const _backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());
 
-        const task = startSaga(function* task(): Saga<void> {
-          const { tracingId } = yield* select(
-            (state: WebknossosState) => state.annotation.volumes[0],
-          );
-          yield call(initializeMappingAndTool, context, tracingId);
-          if (othersMayEdit) {
-            yield put(setCollaborationModeAction(othersMayEdit ? "Concurrent" : "OwnerOnly"));
-          }
+      const task = startSaga(function* task(): Saga<void> {
+        const { tracingId } = yield* select(
+          (state: WebknossosState) => state.annotation.volumes[0],
+        );
+        yield call(initializeMappingAndTool, context, tracingId);
+        if (othersMayEdit) {
+          yield put(setCollaborationModeAction(othersMayEdit ? "Concurrent" : "OwnerOnly"));
+        }
 
-          // Set up the merge-related segment partners. Normally, this would happen
-          // due to the user's interactions.
-          yield loadAgglomerateMeshes([1, 6]);
+        // Set up the merge-related segment partners. Normally, this would happen
+        // due to the user's interactions.
+        yield loadAgglomerateMeshes([1, 6]);
 
-          yield put(
-            updateSegmentAction(1n, { anchorPosition: getPositionForSegmentId(1) }, tracingId),
-          );
-          yield put(setActiveCellAction(1n));
-          // Give mesh loading a little time
-          const loadedMeshIds = getAllCurrentlyLoadedMeshIds(context, tracingId);
-          expect(sortBy([...loadedMeshIds])).toEqual([1n, 6n]);
-          yield loadAgglomerateMeshes([4]);
+        yield put(
+          updateSegmentAction(1n, { anchorPosition: getPositionForSegmentId(1) }, tracingId),
+        );
+        yield put(setActiveCellAction(1n));
+        // Give mesh loading a little time
+        const loadedMeshIds = getAllCurrentlyLoadedMeshIds(context, tracingId);
+        expect(sortBy([...loadedMeshIds])).toEqual([1n, 6n]);
+        yield loadAgglomerateMeshes([4]);
 
-          const loadedMeshIds2 = getAllCurrentlyLoadedMeshIds(context, tracingId);
-          expect(sortBy([...loadedMeshIds2])).toEqual([1n, 4n, 6n]);
+        const loadedMeshIds2 = getAllCurrentlyLoadedMeshIds(context, tracingId);
+        expect(sortBy([...loadedMeshIds2])).toEqual([1n, 4n, 6n]);
 
-          // Execute the actual merge and wait for the finished mapping.
-          const meshTracker = yield* trackMeshes(context, tracingId);
-          yield put(proofreadMergeAction(getPositionForSegmentId(4), 4n));
-          yield take(operationFinished("PROOFREADING")); // operation finished
-          yield meshTracker.consumeFinishedLoadingActions(1);
+        // Execute the actual merge and wait for the finished mapping.
+        const meshTracker = yield* trackMeshes(context, tracingId);
+        yield put(proofreadMergeAction(getPositionForSegmentId(4), 4n));
+        yield take(operationFinished("PROOFREADING")); // operation finished
+        yield meshTracker.consumeFinishedLoadingActions(1);
 
-          const {
-            removedMeshes,
-            addedMeshes,
-            loadedMeshIds: loadedMeshIdsAfterMerge,
-          } = meshTracker.getMeshInfos();
-          expect(sortBy([...loadedMeshIdsAfterMerge])).toEqual([1n, 6n]);
-          expect(sortBy([...removedMeshes])).toEqual([1n, 4n]);
-          expect([...addedMeshes]).toEqual([1n]);
-          yield* meshTracker.cleanUp();
-          yield expectSegmentList(tracingId, [
-            {
-              id: 1n,
-              anchorPosition: [1, 1, 1],
-            },
-            {
-              id: 6n,
-              anchorPosition: [6, 6, 6],
-            },
-          ]);
-        });
-        await task.toPromise();
-      },
-    );
+        const {
+          removedMeshes,
+          addedMeshes,
+          loadedMeshIds: loadedMeshIdsAfterMerge,
+        } = meshTracker.getMeshInfos();
+        expect(sortBy([...loadedMeshIdsAfterMerge])).toEqual([1n, 6n]);
+        expect(sortBy([...removedMeshes])).toEqual([1n, 4n]);
+        expect([...addedMeshes]).toEqual([1n]);
+        yield* meshTracker.cleanUp();
+        yield expectSegmentList(tracingId, [
+          {
+            id: 1n,
+            anchorPosition: [1, 1, 1],
+          },
+          {
+            id: 6n,
+            anchorPosition: [6, 6, 6],
+          },
+        ]);
+      });
+      await task.toPromise();
+    });
 
     it("should reload auxiliary meshes after split", async (context: WebknossosTestContext) => {
       const { mocks } = context;

--- a/frontend/javascripts/test/sagas/proofreading/proofreading_mesh_interaction.spec.ts
+++ b/frontend/javascripts/test/sagas/proofreading/proofreading_mesh_interaction.spec.ts
@@ -133,55 +133,53 @@ describe("Proofreading (with mesh actions)", () => {
   }
 
   // Mesh interactions tests
-  it(
-    "should merge two agglomerates correctly even when merged segments are not loaded (such an action can be triggered via mesh proofreading)",
-    { timeout: 6000 },
-    async (context: WebknossosTestContext) => {
-      const _backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());
+  it("should merge two agglomerates correctly even when merged segments are not loaded (such an action can be triggered via mesh proofreading)", {
+    timeout: 6000,
+  }, async (context: WebknossosTestContext) => {
+    const _backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());
 
-      const { annotation } = Store.getState();
-      const { tracingId } = annotation.volumes[0];
+    const { annotation } = Store.getState();
+    const { tracingId } = annotation.volumes[0];
 
-      const task = startSaga(function* task(): Saga<void> {
-        yield simulateMergeAgglomeratesViaMeshes(context);
+    const task = startSaga(function* task(): Saga<void> {
+      yield simulateMergeAgglomeratesViaMeshes(context);
 
-        const finalMapping = yield* select(
-          (state) =>
-            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-        );
+      const finalMapping = yield* select(
+        (state) =>
+          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+      );
 
-        expect(finalMapping).toEqual(
-          new Map([
-            [1n, 1n],
-            [2n, 1n],
-            [3n, 1n],
-            [4n, 4n],
-            [5n, 4n],
-            [6n, 6n],
-            [7n, 6n],
-            // [1337n, 1n], not loaded due to no rebasing performed as this test has no injected updated actions.
-            // If there would be injected updates (simulating other users' changes) the segment id 1337 would
-            // been looked up for rebasing and thus added to the loaded mapping.
-            // [1338n, 1n], not loaded
-          ]),
-        );
-        yield call(() => context.api.tracing.save());
+      expect(finalMapping).toEqual(
+        new Map([
+          [1n, 1n],
+          [2n, 1n],
+          [3n, 1n],
+          [4n, 4n],
+          [5n, 4n],
+          [6n, 6n],
+          [7n, 6n],
+          // [1337n, 1n], not loaded due to no rebasing performed as this test has no injected updated actions.
+          // If there would be injected updates (simulating other users' changes) the segment id 1337 would
+          // been looked up for rebasing and thus added to the loaded mapping.
+          // [1338n, 1n], not loaded
+        ]),
+      );
+      yield call(() => context.api.tracing.save());
 
-        yield* expectSegmentList(
-          tracingId,
-          [
-            {
-              id: 1n,
-              anchorPosition: [1, 1, 1],
-            },
-          ],
-          _backendMock,
-        );
-      });
+      yield* expectSegmentList(
+        tracingId,
+        [
+          {
+            id: 1n,
+            anchorPosition: [1, 1, 1],
+          },
+        ],
+        _backendMock,
+      );
+    });
 
-      await task.toPromise();
-    },
-  );
+    await task.toPromise();
+  });
 
   it("should load unknown unmapped segment ids of mesh merge operation when incorporating interfered update actions.", async (context: WebknossosTestContext) => {
     const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState());

--- a/frontend/javascripts/test/sagas/proofreading/proofreading_poll_only.spec.ts
+++ b/frontend/javascripts/test/sagas/proofreading/proofreading_poll_only.spec.ts
@@ -38,582 +38,589 @@ import {
   mockInitialBucketAndAgglomerateData,
 } from "./proofreading_test_utils";
 
-describe.each(
-  AnnotationCollaborationModes,
-)("Proofreading (Poll only) with collaborationMode=%s", (collabMode: AnnotationCollaborationMode) => {
-  function* initializePollOnlyAnnotation(context: WebknossosTestContext, tracingId: string) {
-    yield call(initializeMappingAndTool, context, tracingId);
-
-    const mapping0 = yield* select(
-      (state) =>
-        getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-    );
-    expect(mapping0).toEqual(initialMapping);
-
-    yield makeAnnotationPollOnly(context);
-  }
-
-  function* makeAnnotationPollOnly(context: WebknossosTestContext) {
-    const { api } = context;
-    // Set collab mode to concurrent to be able to save the updates about initializing the mapping.
-    yield put(setCollaborationModeAction("Concurrent"));
-    yield call(() => api.tracing.save());
-    context.receivedDataPerSaveRequest.length = 0; // Clear array in-place.
-
-    // Now switch to a poll only mode: Simulate a different user in a different client session than the owner
-    // and enable the actual collaborationMode that should be tested.
-    const differentUser = {
-      ...dummyUser,
-      id: "dummy-user2-id",
-      email: "dummy2@email.com",
-      firstName: "First Name2",
-      lastName: "Last Name2",
-    };
-    yield put(setActiveUserAction(differentUser));
-    yield put(setCollaborationModeAction(collabMode));
-    yield put(setIsUpdatingAnnotationCurrentlyAllowedAction(false));
-  }
-
-  beforeEach<WebknossosTestContext>(async (context) => {
-    await setupWebknossosForTestingWithRestrictions(context, "Exclusive", true, false, "hybrid");
-  });
-
-  afterEach<WebknossosTestContext>(async (context) => {
-    context.tearDownPullQueues();
-    expect(hasRootSagaCrashed()).toBe(false);
-  });
-
-  it("should update the mapping when the server has a new update action with a merge operation", async (context: WebknossosTestContext) => {
-    const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
-      grantMutex: false,
-    });
-
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
-
-    const task = startSaga(function* () {
-      yield initializePollOnlyAnnotation(context, tracingId);
-
-      const foreignMergeAction = {
-        name: "mergeAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1n,
-          segmentId2: 4n,
-          agglomerateId1: 1n,
-          agglomerateId2: 4n,
-        },
-      };
-      backendMock.injectVersion([foreignMergeAction], 4);
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
-
-      const mapping1 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-      );
-
-      expect(mapping1).toEqual(expectedMappingAfterMerge);
-
-      // Expect empty save queue as the user is not allowed to do updates.
-      const saveQueue = yield select((state) => state.save.queue);
-      expect(saveQueue.length).toBe(0);
-      // Checking that only the injected update action was received.
-      expect(context.receivedDataPerSaveRequest.length).toBe(1);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch.actions.length).toBe(1);
-      expect(updateBatch.actions).toEqual([foreignMergeAction]);
-
-      yield expectSegmentList(tracingId, []);
-
-      const activeTool = yield* select((state) => state.uiInformation.activeTool);
-      expect(activeTool).toBe(AnnotationTool.PROOFREAD);
-    });
-
-    await task.toPromise();
-  });
-
-  it("should update the mapping correctly when the server has first a new update action with a split then with a merge operation with segments unknown to the client", async (context: WebknossosTestContext) => {
-    const { api } = context;
-    const backendMock = mockInitialBucketAndAgglomerateData(
-      context,
-      [
-        [7n, 1337n],
-        [4n, 1338n],
-      ],
-      Store.getState(),
-      { grantMutex: false },
-    );
-    // Initial Mapping
-    // 1-2-3
-    // 5-4-1338-1337-7-6
-    // Loaded by client: 1, 2, 3, 4, 5, 6, 7
-
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
-
-    const task = startSaga(function* () {
+describe.each(AnnotationCollaborationModes)(
+  "Proofreading (Poll only) with collaborationMode=%s",
+  (collabMode: AnnotationCollaborationMode) => {
+    function* initializePollOnlyAnnotation(context: WebknossosTestContext, tracingId: string) {
       yield call(initializeMappingAndTool, context, tracingId);
 
       const mapping0 = yield* select(
         (state) =>
           getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
       );
-      expect(mapping0).toEqual(
-        new Map([
-          [1n, 1n],
-          [2n, 1n],
-          [3n, 1n],
-          [4n, 4n],
-          [5n, 4n],
-          [6n, 4n],
-          [7n, 4n],
-        ]),
-      );
+      expect(mapping0).toEqual(initialMapping);
 
-      yield* makeAnnotationPollOnly(context);
+      yield makeAnnotationPollOnly(context);
+    }
 
-      const foreignSplitAction = {
-        name: "splitAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1338n,
-          segmentId2: 1337n,
-          agglomerateId: 4n,
-        },
-      };
-      backendMock.injectVersion([foreignSplitAction], 4);
-
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
-
-      const mapping1 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-      );
-
-      expect(mapping1).toEqual(
-        new Map([
-          [1n, 1n],
-          [2n, 1n],
-          [3n, 1n],
-          [4n, 4n],
-          [5n, 4n],
-          [6n, 1339n],
-          [7n, 1339n],
-        ]),
-      );
-
+    function* makeAnnotationPollOnly(context: WebknossosTestContext) {
+      const { api } = context;
+      // Set collab mode to concurrent to be able to save the updates about initializing the mapping.
+      yield put(setCollaborationModeAction("Concurrent"));
       yield call(() => api.tracing.save());
-      // Checking that only the injected update action was received.
-      expect(context.receivedDataPerSaveRequest.length).toBe(1);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch1 = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch1.actions.length).toBe(1);
-      expect(updateBatch1.actions).toEqual([foreignSplitAction]);
+      context.receivedDataPerSaveRequest.length = 0; // Clear array in-place.
 
-      const foreignMergeAction = {
-        name: "mergeAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1337n,
-          segmentId2: 1338n,
-          agglomerateId1: 1339n,
-          agglomerateId2: 4n,
-        },
+      // Now switch to a poll only mode: Simulate a different user in a different client session than the owner
+      // and enable the actual collaborationMode that should be tested.
+      const differentUser = {
+        ...dummyUser,
+        id: "dummy-user2-id",
+        email: "dummy2@email.com",
+        firstName: "First Name2",
+        lastName: "Last Name2",
       };
-      backendMock.injectVersion([foreignMergeAction], 5);
+      yield put(setActiveUserAction(differentUser));
+      yield put(setCollaborationModeAction(collabMode));
+      yield put(setIsUpdatingAnnotationCurrentlyAllowedAction(false));
+    }
 
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+    beforeEach<WebknossosTestContext>(async (context) => {
+      await setupWebknossosForTestingWithRestrictions(context, "Exclusive", true, false, "hybrid");
+    });
 
-      const mapping2 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+    afterEach<WebknossosTestContext>(async (context) => {
+      context.tearDownPullQueues();
+      expect(hasRootSagaCrashed()).toBe(false);
+    });
+
+    it("should update the mapping when the server has a new update action with a merge operation", async (context: WebknossosTestContext) => {
+      const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
+        grantMutex: false,
+      });
+
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
+
+      const task = startSaga(function* () {
+        yield initializePollOnlyAnnotation(context, tracingId);
+
+        const foreignMergeAction = {
+          name: "mergeAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1n,
+            segmentId2: 4n,
+            agglomerateId1: 1n,
+            agglomerateId2: 4n,
+          },
+        };
+        backendMock.injectVersion([foreignMergeAction], 4);
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+
+        const mapping1 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
+
+        expect(mapping1).toEqual(expectedMappingAfterMerge);
+
+        // Expect empty save queue as the user is not allowed to do updates.
+        const saveQueue = yield select((state) => state.save.queue);
+        expect(saveQueue.length).toBe(0);
+        // Checking that only the injected update action was received.
+        expect(context.receivedDataPerSaveRequest.length).toBe(1);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch.actions.length).toBe(1);
+        expect(updateBatch.actions).toEqual([foreignMergeAction]);
+
+        yield expectSegmentList(tracingId, []);
+
+        const activeTool = yield* select((state) => state.uiInformation.activeTool);
+        expect(activeTool).toBe(AnnotationTool.PROOFREAD);
+      });
+
+      await task.toPromise();
+    });
+
+    it("should update the mapping correctly when the server has first a new update action with a split then with a merge operation with segments unknown to the client", async (context: WebknossosTestContext) => {
+      const { api } = context;
+      const backendMock = mockInitialBucketAndAgglomerateData(
+        context,
+        [
+          [7n, 1337n],
+          [4n, 1338n],
+        ],
+        Store.getState(),
+        { grantMutex: false },
+      );
+      // Initial Mapping
+      // 1-2-3
+      // 5-4-1338-1337-7-6
+      // Loaded by client: 1, 2, 3, 4, 5, 6, 7
+
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
+
+      const task = startSaga(function* () {
+        yield call(initializeMappingAndTool, context, tracingId);
+
+        const mapping0 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
+        expect(mapping0).toEqual(
+          new Map([
+            [1n, 1n],
+            [2n, 1n],
+            [3n, 1n],
+            [4n, 4n],
+            [5n, 4n],
+            [6n, 4n],
+            [7n, 4n],
+          ]),
+        );
+
+        yield* makeAnnotationPollOnly(context);
+
+        const foreignSplitAction = {
+          name: "splitAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1338n,
+            segmentId2: 1337n,
+            agglomerateId: 4n,
+          },
+        };
+        backendMock.injectVersion([foreignSplitAction], 4);
+
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+
+        const mapping1 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
+
+        expect(mapping1).toEqual(
+          new Map([
+            [1n, 1n],
+            [2n, 1n],
+            [3n, 1n],
+            [4n, 4n],
+            [5n, 4n],
+            [6n, 1339n],
+            [7n, 1339n],
+          ]),
+        );
+
+        yield call(() => api.tracing.save());
+        // Checking that only the injected update action was received.
+        expect(context.receivedDataPerSaveRequest.length).toBe(1);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch1 = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch1.actions.length).toBe(1);
+        expect(updateBatch1.actions).toEqual([foreignSplitAction]);
+
+        const foreignMergeAction = {
+          name: "mergeAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1337n,
+            segmentId2: 1338n,
+            agglomerateId1: 1339n,
+            agglomerateId2: 4n,
+          },
+        };
+        backendMock.injectVersion([foreignMergeAction], 5);
+
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+
+        const mapping2 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
+
+        expect(mapping2).toEqual(
+          new Map([
+            [1n, 1n],
+            [2n, 1n],
+            [3n, 1n],
+            [4n, 1339n],
+            [5n, 1339n],
+            [6n, 1339n],
+            [7n, 1339n],
+          ]),
+        );
+
+        yield call(() => api.tracing.save());
+
+        // Checking that only the injected update action was received.
+        // split action:
+        expect(context.receivedDataPerSaveRequest.length).toBe(2);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch2 = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch2.actions.length).toBe(1);
+        expect(updateBatch2.actions).toEqual([foreignSplitAction]);
+        // merge action:
+        expect(context.receivedDataPerSaveRequest[1].length).toBe(1);
+        const updateBatch3 = context.receivedDataPerSaveRequest[1][0];
+        expect(updateBatch3.actions.length).toBe(1);
+        expect(updateBatch3.actions).toEqual([foreignMergeAction]);
+
+        yield expectSegmentList(tracingId, []);
+      });
+
+      await task.toPromise();
+    });
+
+    it("should update the mapping when the server has a new update action with a split operation", async (context: WebknossosTestContext) => {
+      const { api } = context;
+      const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
+        grantMutex: false,
+      });
+
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
+
+      const task = startSaga(function* () {
+        yield initializePollOnlyAnnotation(context, tracingId);
+
+        const foreignSplitAction = {
+          name: "splitAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1n,
+            segmentId2: 2n,
+            agglomerateId: 1n,
+          },
+        };
+        backendMock.injectVersion([foreignSplitAction], 4);
+
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+
+        const mapping1 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
+
+        expect(mapping1).toEqual(expectedMappingAfterSplit);
+
+        yield call(() => api.tracing.save());
+
+        // Checking that only the injected update action was received.
+        expect(context.receivedDataPerSaveRequest.length).toBe(1);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch.actions.length).toBe(1);
+        expect(updateBatch.actions).toEqual([foreignSplitAction]);
+
+        yield expectSegmentList(tracingId, []);
+      });
+
+      await task.toPromise();
+    });
+
+    it("should update the mapping correctly when the server has a new update action with a split operation with segments unknown to the client", async (context: WebknossosTestContext) => {
+      const { api } = context;
+      const backendMock = mockInitialBucketAndAgglomerateData(
+        context,
+        [[7n, 1337n]],
+        Store.getState(),
       );
 
-      expect(mapping2).toEqual(
-        new Map([
-          [1n, 1n],
-          [2n, 1n],
-          [3n, 1n],
-          [4n, 1339n],
-          [5n, 1339n],
-          [6n, 1339n],
-          [7n, 1339n],
-        ]),
-      );
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
 
-      yield call(() => api.tracing.save());
+      const task = startSaga(function* () {
+        yield initializePollOnlyAnnotation(context, tracingId);
 
-      // Checking that only the injected update action was received.
-      // split action:
-      expect(context.receivedDataPerSaveRequest.length).toBe(2);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch2 = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch2.actions.length).toBe(1);
-      expect(updateBatch2.actions).toEqual([foreignSplitAction]);
-      // merge action:
-      expect(context.receivedDataPerSaveRequest[1].length).toBe(1);
-      const updateBatch3 = context.receivedDataPerSaveRequest[1][0];
-      expect(updateBatch3.actions.length).toBe(1);
-      expect(updateBatch3.actions).toEqual([foreignMergeAction]);
+        const foreignSplitAction1 = {
+          name: "splitAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1n,
+            segmentId2: 2n,
+            agglomerateId: 1n,
+          },
+        };
+        const foreignSplitAction2 = {
+          name: "splitAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1338n,
+            segmentId2: 1337n,
+            agglomerateId: 6n,
+          },
+        };
+        backendMock.injectVersion([foreignSplitAction1], 4);
+        backendMock.injectVersion([foreignSplitAction2], 5);
 
-      yield expectSegmentList(tracingId, []);
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+
+        const mapping1 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
+
+        expect(mapping1).toEqual(
+          new Map([
+            [1n, 1n],
+            [2n, 1339n],
+            [3n, 1339n],
+            [4n, 4n],
+            [5n, 4n],
+            [6n, 1340n],
+            [7n, 1340n],
+          ]),
+        );
+
+        yield call(() => api.tracing.save());
+
+        // Checking that only the injected update actions were received.
+        // split 1
+        expect(context.receivedDataPerSaveRequest.length).toBe(2);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch1 = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch1.actions.length).toBe(1);
+        expect(updateBatch1.actions).toEqual([foreignSplitAction1]);
+        //split 2
+        expect(context.receivedDataPerSaveRequest[1].length).toBe(1);
+        const updateBatch2 = context.receivedDataPerSaveRequest[1][0];
+        expect(updateBatch2.actions.length).toBe(1);
+        expect(updateBatch2.actions).toEqual([foreignSplitAction2]);
+
+        yield expectSegmentList(tracingId, []);
+      });
+
+      await task.toPromise();
     });
 
-    await task.toPromise();
-  });
+    it("should update the mapping correctly when the server has a new update action with a merge and split operation with segments unknown to the client", async (context: WebknossosTestContext) => {
+      const { api } = context;
+      const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
+        grantMutex: false,
+      });
 
-  it("should update the mapping when the server has a new update action with a split operation", async (context: WebknossosTestContext) => {
-    const { api } = context;
-    const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
-      grantMutex: false,
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
+
+      const task = startSaga(function* () {
+        yield initializePollOnlyAnnotation(context, tracingId);
+
+        const foreignMergeAction = {
+          name: "mergeAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 7n,
+            segmentId2: 1337n,
+            agglomerateId1: 6n,
+            agglomerateId2: 1337n,
+          },
+        };
+        const foreignSplitAction = {
+          name: "splitAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1338n,
+            segmentId2: 1337n,
+            agglomerateId: 6n,
+          },
+        };
+        backendMock.injectVersion([foreignMergeAction], 4);
+        backendMock.injectVersion([foreignSplitAction], 5);
+
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+
+        const mapping1 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
+
+        expect(mapping1).toEqual(
+          new Map([
+            [1n, 1n],
+            [2n, 1n],
+            [3n, 1n],
+            [4n, 4n],
+            [5n, 4n],
+            [6n, 1339n],
+            [7n, 1339n],
+          ]),
+        );
+
+        yield call(() => api.tracing.save());
+
+        // Checking that only the injected update actions were received.
+        expect(context.receivedDataPerSaveRequest.length).toBe(2);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch1 = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch1.actions.length).toBe(1);
+        expect(updateBatch1.actions).toEqual([foreignMergeAction]);
+        expect(context.receivedDataPerSaveRequest[1].length).toBe(1);
+        const updateBatch2 = context.receivedDataPerSaveRequest[1][0];
+        expect(updateBatch2.actions.length).toBe(1);
+        expect(updateBatch2.actions).toEqual([foreignSplitAction]);
+
+        yield expectSegmentList(tracingId, []);
+      });
+
+      await task.toPromise();
     });
 
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
+    it("should not perform a rebase when there are no local changes", async (context: WebknossosTestContext) => {
+      const { api } = context;
+      const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
+        grantMutex: false,
+      });
 
-    const task = startSaga(function* () {
-      yield initializePollOnlyAnnotation(context, tracingId);
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
 
-      const foreignSplitAction = {
-        name: "splitAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1n,
-          segmentId2: 2n,
-          agglomerateId: 1n,
-        },
-      };
-      backendMock.injectVersion([foreignSplitAction], 4);
+      const task = startSaga(function* () {
+        const rebaseActionChannel = yield actionChannel(["REWIND_FOR_REBASE", "FINISHED_REBASING"]);
+        yield initializePollOnlyAnnotation(context, tracingId);
 
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+        const foreignMergeAction = {
+          name: "mergeAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1n,
+            segmentId2: 4n,
+            agglomerateId1: 1n,
+            agglomerateId2: 4n,
+          },
+        };
+        backendMock.injectVersion([foreignMergeAction], 4);
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
 
-      const mapping1 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-      );
+        const mapping1 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
 
-      expect(mapping1).toEqual(expectedMappingAfterSplit);
+        expect(mapping1).toEqual(expectedMappingAfterMerge);
 
-      yield call(() => api.tracing.save());
+        yield call(() => api.tracing.save());
 
-      // Checking that only the injected update action was received.
-      expect(context.receivedDataPerSaveRequest.length).toBe(1);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch.actions.length).toBe(1);
-      expect(updateBatch.actions).toEqual([foreignSplitAction]);
+        // Checking that only the injected update action was received.
+        expect(context.receivedDataPerSaveRequest.length).toBe(1);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch.actions.length).toBe(1);
+        expect(updateBatch.actions).toEqual([foreignMergeAction]);
 
-      yield expectSegmentList(tracingId, []);
+        // Asserting no rebasing relevant actions were triggered.
+        const rebasingActions = yield flush(rebaseActionChannel);
+        expect(rebasingActions.length).toBe(0);
+
+        const activeTool = yield* select((state) => state.uiInformation.activeTool);
+        expect(activeTool).toBe(AnnotationTool.PROOFREAD);
+
+        yield expectSegmentList(tracingId, []);
+      });
+
+      await task.toPromise();
     });
 
-    await task.toPromise();
-  });
+    it("should poll updates for a simple merge", async (context: WebknossosTestContext) => {
+      const { api } = context;
+      const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
+        grantMutex: false,
+      });
 
-  it("should update the mapping correctly when the server has a new update action with a split operation with segments unknown to the client", async (context: WebknossosTestContext) => {
-    const { api } = context;
-    const backendMock = mockInitialBucketAndAgglomerateData(
-      context,
-      [[7n, 1337n]],
-      Store.getState(),
-    );
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
 
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
+      const task = startSaga(function* () {
+        yield initializePollOnlyAnnotation(context, tracingId);
 
-    const task = startSaga(function* () {
-      yield initializePollOnlyAnnotation(context, tracingId);
+        const foreignMergeAction = {
+          name: "mergeAgglomerate" as const,
+          value: {
+            actionTracingId: "volumeTracingId",
+            segmentId1: 1n,
+            segmentId2: 4n,
+            agglomerateId1: 1n,
+            agglomerateId2: 4n,
+          },
+        };
 
-      const foreignSplitAction1 = {
-        name: "splitAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1n,
-          segmentId2: 2n,
-          agglomerateId: 1n,
-        },
-      };
-      const foreignSplitAction2 = {
-        name: "splitAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1338n,
-          segmentId2: 1337n,
-          agglomerateId: 6n,
-        },
-      };
-      backendMock.injectVersion([foreignSplitAction1], 4);
-      backendMock.injectVersion([foreignSplitAction2], 5);
+        backendMock.injectVersion([foreignMergeAction], 4);
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
 
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+        const mapping1 = yield* select(
+          (state) =>
+            getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
+        );
 
-      const mapping1 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-      );
+        expect(mapping1).toEqual(expectedMappingAfterMerge);
 
-      expect(mapping1).toEqual(
-        new Map([
-          [1n, 1n],
-          [2n, 1339n],
-          [3n, 1339n],
-          [4n, 4n],
-          [5n, 4n],
-          [6n, 1340n],
-          [7n, 1340n],
-        ]),
-      );
+        yield call(() => api.tracing.save());
 
-      yield call(() => api.tracing.save());
+        // Checking that only the injected update action was received.
+        expect(context.receivedDataPerSaveRequest.length).toBe(1);
+        expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
+        const updateBatch = context.receivedDataPerSaveRequest[0][0];
+        expect(updateBatch.actions.length).toBe(1);
+        expect(updateBatch.actions).toEqual([foreignMergeAction]);
 
-      // Checking that only the injected update actions were received.
-      // split 1
-      expect(context.receivedDataPerSaveRequest.length).toBe(2);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch1 = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch1.actions.length).toBe(1);
-      expect(updateBatch1.actions).toEqual([foreignSplitAction1]);
-      //split 2
-      expect(context.receivedDataPerSaveRequest[1].length).toBe(1);
-      const updateBatch2 = context.receivedDataPerSaveRequest[1][0];
-      expect(updateBatch2.actions.length).toBe(1);
-      expect(updateBatch2.actions).toEqual([foreignSplitAction2]);
+        const activeTool = yield* select((state) => state.uiInformation.activeTool);
+        expect(activeTool).toBe(AnnotationTool.PROOFREAD);
 
-      yield expectSegmentList(tracingId, []);
+        yield expectSegmentList(tracingId, []);
+      });
+
+      await task.toPromise();
     });
 
-    await task.toPromise();
-  });
+    it("should simply forward received update actions like agglomerate tree update actions without putting these changes to its own save queue or sending them to the backend", async (context: WebknossosTestContext) => {
+      const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
+        grantMutex: false,
+      });
 
-  it("should update the mapping correctly when the server has a new update action with a merge and split operation with segments unknown to the client", async (context: WebknossosTestContext) => {
-    const { api } = context;
-    const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
-      grantMutex: false,
+      const { annotation } = Store.getState();
+      const { tracingId } = annotation.volumes[0];
+
+      const task = startSaga(function* () {
+        yield call(initializeMappingAndTool, context, tracingId);
+
+        // Set up the merge-related segment partners. Normally, this would happen
+        // due to the user's interactions.
+        yield put(
+          updateSegmentAction(1n, { anchorPosition: getPositionForSegmentId(1) }, tracingId),
+        );
+        yield put(setActiveCellAction(1n));
+        yield makeMappingEditableForTest();
+
+        yield* makeAnnotationPollOnly(context);
+
+        // Store current annotation version, calculate expected version after injecting updates and inject the agglomerate tree loading.
+        const receivedAmountOfUpdateRequests = context.receivedDataPerSaveRequest.length;
+        const versionBeforeForwardingAgglomerateTreeLoading = yield* select(
+          (state) => state.annotation.version,
+        );
+        const injectedAgglomerateTreeLoadingUpdates = loadAgglomerateTree1;
+        const expectedAmountOfUpdatesAfterInjection =
+          receivedAmountOfUpdateRequests + loadAgglomerateTree1.length;
+        backendMock.planMultipleVersionInjections(
+          versionBeforeForwardingAgglomerateTreeLoading + 1,
+          injectedAgglomerateTreeLoadingUpdates as UpdateActionWithoutIsolationRequirement[][],
+        );
+
+        // Load the injected agglomerate tree updates and forward them.
+        yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
+
+        // Expect no pending or additional sent update requests.
+        expect(context.receivedDataPerSaveRequest.length).toBe(
+          expectedAmountOfUpdatesAfterInjection,
+        );
+        let saveQueue = yield* select((state) => state.save.queue);
+        expect(saveQueue.length).toBe(0);
+
+        // Enforce saved state including diffing tracings and storing their changes.
+        yield call(() => context.api.tracing.save());
+
+        // Expect no pending or additional sent update requests.
+        expect(context.receivedDataPerSaveRequest.length).toBe(
+          expectedAmountOfUpdatesAfterInjection,
+        );
+        saveQueue = yield* select((state) => state.save.queue);
+        expect(saveQueue.length).toBe(0);
+
+        yield expectSegmentList(tracingId, [{ id: 1n, anchorPosition: [1, 1, 1] }]);
+      });
+
+      await task.toPromise();
     });
-
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
-
-    const task = startSaga(function* () {
-      yield initializePollOnlyAnnotation(context, tracingId);
-
-      const foreignMergeAction = {
-        name: "mergeAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 7n,
-          segmentId2: 1337n,
-          agglomerateId1: 6n,
-          agglomerateId2: 1337n,
-        },
-      };
-      const foreignSplitAction = {
-        name: "splitAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1338n,
-          segmentId2: 1337n,
-          agglomerateId: 6n,
-        },
-      };
-      backendMock.injectVersion([foreignMergeAction], 4);
-      backendMock.injectVersion([foreignSplitAction], 5);
-
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
-
-      const mapping1 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-      );
-
-      expect(mapping1).toEqual(
-        new Map([
-          [1n, 1n],
-          [2n, 1n],
-          [3n, 1n],
-          [4n, 4n],
-          [5n, 4n],
-          [6n, 1339n],
-          [7n, 1339n],
-        ]),
-      );
-
-      yield call(() => api.tracing.save());
-
-      // Checking that only the injected update actions were received.
-      expect(context.receivedDataPerSaveRequest.length).toBe(2);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch1 = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch1.actions.length).toBe(1);
-      expect(updateBatch1.actions).toEqual([foreignMergeAction]);
-      expect(context.receivedDataPerSaveRequest[1].length).toBe(1);
-      const updateBatch2 = context.receivedDataPerSaveRequest[1][0];
-      expect(updateBatch2.actions.length).toBe(1);
-      expect(updateBatch2.actions).toEqual([foreignSplitAction]);
-
-      yield expectSegmentList(tracingId, []);
-    });
-
-    await task.toPromise();
-  });
-
-  it("should not perform a rebase when there are no local changes", async (context: WebknossosTestContext) => {
-    const { api } = context;
-    const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
-      grantMutex: false,
-    });
-
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
-
-    const task = startSaga(function* () {
-      const rebaseActionChannel = yield actionChannel(["REWIND_FOR_REBASE", "FINISHED_REBASING"]);
-      yield initializePollOnlyAnnotation(context, tracingId);
-
-      const foreignMergeAction = {
-        name: "mergeAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1n,
-          segmentId2: 4n,
-          agglomerateId1: 1n,
-          agglomerateId2: 4n,
-        },
-      };
-      backendMock.injectVersion([foreignMergeAction], 4);
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
-
-      const mapping1 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-      );
-
-      expect(mapping1).toEqual(expectedMappingAfterMerge);
-
-      yield call(() => api.tracing.save());
-
-      // Checking that only the injected update action was received.
-      expect(context.receivedDataPerSaveRequest.length).toBe(1);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch.actions.length).toBe(1);
-      expect(updateBatch.actions).toEqual([foreignMergeAction]);
-
-      // Asserting no rebasing relevant actions were triggered.
-      const rebasingActions = yield flush(rebaseActionChannel);
-      expect(rebasingActions.length).toBe(0);
-
-      const activeTool = yield* select((state) => state.uiInformation.activeTool);
-      expect(activeTool).toBe(AnnotationTool.PROOFREAD);
-
-      yield expectSegmentList(tracingId, []);
-    });
-
-    await task.toPromise();
-  });
-
-  it("should poll updates for a simple merge", async (context: WebknossosTestContext) => {
-    const { api } = context;
-    const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
-      grantMutex: false,
-    });
-
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
-
-    const task = startSaga(function* () {
-      yield initializePollOnlyAnnotation(context, tracingId);
-
-      const foreignMergeAction = {
-        name: "mergeAgglomerate" as const,
-        value: {
-          actionTracingId: "volumeTracingId",
-          segmentId1: 1n,
-          segmentId2: 4n,
-          agglomerateId1: 1n,
-          agglomerateId2: 4n,
-        },
-      };
-
-      backendMock.injectVersion([foreignMergeAction], 4);
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
-
-      const mapping1 = yield* select(
-        (state) =>
-          getMappingInfo(state.temporaryConfiguration.activeMappingByLayer, tracingId).mapping,
-      );
-
-      expect(mapping1).toEqual(expectedMappingAfterMerge);
-
-      yield call(() => api.tracing.save());
-
-      // Checking that only the injected update action was received.
-      expect(context.receivedDataPerSaveRequest.length).toBe(1);
-      expect(context.receivedDataPerSaveRequest[0].length).toBe(1);
-      const updateBatch = context.receivedDataPerSaveRequest[0][0];
-      expect(updateBatch.actions.length).toBe(1);
-      expect(updateBatch.actions).toEqual([foreignMergeAction]);
-
-      const activeTool = yield* select((state) => state.uiInformation.activeTool);
-      expect(activeTool).toBe(AnnotationTool.PROOFREAD);
-
-      yield expectSegmentList(tracingId, []);
-    });
-
-    await task.toPromise();
-  });
-
-  it("should simply forward received update actions like agglomerate tree update actions without putting these changes to its own save queue or sending them to the backend", async (context: WebknossosTestContext) => {
-    const backendMock = mockInitialBucketAndAgglomerateData(context, [], Store.getState(), {
-      grantMutex: false,
-    });
-
-    const { annotation } = Store.getState();
-    const { tracingId } = annotation.volumes[0];
-
-    const task = startSaga(function* () {
-      yield call(initializeMappingAndTool, context, tracingId);
-
-      // Set up the merge-related segment partners. Normally, this would happen
-      // due to the user's interactions.
-      yield put(updateSegmentAction(1n, { anchorPosition: getPositionForSegmentId(1) }, tracingId));
-      yield put(setActiveCellAction(1n));
-      yield makeMappingEditableForTest();
-
-      yield* makeAnnotationPollOnly(context);
-
-      // Store current annotation version, calculate expected version after injecting updates and inject the agglomerate tree loading.
-      const receivedAmountOfUpdateRequests = context.receivedDataPerSaveRequest.length;
-      const versionBeforeForwardingAgglomerateTreeLoading = yield* select(
-        (state) => state.annotation.version,
-      );
-      const injectedAgglomerateTreeLoadingUpdates = loadAgglomerateTree1;
-      const expectedAmountOfUpdatesAfterInjection =
-        receivedAmountOfUpdateRequests + loadAgglomerateTree1.length;
-      backendMock.planMultipleVersionInjections(
-        versionBeforeForwardingAgglomerateTreeLoading + 1,
-        injectedAgglomerateTreeLoadingUpdates as UpdateActionWithoutIsolationRequirement[][],
-      );
-
-      // Load the injected agglomerate tree updates and forward them.
-      yield call(dispatchEnsureHasNewestVersionAsync, Store.dispatch);
-
-      // Expect no pending or additional sent update requests.
-      expect(context.receivedDataPerSaveRequest.length).toBe(expectedAmountOfUpdatesAfterInjection);
-      let saveQueue = yield* select((state) => state.save.queue);
-      expect(saveQueue.length).toBe(0);
-
-      // Enforce saved state including diffing tracings and storing their changes.
-      yield call(() => context.api.tracing.save());
-
-      // Expect no pending or additional sent update requests.
-      expect(context.receivedDataPerSaveRequest.length).toBe(expectedAmountOfUpdatesAfterInjection);
-      saveQueue = yield* select((state) => state.save.queue);
-      expect(saveQueue.length).toBe(0);
-
-      yield expectSegmentList(tracingId, [{ id: 1n, anchorPosition: [1, 1, 1] }]);
-    });
-
-    await task.toPromise();
-  });
-});
+  },
+);

--- a/frontend/javascripts/test/sagas/proofreading/proofreading_split_mapping.spec.ts
+++ b/frontend/javascripts/test/sagas/proofreading/proofreading_split_mapping.spec.ts
@@ -65,65 +65,65 @@ describe("splitAgglomeratesInMapping", () => {
     }).toPromise();
   }
 
-  describe.each([
-    false,
-    true,
-  ])("[addAdditionalSegmentsToMapping=%s] Should (not) include newly additional requested mapping info in split mapping", (addAdditionalSegmentsToMapping) => {
-    it("discovers the split-off agglomerate of a not-locally-mapped segment without polluting the sparse mapping", async (context: WebknossosTestContext) => {
-      // Agglomerate 100 = {segment 1, segment 2}, agglomerate 200 = {segment 3, segment 4}.
-      // The local store mapping does NOT contain segment 2 (only its mesh is loaded), mirroring a
-      // foreign split that is forwarded during live collaboration.
-      const activeMapping = buildActiveMapping(
-        new Map([
+  describe.each([false, true])(
+    "[addAdditionalSegmentsToMapping=%s] Should (not) include newly additional requested mapping info in split mapping",
+    (addAdditionalSegmentsToMapping) => {
+      it("discovers the split-off agglomerate of a not-locally-mapped segment without polluting the sparse mapping", async (context: WebknossosTestContext) => {
+        // Agglomerate 100 = {segment 1, segment 2}, agglomerate 200 = {segment 3, segment 4}.
+        // The local store mapping does NOT contain segment 2 (only its mesh is loaded), mirroring a
+        // foreign split that is forwarded during live collaboration.
+        const activeMapping = buildActiveMapping(
+          new Map([
+            [1n, 100n],
+            [3n, 200n],
+            [4n, 200n],
+          ]),
+        );
+        // Segment info extracted from the foreign update action: Agglomerate 100 = {segment 1, segment 2} was split.
+        const segmentIdToOldAgglomerateId = new Map([
           [1n, 100n],
+          [2n, 100n],
+        ]);
+
+        // The split keeps segment 1 on agglomerate 100 and moves segment 2 to the new agglomerate 300.
+        const mappingAfterSplit: [bigint, bigint][] = [
+          [1n, 100n],
+          [2n, 300n],
           [3n, 200n],
           [4n, 200n],
-        ]),
-      );
-      // Segment info extracted from the foreign update action: Agglomerate 100 = {segment 1, segment 2} was split.
-      const segmentIdToOldAgglomerateId = new Map([
-        [1n, 100n],
-        [2n, 100n],
-      ]);
+        ];
 
-      // The split keeps segment 1 on agglomerate 100 and moves segment 2 to the new agglomerate 300.
-      const mappingAfterSplit: [bigint, bigint][] = [
-        [1n, 100n],
-        [2n, 300n],
-        [3n, 200n],
-        [4n, 200n],
-      ];
+        const result = await runSplit(
+          context,
+          activeMapping,
+          segmentIdToOldAgglomerateId,
+          addAdditionalSegmentsToMapping,
+          mappingAfterSplit,
+        );
 
-      const result = await runSplit(
-        context,
-        activeMapping,
-        segmentIdToOldAgglomerateId,
-        addAdditionalSegmentsToMapping,
-        mappingAfterSplit,
-      );
-
-      expect(result).toBeDefined();
-      // The new agglomerate 300 is discovered even though segment 2 is not in the local mapping.
-      expect(result?.newAgglomerateIds).toEqual(new Set([100n, 300n]));
-      expect(result?.oldAgglomerateIds).toEqual(new Set([100n]));
-      // Both the retained and the split-off agglomerate inherit from the original agglomerate 100.
-      expect(result?.newToOldAgglomerateIds).toEqual(
-        new Map([
-          [100n, 100n],
-          [300n, 100n],
-        ]),
-      );
-      // If addAdditionalSegmentsToMapping = true
-      // - Segment 2 stays out of the (sparse) mapping, because it was not present locally.
-      // - Else it is present in the mapping.
-      const maybeAdditionalEntry: [bigint, bigint][] = addAdditionalSegmentsToMapping
-        ? [[2n, 300n]]
-        : [];
-      expect(result?.mappingWithSplitApplied).toEqual(
-        new Map([[1n, 100n], [3n, 200n], [4n, 200n], ...maybeAdditionalEntry]),
-      );
-    });
-  });
+        expect(result).toBeDefined();
+        // The new agglomerate 300 is discovered even though segment 2 is not in the local mapping.
+        expect(result?.newAgglomerateIds).toEqual(new Set([100n, 300n]));
+        expect(result?.oldAgglomerateIds).toEqual(new Set([100n]));
+        // Both the retained and the split-off agglomerate inherit from the original agglomerate 100.
+        expect(result?.newToOldAgglomerateIds).toEqual(
+          new Map([
+            [100n, 100n],
+            [300n, 100n],
+          ]),
+        );
+        // If addAdditionalSegmentsToMapping = true
+        // - Segment 2 stays out of the (sparse) mapping, because it was not present locally.
+        // - Else it is present in the mapping.
+        const maybeAdditionalEntry: [bigint, bigint][] = addAdditionalSegmentsToMapping
+          ? [[2n, 300n]]
+          : [];
+        expect(result?.mappingWithSplitApplied).toEqual(
+          new Map([[1n, 100n], [3n, 200n], [4n, 200n], ...maybeAdditionalEntry]),
+        );
+      });
+    },
+  );
 
   it("re-maps the local segments of every involved agglomerate when multiple agglomerates are split in one batch", async (context: WebknossosTestContext) => {
     // Agglomerate 100 = {1, 2}, agglomerate 200 = {3, 4}. Both are split in the same batch:

--- a/frontend/javascripts/test/sagas/saving/pushSaveQueueAsync.spec.ts
+++ b/frontend/javascripts/test/sagas/saving/pushSaveQueueAsync.spec.ts
@@ -133,57 +133,55 @@ describe("pushSaveQueueAsync (integration) - 1", () => {
     await task.toPromise();
   });
 
-  it<WebknossosTestContext>(
-    "sends multiple save requests on saveNow when save queue was filled during saving",
-    { timeout: 10_000 },
-    async (context) => {
-      const task = startSaga(function* () {
-        const savingDoneChannel = yield actionChannel("UNREGISTER_OPERATION");
+  it<WebknossosTestContext>("sends multiple save requests on saveNow when save queue was filled during saving", {
+    timeout: 10_000,
+  }, async (context) => {
+    const task = startSaga(function* () {
+      const savingDoneChannel = yield actionChannel("UNREGISTER_OPERATION");
 
-        // sendSaveRequestWithToken is used for saving and the first request
-        // will fulfill the promise in saveRequestStartedDeferred.
-        // The first request is finished when saveRequestFinishDeferred is resolved.
-        // The second request will go through immediately (we don't need control
-        // over that).
-        const saveRequestStartedDeferred = new Deferred<void, void>();
-        const saveRequestFinishDeferred = new Deferred<void, void>();
-        context.mocks.sendSaveRequestWithToken.mockImplementation(() => {
-          saveRequestStartedDeferred.resolve();
-          return saveRequestFinishDeferred.promise();
-        });
-        const callsBefore = context.mocks.sendSaveRequestWithToken.mock.calls.length;
-
-        // Create a node and start saving
-        yield put(createNodeAction([1, 1, 1], [], [0, 0, 0], 0, 0));
-        // Without the following line, the test becomes flaky under high CPU load
-        // because the diffing saga is executed only after the saveNow() action
-        // is dispatched below. Then, the saveNow action will be ignored because
-        // nothing is in the save queue yet.
-        yield call(
-          dispatchEnsureTracingsWereDiffedToSaveQueueAction,
-          Store.dispatch,
-          Store.getState().annotation,
-        );
-
-        // Kick off saving.
-        yield put(saveNowAction());
-
-        // Wait until saving started.
-        yield call(() => saveRequestStartedDeferred.promise());
-
-        // Create another node while saving is active.
-        Store.dispatch(createNodeAction([1, 1, 1], [], [0, 0, 0], 0, 0));
-
-        // Let the first save request finish.
-        saveRequestFinishDeferred.resolve();
-
-        // Wait for the save operation to complete.
-        yield* take(savingDoneChannel);
-        // Since the second node was created during the first save request, a second save request
-        // should have been made.
-        expect(context.mocks.sendSaveRequestWithToken.mock.calls.length).toEqual(callsBefore + 2);
+      // sendSaveRequestWithToken is used for saving and the first request
+      // will fulfill the promise in saveRequestStartedDeferred.
+      // The first request is finished when saveRequestFinishDeferred is resolved.
+      // The second request will go through immediately (we don't need control
+      // over that).
+      const saveRequestStartedDeferred = new Deferred<void, void>();
+      const saveRequestFinishDeferred = new Deferred<void, void>();
+      context.mocks.sendSaveRequestWithToken.mockImplementation(() => {
+        saveRequestStartedDeferred.resolve();
+        return saveRequestFinishDeferred.promise();
       });
-      await task.toPromise();
-    },
-  );
+      const callsBefore = context.mocks.sendSaveRequestWithToken.mock.calls.length;
+
+      // Create a node and start saving
+      yield put(createNodeAction([1, 1, 1], [], [0, 0, 0], 0, 0));
+      // Without the following line, the test becomes flaky under high CPU load
+      // because the diffing saga is executed only after the saveNow() action
+      // is dispatched below. Then, the saveNow action will be ignored because
+      // nothing is in the save queue yet.
+      yield call(
+        dispatchEnsureTracingsWereDiffedToSaveQueueAction,
+        Store.dispatch,
+        Store.getState().annotation,
+      );
+
+      // Kick off saving.
+      yield put(saveNowAction());
+
+      // Wait until saving started.
+      yield call(() => saveRequestStartedDeferred.promise());
+
+      // Create another node while saving is active.
+      Store.dispatch(createNodeAction([1, 1, 1], [], [0, 0, 0], 0, 0));
+
+      // Let the first save request finish.
+      saveRequestFinishDeferred.resolve();
+
+      // Wait for the save operation to complete.
+      yield* take(savingDoneChannel);
+      // Since the second node was created during the first save request, a second save request
+      // should have been made.
+      expect(context.mocks.sendSaveRequestWithToken.mock.calls.length).toEqual(callsBefore + 2);
+    });
+    await task.toPromise();
+  });
 });

--- a/frontend/javascripts/test/sagas/volumetracing/volume_diffing.spec.ts
+++ b/frontend/javascripts/test/sagas/volumetracing/volume_diffing.spec.ts
@@ -173,54 +173,52 @@ describe("diffSegmentGroups for volume tracings", () => {
 describe("uncachedDiffSegmentLists should diff segment lists", () => {
   // Each list defines which segment items should already exist before
   // the merge is executed.
-  describe.for([
-    [],
-    [id1, id2],
-    [id1],
-    [id2],
-  ])("mergeSegment actions should be detected during diffing", (segmentItemsToCreateInSetup) => {
-    test(`with prepared segments: [${segmentItemsToCreateInSetup}]`, () => {
-      let newState = initialState;
-      if (segmentItemsToCreateInSetup.includes(id1)) {
-        newState = VolumeTracingReducer(newState, createSegment1);
-      }
-      if (segmentItemsToCreateInSetup.includes(id2)) {
-        newState = VolumeTracingReducer(newState, createSegment2);
-      }
-      const stateBeforeMerge = newState;
-      newState = VolumeTracingReducer(
-        newState,
-        mergeSegmentItemsAction(id1, id2, id1, id2, VOLUME_TRACING_ID),
-      );
-      const stateAfterMerge = newState;
+  describe.for([[], [id1, id2], [id1], [id2]])(
+    "mergeSegment actions should be detected during diffing",
+    (segmentItemsToCreateInSetup) => {
+      test(`with prepared segments: [${segmentItemsToCreateInSetup}]`, () => {
+        let newState = initialState;
+        if (segmentItemsToCreateInSetup.includes(id1)) {
+          newState = VolumeTracingReducer(newState, createSegment1);
+        }
+        if (segmentItemsToCreateInSetup.includes(id2)) {
+          newState = VolumeTracingReducer(newState, createSegment2);
+        }
+        const stateBeforeMerge = newState;
+        newState = VolumeTracingReducer(
+          newState,
+          mergeSegmentItemsAction(id1, id2, id1, id2, VOLUME_TRACING_ID),
+        );
+        const stateAfterMerge = newState;
 
-      const prevVolumeTracing = stateBeforeMerge.annotation.volumes[0];
-      const volumeTracing = stateAfterMerge.annotation.volumes[0];
+        const prevVolumeTracing = stateBeforeMerge.annotation.volumes[0];
+        const volumeTracing = stateAfterMerge.annotation.volumes[0];
 
-      const updateActions = Array.from(
-        uncachedDiffSegmentLists(
-          VOLUME_TRACING_ID,
-          prevVolumeTracing.segments,
-          volumeTracing.segments,
-          prevVolumeTracing.segmentJournal,
-          volumeTracing.segmentJournal,
-        ),
-      );
+        const updateActions = Array.from(
+          uncachedDiffSegmentLists(
+            VOLUME_TRACING_ID,
+            prevVolumeTracing.segments,
+            volumeTracing.segments,
+            prevVolumeTracing.segmentJournal,
+            volumeTracing.segmentJournal,
+          ),
+        );
 
-      expect(updateActions).toEqual([
-        {
-          name: "mergeSegmentItems",
-          value: {
-            actionTracingId: VOLUME_TRACING_ID,
-            agglomerateId1: id1,
-            agglomerateId2: id2,
-            segmentId1: id1,
-            segmentId2: id2,
+        expect(updateActions).toEqual([
+          {
+            name: "mergeSegmentItems",
+            value: {
+              actionTracingId: VOLUME_TRACING_ID,
+              agglomerateId1: id1,
+              agglomerateId2: id2,
+              segmentId1: id1,
+              segmentId2: id2,
+            },
           },
-        },
-      ]);
-    });
-  });
+        ]);
+      });
+    },
+  );
 
   test("mergeSegments should be detected along with another segment update", () => {
     let newState = initialState;

--- a/frontend/javascripts/test/shaders/shader_syntax.spec.ts
+++ b/frontend/javascripts/test/shaders/shader_syntax.spec.ts
@@ -8,284 +8,284 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 type ShaderFunction = (params: Params) => string;
 
-describe.for<ShaderFunction>([
-  getMainFragmentShader,
-  getMainVertexShader,
-])("Shader Syntax %o", (getShader) => {
-  const originalWarn = console.warn;
+describe.for<ShaderFunction>([getMainFragmentShader, getMainVertexShader])(
+  "Shader Syntax %o",
+  (getShader) => {
+    const originalWarn = console.warn;
 
-  interface TestContext {
-    warningEmittedCount: number;
-  }
+    interface TestContext {
+      warningEmittedCount: number;
+    }
 
-  beforeEach<TestContext>(async (context) => {
-    console.warn = (...args: any[]) => {
-      context.warningEmittedCount++;
-      originalWarn(...args);
-    };
-    context.warningEmittedCount = 0;
-  });
-
-  it<TestContext>("Ortho Mode", ({ warningEmittedCount }) => {
-    const code = getShader({
-      globalLayerCount: 2,
-      colorLayerNames: ["color_layer_1", "color_layer_2"],
-      textureLayerInfos: {
-        ["color_layer_1"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_1",
-          elementClass: "uint8",
-        },
-        ["color_layer_2"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_2",
-          elementClass: "uint8",
-        },
-      },
-      orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
-      segmentationLayerNames: [],
-      magnificationsCount: mags.length,
-      voxelSizeFactor: [1, 1, 1],
-      isOrthogonal: true,
-      voxelSizeFactorInverted: [1, 1, 1],
-      useInterpolation: false,
-      tpsTransformPerLayer: {},
-      isWindows: false,
+    beforeEach<TestContext>(async (context) => {
+      console.warn = (...args: any[]) => {
+        context.warningEmittedCount++;
+        originalWarn(...args);
+      };
+      context.warningEmittedCount = 0;
     });
 
-    /*
-     * If the code contains a syntax error, parse() will throw an exception
-     * which makes the test fail.
-     * If a warning was emitted during parsing, the `warningEmittedCount`
-     * will reflect this.
-     */
-    parser.parse(code);
-    expect(warningEmittedCount).toBe(0);
-  });
+    it<TestContext>("Ortho Mode", ({ warningEmittedCount }) => {
+      const code = getShader({
+        globalLayerCount: 2,
+        colorLayerNames: ["color_layer_1", "color_layer_2"],
+        textureLayerInfos: {
+          ["color_layer_1"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_1",
+            elementClass: "uint8",
+          },
+          ["color_layer_2"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_2",
+            elementClass: "uint8",
+          },
+        },
+        orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
+        segmentationLayerNames: [],
+        magnificationsCount: mags.length,
+        voxelSizeFactor: [1, 1, 1],
+        isOrthogonal: true,
+        voxelSizeFactorInverted: [1, 1, 1],
+        useInterpolation: false,
+        tpsTransformPerLayer: {},
+        isWindows: false,
+      });
 
-  it<TestContext>("Ortho Mode + Segmentation - Mapping", ({ warningEmittedCount }) => {
-    const code = getShader({
-      globalLayerCount: 2,
-      colorLayerNames: ["color_layer_1", "color_layer_2"],
-      textureLayerInfos: {
-        ["color_layer_1"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_1",
-          elementClass: "uint8",
-        },
-        ["color_layer_2"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_2",
-          elementClass: "uint8",
-        },
-        ["segmentationLayer"]: {
-          isColor: true,
-          packingDegree: 1.0,
-          dataTextureCount: 4,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "segmentationLayer",
-          elementClass: "uint8",
-        },
-      },
-      orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
-      segmentationLayerNames: ["segmentationLayer"],
-      magnificationsCount: mags.length,
-      voxelSizeFactor: [1, 1, 1],
-      isOrthogonal: true,
-      useInterpolation: false,
-      voxelSizeFactorInverted: [1, 1, 1],
-      tpsTransformPerLayer: {},
-      isWindows: true,
-    });
-    parser.parse(code);
-    expect(warningEmittedCount).toBe(0);
-  });
-
-  it<TestContext>("Ortho Mode + Segmentation + Mapping", ({ warningEmittedCount }) => {
-    const code = getShader({
-      globalLayerCount: 2,
-      colorLayerNames: ["color_layer_1", "color_layer_2"],
-      textureLayerInfos: {
-        ["color_layer_1"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_1",
-          elementClass: "uint8",
-        },
-        ["color_layer_2"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_2",
-          elementClass: "uint8",
-        },
-        ["segmentationLayer"]: {
-          isColor: false,
-          packingDegree: 1.0,
-          dataTextureCount: 4,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "segmentationLayer",
-          elementClass: "uint8",
-        },
-      },
-      orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
-      segmentationLayerNames: ["segmentationLayer"],
-      magnificationsCount: mags.length,
-      voxelSizeFactor: [1, 1, 1],
-      isOrthogonal: true,
-      useInterpolation: true,
-      voxelSizeFactorInverted: [1, 1, 1],
-      tpsTransformPerLayer: {},
-      isWindows: true,
+      /*
+       * If the code contains a syntax error, parse() will throw an exception
+       * which makes the test fail.
+       * If a warning was emitted during parsing, the `warningEmittedCount`
+       * will reflect this.
+       */
+      parser.parse(code);
+      expect(warningEmittedCount).toBe(0);
     });
 
-    parser.parse(code);
-    expect(warningEmittedCount).toBe(0);
-  });
-
-  it<TestContext>("Flight Mode (no segmentation available)", ({ warningEmittedCount }) => {
-    const code = getShader({
-      globalLayerCount: 2,
-      colorLayerNames: ["color_layer_1", "color_layer_2"],
-      textureLayerInfos: {
-        ["color_layer_1"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_1",
-          elementClass: "uint8",
+    it<TestContext>("Ortho Mode + Segmentation - Mapping", ({ warningEmittedCount }) => {
+      const code = getShader({
+        globalLayerCount: 2,
+        colorLayerNames: ["color_layer_1", "color_layer_2"],
+        textureLayerInfos: {
+          ["color_layer_1"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_1",
+            elementClass: "uint8",
+          },
+          ["color_layer_2"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_2",
+            elementClass: "uint8",
+          },
+          ["segmentationLayer"]: {
+            isColor: true,
+            packingDegree: 1.0,
+            dataTextureCount: 4,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "segmentationLayer",
+            elementClass: "uint8",
+          },
         },
-        ["color_layer_2"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_2",
-          elementClass: "uint8",
-        },
-      },
-      orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
-      segmentationLayerNames: [],
-      magnificationsCount: mags.length,
-      voxelSizeFactor: [1, 1, 1],
-      isOrthogonal: false,
-      useInterpolation: false,
-      voxelSizeFactorInverted: [1, 1, 1],
-      tpsTransformPerLayer: {},
-      isWindows: true,
+        orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
+        segmentationLayerNames: ["segmentationLayer"],
+        magnificationsCount: mags.length,
+        voxelSizeFactor: [1, 1, 1],
+        isOrthogonal: true,
+        useInterpolation: false,
+        voxelSizeFactorInverted: [1, 1, 1],
+        tpsTransformPerLayer: {},
+        isWindows: true,
+      });
+      parser.parse(code);
+      expect(warningEmittedCount).toBe(0);
     });
-    parser.parse(code);
-    expect(warningEmittedCount).toBe(0);
-  });
 
-  it<TestContext>("Flight Mode (segmentation available)", ({ warningEmittedCount }) => {
-    const code = getShader({
-      globalLayerCount: 2,
-      colorLayerNames: ["color_layer_1", "color_layer_2"],
-      textureLayerInfos: {
-        ["color_layer_1"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_1",
-          elementClass: "uint8",
+    it<TestContext>("Ortho Mode + Segmentation + Mapping", ({ warningEmittedCount }) => {
+      const code = getShader({
+        globalLayerCount: 2,
+        colorLayerNames: ["color_layer_1", "color_layer_2"],
+        textureLayerInfos: {
+          ["color_layer_1"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_1",
+            elementClass: "uint8",
+          },
+          ["color_layer_2"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_2",
+            elementClass: "uint8",
+          },
+          ["segmentationLayer"]: {
+            isColor: false,
+            packingDegree: 1.0,
+            dataTextureCount: 4,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "segmentationLayer",
+            elementClass: "uint8",
+          },
         },
-        ["color_layer_2"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_2",
-          elementClass: "uint8",
-        },
-        ["segmentationLayer"]: {
-          isColor: false,
-          packingDegree: 1.0,
-          dataTextureCount: 4,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "segmentationLayer",
-          elementClass: "uint8",
-        },
-      },
-      orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
-      segmentationLayerNames: ["segmentationLayer"],
-      magnificationsCount: mags.length,
-      voxelSizeFactor: [1, 1, 1],
-      isOrthogonal: false,
-      useInterpolation: true,
-      voxelSizeFactorInverted: [1, 1, 1],
-      tpsTransformPerLayer: {},
-      isWindows: false,
-    });
-    parser.parse(code);
-    expect(warningEmittedCount).toBe(0);
-  });
+        orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
+        segmentationLayerNames: ["segmentationLayer"],
+        magnificationsCount: mags.length,
+        voxelSizeFactor: [1, 1, 1],
+        isOrthogonal: true,
+        useInterpolation: true,
+        voxelSizeFactorInverted: [1, 1, 1],
+        tpsTransformPerLayer: {},
+        isWindows: true,
+      });
 
-  it<TestContext>("Ortho Mode (rgb and float layer)", ({ warningEmittedCount }) => {
-    const code = getShader({
-      globalLayerCount: 2,
-      colorLayerNames: ["color_layer_1", "color_layer_2"],
-      textureLayerInfos: {
-        ["color_layer_1"]: {
-          isColor: true,
-          packingDegree: 1.0,
-          dataTextureCount: 1,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_1",
-          elementClass: "uint24",
-        },
-        ["color_layer_2"]: {
-          isColor: true,
-          packingDegree: 4.0,
-          dataTextureCount: 2,
-          isSigned: false,
-          glslPrefix: "",
-          unsanitizedName: "color_layer_2",
-          elementClass: "float",
-        },
-      },
-      orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
-      segmentationLayerNames: [],
-      magnificationsCount: mags.length,
-      voxelSizeFactor: [1, 1, 1],
-      isOrthogonal: true,
-      useInterpolation: false,
-      voxelSizeFactorInverted: [1, 1, 1],
-      tpsTransformPerLayer: {},
-      isWindows: true,
+      parser.parse(code);
+      expect(warningEmittedCount).toBe(0);
     });
-    parser.parse(code);
-    expect(warningEmittedCount).toBe(0);
-  });
-});
+
+    it<TestContext>("Flight Mode (no segmentation available)", ({ warningEmittedCount }) => {
+      const code = getShader({
+        globalLayerCount: 2,
+        colorLayerNames: ["color_layer_1", "color_layer_2"],
+        textureLayerInfos: {
+          ["color_layer_1"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_1",
+            elementClass: "uint8",
+          },
+          ["color_layer_2"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_2",
+            elementClass: "uint8",
+          },
+        },
+        orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
+        segmentationLayerNames: [],
+        magnificationsCount: mags.length,
+        voxelSizeFactor: [1, 1, 1],
+        isOrthogonal: false,
+        useInterpolation: false,
+        voxelSizeFactorInverted: [1, 1, 1],
+        tpsTransformPerLayer: {},
+        isWindows: true,
+      });
+      parser.parse(code);
+      expect(warningEmittedCount).toBe(0);
+    });
+
+    it<TestContext>("Flight Mode (segmentation available)", ({ warningEmittedCount }) => {
+      const code = getShader({
+        globalLayerCount: 2,
+        colorLayerNames: ["color_layer_1", "color_layer_2"],
+        textureLayerInfos: {
+          ["color_layer_1"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_1",
+            elementClass: "uint8",
+          },
+          ["color_layer_2"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_2",
+            elementClass: "uint8",
+          },
+          ["segmentationLayer"]: {
+            isColor: false,
+            packingDegree: 1.0,
+            dataTextureCount: 4,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "segmentationLayer",
+            elementClass: "uint8",
+          },
+        },
+        orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
+        segmentationLayerNames: ["segmentationLayer"],
+        magnificationsCount: mags.length,
+        voxelSizeFactor: [1, 1, 1],
+        isOrthogonal: false,
+        useInterpolation: true,
+        voxelSizeFactorInverted: [1, 1, 1],
+        tpsTransformPerLayer: {},
+        isWindows: false,
+      });
+      parser.parse(code);
+      expect(warningEmittedCount).toBe(0);
+    });
+
+    it<TestContext>("Ortho Mode (rgb and float layer)", ({ warningEmittedCount }) => {
+      const code = getShader({
+        globalLayerCount: 2,
+        colorLayerNames: ["color_layer_1", "color_layer_2"],
+        textureLayerInfos: {
+          ["color_layer_1"]: {
+            isColor: true,
+            packingDegree: 1.0,
+            dataTextureCount: 1,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_1",
+            elementClass: "uint24",
+          },
+          ["color_layer_2"]: {
+            isColor: true,
+            packingDegree: 4.0,
+            dataTextureCount: 2,
+            isSigned: false,
+            glslPrefix: "",
+            unsanitizedName: "color_layer_2",
+            elementClass: "float",
+          },
+        },
+        orderedColorLayerNames: ["color_layer_1", "color_layer_2"],
+        segmentationLayerNames: [],
+        magnificationsCount: mags.length,
+        voxelSizeFactor: [1, 1, 1],
+        isOrthogonal: true,
+        useInterpolation: false,
+        voxelSizeFactorInverted: [1, 1, 1],
+        tpsTransformPerLayer: {},
+        isWindows: true,
+      });
+      parser.parse(code);
+      expect(warningEmittedCount).toBe(0);
+    });
+  },
+);

--- a/frontend/javascripts/viewer/controller/td_controller.tsx
+++ b/frontend/javascripts/viewer/controller/td_controller.tsx
@@ -126,8 +126,7 @@ class TDController extends PureComponent<Props> {
     if (
       maybeGetActiveNodeFromProps(this.props) !== maybeGetActiveNodeFromProps(prevProps) &&
       maybeGetActiveNodeFromProps(this.props) !== INVALID_ACTIVE_NODE_ID &&
-      this.props.annotation &&
-      this.props.annotation.skeleton
+      this.props.annotation?.skeleton
     ) {
       // The rotation center of this viewport is not updated to the new position after selecting a node in the viewport.
       // This happens because the selection of the node does not trigger a call to setTargetAndFixPosition directly.

--- a/frontend/javascripts/viewer/model/accessors/view_mode_accessor.ts
+++ b/frontend/javascripts/viewer/model/accessors/view_mode_accessor.ts
@@ -285,7 +285,7 @@ function _calculateGlobalPos(
 ): PositionWithRounding {
   const positions = _calculateMaybeGlobalPos(state, clickPos, planeId, useRound);
 
-  if (!positions || !positions.rounded) {
+  if (!positions?.rounded) {
     console.error("Trying to calculate the global position, but no data viewport is active.");
     return { rounded: [0, 0, 0], floating: [0, 0, 0] };
   }

--- a/frontend/javascripts/viewer/model/reducers/proofreading_reducer.ts
+++ b/frontend/javascripts/viewer/model/reducers/proofreading_reducer.ts
@@ -12,7 +12,7 @@ function ProofreadingReducer(state: WebknossosState, action: ProofreadAction): W
   switch (action.type) {
     case "TOGGLE_SEGMENT_IN_PARTITION": {
       const layerData = state.localSegmentationStateByLayer[layerName];
-      if (!layerData || !layerData.minCutPartitions) {
+      if (!layerData?.minCutPartitions) {
         return state;
       }
       const minCutPartitions = layerData.minCutPartitions;

--- a/frontend/javascripts/viewer/model/sagas/volume/proofreading/preparation_sagas.ts
+++ b/frontend/javascripts/viewer/model/sagas/volume/proofreading/preparation_sagas.ts
@@ -50,7 +50,7 @@ export function* createEditableMapping(ctx?: OperationContext): Saga<string> {
    */
   // Get volume tracing again to make sure the version is up to date
   const volumeTracing = yield* select((state) => getActiveSegmentationTracing(state));
-  if (!volumeTracing || !volumeTracing.mappingName) {
+  if (!volumeTracing?.mappingName) {
     // This should never occur, because the proofreading tool is only available when a volume tracing layer is active.
     throw new Error("No active segmentation tracing layer. Cannot create editable mapping.");
   }

--- a/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/volume/proofreading/proofread_saga.ts
@@ -163,7 +163,7 @@ function* showToastIfSegmentOfOtherAgglomerateWasSelected(
     return;
   }
   const layerData = yield* select((state) => state.localSegmentationStateByLayer[layerName]);
-  if (!layerData || !layerData.minCutPartitions) {
+  if (!layerData?.minCutPartitions) {
     return;
   }
   const minCutPartitions = layerData.minCutPartitions;

--- a/frontend/javascripts/viewer/model/sagas/volume/quick_select/quick_select_ml_saga.ts
+++ b/frontend/javascripts/viewer/model/sagas/volume/quick_select/quick_select_ml_saga.ts
@@ -292,9 +292,7 @@ export default function* performQuickSelect(
         targetBox.fromMagToMag1(labeledMag),
         targetW,
         // a.hi(x,y) => a[:x, :y], // a.lo(x,y) => a[x:, y:]
-        mask
-          .hi(maxUV[0], maxUV[1], 1)
-          .lo(minUV[0], minUV[1], 0),
+        mask.hi(maxUV[0], maxUV[1], 1).lo(minUV[0], minUV[1], 0),
         overwriteMode,
         labeledZoomStep,
         // Only finish annotation stroke in the last iteration.

--- a/frontend/javascripts/viewer/model/sagas/volumetracing_saga.tsx
+++ b/frontend/javascripts/viewer/model/sagas/volumetracing_saga.tsx
@@ -269,7 +269,7 @@ export function* editVolumeLayerAsync(): Saga<never> {
       };
       if (finishEditingAction) break;
 
-      if (!addToContourListAction || addToContourListAction.type !== "ADD_TO_CONTOUR_LIST") {
+      if (addToContourListAction?.type !== "ADD_TO_CONTOUR_LIST") {
         throw new Error("Unexpected action. Satisfy typescript.");
       }
 

--- a/frontend/javascripts/viewer/view/action_bar/download_modal/download_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/download_modal/download_modal_view.tsx
@@ -17,7 +17,7 @@ type Props = {
   initialBoundingBoxId?: number;
 };
 
-function _DownloadModalView({
+function DownloadModalViewInner({
   isOpen,
   onClose,
   isAnnotation,
@@ -73,5 +73,5 @@ function _DownloadModalView({
   );
 }
 
-const DownloadModalView = makeComponentLazy(_DownloadModalView);
+const DownloadModalView = makeComponentLazy(DownloadModalViewInner);
 export default DownloadModalView;

--- a/frontend/javascripts/viewer/view/action_bar/merge_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/merge_modal_view.tsx
@@ -58,7 +58,7 @@ const sectionDivider = (title: string) => (
   </Divider>
 );
 
-function _MergeModalView({ isOpen, onOk }: Props) {
+function MergeModalViewInner({ isOpen, onOk }: Props) {
   const annotationId = useWkSelector((state) => state.annotation.annotationId);
   const annotationType = useWkSelector((state) => state.annotation.annotationType);
   const dispatch = useDispatch();
@@ -153,7 +153,7 @@ function _MergeModalView({ isOpen, onOk }: Props) {
     const tracing = await getTracingForAnnotationType(annotation, skeletonDescriptorMaybe);
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'trees' does not exist on type 'ServerTra... Remove this comment to see the full error message
-    if (!tracing || !tracing.trees) {
+    if (!tracing?.trees) {
       Toast.error(messages["merge.volume_unsupported"]);
       return;
     }
@@ -346,6 +346,6 @@ function _MergeModalView({ isOpen, onOk }: Props) {
   );
 }
 
-const MergeModalView = makeComponentLazy(_MergeModalView);
+const MergeModalView = makeComponentLazy(MergeModalViewInner);
 
 export default MergeModalView;

--- a/frontend/javascripts/viewer/view/action_bar/private_links_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/private_links_view.tsx
@@ -319,9 +319,7 @@ function HumanizedDuration({ expirationDate }: { expirationDate: dayjs.Dayjs }) 
         // expiration date at 08:00, moment.to() would round the duration and
         // render "2 days" which is confusing if the user selected (in 1 day).
         // Therefore, we pin the time at each date to 23:59 UTC.
-        now
-          .endOf("day")
-          .to(expirationDate.endOf("day"));
+        now.endOf("day").to(expirationDate.endOf("day"));
   return (
     <span style={{ color: "var(--ant-color-text-secondary)", marginLeft: 4 }}>{duration}</span>
   );
@@ -412,7 +410,7 @@ function PrivateLinksView({ annotationId }: { annotationId: string }) {
   );
 }
 
-function _PrivateLinksModal({
+function PrivateLinksModalInner({
   isOpen,
   onOk,
   annotationId,
@@ -448,4 +446,4 @@ function _PrivateLinksModal({
   );
 }
 
-export const PrivateLinksModal = makeComponentLazy(_PrivateLinksModal);
+export const PrivateLinksModal = makeComponentLazy(PrivateLinksModalInner);

--- a/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/share_modal_view.tsx
@@ -201,7 +201,7 @@ const LEFT_COL_STYLE = {
   paddingRight: 6,
 };
 
-function _ShareModalView(props: Props) {
+function ShareModalViewInner(props: Props) {
   const { isOpen, onOk, annotationType, annotationId } = props;
   const dispatch = useDispatch();
 
@@ -681,5 +681,5 @@ export function CopyableSharingLink({
   );
 }
 
-const ShareModalView = makeComponentLazy(_ShareModalView);
+const ShareModalView = makeComponentLazy(ShareModalViewInner);
 export default ShareModalView;

--- a/frontend/javascripts/viewer/view/action_bar/share_view_dataset_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/share_view_dataset_modal_view.tsx
@@ -13,7 +13,7 @@ type Props = {
   onOk: () => any;
 };
 
-function _ShareViewDatasetModalView(props: Props) {
+function ShareViewDatasetModalViewInner(props: Props) {
   const { isOpen, onOk } = props;
   const dataset = useWkSelector((state) => state.dataset);
   const sharingToken = useDatasetSharingToken(dataset);
@@ -101,5 +101,5 @@ function _ShareViewDatasetModalView(props: Props) {
   );
 }
 
-const ShareViewDatasetModalView = makeComponentLazy(_ShareViewDatasetModalView);
+const ShareViewDatasetModalView = makeComponentLazy(ShareViewDatasetModalViewInner);
 export default ShareViewDatasetModalView;

--- a/frontend/javascripts/viewer/view/action_bar/user_scripts_modal_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar/user_scripts_modal_view.tsx
@@ -17,7 +17,7 @@ type UserScriptsModalViewProps = {
   isOpen: boolean;
 };
 
-const _UserScriptsModalView: React.FC<UserScriptsModalViewProps> = ({ onOK, isOpen }) => {
+const UserScriptsModalViewInner: React.FC<UserScriptsModalViewProps> = ({ onOK, isOpen }) => {
   const { modal } = App.useApp();
   const [code, setCode] = useState("");
   const [isCodeChanged, setIsCodeChanged] = useState(false);
@@ -116,6 +116,6 @@ const _UserScriptsModalView: React.FC<UserScriptsModalViewProps> = ({ onOK, isOp
   );
 };
 
-const UserScriptsModalView = makeComponentLazy(memo(_UserScriptsModalView));
+const UserScriptsModalView = makeComponentLazy(memo(UserScriptsModalViewInner));
 
 export default UserScriptsModalView;

--- a/frontend/javascripts/viewer/view/components/command_palette.tsx
+++ b/frontend/javascripts/viewer/view/components/command_palette.tsx
@@ -449,10 +449,10 @@ export const CommandPalette = () => {
 
   const [commands, setCommands] = useState<CommandWithoutId[]>(allStaticCommands);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: rerun when inputs that the
-  // static commands close over change. userConfig is included so the "Toggle …" commands
-  // capture the current boolean value and actually flip it instead of repeatedly applying
-  // the value that was current when the palette mounted.
+  // Rerun when inputs that the static commands close over change. userConfig is included so
+  // the "Toggle …" commands capture the current boolean value and actually flip it instead of
+  // repeatedly applying the value that was current when the palette mounted.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
   useEffect(() => {
     setCommands(allStaticCommands);
   }, [allowUpdate, userConfig]);

--- a/frontend/javascripts/viewer/view/layouting/flex_layout_wrapper.tsx
+++ b/frontend/javascripts/viewer/view/layouting/flex_layout_wrapper.tsx
@@ -176,7 +176,7 @@ class FlexLayoutWrapper extends PureComponent<Props, State> {
   openRightBorderTabById(tabType: BorderTabType) {
     const rightBorderId = "right-border-tab-container";
     const node = this.state.model.getNodeById(rightBorderId);
-    if (!node || node.getType() !== "tab") return;
+    if (node?.getType() !== "tab") return;
 
     const isRightOpen = getBorderOpenStatus(this.state.model).right;
     if (!isRightOpen) this.toggleBorder("right");

--- a/frontend/javascripts/viewer/view/right_border_tabs/abstract_tree_renderer.ts
+++ b/frontend/javascripts/viewer/view/right_border_tabs/abstract_tree_renderer.ts
@@ -140,7 +140,7 @@ class AbstractTreeRenderer {
    * @param  {Number} @activeNodeId node id
    */
 
-  // biome-ignore lint/suspicious/useAdjacentOverloadSignatures: Careful, there is a static drawTree() method as well.
+  // Careful, there is a static drawTree() method as well.
   drawTree(tree: Tree, activeNodeId: number) {
     let root;
     this.tree = tree;

--- a/frontend/javascripts/viewer/view/right_border_tabs/metadata_table.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/metadata_table.tsx
@@ -14,7 +14,7 @@ import { InputWithUpdateOnBlur } from "../components/input_with_update_on_blur";
 
 const getKeyInputIdForIndex = (index: number) => `metadata-key-input-id-${index}`;
 
-function _MetadataTableRows<ItemType extends { metadata: MetadataEntryProto[] }>({
+function MetadataTableRowsInner<ItemType extends { metadata: MetadataEntryProto[] }>({
   item,
   setMetadata,
   readOnly,
@@ -159,4 +159,4 @@ function _MetadataTableRows<ItemType extends { metadata: MetadataEntryProto[] }>
   );
 }
 
-export const MetadataEntryTableRows = memo(_MetadataTableRows) as typeof _MetadataTableRows;
+export const MetadataEntryTableRows = memo(MetadataTableRowsInner) as typeof MetadataTableRowsInner;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/scalableminds/webknossos.git"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.13",
+    "@biomejs/biome": "^2.5.8",
     "@redux-saga/testing-utils": "^1.1.5",
     "@rolldown/plugin-babel": "^0.2.3",
     "@shaderfrog/glsl-parser": "^0.3.0",
@@ -99,7 +99,7 @@
     "check-untyped-saga-selects": "./tools/check-no-untyped-select-imports.js",
     "check-untyped-use-selector": "./tools/check-no-untyped-use-selector-imports.js",
     "check-bare-dynamic-imports": "./tools/check-no-bare-dynamic-imports.js",
-    "check-frontend": "yarn run biome check --diagnostic-level=error --max-diagnostics 50 frontend package.json && tools/assert-no-test-only.sh && yarn check-untyped-saga-selects && yarn check-untyped-use-selector && yarn check-bare-dynamic-imports",
+    "check-frontend": "yarn run biome check --reporter=concise --diagnostic-level=error --max-diagnostics 50 frontend package.json && tools/assert-no-test-only.sh && yarn check-untyped-saga-selects && yarn check-untyped-use-selector && yarn check-bare-dynamic-imports",
     "fix-frontend": "yarn run biome check --diagnostic-level=error --max-diagnostics 50 frontend package.json --write && echo Please proofread the applied suggestions, as they may not be safe.",
     "fix-backend": "sbt --client \";scalafmt; Test/scalafmt; util/scalafmt; webknossosTracingstore/scalafmt; webknossosDatastore/scalafmt; webknossosSlickCodegen/scalafmt; scalafix ; Test/scalafix ; util/scalafix ; webknossosTracingstore/scalafix ; webknossosDatastore/scalafix ; webknossosSlickCodegen/scalafix \"",
     "licenses-backend": "sbt --client dumpLicenseReport",

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,18 +313,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:^2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/biome@npm:2.3.13"
+"@biomejs/biome@npm:^2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/biome@npm:2.5.8"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:2.3.13"
-    "@biomejs/cli-darwin-x64": "npm:2.3.13"
-    "@biomejs/cli-linux-arm64": "npm:2.3.13"
-    "@biomejs/cli-linux-arm64-musl": "npm:2.3.13"
-    "@biomejs/cli-linux-x64": "npm:2.3.13"
-    "@biomejs/cli-linux-x64-musl": "npm:2.3.13"
-    "@biomejs/cli-win32-arm64": "npm:2.3.13"
-    "@biomejs/cli-win32-x64": "npm:2.3.13"
+    "@biomejs/cli-darwin-arm64": "npm:2.5.8"
+    "@biomejs/cli-darwin-x64": "npm:2.5.8"
+    "@biomejs/cli-linux-arm64": "npm:2.5.8"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.5.8"
+    "@biomejs/cli-linux-x64": "npm:2.5.8"
+    "@biomejs/cli-linux-x64-musl": "npm:2.5.8"
+    "@biomejs/cli-win32-arm64": "npm:2.5.8"
+    "@biomejs/cli-win32-x64": "npm:2.5.8"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -344,62 +344,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 10c0/920c44c755ab8efa2114b441baf74b8f5fae8e6ad98a301ce02228f546d20ef6ab7c33b990b0a4acd1ffc8f5985ae839cf1fec59a6f169732a0f86c14308728b
+  checksum: 10c0/244e17bc70d25cbbf0838ffc32e472a64ab4e19093c9603aa9e266b1f99a00d5b64590a52678a84ae60ac71e0f268efe437b16852e4c08ddce28131dd35847f3
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-darwin-arm64@npm:2.3.13"
+"@biomejs/cli-darwin-arm64@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.5.8"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-darwin-x64@npm:2.3.13"
+"@biomejs/cli-darwin-x64@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-darwin-x64@npm:2.5.8"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.3.13"
+"@biomejs/cli-linux-arm64-musl@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.5.8"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-linux-arm64@npm:2.3.13"
+"@biomejs/cli-linux-arm64@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-linux-arm64@npm:2.5.8"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-linux-x64-musl@npm:2.3.13"
+"@biomejs/cli-linux-x64-musl@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.5.8"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-linux-x64@npm:2.3.13"
+"@biomejs/cli-linux-x64@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-linux-x64@npm:2.5.8"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-win32-arm64@npm:2.3.13"
+"@biomejs/cli-win32-arm64@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-win32-arm64@npm:2.5.8"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:2.3.13":
-  version: 2.3.13
-  resolution: "@biomejs/cli-win32-x64@npm:2.3.13"
+"@biomejs/cli-win32-x64@npm:2.5.8":
+  version: 2.5.8
+  resolution: "@biomejs/cli-win32-x64@npm:2.5.8"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -13822,7 +13822,7 @@ __metadata:
     "@airbrake/browser": "npm:^2.1.7"
     "@ant-design/colors": "npm:^8.0.1"
     "@ant-design/icons": "npm:^6.3.2"
-    "@biomejs/biome": "npm:^2.3.13"
+    "@biomejs/biome": "npm:^2.5.8"
     "@dnd-kit/core": "npm:^6.1.0"
     "@dnd-kit/sortable": "npm:^8.0.0"
     "@github/webauthn-json": "npm:^2.1.1"


### PR DESCRIPTION
### Summary

Bumps Biome across two minor releases (2.4.0, 2.5.0), which promoted 94 nursery rules to stable groups and improved detection in rules we already enable.

Pinned to **2.5.8, not 2.5.9** — our `npmMinimalAgeGate: 3d` quarantines releases younger than three days, and 2.5.9 was 1.4 days old. Its delta is CSS/HTML parser patches plus two nursery rules, so nothing here changes. 

**Config** (all three were required — Biome refused to start otherwise):
- `nursery.noReactForwardRef` → `suspicious.noReactForwardRef` (promoted in 2.4.0, so the old key is an unknown-key error)
- `linter.rules.recommended: true` → `preset: "recommended"` (via `biome migrate`; the deprecation diagnostic aborts under `--diagnostic-level=error`)
- `noAmbiguousAnchorText: "off"` — newly recommended in `a11y`, flagged 6 "Learn more"/"here" links; disabled alongside our other a11y opt-outs

**Code** — 60 errors → 0:
- **Renamed the seven `_Foo` inner components to `FooInner`.** 2.4.0 improved `useHookAtTopLevel` detection, which doesn't treat a leading-underscore function as a component, so every hook inside them became an error — 34 false positives. Follows the `DuplicateAnnotationModalInner` convention already in the tree; exported names are unchanged.
- **Fixed unsafe optional chaining** in `bounding_box_saving.spec.ts:265`/`:280`, where `(batch?.actions[0] as T).value` is dereferenced outside the parens and would throw. The lines just above already used plain `.`.
- Applied the formatter (15 files — curried `test.each`/`test.for` arguments now break past `lineWidth`, plus one member-chain collapse) and the `useOptionalChain` (10) / `noExtraBooleanCast` (1) fixes.

Also adopts the new `--reporter=concise` in `check-frontend` — one line per diagnostic instead of a boxed block.


Warnings went from 26 to 22 — no new categories, all pre-existing `useExhaustiveDependencies` / `noNodejsImportProtocol` / `noUnusedPrivateClassMembers`.

### Steps to test:
- `yarn check-frontend` → 0 errors (CI gates on this)
- `yarn typecheck` → passes; catches any bad rename
- `yarn test` → 3186 passed, 4 skipped


------
(Please delete unneeded items, merge only when none are left open)
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)