### PR TITLE
Add option to scale composed layers according to voxel size

### DIFF
--- a/docs/datasets/composing.md
+++ b/docs/datasets/composing.md
@@ -5,7 +5,7 @@ This feature allows you to combine layers from previously added datasets to crea
 During composition, transforms can optionally be defined in case the datasets are not in the same coordinate system.
 There are three different ways to compose a new dataset:
 
-1. Combine datasets by selecting from existing datasets. No transforms between these datasets will be added.
+1. Combine datasets by selecting from existing datasets. No transforms between these datasets will be added. If the selected datasets have different voxel sizes, the new dataset uses the finest of them and each layer keeps its physical size. For the case that the differing voxel sizes cannot be expressed as mags, a "Respect voxel size" option is offered, which scales each layer with a transform instead.
 2. Create landmark annotations (using the skeleton tool) for each dataset. Then, these datasets can be combined while transforming one dataset to match the other.
 3. Similar to (2), two datasets can be combined while respecting landmarks that were generated with BigWarp.
 

--- a/frontend/javascripts/admin/dataset/composition_wizard/04_configure_new_dataset.tsx
+++ b/frontend/javascripts/admin/dataset/composition_wizard/04_configure_new_dataset.tsx
@@ -24,17 +24,26 @@ import { estimateAffineMatrix4x4 } from "libs/estimate_affine";
 import { formatNumber } from "libs/format_utils";
 import { useEffectOnlyOnce, useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
-import { isUserAdminOrDatasetManager } from "libs/utils";
+import { isPowerOfTwo, isUserAdminOrDatasetManager } from "libs/utils";
 import uniqBy from "lodash-es/uniqBy";
 import messages from "messages";
 import React, { useState } from "react";
-import type { APIDataLayer, APIDataset, APITeam, LayerLink } from "types/api_types";
+import type { APIDataLayer, APIDataset, APITeam, LayerLink, VoxelSize } from "types/api_types";
 import { syncValidator } from "types/validation";
 import { WkDevFlags } from "viewer/api/wk_dev";
 import type { Vector3 } from "viewer/constants";
 import { getReadableURLPart, getViewDatasetURL } from "viewer/model/accessors/dataset_accessor";
-import { flatToNestedMatrix } from "viewer/model/accessors/dataset_layer_transformation_accessor";
+import {
+  buildLiveTransforms,
+  flatToNestedMatrix,
+} from "viewer/model/accessors/dataset_layer_transformation_accessor";
+import BoundingBox from "viewer/model/bucket_data_handling/bounding_box";
 import { checkLandmarksForThinPlateSpline } from "viewer/model/helpers/transformation_helpers";
+import {
+  areVoxelSizesPowerOfTwoMultiples,
+  getFinestVoxelSize,
+  getVoxelSizeScaleFactor,
+} from "viewer/model/scaleinfo";
 import type { WizardComponentProps } from "./common";
 
 const FormItem = Form.Item;
@@ -47,6 +56,103 @@ async function guardedWithErrorToast(fn: () => Promise<any>) {
     console.error(error);
     ErrorHandling.notify(error as Error);
   }
+}
+
+// Scale factors this close to 1 are treated as identity, so that layers whose voxel size already
+// matches the new dataset's keep their empty transformation list.
+const VOXEL_SIZE_SCALE_EPSILON = 1e-6;
+
+// The scaling of a layer happens about the coordinate origin: a voxel at index p lies at the
+// physical position p * sourceVoxelSize, i.e. at p * scale in the new dataset's voxel grid. Passing
+// a bounding box that is centered on the origin makes the two enclosing translations of the
+// transformation chain identities, so that the chain is exactly that scaling.
+const ORIGIN_CENTERED_BOUNDING_BOX = new BoundingBox({ min: [0, 0, 0], max: [0, 0, 0] });
+
+// Adds a scaling transform to each layer that compensates for the difference between its source
+// dataset's voxel size and the voxel size of the dataset that is about to be created.
+// The transform is emitted in the same 7-matrix format that the Layer Transforms editor produces,
+// so that the result stays editable there.
+export function withVoxelSizeTransforms(
+  layers: LayerLink[],
+  linkedDatasets: APIDataset[],
+  targetVoxelSize: VoxelSize,
+): LayerLink[] {
+  return layers.map((layer) => {
+    const sourceDataset = linkedDatasets.find((dataset) => dataset.id === layer.sourceDatasetId);
+    if (sourceDataset == null) {
+      return layer;
+    }
+    const scale = getVoxelSizeScaleFactor(sourceDataset.dataSource.scale, targetVoxelSize);
+    if (scale.every((value) => Math.abs(value - 1) < VOXEL_SIZE_SCALE_EPSILON)) {
+      return layer;
+    }
+    return {
+      ...layer,
+      transformations: [
+        ...layer.transformations,
+        ...buildLiveTransforms(scale, [0, 0, 0], [0, 0, 0], ORIGIN_CENTERED_BOUNDING_BOX),
+      ],
+    };
+  });
+}
+
+// Returns the linked datasets that the given layers actually stem from, in the order in which they
+// were linked. Layers can be removed in this wizard step, so this can be a subset of all datasets
+// that were selected in the previous step.
+export function getUsedDatasets(layers: LayerLink[], linkedDatasets: APIDataset[]): APIDataset[] {
+  const usedDatasetIds = new Set(layers.map((layer) => layer.sourceDatasetId));
+  return linkedDatasets.filter((dataset) => usedDatasetIds.has(dataset.id));
+}
+
+// Returns whether the given voxel sizes are not all the same (up to the scale factor epsilon, so
+// that voxel sizes which only differ in their unit are still considered equal).
+export function doVoxelSizesDiffer(voxelSizes: VoxelSize[]): boolean {
+  if (voxelSizes.length === 0) {
+    return false;
+  }
+  const finestVoxelSize = getFinestVoxelSize(voxelSizes);
+  return voxelSizes.some((voxelSize) =>
+    getVoxelSizeScaleFactor(voxelSize, finestVoxelSize).some(
+      (factor) => Math.abs(factor - 1) >= VOXEL_SIZE_SCALE_EPSILON,
+    ),
+  );
+}
+
+// The backend can respect differing voxel sizes exactly and without any transformations by rebasing
+// the mags of each layer onto the finest voxel size. It does so when no layer carries a
+// transformation (see ComposeService.createDatasource), which requires that all resulting mags are
+// powers of two (see ExploreLayerUtils.rescaleLayersByCommonVoxelSize). That path yields a dataset
+// whose layers stay untransformed, so it is preferred over adding scaling transformations.
+export function canBackendRespectVoxelSizes(
+  layers: LayerLink[],
+  linkedDatasets: APIDataset[],
+): boolean {
+  if (layers.some((layer) => layer.transformations.length > 0)) {
+    return false;
+  }
+  const usedDatasets = getUsedDatasets(layers, linkedDatasets);
+  if (!areVoxelSizesPowerOfTwoMultiples(usedDatasets.map((dataset) => dataset.dataSource.scale))) {
+    return false;
+  }
+  return layers.every((layerLink) => {
+    const sourceLayer = linkedDatasets
+      .find((dataset) => dataset.id === layerLink.sourceDatasetId)
+      ?.dataSource.dataLayers.find((layer) => layer.name === layerLink.sourceLayerName);
+    return (
+      sourceLayer != null && sourceLayer.mags.every((mag) => mag.mag.every((v) => isPowerOfTwo(v)))
+    );
+  });
+}
+
+// Returns whether the user should be able to decide about scaling the layers according to their
+// voxel sizes. This is only the case if the voxel sizes actually differ and if the backend cannot
+// respect them on its own.
+function shouldOfferVoxelSizeScaling(layers: LayerLink[], linkedDatasets: APIDataset[]): boolean {
+  const usedDatasets = getUsedDatasets(layers, linkedDatasets);
+  return (
+    doVoxelSizesDiffer(usedDatasets.map((dataset) => dataset.dataSource.scale)) &&
+    !canBackendRespectVoxelSizes(layers, linkedDatasets)
+  );
 }
 
 export function ConfigureNewDataset(props: WizardComponentProps) {
@@ -102,6 +208,7 @@ export function ConfigureNewDataset(props: WizardComponentProps) {
     }
     const layersWithoutTransforms = form.getFieldValue(["layers"]) as LayerLink[];
     const useThinPlateSplines = (form.getFieldValue("useThinPlateSplines") ?? false) as boolean;
+    const respectVoxelSize = (form.getFieldValue("respectVoxelSize") ?? false) as boolean;
 
     const affineMeanError = { meanError: 0 };
 
@@ -172,6 +279,29 @@ export function ConfigureNewDataset(props: WizardComponentProps) {
       }
     }
 
+    // Layers can be removed in this step, so only the datasets that the remaining layers stem from
+    // may influence the voxel size of the new dataset.
+    const usedDatasets = getUsedDatasets(layersWithTransforms, linkedDatasets);
+    if (usedDatasets.length === 0) {
+      Toast.error("Please keep at least one layer.");
+      return;
+    }
+    // When the voxel sizes should be respected, the new dataset uses the finest voxel size of all
+    // used source datasets so that no layer needs to be downscaled.
+    const targetVoxelSize = respectVoxelSize
+      ? getFinestVoxelSize(usedDatasets.map((dataset) => dataset.dataSource.scale))
+      : usedDatasets.slice(-1)[0].dataSource.scale;
+    // Scaling transformations are only needed if the backend cannot respect the voxel sizes itself.
+    const needsVoxelSizeTransforms =
+      respectVoxelSize && shouldOfferVoxelSizeScaling(layersWithTransforms, linkedDatasets);
+    if (needsVoxelSizeTransforms) {
+      layersWithTransforms = withVoxelSizeTransforms(
+        layersWithTransforms,
+        usedDatasets,
+        targetVoxelSize,
+      );
+    }
+
     const newDatasetName = form.getFieldValue(["name"]);
     setIsLoading(true);
     try {
@@ -180,7 +310,7 @@ export function ConfigureNewDataset(props: WizardComponentProps) {
         newDatasetName,
         targetFolderId: form.getFieldValue(["targetFolderId"]),
         organizationId: activeUser.organization,
-        voxelSize: linkedDatasets.slice(-1)[0].dataSource.scale,
+        voxelSize: targetVoxelSize,
         layers: layersWithTransforms,
       });
 
@@ -199,7 +329,9 @@ export function ConfigureNewDataset(props: WizardComponentProps) {
           "",
           "The layers were combined " +
             (sourcePoints.length === 0
-              ? "without any transforms"
+              ? needsVoxelSizeTransforms
+                ? "without any transforms, except for a scaling that compensates for the differing voxel sizes of the source datasets"
+                : "without any transforms"
               : `with ${
                   useThinPlateSplines
                     ? `Thin-Plate-Splines (${sourcePoints.length} correspondences)`
@@ -289,6 +421,24 @@ export function ConfigureNewDataset(props: WizardComponentProps) {
               <Checkbox>Use Thin-Plate-Splines (Experimental)</Checkbox>
             </FormItem>
           )}
+        {wizardContext.sourcePoints.length === 0 && (
+          <Form.Item
+            noStyle
+            shouldUpdate={(prevValues, curValues) => prevValues.layers !== curValues.layers}
+          >
+            {({ getFieldValue }) =>
+              shouldOfferVoxelSizeScaling(getFieldValue("layers") || [], linkedDatasets) ? (
+                <FormItem name={["respectVoxelSize"]} valuePropName="checked">
+                  <Checkbox>
+                    <Tooltip title="The voxel sizes of the selected datasets differ in a way that WEBKNOSSOS cannot express as mags. Enable this option to scale each layer so that it keeps its physical size. The new dataset then uses the finest voxel size of the selected datasets.">
+                      Respect voxel size
+                    </Tooltip>
+                  </Checkbox>
+                </FormItem>
+              ) : null
+            }
+          </Form.Item>
+        )}
 
         <FormItem
           style={{

--- a/frontend/javascripts/libs/utils.ts
+++ b/frontend/javascripts/libs/utils.ts
@@ -184,6 +184,16 @@ export function roundTo(value: number, digits: number): number {
   return Math.round(value * digitMultiplier) / digitMultiplier;
 }
 
+// Returns whether the given value is a power of two (1, 2, 4, ...). Values that are only
+// approximately a power of two are accepted, so that this can be used on quotients of floats.
+export function isPowerOfTwo(value: number, epsilon: number = 1e-4): boolean {
+  if (!Number.isFinite(value) || value <= 0) {
+    return false;
+  }
+  const exponent = Math.log2(value);
+  return Math.abs(exponent - Math.round(exponent)) < epsilon;
+}
+
 // Color conversion helpers (rgbToHex, hexToRgb, stringToNormalizedRgbColor, …) live in
 // libs/colors.ts.
 

--- a/frontend/javascripts/test/admin/compose_voxel_size.spec.ts
+++ b/frontend/javascripts/test/admin/compose_voxel_size.spec.ts
@@ -1,0 +1,204 @@
+import {
+  canBackendRespectVoxelSizes,
+  doVoxelSizesDiffer,
+  getUsedDatasets,
+  withVoxelSizeTransforms,
+} from "admin/dataset/composition_wizard/04_configure_new_dataset";
+import type { APIDataset, LayerLink, VoxelSize } from "types/api_types";
+import { UnitLong, type Vector3 } from "viewer/constants";
+import {
+  combineCoordinateTransformations,
+  EXPECTED_LIVE_TRANSFORMATION_LENGTH,
+  extractSRTFromTransforms,
+  hasValidLiveTransformationPattern,
+} from "viewer/model/accessors/dataset_layer_transformation_accessor";
+import { transformPointUnscaled } from "viewer/model/helpers/transformation_helpers";
+import { getFinestVoxelSize } from "viewer/model/scaleinfo";
+import { describe, expect, it } from "vitest";
+
+function makeDataset(id: string, voxelSize: VoxelSize, mags: Vector3[] = [[1, 1, 1]]): APIDataset {
+  // Only the fields that the tested functions read are relevant here.
+  return {
+    id,
+    dataSource: {
+      scale: voxelSize,
+      dataLayers: [{ name: `${id}_layer`, mags: mags.map((mag) => ({ mag })) }],
+    },
+  } as unknown as APIDataset;
+}
+
+function makeLayerLink(sourceDatasetId: string, name: string): LayerLink {
+  return {
+    sourceDatasetId,
+    sourceDatasetName: sourceDatasetId,
+    sourceLayerName: name,
+    targetLayerName: name,
+    transformations: [],
+  };
+}
+
+const COARSE = { factor: [6, 6, 6], unit: UnitLong.nm } as VoxelSize;
+const FINE = { factor: [2, 2, 2], unit: UnitLong.nm } as VoxelSize;
+
+describe("withVoxelSizeTransforms", () => {
+  const datasets = [makeDataset("coarse", COARSE), makeDataset("fine", FINE)];
+  const layers = [makeLayerLink("coarse", "coarse_layer"), makeLayerLink("fine", "fine_layer")];
+  const targetVoxelSize = getFinestVoxelSize(datasets.map((d) => d.dataSource.scale));
+
+  it("should use the finest voxel size as the target", () => {
+    expect(targetVoxelSize).toEqual(FINE);
+  });
+
+  it("should emit the scaling in the editable 7-matrix format", () => {
+    const [coarseLayer] = withVoxelSizeTransforms(layers, datasets, targetVoxelSize);
+
+    expect(coarseLayer.transformations).toHaveLength(EXPECTED_LIVE_TRANSFORMATION_LENGTH);
+    // The Layer Transforms editor must accept the generated transforms and read back the scaling.
+    expect(hasValidLiveTransformationPattern(coarseLayer.transformations)).toBe(true);
+    expect(extractSRTFromTransforms(coarseLayer.transformations)).toEqual({
+      scale: [3, 3, 3],
+      rotation: [0, 0, 0],
+      translation: [0, 0, 0],
+    });
+  });
+
+  it("should map a voxel to p * scale", () => {
+    const [coarseLayer] = withVoxelSizeTransforms(layers, datasets, targetVoxelSize);
+    const transform = combineCoordinateTransformations(coarseLayer.transformations, [1, 1, 1]);
+
+    expect(transformPointUnscaled(transform)([0, 0, 0])).toEqual([0, 0, 0]);
+    expect(transformPointUnscaled(transform)([10, 20, 30])).toEqual([30, 60, 90]);
+  });
+
+  it("should not add an identity transform for the layer that already matches", () => {
+    const [, fineLayer] = withVoxelSizeTransforms(layers, datasets, targetVoxelSize);
+
+    expect(fineLayer.transformations).toEqual([]);
+  });
+
+  it("should append to transformations that are already present", () => {
+    const existing = { type: "affine" as const, matrix: [[1, 0, 0, 5]] as any };
+    const layersWithExisting = [
+      { ...makeLayerLink("coarse", "coarse_layer"), transformations: [existing] },
+    ];
+
+    const [layer] = withVoxelSizeTransforms(layersWithExisting, datasets, targetVoxelSize);
+
+    expect(layer.transformations).toHaveLength(1 + EXPECTED_LIVE_TRANSFORMATION_LENGTH);
+    expect(layer.transformations[0]).toBe(existing);
+  });
+
+  it("should leave layers of unknown datasets untouched", () => {
+    const orphan = [makeLayerLink("does_not_exist", "orphan_layer")];
+
+    expect(withVoxelSizeTransforms(orphan, datasets, targetVoxelSize)[0].transformations).toEqual(
+      [],
+    );
+  });
+
+  it("should handle anisotropic voxel sizes per axis", () => {
+    const anisotropicDatasets = [
+      makeDataset("a", { factor: [4, 8, 40], unit: UnitLong.nm } as VoxelSize),
+      makeDataset("b", { factor: [2, 2, 10], unit: UnitLong.nm } as VoxelSize),
+    ];
+    const target = getFinestVoxelSize(anisotropicDatasets.map((d) => d.dataSource.scale));
+    const [layerA] = withVoxelSizeTransforms(
+      [makeLayerLink("a", "layer_a")],
+      anisotropicDatasets,
+      target,
+    );
+
+    expect(target).toEqual({ factor: [2, 2, 10], unit: UnitLong.nm });
+    expect(hasValidLiveTransformationPattern(layerA.transformations)).toBe(true);
+    expect(extractSRTFromTransforms(layerA.transformations).scale).toEqual([2, 4, 4]);
+  });
+});
+
+describe("getUsedDatasets", () => {
+  const datasets = [makeDataset("coarse", COARSE), makeDataset("fine", FINE)];
+
+  it("should only return the datasets that the given layers stem from", () => {
+    const layers = [makeLayerLink("fine", "fine_layer")];
+
+    expect(getUsedDatasets(layers, datasets).map((dataset) => dataset.id)).toEqual(["fine"]);
+  });
+
+  it("should keep the order in which the datasets were linked", () => {
+    const layers = [makeLayerLink("fine", "fine_layer"), makeLayerLink("coarse", "coarse_layer")];
+
+    expect(getUsedDatasets(layers, datasets).map((dataset) => dataset.id)).toEqual([
+      "coarse",
+      "fine",
+    ]);
+  });
+});
+
+describe("doVoxelSizesDiffer", () => {
+  it("should ignore voxel sizes that only differ in their unit", () => {
+    expect(doVoxelSizesDiffer([FINE, { factor: [0.002, 0.002, 0.002], unit: UnitLong.µm }])).toBe(
+      false,
+    );
+  });
+
+  it("should detect differing voxel sizes", () => {
+    expect(doVoxelSizesDiffer([COARSE, FINE])).toBe(true);
+  });
+
+  it("should not consider a single voxel size to be differing", () => {
+    expect(doVoxelSizesDiffer([COARSE])).toBe(false);
+    expect(doVoxelSizesDiffer([])).toBe(false);
+  });
+});
+
+describe("canBackendRespectVoxelSizes", () => {
+  const POWER_OF_TWO = { factor: [4, 4, 4], unit: UnitLong.nm } as VoxelSize;
+
+  it("should be true for voxel sizes that are power-of-two multiples of each other", () => {
+    // The backend rebases the mags of the 4 nm dataset onto 2 nm, so no transform is needed.
+    const datasets = [makeDataset("a", POWER_OF_TWO), makeDataset("b", FINE)];
+    const layers = [makeLayerLink("a", "a_layer"), makeLayerLink("b", "b_layer")];
+
+    expect(canBackendRespectVoxelSizes(layers, datasets)).toBe(true);
+  });
+
+  it("should be false for a non-power-of-two ratio", () => {
+    // 6 nm / 2 nm = 3, which the backend cannot express as a mag.
+    const datasets = [makeDataset("coarse", COARSE), makeDataset("fine", FINE)];
+    const layers = [makeLayerLink("coarse", "coarse_layer"), makeLayerLink("fine", "fine_layer")];
+
+    expect(canBackendRespectVoxelSizes(layers, datasets)).toBe(false);
+  });
+
+  it("should ignore datasets whose layers were all removed", () => {
+    const datasets = [makeDataset("coarse", COARSE), makeDataset("fine", FINE)];
+    const layers = [makeLayerLink("fine", "fine_layer")];
+
+    expect(canBackendRespectVoxelSizes(layers, datasets)).toBe(true);
+  });
+
+  it("should be false if a source layer has a non-power-of-two mag", () => {
+    const datasets = [
+      makeDataset("a", POWER_OF_TWO, [
+        [1, 1, 1],
+        [3, 3, 3],
+      ]),
+      makeDataset("b", FINE),
+    ];
+    const layers = [makeLayerLink("a", "a_layer"), makeLayerLink("b", "b_layer")];
+
+    expect(canBackendRespectVoxelSizes(layers, datasets)).toBe(false);
+  });
+
+  it("should be false if a layer already carries a transformation", () => {
+    const datasets = [makeDataset("a", POWER_OF_TWO), makeDataset("b", FINE)];
+    const layers = [
+      {
+        ...makeLayerLink("a", "a_layer"),
+        transformations: [{ type: "affine" as const, matrix: [[1, 0, 0, 5]] as any }],
+      },
+      makeLayerLink("b", "b_layer"),
+    ];
+
+    expect(canBackendRespectVoxelSizes(layers, datasets)).toBe(false);
+  });
+});

--- a/frontend/javascripts/test/model/scaleinfo.spec.ts
+++ b/frontend/javascripts/test/model/scaleinfo.spec.ts
@@ -1,5 +1,10 @@
 import { UnitLong, UnitShort } from "viewer/constants";
-import { convertVoxelSizeToUnit } from "viewer/model/scaleinfo";
+import {
+  areVoxelSizesPowerOfTwoMultiples,
+  convertVoxelSizeToUnit,
+  getFinestVoxelSize,
+  getVoxelSizeScaleFactor,
+} from "viewer/model/scaleinfo";
 import { describe, expect, it } from "vitest";
 
 describe("Format Utils", () => {
@@ -40,5 +45,123 @@ describe("Format Utils", () => {
     expect([1e-6, 1e-6, 1e-6]).toEqual(
       convertVoxelSizeToUnit({ factor: [1, 1, 1], unit: UnitLong.µm }, UnitShort.m),
     );
+  });
+});
+
+describe("getVoxelSizeScaleFactor", () => {
+  it("should scale a coarser source up to a finer target", () => {
+    expect(
+      getVoxelSizeScaleFactor(
+        { factor: [6, 6, 6], unit: UnitLong.nm },
+        { factor: [2, 2, 2], unit: UnitLong.nm },
+      ),
+    ).toEqual([3, 3, 3]);
+  });
+
+  it("should return the identity for identical voxel sizes", () => {
+    expect(
+      getVoxelSizeScaleFactor(
+        { factor: [4, 4, 40], unit: UnitLong.nm },
+        { factor: [4, 4, 40], unit: UnitLong.nm },
+      ),
+    ).toEqual([1, 1, 1]);
+  });
+
+  it("should scale each axis independently", () => {
+    expect(
+      getVoxelSizeScaleFactor(
+        { factor: [4, 8, 40], unit: UnitLong.nm },
+        { factor: [2, 2, 10], unit: UnitLong.nm },
+      ),
+    ).toEqual([2, 4, 4]);
+  });
+
+  it("should handle differing units", () => {
+    expect(
+      getVoxelSizeScaleFactor(
+        { factor: [1, 1, 1], unit: UnitLong.µm },
+        { factor: [10, 10, 10], unit: UnitLong.nm },
+      ),
+    ).toEqual([100, 100, 100]);
+  });
+
+  it("should fall back to 1 for degenerate target voxel sizes", () => {
+    expect(
+      getVoxelSizeScaleFactor(
+        { factor: [6, 6, 6], unit: UnitLong.nm },
+        { factor: [0, 2, 2], unit: UnitLong.nm },
+      ),
+    ).toEqual([1, 3, 3]);
+  });
+});
+
+describe("getFinestVoxelSize", () => {
+  it("should return a single voxel size unchanged", () => {
+    expect(getFinestVoxelSize([{ factor: [6, 6, 6], unit: UnitLong.nm }])).toEqual({
+      factor: [6, 6, 6],
+      unit: UnitLong.nm,
+    });
+  });
+
+  it("should take the per-axis minimum", () => {
+    expect(
+      getFinestVoxelSize([
+        { factor: [4, 4, 40], unit: UnitLong.nm },
+        { factor: [2, 8, 10], unit: UnitLong.nm },
+      ]),
+    ).toEqual({ factor: [2, 4, 10], unit: UnitLong.nm });
+  });
+
+  it("should use the unit of the finest voxel size when units differ", () => {
+    // 1 µm is coarser than 10 nm, so the result is expressed in nm.
+    expect(
+      getFinestVoxelSize([
+        { factor: [1, 1, 1], unit: UnitLong.µm },
+        { factor: [10, 10, 10], unit: UnitLong.nm },
+      ]),
+    ).toEqual({ factor: [10, 10, 10], unit: UnitLong.nm });
+  });
+
+  it("should throw for an empty list", () => {
+    expect(() => getFinestVoxelSize([])).toThrow();
+  });
+});
+
+describe("areVoxelSizesPowerOfTwoMultiples", () => {
+  it("should accept voxel sizes that are power-of-two multiples of the finest one", () => {
+    expect(
+      areVoxelSizesPowerOfTwoMultiples([
+        { factor: [2, 2, 10], unit: UnitLong.nm },
+        { factor: [8, 8, 20], unit: UnitLong.nm },
+      ]),
+    ).toBe(true);
+  });
+
+  it("should accept voxel sizes that only differ in their unit", () => {
+    expect(
+      areVoxelSizesPowerOfTwoMultiples([
+        { factor: [1, 1, 1], unit: UnitLong.µm },
+        { factor: [1000, 1000, 1000], unit: UnitLong.nm },
+      ]),
+    ).toBe(true);
+  });
+
+  it("should reject a non-power-of-two ratio on a single axis", () => {
+    expect(
+      areVoxelSizesPowerOfTwoMultiples([
+        { factor: [2, 2, 10], unit: UnitLong.nm },
+        { factor: [8, 8, 30], unit: UnitLong.nm },
+      ]),
+    ).toBe(false);
+  });
+
+  it("should reject a ratio that is only close to a power of two", () => {
+    // 3 / 2 rounds to 2, which the backend would silently accept as a mag.
+    expect(
+      areVoxelSizesPowerOfTwoMultiples([
+        { factor: [2, 2, 2], unit: UnitLong.nm },
+        { factor: [3, 3, 3], unit: UnitLong.nm },
+      ]),
+    ).toBe(false);
   });
 });

--- a/frontend/javascripts/viewer/model/scaleinfo.ts
+++ b/frontend/javascripts/viewer/model/scaleinfo.ts
@@ -1,6 +1,7 @@
 import { UnitsMap } from "libs/format_utils";
+import { isPowerOfTwo } from "libs/utils";
 import type { VoxelSize } from "types/api_types";
-import { LongUnitToShortUnitMap, type UnitShort, type Vector3 } from "viewer/constants";
+import { LongUnitToShortUnitMap, UnitShort, type Vector3 } from "viewer/constants";
 
 export function getBaseVoxelInUnit(voxelSizeFactor: Vector3): number {
   // base voxel should be a cube with highest resolution
@@ -46,4 +47,58 @@ export function convertVoxelSizeToUnit(voxelSize: VoxelSize, newUnit: UnitShort)
   const conversionFactor = UnitsMap[shortUnit] / UnitsMap[newUnit];
   const voxelSizeInNewUnit = voxelSize.factor.map((value) => value * conversionFactor) as Vector3;
   return voxelSizeInNewUnit;
+}
+
+// Returns the per-axis factor by which a layer needs to be scaled so that data stored with
+// sourceVoxelSize appears at its correct physical size in a dataset that uses targetVoxelSize.
+// E.g. a source voxel size of 6/6/6 in a target of 2/2/2 yields [3, 3, 3].
+export function getVoxelSizeScaleFactor(
+  sourceVoxelSize: VoxelSize,
+  targetVoxelSize: VoxelSize,
+): Vector3 {
+  const sourceFactor = convertVoxelSizeToUnit(
+    sourceVoxelSize,
+    LongUnitToShortUnitMap[targetVoxelSize.unit],
+  );
+  return sourceFactor.map((sourceValue, index) => {
+    const targetValue = targetVoxelSize.factor[index];
+    // Guard against degenerate voxel sizes, which would yield a non-finite scale factor.
+    return targetValue !== 0 && Number.isFinite(targetValue) && Number.isFinite(sourceValue)
+      ? sourceValue / targetValue
+      : 1;
+  }) as Vector3;
+}
+
+// Returns the finest of the given voxel sizes, i.e. the per-axis minimum. Voxel sizes may use
+// different units; the result is expressed in the unit of the voxel size with the smallest base
+// voxel, so that the common case of all voxel sizes sharing a unit preserves that unit.
+export function getFinestVoxelSize(voxelSizes: VoxelSize[]): VoxelSize {
+  if (voxelSizes.length === 0) {
+    throw new Error("Cannot determine the finest voxel size of an empty list of voxel sizes.");
+  }
+  const finestVoxelSize = voxelSizes.reduce((finest, current) =>
+    getBaseVoxelInUnit(convertVoxelSizeToUnit(current, UnitShort.nm)) <
+    getBaseVoxelInUnit(convertVoxelSizeToUnit(finest, UnitShort.nm))
+      ? current
+      : finest,
+  );
+  const unit = finestVoxelSize.unit;
+  const factor = voxelSizes
+    .map((voxelSize) => convertVoxelSizeToUnit(voxelSize, LongUnitToShortUnitMap[unit]))
+    .reduce(
+      (finestFactor, currentFactor) =>
+        finestFactor.map((value, index) => Math.min(value, currentFactor[index])) as Vector3,
+    );
+  return { factor, unit };
+}
+
+// Returns whether each of the given voxel sizes is a power-of-two multiple of the finest of them on
+// every axis. This is the condition under which the backend can express differing voxel sizes by
+// rebasing the layers' mags onto a common voxel size instead of by scaling transformations
+// (see ExploreLayerUtils.magFromVoxelSize).
+export function areVoxelSizesPowerOfTwoMultiples(voxelSizes: VoxelSize[]): boolean {
+  const finestVoxelSize = getFinestVoxelSize(voxelSizes);
+  return voxelSizes.every((voxelSize) =>
+    getVoxelSizeScaleFactor(voxelSize, finestVoxelSize).every((factor) => isPowerOfTwo(factor)),
+  );
 }

--- a/unreleased_changes/compose_scale_from_voxel_size.md
+++ b/unreleased_changes/compose_scale_from_voxel_size.md
@@ -1,0 +1,2 @@
+### Added
+- When composing a new dataset from existing datasets whose differing voxel sizes cannot be expressed as mags, the layers can now be scaled according to the voxel sizes of their source datasets via the new "Respect voxel size" option. The new dataset then uses the finest voxel size of the selected datasets.


### PR DESCRIPTION
When composing a dataset from datasets with differing voxel sizes, the new dataset now uses the finest of them. WEBKNOSSOS already respects the physical sizes exactly by rebasing the layers' mags whenever the voxel size ratios are powers of two, so the new "Respect voxel size" option is only offered when that is impossible and scaling transforms are the only remaining way to keep the physical sizes.

### Summary


### Steps to test:
- abc


### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
