### PR TITLE
Fix branch name normalization for nightly GH action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Process and Log Branch Name
         run: |
           echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-          SUBDOMAIN=$(echo "${{ github.ref_name }}" | tr -dc '[:alpha:]' | tr '[:upper:]' '[:lower:]')
+          SUBDOMAIN=$(echo "${{ github.ref_name }}" | tr '/-' '_' | tr '[:upper:]' '[:lower:]')
           TAG_NAME=$(echo "${{ github.ref_name }}" | sed 's/[\/-]/_/g')
 
           echo "SUBDOMAIN=$SUBDOMAIN" >> $GITHUB_ENV


### PR DESCRIPTION
### Summary
Running the nightly tests on a custom dev branch doesn't work currently.
Context: https://scm.slack.com/archives/C143WEU77/p1788162811078789?thread_ts=1787838776.298089&cid=C143WEU77

### Steps to test:
- I ran `echo "asdjfk-djsafk/-df" | tr '/-' '_'` in bash to check that it works as desired
