### PR TITLE
In AiModal share orgas modal, allow searching orgas by name or id

### DIFF
--- a/frontend/javascripts/admin/voxelytics/ai_model_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/ai_model_list_view.tsx
@@ -267,6 +267,11 @@ function EditModelSharedOrganizationsModal({
           placeholder="Please select"
           onChange={handleChange}
           options={options}
+          filterOption={(input, option) =>
+            option != null &&
+            (option.label.toLowerCase().includes(input.toLowerCase()) ||
+              option.value.toLowerCase().includes(input.toLowerCase()))
+          }
           value={selectedOrganizationIds}
         />
       </Flex>


### PR DESCRIPTION
### Summary
 - This only filtered by id. Most users search by name.

### Steps to test:
(I did that locally)
- with isWkorgInstance=true and after yarn enable-jobs, create a second orga
- in the first main orga, share the sample ai model with the other orga. search by id and by name should work int he modal.

### Issues:
- fixes https://scm.slack.com/archives/C5AKLAV0B/p1787828816876599?thread_ts=1786027934.013059&cid=C5AKLAV0B
