### PR TITLE
Use API v15 in path deletion service

### DIFF
--- a/tools/deletion-service/main.py
+++ b/tools/deletion-service/main.py
@@ -20,7 +20,7 @@ import s3fs
 
 logger = logging.getLogger(__name__)
 
-WK_API_VERSION = 12
+WK_API_VERSION = 15
 NUM_REQUEST_RETRIES = 10
 
 


### PR DESCRIPTION
Found a problem with our api versioning concept in the context of play routes priorities. Will need a better fix on wk side, but this should fix the path deletion service immediately at least.