### PR TITLE
Avoid false conflict on retry of last group of the transaction

### DIFF
--- a/unreleased_changes/9944.md
+++ b/unreleased_changes/9944.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a bug where some annotation save request retries would wrongly be answered with 409 CONFLICT, forcing a reload.

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
@@ -176,9 +176,10 @@ class AnnotationTransactionService @Inject() (
         actions = allActionGroups.flatMap(_.actions),
         stats = lastActionGroup.stats, // the latest stats do count
         info = lastActionGroup.info, // frontend sets this identically for all groups of transaction
-        transactionId = f"${lastActionGroup.transactionId}-concatenated",
+        transactionId = lastActionGroup.transactionId, // needed for correct handledGroup lookup in case of retry
         transactionGroupCount = 1,
-        transactionGroupIndex = 0
+        transactionGroupIndex =
+          lastActionGroup.transactionGroupIndex // needed for correct handledGroup lookup in case of retry
       )
     }
 

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
@@ -207,17 +207,19 @@ class AnnotationTransactionService @Inject() (
       ec: ExecutionContext,
       tc: TokenContext,
       stats: UpdateTimingStats = new UpdateTimingStats
-  ): Fox[Long] = {
-    stats.recordRequestShape(updateGroups)
-    if (updateGroups.forall(_.transactionGroupCount == 1)) {
-      commitUpdates(annotationId, updateGroups)
-    } else {
-      updateGroups.foldLeft(annotationService.currentMaterializableVersion(annotationId)) {
-        (currentCommittedVersionFox, updateGroup) =>
-          handleUpdateGroupOfTransaction(annotationId, currentCommittedVersionFox, updateGroup)
+  ): Fox[Long] = for {
+    _ <- handledGroupIdStore.checkHealth
+    _ = stats.recordRequestShape(updateGroups)
+    newVersion <-
+      if (updateGroups.forall(_.transactionGroupCount == 1)) {
+        commitUpdates(annotationId, updateGroups)
+      } else {
+        updateGroups.foldLeft(annotationService.currentMaterializableVersion(annotationId)) {
+          (currentCommittedVersionFox, updateGroup) =>
+            handleUpdateGroupOfTransaction(annotationId, currentCommittedVersionFox, updateGroup)
+        }
       }
-    }
-  }
+  } yield newVersion
 
   // Perform version check and commit the passed updates
   private def commitUpdates(annotationId: ObjectId, updateGroups: List[UpdateActionGroup])(using


### PR DESCRIPTION
### Summary
Reduces the probability of false `409 CONFLICT` responses on save request retries in two ways:
- When concatenating the updates of a transaction, keep the last group’s own `transactionId` and `transactionGroupIndex`. This makes `commitUpdates` save the “handled” marker under the right key. Ths key must match what a retry of this exact request would look up. Before this change, a retried request for an already-committed multi-group transaction would always be rejected as a conflict, even though nothing was lost.
- Add a redis health check to the beginning of `handleUpdateGroups`. Before this change, if redis was down, the update could go to fossildb, but then the handled-marker would not be saved to redis. Now, redis needs to die in the exact instant the function is running. Only then will a retry be wrongly rejected because the “handled” marker is missing. Still a race condition, but way less likely.

Note that users still getting the false 409 CONFLICT can recover by reloading the page, discarding only the work since the last successful save (should be at most two minutes).

Related: #9937

This does not create full save request atomicity/transactionality, which is tracked in #7307

### Issues
 - fixes #9504 (not fully fixed, but drastically reduced likelihood of the error, [which we decided is acceptable for the moment](https://scm.slack.com/archives/C5AKLAV0B/p1787829843450009?thread_ts=1787824986.033669&cid=C5AKLAV0B))

### Steps to test:
- Not sure how to provoke the error cases. Normal annotating (also with many updates at once) should still work.

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
