### PR TITLE
[2nd Attempt] Fix branch name normalization for nightly GH action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Process and Log Branch Name
         run: |
           echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-          SUBDOMAIN=$(echo "${{ github.ref_name }}" | tr '/-' '_' | tr '[:upper:]' '[:lower:]')
+          SUBDOMAIN=$(echo "${{ github.ref_name }}" | tr -dc '[:alnum:]' | tr '[:upper:]' '[:lower:]' | sed 's/^[0-9]*//')
           TAG_NAME=$(echo "${{ github.ref_name }}" | sed 's/[\/-]/_/g')
 
           echo "SUBDOMAIN=$SUBDOMAIN" >> $GITHUB_ENV


### PR DESCRIPTION
### Summary
Running the nightly tests on a custom dev branch doesn't work currently.
Context:
https://scm.slack.com/archives/C143WEU77/p1788162811078789?thread_ts=1787838776.298089&cid=C143WEU77

https://github.com/scalableminds/webknossos/commit/775ce59d6739832cb524c05d0aefa402d40aec01 tried to fix this but used the tag name normalization instead of the subdomain normalization.

`echo 1234ABC123abc-/-ABC_3 | tr -dc '[:alnum:]' | tr '[:upper:]' '[:lower:]' | sed 's/^[0-9]*//'` yields 
`abc123abcabc3`.