### PR TITLE
Fix source maps served with wrong Content-Type, breaking DevTools debugging

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,6 +18,7 @@ play {
     }
     fileMimeTypes = ${play.http.fileMimeTypes} """
       wasm=application/wasm
+      map=application/json
     """
   }
 

--- a/unreleased_changes/9930.md
+++ b/unreleased_changes/9930.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed that JS source maps were served with an incorrect `Content-Type`, which could prevent browser DevTools from properly debugging original TypeScript source files on deployed instances.


### PR DESCRIPTION
### Summary
JS source maps served from `/assets/*` were served with the wrong `Content-Type`, which prevented Chrome DevTools from loading them, so breakpoints in original TypeScript files (e.g. `volume_interpolation_saga.ts`) couldn't bind on deployed instances like `master.webknossos.xyz`.

Root cause: Play Framework's built-in default MIME type table maps the `.map` extension to `application/x-navimap` (a legacy, unrelated type inherited from Apache's `mime.types`). `conf/application.conf` only overrode the type for `.wasm`, never for `.map`, so this default leaked through.

Confirmed against the live deployment before fixing:
```
$ curl -I https://master.webknossos.xyz/assets/index-BvGfOmeS.js.map
content-type: application/x-navimap
```
(should be `application/json`)

This isn't a regression from a recent change — the `map=application/x-navimap` default is baked into Play Framework itself and predates this repo's webpack→Vite migration (`#9188`); the `/assets/*` route has always been served through `controllers.Assets.at`, which relies on the same `fileMimeTypes` config. It was simply never overridden.

Fix: add `map=application/json` to the `fileMimeTypes` override in `conf/application.conf`, alongside the existing `wasm` override.

### Steps to test:
- Deploy this branch (or run locally against a built `public/assets` bundle, not the Vite dev server, since the dev server always served correct headers already).
- `curl -I <host>/assets/<some-bundle>.js.map` and confirm `Content-Type: application/json`.
- Open the deployed page in Chrome, open DevTools → Sources, find a `.ts` file (e.g. `volume_interpolation_saga.ts`), set a breakpoint, and confirm it binds (solid red dot) and is hit.

### Issues:
- none

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment