### PR TITLE
Fix flaky COPY FROM STDIN in dbtool.js test DB import

### DIFF
--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -155,12 +155,6 @@ function importTestCsvFiles() {
       ],
       {
         input: fs.readFileSync(path.join(csvFolder, filename)),
-        // Setting session_replication_role via a leading `SET` statement in the same
-        // -c string as the COPY is unreliable: psql doesn't consistently relay the
-        // piped stdin into the COPY when it isn't the sole statement, which can abort
-        // the connection with "unexpected COPY_IN result" / "unexpected EOF on client
-        // connection" on the server side. Setting it via PGOPTIONS applies it at
-        // connection startup instead, so the -c string only ever contains the COPY.
         env: {
           ...process.env,
           PGOPTIONS: process.env.PGOPTIONS

--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -163,7 +163,9 @@ function importTestCsvFiles() {
         // connection startup instead, so the -c string only ever contains the COPY.
         env: {
           ...process.env,
-          PGOPTIONS: "-c session_replication_role=replica",
+          PGOPTIONS: process.env.PGOPTIONS
+            ? `${process.env.PGOPTIONS} -c session_replication_role=replica`
+            : "-c session_replication_role=replica",
         },
       },
     );

--- a/tools/postgres/dbtool.js
+++ b/tools/postgres/dbtool.js
@@ -151,13 +151,20 @@ function importTestCsvFiles() {
       [
         PG_CONFIG.url,
         "-c",
-        `SET session_replication_role = replica; COPY webknossos.${filename.slice(
-          0,
-          -4,
-        )} FROM STDOUT WITH CSV HEADER QUOTE ''''`,
+        `COPY webknossos.${filename.slice(0, -4)} FROM STDIN WITH CSV HEADER QUOTE ''''`,
       ],
       {
         input: fs.readFileSync(path.join(csvFolder, filename)),
+        // Setting session_replication_role via a leading `SET` statement in the same
+        // -c string as the COPY is unreliable: psql doesn't consistently relay the
+        // piped stdin into the COPY when it isn't the sole statement, which can abort
+        // the connection with "unexpected COPY_IN result" / "unexpected EOF on client
+        // connection" on the server side. Setting it via PGOPTIONS applies it at
+        // connection startup instead, so the -c string only ever contains the COPY.
+        env: {
+          ...process.env,
+          PGOPTIONS: "-c session_replication_role=replica",
+        },
       },
     );
   }

--- a/unreleased_changes/9927.md
+++ b/unreleased_changes/9927.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a flaky failure in the test-database CSV import (`tools/postgres/dbtool.js`) where combining `SET session_replication_role = replica;` with `COPY ... FROM STDIN` in a single `psql -c` call could abort the connection instead of importing the data.

--- a/unreleased_changes/9927.md
+++ b/unreleased_changes/9927.md
@@ -1,2 +1,0 @@
-### Fixed
-- Fixed a flaky failure in the test-database CSV import (`tools/postgres/dbtool.js`) where combining `SET session_replication_role = replica;` with `COPY ... FROM STDIN` in a single `psql -c` call could abort the connection instead of importing the data.


### PR DESCRIPTION
## Summary

`tools/postgres/dbtool.js`'s test-DB CSV import combines a leading `SET session_replication_role = replica;` with `COPY <table> FROM STDIN ...` inside a single `psql -c "stmt1; stmt2"` invocation, piping the CSV bytes to psql's stdin. This is unreliable: `psql -c` sends the whole string as one query, and its COPY-data-relay path doesn't consistently engage when the COPY isn't the sole statement being executed. The result is a connection abort instead of the import completing.

## How this was found

Discovered while debugging a reproducible `scalableminds/webknossos-libs` CI failure ([run](https://github.com/scalableminds/webknossos-libs/actions/runs/32493064723/job/97355965338)) in the `prepare-test-db` step, which shells out to this script against a freshly pulled `scalableminds/webknossos` image.

Client-side:
```
Error: PSQL exit code: 2
PSQL stderr:
unexpected COPY_IN result, aborting connection
```

Server-side (postgres log), confirming zero row data ever actually got relayed:
```
ERROR:  unexpected EOF on client connection with an open transaction
CONTEXT:  COPY multiusers, line 1
STATEMENT:  SET session_replication_role = replica; COPY webknossos.multiusers FROM STDOUT WITH CSV HEADER QUOTE ''''
```

## Fix

- Set `session_replication_role` via `PGOPTIONS="-c session_replication_role=replica"` at connection startup instead of as a leading statement in the same `-c` string, so the `-c` argument only ever contains the bare `COPY` statement.
- Also changed `FROM STDOUT` to the semantically correct `FROM STDIN` for clarity (Postgres's grammar happens to accept both as synonyms for "the client connection" regardless of `FROM`/`TO` direction, which is presumably why this went unnoticed, but `STDIN` is what's actually meant here for an import).

## Testing

- Not able to run the full docker-based test DB setup in this sandbox; please verify with `docker compose run --rm prepare-test-db` (or `yarn prepare-test-db` / however it's invoked here) before merging.
- Reasoned through the fix against the observed client/server error signatures above; happy to iterate if CI or manual testing surfaces anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
