### PR TITLE
Commit annotationUpdates *after* bucket updates to avoid inconsistent state on failure

### DIFF
--- a/unreleased_changes/9961.md
+++ b/unreleased_changes/9961.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed a rare case where annotation save requests could be partially successful, creating inconsistent state on the server.

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
@@ -274,6 +274,14 @@ class AnnotationTransactionService @Inject() (
     case _                               => false
   }
 
+  /* Handles a single update group by applying bucket-mutating actions and storing the updates as a single version entry
+     in annotationUpdates.
+     Note on ordering: bucket-mutating actions are applied *before* the update actions are written to annotationUpdates.
+     This protects against inconsistent states because all readers will consider annotationUpdates the source of truth
+     for the newest version number. Only after that last put succeeds the data is considered committed.
+     If it or anything before fails, readers will see the previous versions and a save retry will write the same data
+     at the same version again.
+   */
   private def handleUpdateGroup(annotationId: ObjectId, updateActionGroup: UpdateActionGroup)(using
       ec: ExecutionContext,
       tc: TokenContext,
@@ -284,14 +292,6 @@ class AnnotationTransactionService @Inject() (
       _ <- Fox.fromBool(
         updateActionsProcessed.length <= 1000000
       ) ?~> "Annotation update transactions with more than 1M update actions are not currently supported"
-      updateActionsJson = Json.toJson(updateActionsProcessed)
-      _ <- stats.time("annotationUpdates.put")(
-        tracingDataStore.annotationUpdates.put(
-          annotationId.toString,
-          updateActionGroup.version,
-          jsonToBytes(updateActionsJson)
-        )
-      )
       bucketMutatingActions = findBucketMutatingActions(updateActionGroup)
       _ = stats.count("volumeBucketMutatingActions", bucketMutatingActions.length)
       actionsGrouped: Map[String, List[BucketMutatingVolumeUpdateAction]] = bucketMutatingActions.groupBy(
@@ -311,6 +311,14 @@ class AnnotationTransactionService @Inject() (
           )
         } yield ()
       }
+      updateActionsJson = Json.toJson(updateActionsProcessed)
+      _ <- stats.time("annotationUpdates.put")(
+        tracingDataStore.annotationUpdates.put(
+          annotationId.toString,
+          updateActionGroup.version,
+          jsonToBytes(updateActionsJson)
+        )
+      )
     } yield ()
 
   private def findBucketMutatingActions(updateActionGroup: UpdateActionGroup): List[BucketMutatingVolumeUpdateAction] =

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/annotation/AnnotationTransactionService.scala
@@ -337,8 +337,11 @@ class AnnotationTransactionService @Inject() (
     }
     actionsWithInfo.map {
       case a: UpdateBucketVolumeAction => a.withoutBase64Data
-      case a: AddLayerAnnotationAction => a.copy(tracingId = Some(TracingId.generate))
-      case a                           => a
+      case a: AddLayerAnnotationAction =>
+        // Note: this generated tracingId must not be read from this action before it was committed to fossildb,
+        // to keep save retries idempotent.
+        a.copy(tracingId = Some(TracingId.generate))
+      case a => a
     }
   }
 


### PR DESCRIPTION
### Summary
 - bucket-mutating actions of a group are now applied *before* the update actions are written to annotationUpdates. This protects against inconsistent states because all readers will consider annotationUpdates the source of truth for the newest version number. Only after that last put succeeds the data is considered committed. If it or anything before fails, readers will see the previous versions and a save retry will write the same data at the same version again.
 - Downside: if concurrent save requests happen with the same new version number, the time window before the CONFLICT is correctly detected is slightly larger now, because both would start writing bucket data before incrementing the version number. We should tighten the mutex protection. to cover also multi-tab editing by the same user in all collaboration modes. This is failure mode (A) in issue #7307

### Steps to test:
(I tested this locally)
- Insert a `_ <- Fox.failure("boom")` after updating bucket data in the function but before `annotationUpdates.put`
- brush some, save should fail
- open annotation in other tab, should still see old data
- remove the artificial failure, now a retry should succeed

### Issues:
- contributes to #7307 (solves described failure mode B)

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
