### PR TITLE
Prevent unwanted route shadowing in versioned routes files

### DIFF
--- a/conf/webknossos.versioned.routes
+++ b/conf/webknossos.versioned.routes
@@ -22,7 +22,11 @@
 ->       /v15/                                                                webknossos.latest.Routes
 
 # v14: support changes to v15
-GET      /v14/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
+# datasetId excludes "pathsToDelete" and "findByImportURL", which are literal routes in webknossos.latest.routes.
+# Without the exclusion, this route would greedily match e.g. /v14/datasets/pathsToDelete, fail to bind it as an ObjectId, and
+# answer 400 before ever falling through to the forwarded literal route. Keep this list in sync with any literal route added directly
+# under /datasets in webknossos.latest.routes (RouteShadowingTestSuite catches a missed one).
+GET      /v14/datasets/$datasetId<(?!pathsToDelete$|findByImportURL$)[^/]+>   controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v14/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v14/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)
 POST     /v14/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
@@ -30,7 +34,8 @@ POST     /v14/datasets/:datasetId/reserveUploadToPathsForPreliminary          co
 ->       /v14/                                                                webknossos.latest.Routes
 
 # v13: support changes to v15
-GET      /v13/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
+# datasetId exclusions, see comment on the v14 route above.
+GET      /v13/datasets/$datasetId<(?!pathsToDelete$|findByImportURL$)[^/]+>   controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v13/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v13/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)
 POST     /v13/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
@@ -38,7 +43,8 @@ POST     /v13/datasets/:datasetId/reserveUploadToPathsForPreliminary          co
 ->       /v13/                                                                webknossos.latest.Routes
 
 # v12: support changes to v15
-GET      /v12/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
+# datasetId exclusions, see comment on the v14 route above.
+GET      /v12/datasets/$datasetId<(?!pathsToDelete$|findByImportURL$)[^/]+>   controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v12/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v12/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
 POST     /v12/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
@@ -46,7 +52,8 @@ POST     /v12/datasets/:datasetId/reserveUploadToPathsForPreliminary          co
 ->       /v12/                                                                webknossos.latest.Routes
 
 # v11: support changes to v15
-GET      /v11/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
+# datasetId exclusions, see comment on the v14 route above.
+GET      /v11/datasets/$datasetId<(?!pathsToDelete$|findByImportURL$)[^/]+>   controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v11/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v11/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
 POST     /v11/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()
@@ -54,7 +61,8 @@ POST     /v11/datasets/:datasetId/reserveUploadToPathsForPreliminary          co
 ->       /v11/                                                                webknossos.latest.Routes
 
 # v10: support changes to v15
-GET      /v10/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
+# datasetId exclusions, see comment on the v14 route above.
+GET      /v10/datasets/$datasetId<(?!pathsToDelete$|findByImportURL$)[^/]+>   controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v10/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v10/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
 POST     /v10/datasets/reserveUploadToPaths                                   controllers.LegacyApiController.reserveUploadToPathsV14()

--- a/test/backend/RouteShadowingTestSuite.scala
+++ b/test/backend/RouteShadowingTestSuite.scala
@@ -1,0 +1,128 @@
+package backend
+
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.io.Source
+
+/** webknossos.versioned.routes (and its datastore/tracingstore siblings) override individual endpoints for legacy API
+  * versions and forward everything else to the corresponding *.latest.routes file via a "->" include.
+  *
+  * Play routes are matched top to bottom, and once a route's pattern matches, a failed path-parameter bind (e.g. as
+  * ObjectId) answers 400 rather than falling through to the next, differently-shaped matching route. So a versioned
+  * override with a generic parameter (like :datasetId) can silently shadow a literal route that only exists in the
+  * *.latest.routes file, unless the parameter explicitly excludes it (see #9954, where /v13/datasets/pathsToDelete was
+  * swallowed by /v13/datasets/:datasetId instead of reaching the forwarded, literal pathsToDelete route).
+  *
+  * This test statically expands each versioned routes file - resolving its "->" forwards - into the effective, fully
+  * ordered route table Play would build, and asserts that no literal route ends up unreachable because an earlier,
+  * differently-shaped route in that table would also match its path.
+  */
+class RouteShadowingTestSuite extends AnyWordSpec {
+
+  sealed private trait Segment {
+    def matches(actual: String): Boolean
+  }
+  private case class Literal(value: String) extends Segment {
+    override def matches(actual: String): Boolean = actual == value
+  }
+  private case class Param(regex: String) extends Segment {
+    override def matches(actual: String): Boolean = actual.matches(regex)
+  }
+
+  private case class RouteEntry(method: String, segments: List[Segment], description: String)
+
+  private val defaultParamRegex = "[^/]+"
+  private val routeLineRegex = """^(GET|POST|PUT|PATCH|DELETE)\s+(\S+)\s+\S.*$""".r
+  private val forwardLineRegex = """^->\s+(\S+)\s+(\S+)\s*$""".r
+  private val customParamRegex = """^[:$][A-Za-z0-9_]+<(.+)>$""".r
+
+  // Maps the router identifiers used in "->" forwards to the conf file they are compiled from.
+  private val includeTargets: Map[String, String] = Map(
+    "webknossos.latest.Routes" -> "conf/webknossos.latest.routes",
+    "datastore.latest.Routes" -> "webknossos-datastore/conf/datastore.latest.routes",
+    "tracingstore.latest.Routes" -> "webknossos-tracingstore/conf/tracingstore.latest.routes"
+  )
+
+  private val versionedRouteFiles = Seq(
+    "conf/webknossos.versioned.routes",
+    "webknossos-datastore/conf/datastore.versioned.routes",
+    "webknossos-tracingstore/conf/tracingstore.versioned.routes"
+  )
+
+  private def readLines(path: String): List[String] = {
+    val src = Source.fromFile(path)
+    try src.getLines().toList
+    finally src.close()
+  }
+
+  private def parseSegment(raw: String): Segment =
+    if (raw.startsWith(":") || raw.startsWith("$")) {
+      raw match {
+        case customParamRegex(regex) => Param(regex)
+        case _                       => Param(defaultParamRegex)
+      }
+    } else Literal(raw)
+
+  private def parsePath(path: String): List[Segment] =
+    path.split("/", -1).filter(_.nonEmpty).map(parseSegment).toList
+
+  private def joinPrefix(prefix: String, path: String): String = {
+    val normalizedPrefix = if (prefix.endsWith("/")) prefix.dropRight(1) else prefix
+    val normalizedPath = if (path.startsWith("/")) path else s"/$path"
+    s"$normalizedPrefix$normalizedPath"
+  }
+
+  // Expands a routes file into the effective, fully ordered route table Play would build, resolving "->" forwards
+  // (to files we know about) recursively. `prefix` is the path already consumed by enclosing forwards.
+  private def expandFile(path: String, prefix: String): List[RouteEntry] =
+    readLines(path).flatMap { rawLine =>
+      val line = rawLine.trim
+      if (line.isEmpty || line.startsWith("#")) List.empty
+      else
+        line match {
+          case routeLineRegex(method, routePath) =>
+            List(RouteEntry(method, parsePath(joinPrefix(prefix, routePath)), s"$path: $line"))
+          case forwardLineRegex(forwardPrefix, target) =>
+            includeTargets.get(target) match {
+              case Some(targetFile) => expandFile(targetFile, joinPrefix(prefix, forwardPrefix))
+              case None => List.empty // forward to a router we don't statically resolve; nothing more to expand
+            }
+          case _ => List.empty
+        }
+    }
+
+  // A literal (fully static) route is "shadowed" if an earlier route in the effective table has the same method and
+  // segment count, and would also match this route's literal path - meaning it is intercepted before ever being
+  // reached, regardless of whether that earlier route's own parameter binding would ultimately succeed.
+  private def findShadowedRoutes(table: List[RouteEntry]): List[(RouteEntry, RouteEntry)] =
+    table.zipWithIndex.flatMap {
+      case (entry, index) if entry.segments.forall(_.isInstanceOf[Literal]) =>
+        table
+          .take(index)
+          .find { earlier =>
+            earlier.segments != entry.segments &&
+            earlier.method == entry.method &&
+            earlier.segments.length == entry.segments.length &&
+            earlier.segments.zip(entry.segments).forall {
+              case (earlierSegment, Literal(value)) => earlierSegment.matches(value)
+              case _                                => false
+            }
+          }
+          .map(earlier => (earlier, entry))
+      case _ => None
+    }
+
+  "Versioned routes files" should
+    versionedRouteFiles.foreach { path =>
+      s"not let an override in $path shadow a literal route reachable only via its -> forward" in {
+        val table = expandFile(path, "")
+        val shadowed = findShadowedRoutes(table)
+        assert(
+          shadowed.isEmpty,
+          "\n" + shadowed.map { case (earlier, unreachable) =>
+            s"  ${unreachable.description}\n    is shadowed by earlier route:\n  ${earlier.description}"
+          }.mkString("\n")
+        )
+      }
+    }
+}


### PR DESCRIPTION
### Summary
 - For older api versions, `GET datasets/pathsToDelete` and `GET datasets/findByImportURL` became unreachable due to shadowing in the routes file (see #9954 for details)
 - This is prevented now by excluding these literals from the shadowing `GET  datasets/:datsetId`
 - A regression test checks that no such shadowing is created again later.
 - Note for reviewer: I think the test code doesn’t have to be reviewed with full effort, the important part is that the fix works.

### Steps to test:
- CI should be enough. I verified that the test does catch this issue.

### Issues:
- fixes #9954

------
- (no changelog as no user-facing routes were hit)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
