### PR TITLE
Fix id remapping inconsistency when merging annotations

### DIFF
--- a/test/backend/AnnotationUserStateTestSuite.scala
+++ b/test/backend/AnnotationUserStateTestSuite.scala
@@ -79,9 +79,8 @@ class AnnotationUserStateTestSuite extends AsyncWordSpec with AnnotationUserStat
       val mergedUserStates = mergeVolumeUserStates(
         tracingAUserStates,
         tracingBUserStates,
-        groupMappingA = (groupId: Int) => groupId + 5,
+        groupMappingB = (groupId: Int) => groupId + 5,
         segmentIdMapB,
-        Map.empty,
         Map.empty
       )
       assert(
@@ -90,7 +89,7 @@ class AnnotationUserStateTestSuite extends AsyncWordSpec with AnnotationUserStat
             .emptyUserState(userAId)
             .copy(
               segmentVisibilities = Seq(Id64WithBool(1, true), Id64WithBool(2L, false)),
-              segmentGroupExpandedStates = Seq(Id32WithBool(6, true), Id32WithBool(1, false))
+              segmentGroupExpandedStates = Seq(Id32WithBool(1, true), Id32WithBool(6, false))
             )
         )
       )

--- a/test/backend/AnnotationUserStateTestSuite.scala
+++ b/test/backend/AnnotationUserStateTestSuite.scala
@@ -63,7 +63,8 @@ class AnnotationUserStateTestSuite extends AsyncWordSpec with AnnotationUserStat
           .emptyUserState(userAId)
           .copy(
             segmentVisibilities = Seq(Id64WithBool(1L, true)),
-            segmentGroupExpandedStates = Seq(Id32WithBool(1, true))
+            segmentGroupExpandedStates = Seq(Id32WithBool(1, true)),
+            boundingBoxVisibilities = Seq(Id32WithBool(1, true))
           )
       )
       val tracingBUserStates = Seq(
@@ -71,17 +72,21 @@ class AnnotationUserStateTestSuite extends AsyncWordSpec with AnnotationUserStat
           .emptyUserState(userAId)
           .copy(
             segmentVisibilities = Seq(Id64WithBool(1L, false)),
-            segmentGroupExpandedStates = Seq(Id32WithBool(1, false))
+            segmentGroupExpandedStates = Seq(Id32WithBool(1, false)),
+            boundingBoxVisibilities = Seq(Id32WithBool(1, false))
           )
       )
 
       val segmentIdMapB = Map((1L, 2L))
+      // Unlike segment/group ids, tracing A's bounding box ids can also be remapped (see BoundingBoxMerger),
+      // so bboxIdMapA is applied to A's user state just like bboxIdMapB is applied to B's.
       val mergedUserStates = mergeVolumeUserStates(
         tracingAUserStates,
         tracingBUserStates,
         groupMappingB = (groupId: Int) => groupId + 5,
         segmentIdMapB,
-        Map.empty
+        bboxIdMapA = Map(1 -> 10),
+        bboxIdMapB = Map(1 -> 11)
       )
       assert(
         mergedUserStates == Seq(
@@ -89,7 +94,8 @@ class AnnotationUserStateTestSuite extends AsyncWordSpec with AnnotationUserStat
             .emptyUserState(userAId)
             .copy(
               segmentVisibilities = Seq(Id64WithBool(1, true), Id64WithBool(2L, false)),
-              segmentGroupExpandedStates = Seq(Id32WithBool(1, true), Id32WithBool(6, false))
+              segmentGroupExpandedStates = Seq(Id32WithBool(1, true), Id32WithBool(6, false)),
+              boundingBoxVisibilities = Seq(Id32WithBool(10, true), Id32WithBool(11, false))
             )
         )
       )

--- a/test/backend/MergeUtilsTestSuite.scala
+++ b/test/backend/MergeUtilsTestSuite.scala
@@ -6,16 +6,16 @@ import com.scalableminds.webknossos.tracingstore.tracings.{BoundingBoxMerger, Gr
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.TreeUtils
 import org.scalatest.wordspec.AnyWordSpec
 
-// Covers the merge convention of TreeUtils and GroupUtils: tracing A's ids are never remapped, tracing
-// B's ids are densified and offset to continue right after A's. BoundingBoxMerger is the deliberate
-// exception: bounding boxes support content-based deduplication, so both tracings' ids may be remapped.
+// Covers the merge convention of TreeUtils and GroupUtils: tracing A’s ids are never remapped, tracing
+// B’s ids are offset to continue right after A’s. BoundingBoxMerger is the deliberate
+// exception: bounding boxes support content-based deduplication, so both tracings’ ids may be remapped.
 class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
 
   private def bbox(id: Int, topLeft: Int = 0) =
     NamedBoundingBoxProto(id, boundingBox = BoundingBoxProto(Vec3IntProto(topLeft, 0, 0), 1, 1, 1))
 
   "TreeUtils.calculateNodeMapping" should {
-    "offset tracing B's node ids to continue right after tracing A's, leaving A untouched" in {
+    "offset tracing B’s node ids to continue right after tracing A’s, leaving A untouched" in {
       val treesA = Seq(Dummies.tree1) // node ids 0, 1, 2, 7 => max 7
       val treesB = Seq(Dummies.tree2) // node ids 4, 5, 6 => min 4
       val mapping = TreeUtils.calculateNodeMapping(treesA, treesB)
@@ -29,10 +29,27 @@ class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
       val mapping = TreeUtils.calculateNodeMapping(Seq(Dummies.tree1), Seq.empty)
       assert(mapping(4) == 4)
     }
+
+    "only shift tracing B’s node ids, not densify them: gaps within B’s own ids survive" in {
+      val treesA =
+        Seq(Dummies.tree1.copy(nodes = Seq(Dummies.createDummyNode(0), Dummies.createDummyNode(10)))) // max 10
+      val treesB = Seq(
+        Dummies.tree2
+          .copy(nodes = Seq(Dummies.createDummyNode(4), Dummies.createDummyNode(5), Dummies.createDummyNode(9)))
+      ) // ids 4, 5, 9: a gap of 3 (6, 7, 8 missing) between 5 and 9; min 4
+
+      val mapping = TreeUtils.calculateNodeMapping(treesA, treesB)
+
+      // offset = maxA(10) + 1 - minB(4) = 7: every id is shifted by the same amount, so the internal
+      // gap is preserved (12 -> 16, a gap of 4), unlike tree ids below, which get fully compacted.
+      assert(mapping(4) == 11)
+      assert(mapping(5) == 12)
+      assert(mapping(9) == 16)
+    }
   }
 
   "TreeUtils.calculateTreeMapping" should {
-    "densify tracing B's tree ids and offset them to continue right after tracing A's max tree id" in {
+    "densify tracing B’s tree ids and offset them to continue right after tracing A’s max tree id" in {
       val treesA = Seq(Dummies.tree1.copy(treeId = 1), Dummies.tree2.copy(treeId = 9))
       val treesB = Seq(Dummies.tree1.copy(treeId = 5), Dummies.tree2.copy(treeId = 3))
 
@@ -40,12 +57,23 @@ class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
 
       assert(treeIdMapB == Map(3 -> 10, 5 -> 11))
     }
+
+    "close gaps within tracing B’s own tree ids, unlike node ids, which are only shifted" in {
+      val treesA = Seq(Dummies.tree1.copy(treeId = 1)) // max tree id 1
+      val treesB = Seq(Dummies.tree1.copy(treeId = 3), Dummies.tree2.copy(treeId = 100)) // a huge gap between 3 and 100
+
+      val treeIdMapB = TreeUtils.calculateTreeMapping(treesA, treesB)
+
+      // B’s sorted tree ids [3, 100] are renumbered consecutively as 2, 3 (offset 1 + index + 1) -- the
+      // gap of 97 is closed, not preserved as a shift (which would have produced 4 -> 101).
+      assert(treeIdMapB == Map(3 -> 2, 100 -> 3))
+    }
   }
 
   "TreeUtils.mergeTrees" should {
-    "leave tracing A's trees byte-identical and append the remapped tracing B trees" in {
-      val treesA = Seq(Dummies.tree1) // treeId 1, nodes 0, 1, 2, 7
-      val treesB = Seq(Dummies.tree2.copy(treeId = 9, groupId = Some(1))) // nodes 4, 5, 6
+    "leave tracing A’s trees untouched and append the remapped tracing B trees" in {
+      val treesA = Seq(Dummies.tree1)
+      val treesB = Seq(Dummies.tree2.copy(treeId = 9, groupId = Some(1)))
 
       val treeIdMapB = TreeUtils.calculateTreeMapping(treesA, treesB)
       val nodeMappingB = TreeUtils.calculateNodeMapping(treesA, treesB)
@@ -63,7 +91,7 @@ class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
   }
 
   "GroupUtils.calculateTreeGroupMapping / mergeTreeGroups" should {
-    "offset tracing B's group ids to continue right after tracing A's, leaving A untouched" in {
+    "offset tracing B’s group ids to continue right after tracing A’s, leaving A untouched" in {
       val groupsA = Seq(TreeGroup("G1", 1, Seq.empty), TreeGroup("G2", 5, Seq.empty))
       val groupsB = Seq(TreeGroup("G3", 2, Seq.empty))
 
@@ -77,9 +105,9 @@ class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
   }
 
   "BoundingBoxMerger.combineUserBoundingBoxes" should {
-    "pool and renumber both tracings' boxes from scratch, in A-then-B order" in {
+    "pool and renumber both tracings’ boxes from scratch, in A-then-B order" in {
       val boxesA = Seq(bbox(1), bbox(3, topLeft = 1))
-      val boxesB = Seq(bbox(1, topLeft = 2)) // distinct content from A's boxes, but a colliding id
+      val boxesB = Seq(bbox(1, topLeft = 2)) // distinct content from A’s boxes, but a colliding id
 
       val (merged, idMapA, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
 
@@ -89,15 +117,15 @@ class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
       assert(idMapB == Map(1 -> 2))
     }
 
-    "deduplicate a box that exists identically in both tracings, keeping tracing A's copy" in {
+    "deduplicate a box that exists identically in both tracings, keeping tracing A’s copy" in {
       val boxesA = Seq(bbox(1))
-      val boxesB = Seq(bbox(7)) // same content (topLeft = 0) as A's box, just a different id
+      val boxesB = Seq(bbox(7)) // same content (topLeft = 0) as A’s box, just a different id
 
       val (merged, idMapA, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
 
       assert(merged == Seq(bbox(0)))
       assert(idMapA == Map(1 -> 0))
-      assert(idMapB.isEmpty) // B's duplicate was dropped entirely, not remapped onto anything
+      assert(idMapB.isEmpty) // B’s duplicate was dropped entirely, not remapped onto anything
     }
 
     "deduplicate two boxes with the same content within tracing A itself" in {
@@ -109,7 +137,7 @@ class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
       assert(idMapA == Map(1 -> 0)) // id 2 was dropped as a duplicate and is absent from the map
     }
 
-    "fold tracing A's deprecated legacy single bounding box into the same pool" in {
+    "fold tracing A’s deprecated legacy single bounding box into the same pool" in {
       val boxesA = Seq(bbox(3))
       val singleA = BoundingBoxProto(Vec3IntProto(5, 0, 0), 1, 1, 1) // distinct content from boxesA
 

--- a/test/backend/MergeUtilsTestSuite.scala
+++ b/test/backend/MergeUtilsTestSuite.scala
@@ -1,0 +1,100 @@
+package backend
+
+import com.scalableminds.webknossos.datastore.SkeletonTracing.{Edge, TreeGroup}
+import com.scalableminds.webknossos.datastore.geometry.{BoundingBoxProto, NamedBoundingBoxProto, Vec3IntProto}
+import com.scalableminds.webknossos.tracingstore.tracings.{BoundingBoxMerger, GroupUtils}
+import com.scalableminds.webknossos.tracingstore.tracings.skeleton.TreeUtils
+import org.scalatest.wordspec.AnyWordSpec
+
+// Covers the merge convention shared by TreeUtils, GroupUtils and BoundingBoxMerger: tracing A's ids
+// are never remapped, tracing B's ids are densified/deduplicated and offset to continue right after A's.
+class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
+
+  private def bbox(id: Int, topLeft: Int = 0) =
+    NamedBoundingBoxProto(id, boundingBox = BoundingBoxProto(Vec3IntProto(topLeft, 0, 0), 1, 1, 1))
+
+  "TreeUtils.calculateNodeMapping" should {
+    "offset tracing B's node ids to continue right after tracing A's, leaving A untouched" in {
+      val treesA = Seq(Dummies.tree1) // node ids 0, 1, 2, 7 => max 7
+      val treesB = Seq(Dummies.tree2) // node ids 4, 5, 6 => min 4
+      val mapping = TreeUtils.calculateNodeMapping(treesA, treesB)
+
+      assert(mapping(4) == 8)
+      assert(mapping(5) == 9)
+      assert(mapping(6) == 10)
+    }
+
+    "not offset anything if tracing B has no trees" in {
+      val mapping = TreeUtils.calculateNodeMapping(Seq(Dummies.tree1), Seq.empty)
+      assert(mapping(4) == 4)
+    }
+  }
+
+  "TreeUtils.calculateTreeMapping" should {
+    "densify tracing B's tree ids and offset them to continue right after tracing A's max tree id" in {
+      val treesA = Seq(Dummies.tree1.copy(treeId = 1), Dummies.tree2.copy(treeId = 9))
+      val treesB = Seq(Dummies.tree1.copy(treeId = 5), Dummies.tree2.copy(treeId = 3))
+
+      val treeIdMapB = TreeUtils.calculateTreeMapping(treesA, treesB)
+
+      assert(treeIdMapB == Map(3 -> 10, 5 -> 11))
+    }
+  }
+
+  "TreeUtils.mergeTrees" should {
+    "leave tracing A's trees byte-identical and append the remapped tracing B trees" in {
+      val treesA = Seq(Dummies.tree1) // treeId 1, nodes 0, 1, 2, 7
+      val treesB = Seq(Dummies.tree2.copy(treeId = 9, groupId = Some(1))) // nodes 4, 5, 6
+
+      val treeIdMapB = TreeUtils.calculateTreeMapping(treesA, treesB)
+      val nodeMappingB = TreeUtils.calculateNodeMapping(treesA, treesB)
+      val groupMappingB = (groupId: Int) => groupId + 100
+
+      val merged = TreeUtils.mergeTrees(treesA, treesB, treeIdMapB, nodeMappingB, groupMappingB)
+
+      assert(merged.head == Dummies.tree1)
+      val mergedTreeB = merged(1)
+      assert(mergedTreeB.treeId == treeIdMapB(9))
+      assert(mergedTreeB.nodes.map(_.id).toSet == Set(8, 9, 10))
+      assert(mergedTreeB.edges.toSet == Set(Edge(8, 9), Edge(9, 10)))
+      assert(mergedTreeB.groupId.contains(101))
+    }
+  }
+
+  "GroupUtils.calculateTreeGroupMapping / mergeTreeGroups" should {
+    "offset tracing B's group ids to continue right after tracing A's, leaving A untouched" in {
+      val groupsA = Seq(TreeGroup("G1", 1, Seq.empty), TreeGroup("G2", 5, Seq.empty))
+      val groupsB = Seq(TreeGroup("G3", 2, Seq.empty))
+
+      val groupMappingB = GroupUtils.calculateTreeGroupMapping(groupsA, groupsB)
+      assert(groupMappingB(2) == 6)
+
+      val merged = GroupUtils.mergeTreeGroups(groupsA, groupsB, groupMappingB)
+      assert(merged.map(_.groupId) == Seq(1, 5, 6))
+      assert(merged.take(2) == groupsA)
+    }
+  }
+
+  "BoundingBoxMerger.combineUserBoundingBoxes" should {
+    "leave tracing A's boxes and ids untouched and append tracing B's non-duplicate boxes with new ids" in {
+      val boxesA = Seq(bbox(1), bbox(3))
+      val boxesB = Seq(bbox(1, topLeft = 1)) // distinct content from any of A's boxes, but has a colliding id
+
+      val (merged, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
+
+      assert(merged.take(2) == boxesA)
+      assert(merged(2).id == 4)
+      assert(idMapB == Map(1 -> 4))
+    }
+
+    "drop tracing B's boxes that duplicate one of tracing A's by content, without touching A" in {
+      val boxesA = Seq(bbox(1))
+      val boxesB = Seq(bbox(7)) // same content (topLeft = 0) as A's box, just a different id
+
+      val (merged, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
+
+      assert(merged == boxesA)
+      assert(idMapB.isEmpty)
+    }
+  }
+}

--- a/test/backend/MergeUtilsTestSuite.scala
+++ b/test/backend/MergeUtilsTestSuite.scala
@@ -6,8 +6,9 @@ import com.scalableminds.webknossos.tracingstore.tracings.{BoundingBoxMerger, Gr
 import com.scalableminds.webknossos.tracingstore.tracings.skeleton.TreeUtils
 import org.scalatest.wordspec.AnyWordSpec
 
-// Covers the merge convention shared by TreeUtils, GroupUtils and BoundingBoxMerger: tracing A's ids
-// are never remapped, tracing B's ids are densified/deduplicated and offset to continue right after A's.
+// Covers the merge convention of TreeUtils and GroupUtils: tracing A's ids are never remapped, tracing
+// B's ids are densified and offset to continue right after A's. BoundingBoxMerger is the deliberate
+// exception: bounding boxes support content-based deduplication, so both tracings' ids may be remapped.
 class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
 
   private def bbox(id: Int, topLeft: Int = 0) =
@@ -76,25 +77,46 @@ class MergeUtilsTestSuite extends AnyWordSpec with BoundingBoxMerger {
   }
 
   "BoundingBoxMerger.combineUserBoundingBoxes" should {
-    "leave tracing A's boxes and ids untouched and append tracing B's non-duplicate boxes with new ids" in {
-      val boxesA = Seq(bbox(1), bbox(3))
-      val boxesB = Seq(bbox(1, topLeft = 1)) // distinct content from any of A's boxes, but has a colliding id
+    "pool and renumber both tracings' boxes from scratch, in A-then-B order" in {
+      val boxesA = Seq(bbox(1), bbox(3, topLeft = 1))
+      val boxesB = Seq(bbox(1, topLeft = 2)) // distinct content from A's boxes, but a colliding id
 
-      val (merged, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
+      val (merged, idMapA, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
 
-      assert(merged.take(2) == boxesA)
-      assert(merged(2).id == 4)
-      assert(idMapB == Map(1 -> 4))
+      assert(merged.map(_.boundingBox) == (boxesA ++ boxesB).map(_.boundingBox))
+      assert(merged.map(_.id) == Seq(0, 1, 2))
+      assert(idMapA == Map(1 -> 0, 3 -> 1))
+      assert(idMapB == Map(1 -> 2))
     }
 
-    "drop tracing B's boxes that duplicate one of tracing A's by content, without touching A" in {
+    "deduplicate a box that exists identically in both tracings, keeping tracing A's copy" in {
       val boxesA = Seq(bbox(1))
       val boxesB = Seq(bbox(7)) // same content (topLeft = 0) as A's box, just a different id
 
-      val (merged, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
+      val (merged, idMapA, idMapB) = combineUserBoundingBoxes(None, None, boxesA, boxesB)
 
-      assert(merged == boxesA)
-      assert(idMapB.isEmpty)
+      assert(merged == Seq(bbox(0)))
+      assert(idMapA == Map(1 -> 0))
+      assert(idMapB.isEmpty) // B's duplicate was dropped entirely, not remapped onto anything
+    }
+
+    "deduplicate two boxes with the same content within tracing A itself" in {
+      val boxesA = Seq(bbox(1), bbox(2)) // both topLeft = 0, i.e. identical content
+
+      val (merged, idMapA, _) = combineUserBoundingBoxes(None, None, boxesA, Seq.empty)
+
+      assert(merged == Seq(bbox(0)))
+      assert(idMapA == Map(1 -> 0)) // id 2 was dropped as a duplicate and is absent from the map
+    }
+
+    "fold tracing A's deprecated legacy single bounding box into the same pool" in {
+      val boxesA = Seq(bbox(3))
+      val singleA = BoundingBoxProto(Vec3IntProto(5, 0, 0), 1, 1, 1) // distinct content from boxesA
+
+      val (merged, idMapA, _) = combineUserBoundingBoxes(Some(singleA), None, boxesA, Seq.empty)
+
+      assert(merged.map(_.boundingBox) == Seq(boxesA.head.boundingBox, singleA))
+      assert(idMapA == Map(3 -> 0))
     }
   }
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/AnnotationUserStateUtils.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/AnnotationUserStateUtils.scala
@@ -228,24 +228,26 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
   private def mapIdBool(idToBools: Id32WithBool, functionalIdMapping: FunctionalGroupMapping): Id32WithBool =
     idToBools.copy(id = functionalIdMapping(idToBools.id))
 
-  // Merges user states of multiple skeleton tracings, respecting mapped ids of the tracing elements. The user set is preserved
+  // Merges user states of multiple skeleton tracings, respecting mapped ids of the tracing elements. The user set is preserved.
+  // Tracing A's ids are never remapped (see TreeUtils/GroupUtils/BoundingBoxMerger), so only B's user state needs id mapping.
   protected def mergeSkeletonUserStates(
       tracingAUserStates: Seq[SkeletonUserStateProto],
       tracingBUserStates: Seq[SkeletonUserStateProto],
-      groupMapping: FunctionalGroupMapping,
-      treeIdMapA: TreeIdMap,
+      groupMappingB: FunctionalGroupMapping,
       treeIdMapB: TreeIdMap,
-      bboxIdMapA: UserBboxIdMap,
       bboxIdMapB: UserBboxIdMap
   ): Seq[SkeletonUserStateProto] = {
-    val tracingAUserStatesMapped =
-      tracingAUserStates.map(applyIdMappingsOnSkeletonUserState(_, groupMapping, treeIdMapA, bboxIdMapA))
     val tracingBUserStatesMapped = tracingBUserStates
-      .map(userState => userState.copy(treeVisibilities = mapId32Bools(userState.treeVisibilities, treeIdMapB)))
+      .map(userState =>
+        userState.copy(
+          treeVisibilities = mapId32Bools(userState.treeVisibilities, treeIdMapB),
+          treeGroupExpandedStates = mapIdBools(userState.treeGroupExpandedStates, groupMappingB)
+        )
+      )
       .map(applyBboxIdMapOnSkeletonUserState(_, bboxIdMapB))
 
     val byUserId = scala.collection.mutable.Map[String, SkeletonUserStateProto]()
-    tracingAUserStatesMapped.foreach { userState =>
+    tracingAUserStates.foreach { userState =>
       byUserId.put(userState.userId, userState)
     }
     tracingBUserStatesMapped.foreach { userState =>
@@ -271,17 +273,6 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
       treeVisibilities = tracingAUserState.treeVisibilities ++ tracingBUserState.treeVisibilities
     )
 
-  private def applyIdMappingsOnSkeletonUserState(
-      userStateA: SkeletonUserStateProto,
-      groupMapping: FunctionalGroupMapping,
-      treeIdMapA: TreeIdMap,
-      bboxIdMapA: Map[Int, Int]
-  ): SkeletonUserStateProto =
-    applyBboxIdMapOnSkeletonUserState(userStateA, bboxIdMapA).copy(
-      treeGroupExpandedStates = mapIdBools(userStateA.treeGroupExpandedStates, groupMapping),
-      treeVisibilities = mapId32Bools(userStateA.treeVisibilities, treeIdMapA)
-    )
-
   private def applyBboxIdMapOnSkeletonUserState(
       userState: SkeletonUserStateProto,
       bboxIdMap: Map[Int, Int]
@@ -296,26 +287,27 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
     userState.copy(boundingBoxVisibilities = newVisibilities)
   }
 
-  // Merges user states of multiple skeleton tracings, respecting mapped ids of the tracing elements. The user set is preserved
+  // Merges user states of multiple volume tracings, respecting mapped ids of the tracing elements. The user set is preserved.
+  // Tracing A's ids are never remapped (see GroupUtils/BoundingBoxMerger/MergedVolume), so only B's user state needs id mapping.
   protected def mergeVolumeUserStates(
       tracingAUserStates: Seq[VolumeUserStateProto],
       tracingBUserStates: Seq[VolumeUserStateProto],
-      groupMappingA: FunctionalGroupMapping,
+      groupMappingB: FunctionalGroupMapping,
       segmentIdMapB: Map[Long, Long],
-      bboxIdMapA: UserBboxIdMap,
       bboxIdMapB: UserBboxIdMap
   ): Seq[VolumeUserStateProto] = {
-    val tracingAUserStatesMapped =
-      tracingAUserStates.map(applyIdMappingsOnVolumeUserState(_, groupMappingA, bboxIdMapA))
     val tracingBUserStatesMapped =
       tracingBUserStates
         .map(userState =>
-          userState.copy(segmentVisibilities = mapId64Bools(userState.segmentVisibilities, segmentIdMapB))
+          userState.copy(
+            segmentVisibilities = mapId64Bools(userState.segmentVisibilities, segmentIdMapB),
+            segmentGroupExpandedStates = mapIdBools(userState.segmentGroupExpandedStates, groupMappingB)
+          )
         )
         .map(applyBboxIdMapOnVolumeUserState(_, bboxIdMapB))
 
     val byUserId = scala.collection.mutable.Map[String, VolumeUserStateProto]()
-    tracingAUserStatesMapped.foreach { userState =>
+    tracingAUserStates.foreach { userState =>
       byUserId.put(userState.userId, userState)
     }
     tracingBUserStatesMapped.foreach { userState =>
@@ -340,15 +332,6 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
         tracingAUserState.segmentGroupExpandedStates ++ tracingBUserState.segmentGroupExpandedStates,
       boundingBoxVisibilities = tracingAUserState.boundingBoxVisibilities ++ tracingBUserState.boundingBoxVisibilities,
       segmentVisibilities = tracingAUserState.segmentVisibilities ++ tracingBUserState.segmentVisibilities
-    )
-
-  private def applyIdMappingsOnVolumeUserState(
-      userStateA: VolumeUserStateProto,
-      groupMappingA: FunctionalGroupMapping,
-      bboxIdMapA: Map[Int, Int]
-  ): VolumeUserStateProto =
-    applyBboxIdMapOnVolumeUserState(userStateA, bboxIdMapA).copy(
-      segmentGroupExpandedStates = mapIdBools(userStateA.segmentGroupExpandedStates, groupMappingA)
     )
 
   private def applyBboxIdMapOnVolumeUserState(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/AnnotationUserStateUtils.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/AnnotationUserStateUtils.scala
@@ -229,14 +229,17 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
     idToBools.copy(id = functionalIdMapping(idToBools.id))
 
   // Merges user states of multiple skeleton tracings, respecting mapped ids of the tracing elements. The user set is preserved.
-  // Tracing A's ids are never remapped (see TreeUtils/GroupUtils/BoundingBoxMerger), so only B's user state needs id mapping.
+  // Tracing A's tree/group ids are never remapped (see TreeUtils/GroupUtils), so only B's user state needs that mapping.
+  // Bounding box ids are the exception (see BoundingBoxMerger): both sides may be remapped, so both bboxIdMaps are applied.
   protected def mergeSkeletonUserStates(
       tracingAUserStates: Seq[SkeletonUserStateProto],
       tracingBUserStates: Seq[SkeletonUserStateProto],
       groupMappingB: FunctionalGroupMapping,
       treeIdMapB: TreeIdMap,
+      bboxIdMapA: UserBboxIdMap,
       bboxIdMapB: UserBboxIdMap
   ): Seq[SkeletonUserStateProto] = {
+    val tracingAUserStatesMapped = tracingAUserStates.map(applyBboxIdMapOnSkeletonUserState(_, bboxIdMapA))
     val tracingBUserStatesMapped = tracingBUserStates
       .map(userState =>
         userState.copy(
@@ -247,7 +250,7 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
       .map(applyBboxIdMapOnSkeletonUserState(_, bboxIdMapB))
 
     val byUserId = scala.collection.mutable.Map[String, SkeletonUserStateProto]()
-    tracingAUserStates.foreach { userState =>
+    tracingAUserStatesMapped.foreach { userState =>
       byUserId.put(userState.userId, userState)
     }
     tracingBUserStatesMapped.foreach { userState =>
@@ -288,14 +291,17 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
   }
 
   // Merges user states of multiple volume tracings, respecting mapped ids of the tracing elements. The user set is preserved.
-  // Tracing A's ids are never remapped (see GroupUtils/BoundingBoxMerger/MergedVolume), so only B's user state needs id mapping.
+  // Tracing A's group/segment ids are never remapped (see GroupUtils/MergedVolume), so only B's user state needs that mapping.
+  // Bounding box ids are the exception (see BoundingBoxMerger): both sides may be remapped, so both bboxIdMaps are applied.
   protected def mergeVolumeUserStates(
       tracingAUserStates: Seq[VolumeUserStateProto],
       tracingBUserStates: Seq[VolumeUserStateProto],
       groupMappingB: FunctionalGroupMapping,
       segmentIdMapB: Map[Long, Long],
+      bboxIdMapA: UserBboxIdMap,
       bboxIdMapB: UserBboxIdMap
   ): Seq[VolumeUserStateProto] = {
+    val tracingAUserStatesMapped = tracingAUserStates.map(applyBboxIdMapOnVolumeUserState(_, bboxIdMapA))
     val tracingBUserStatesMapped =
       tracingBUserStates
         .map(userState =>
@@ -307,7 +313,7 @@ trait AnnotationUserStateUtils extends BoundingBoxMerger with IdWithBoolUtils {
         .map(applyBboxIdMapOnVolumeUserState(_, bboxIdMapB))
 
     val byUserId = scala.collection.mutable.Map[String, VolumeUserStateProto]()
-    tracingAUserStates.foreach { userState =>
+    tracingAUserStatesMapped.foreach { userState =>
       byUserId.put(userState.userId, userState)
     }
     tracingBUserStatesMapped.foreach { userState =>

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
@@ -1,15 +1,9 @@
 package com.scalableminds.webknossos.tracingstore.tracings
 
-import com.scalableminds.util.enumeration.ExtendedEnumeration
 import com.scalableminds.util.geometry.BoundingBox
 import com.scalableminds.webknossos.datastore.geometry.NamedBoundingBoxProto
 import com.scalableminds.webknossos.datastore.geometry.BoundingBoxProto as ProtoBoundingBox
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
-
-// Mark where a bounding box came from during merge for lookup in the correct id map
-object BoundingBoxSource extends ExtendedEnumeration {
-  val singleA, singleB, userA, userB = Value
-}
 
 trait BoundingBoxMerger extends ProtoGeometryConversions {
 
@@ -30,36 +24,34 @@ trait BoundingBoxMerger extends ProtoGeometryConversions {
       )
     } yield boundingBoxToProto(union)
 
+  // Merge convention: tracing A's bounding boxes (including its legacy single box) are left untouched,
+  // keeping their ids. Tracing B's boxes are deduplicated against A's by content, and any that remain
+  // are assigned fresh ids continuing right after A's, then appended (see TreeUtils/GroupUtils for the
+  // analogous rule applied to node/tree/group ids).
   protected def combineUserBoundingBoxes(
       singleBoundingBoxAOpt: Option[ProtoBoundingBox],
       singleBoundingBoxBOpt: Option[ProtoBoundingBox],
       userBoundingBoxesA: Seq[NamedBoundingBoxProto],
       userBoundingBoxesB: Seq[NamedBoundingBoxProto]
-  ): (Seq[NamedBoundingBoxProto], UserBboxIdMap, UserBboxIdMap) = {
+  ): (Seq[NamedBoundingBoxProto], UserBboxIdMap) = {
     // note that the singleBoundingBox field is deprecated but still supported here to avoid database evolutions
-    val singleBoundingBoxANamed =
-      singleBoundingBoxAOpt.map(bb => (NamedBoundingBoxProto(0, boundingBox = bb), BoundingBoxSource.singleA))
-    val singleBoundingBoxBNamed =
-      singleBoundingBoxBOpt.map(bb => (NamedBoundingBoxProto(0, boundingBox = bb), BoundingBoxSource.singleB))
+    val singleBoundingBoxANamed = singleBoundingBoxAOpt.map(bb => NamedBoundingBoxProto(0, boundingBox = bb))
+    val singleBoundingBoxBNamed = singleBoundingBoxBOpt.map(bb => NamedBoundingBoxProto(0, boundingBox = bb))
 
-    val allBoundingBoxes: Seq[(NamedBoundingBoxProto, BoundingBoxSource.Value)] = userBoundingBoxesA.map(
-      (_, BoundingBoxSource.userA)
-    ) ++ userBoundingBoxesB.map((_, BoundingBoxSource.userB)) ++ singleBoundingBoxANamed ++ singleBoundingBoxBNamed
-    val newBoxesAndPrevIds: Seq[(NamedBoundingBoxProto, BoundingBoxSource.Value, Int)] =
-      allBoundingBoxes.distinctBy(_._1.copy(id = 0)).zipWithIndex.map { case ((uBB, source), idx) =>
-        (uBB.copy(id = idx), source, uBB.id)
-      }
+    val boxesA: Seq[NamedBoundingBoxProto] = userBoundingBoxesA ++ singleBoundingBoxANamed
+    val boxesAByContent: Set[NamedBoundingBoxProto] = boxesA.map(_.copy(id = 0)).toSet
 
-    val idMapA: Map[Int, Int] = newBoxesAndPrevIds.flatMap {
-      case (newBox, source, oldId) if source == BoundingBoxSource.userA => Some((oldId, newBox.id))
-      case _                                                            => None
-    }.toMap
-    val idMapB: Map[Int, Int] = newBoxesAndPrevIds.flatMap {
-      case (newBox, source, oldId) if source == BoundingBoxSource.userB => Some((oldId, newBox.id))
-      case _                                                            => None
-    }.toMap
-    val newBoxes = newBoxesAndPrevIds.map(_._1)
-    (newBoxes, idMapA, idMapB)
+    val idOffset = boxesA.map(_.id).maxOption.getOrElse(-1) + 1
+    val newBoxesBWithPrevIds: Seq[(NamedBoundingBoxProto, Int)] =
+      (userBoundingBoxesB ++ singleBoundingBoxBNamed)
+        .distinctBy(_.copy(id = 0))
+        .filterNot(bb => boxesAByContent.contains(bb.copy(id = 0)))
+        .zipWithIndex
+        .map { case (bb, index) => (bb.copy(id = index + idOffset), bb.id) }
+
+    val idMapB: Map[Int, Int] = newBoxesBWithPrevIds.map { case (newBox, oldId) => (oldId, newBox.id) }.toMap
+    val newBoxes = boxesA ++ newBoxesBWithPrevIds.map(_._1)
+    (newBoxes, idMapB)
   }
 
   protected def addAdditionalBoundingBoxes(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
@@ -30,13 +30,8 @@ trait BoundingBoxMerger extends ProtoGeometryConversions {
       )
     } yield boundingBoxToProto(union)
 
-  // Bounding boxes are the one merged element type that supports content-based deduplication (unlike
-  // node, tree, group or segment ids, which never carry duplicate meaning and so always follow the
-  // simpler "A fixed, B remapped" convention used everywhere else, see TreeUtils/GroupUtils/MergedVolume).
-  // A duplicate pair can involve two boxes from the same tracing, so both sides may need renumbering:
-  // all of A's and B's boxes (plus their deprecated legacy single-box fields) are pooled, deduplicated
-  // by content, and renumbered from scratch. Both idMapA and idMapB are returned and must be applied to
-  // that tracing's own user states, unlike the other merged elements where only B's user state needs it.
+  // Bounding boxes are deduplicated based on content across A and B and given all-new IDs.
+  // This approach is different from merging trees and groups, where we just shift the ids of B.
   protected def combineUserBoundingBoxes(
       singleBoundingBoxAOpt: Option[ProtoBoundingBox],
       singleBoundingBoxBOpt: Option[ProtoBoundingBox],

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/BoundingBoxMerger.scala
@@ -1,9 +1,15 @@
 package com.scalableminds.webknossos.tracingstore.tracings
 
+import com.scalableminds.util.enumeration.ExtendedEnumeration
 import com.scalableminds.util.geometry.BoundingBox
 import com.scalableminds.webknossos.datastore.geometry.NamedBoundingBoxProto
 import com.scalableminds.webknossos.datastore.geometry.BoundingBoxProto as ProtoBoundingBox
 import com.scalableminds.webknossos.datastore.helpers.ProtoGeometryConversions
+
+// Mark where a bounding box came from during merge for lookup in the correct id map
+object BoundingBoxSource extends ExtendedEnumeration {
+  val singleA, singleB, userA, userB = Value
+}
 
 trait BoundingBoxMerger extends ProtoGeometryConversions {
 
@@ -24,34 +30,43 @@ trait BoundingBoxMerger extends ProtoGeometryConversions {
       )
     } yield boundingBoxToProto(union)
 
-  // Merge convention: tracing A's bounding boxes (including its legacy single box) are left untouched,
-  // keeping their ids. Tracing B's boxes are deduplicated against A's by content, and any that remain
-  // are assigned fresh ids continuing right after A's, then appended (see TreeUtils/GroupUtils for the
-  // analogous rule applied to node/tree/group ids).
+  // Bounding boxes are the one merged element type that supports content-based deduplication (unlike
+  // node, tree, group or segment ids, which never carry duplicate meaning and so always follow the
+  // simpler "A fixed, B remapped" convention used everywhere else, see TreeUtils/GroupUtils/MergedVolume).
+  // A duplicate pair can involve two boxes from the same tracing, so both sides may need renumbering:
+  // all of A's and B's boxes (plus their deprecated legacy single-box fields) are pooled, deduplicated
+  // by content, and renumbered from scratch. Both idMapA and idMapB are returned and must be applied to
+  // that tracing's own user states, unlike the other merged elements where only B's user state needs it.
   protected def combineUserBoundingBoxes(
       singleBoundingBoxAOpt: Option[ProtoBoundingBox],
       singleBoundingBoxBOpt: Option[ProtoBoundingBox],
       userBoundingBoxesA: Seq[NamedBoundingBoxProto],
       userBoundingBoxesB: Seq[NamedBoundingBoxProto]
-  ): (Seq[NamedBoundingBoxProto], UserBboxIdMap) = {
+  ): (Seq[NamedBoundingBoxProto], UserBboxIdMap, UserBboxIdMap) = {
     // note that the singleBoundingBox field is deprecated but still supported here to avoid database evolutions
-    val singleBoundingBoxANamed = singleBoundingBoxAOpt.map(bb => NamedBoundingBoxProto(0, boundingBox = bb))
-    val singleBoundingBoxBNamed = singleBoundingBoxBOpt.map(bb => NamedBoundingBoxProto(0, boundingBox = bb))
+    val singleBoundingBoxANamed =
+      singleBoundingBoxAOpt.map(bb => (NamedBoundingBoxProto(0, boundingBox = bb), BoundingBoxSource.singleA))
+    val singleBoundingBoxBNamed =
+      singleBoundingBoxBOpt.map(bb => (NamedBoundingBoxProto(0, boundingBox = bb), BoundingBoxSource.singleB))
 
-    val boxesA: Seq[NamedBoundingBoxProto] = userBoundingBoxesA ++ singleBoundingBoxANamed
-    val boxesAByContent: Set[NamedBoundingBoxProto] = boxesA.map(_.copy(id = 0)).toSet
+    val allBoundingBoxes: Seq[(NamedBoundingBoxProto, BoundingBoxSource.Value)] = userBoundingBoxesA.map(
+      (_, BoundingBoxSource.userA)
+    ) ++ userBoundingBoxesB.map((_, BoundingBoxSource.userB)) ++ singleBoundingBoxANamed ++ singleBoundingBoxBNamed
+    val newBoxesAndPrevIds: Seq[(NamedBoundingBoxProto, BoundingBoxSource.Value, Int)] =
+      allBoundingBoxes.distinctBy(_._1.copy(id = 0)).zipWithIndex.map { case ((uBB, source), idx) =>
+        (uBB.copy(id = idx), source, uBB.id)
+      }
 
-    val idOffset = boxesA.map(_.id).maxOption.getOrElse(-1) + 1
-    val newBoxesBWithPrevIds: Seq[(NamedBoundingBoxProto, Int)] =
-      (userBoundingBoxesB ++ singleBoundingBoxBNamed)
-        .distinctBy(_.copy(id = 0))
-        .filterNot(bb => boxesAByContent.contains(bb.copy(id = 0)))
-        .zipWithIndex
-        .map { case (bb, index) => (bb.copy(id = index + idOffset), bb.id) }
-
-    val idMapB: Map[Int, Int] = newBoxesBWithPrevIds.map { case (newBox, oldId) => (oldId, newBox.id) }.toMap
-    val newBoxes = boxesA ++ newBoxesBWithPrevIds.map(_._1)
-    (newBoxes, idMapB)
+    val idMapA: Map[Int, Int] = newBoxesAndPrevIds.flatMap {
+      case (newBox, source, oldId) if source == BoundingBoxSource.userA => Some((oldId, newBox.id))
+      case _                                                            => None
+    }.toMap
+    val idMapB: Map[Int, Int] = newBoxesAndPrevIds.flatMap {
+      case (newBox, source, oldId) if source == BoundingBoxSource.userB => Some((oldId, newBox.id))
+      case _                                                            => None
+    }.toMap
+    val newBoxes = newBoxesAndPrevIds.map(_._1)
+    (newBoxes, idMapA, idMapB)
   }
 
   protected def addAdditionalBoundingBoxes(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/GroupUtils.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/GroupUtils.scala
@@ -24,6 +24,8 @@ object GroupUtils {
 
   type FunctionalGroupMapping = Function[Int, Int]
 
+  // Merge convention: group A's ids are left untouched; group B's are offset to continue right after
+  // A's (see TreeUtils for the analogous node/tree id rule).
   private def calculateGroupMapping(groupsA: Seq[TracingItemGroup], groupsB: Seq[TracingItemGroup]): Int => Int = {
     val groupIdOffset = calculateGroupIdOffset(groupsA, groupsB)
     (groupId: Int) => groupId + groupIdOffset
@@ -40,22 +42,22 @@ object GroupUtils {
     if (groupsB.isEmpty)
       0
     else {
-      val targetGroupMaxId = if (groupsB.isEmpty) 0 else maxGroupIdRecursive(groupsB)
-      val sourceGroupMinId = if (groupsA.isEmpty) 0 else minGroupIdRecursive(groupsA)
-      math.max(targetGroupMaxId + 1 - sourceGroupMinId, 0)
+      val groupMaxIdA = if (groupsA.isEmpty) 0 else maxGroupIdRecursive(groupsA)
+      val groupMinIdB = minGroupIdRecursive(groupsB)
+      math.max(groupMaxIdA + 1 - groupMinIdB, 0)
     }
 
   private def mergeGroups(
       groupsA: Seq[TracingItemGroup],
       groupsB: Seq[TracingItemGroup],
-      groupMappingA: FunctionalGroupMapping
+      groupMappingB: FunctionalGroupMapping
   ): Seq[TracingItemGroup] = {
     def applyGroupMappingRecursive(groups: Seq[TracingItemGroup]): Seq[TracingItemGroup] =
       groups.map(group =>
-        group.withGroupId(groupMappingA(group.groupId)).withChildren(applyGroupMappingRecursive(group.children))
+        group.withGroupId(groupMappingB(group.groupId)).withChildren(applyGroupMappingRecursive(group.children))
       )
 
-    applyGroupMappingRecursive(groupsA) ++ groupsB
+    groupsA ++ applyGroupMappingRecursive(groupsB)
   }
 
   private def getAllChildrenGroups(rootGroup: TracingItemGroup): Seq[TracingItemGroup] = {
@@ -84,18 +86,18 @@ object GroupUtils {
   def mergeTreeGroups(
       groupsA: Seq[TreeGroup],
       groupsB: Seq[TreeGroup],
-      groupMappingA: FunctionalGroupMapping
+      groupMappingB: FunctionalGroupMapping
   ): Seq[TreeGroup] =
-    mergeGroups(groupsA.map(tg => new TreeItemGroup(tg)), groupsB.map(tg => new TreeItemGroup(tg)), groupMappingA).map(
+    mergeGroups(groupsA.map(tg => new TreeItemGroup(tg)), groupsB.map(tg => new TreeItemGroup(tg)), groupMappingB).map(
       tig => tig.inner.asInstanceOf[TreeGroup]
     )
 
   def mergeSegmentGroups(
       groupsA: Seq[SegmentGroup],
       groupsB: Seq[SegmentGroup],
-      groupMappingA: FunctionalGroupMapping
+      groupMappingB: FunctionalGroupMapping
   ): Seq[SegmentGroup] =
-    mergeGroups(groupsA.map(tg => new SegmentItemGroup(tg)), groupsB.map(tg => new SegmentItemGroup(tg)), groupMappingA)
+    mergeGroups(groupsA.map(tg => new SegmentItemGroup(tg)), groupsB.map(tg => new SegmentItemGroup(tg)), groupMappingB)
       .map(tig => tig.inner.asInstanceOf[SegmentGroup])
 
   def getAllTreeGroupIds(treeGroups: Seq[TreeGroup], ids: Seq[Int] = Seq[Int]()): Seq[Int] =

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -112,20 +112,19 @@ class SkeletonTracingService @Inject() (
       mergedAdditionalAxes <- AdditionalAxis.mergeAndAssertSameAdditionalAxes(
         Seq(tracingA, tracingB).map(t => AdditionalAxis.fromProtosAsOpt(t.additionalAxes))
       )
-      nodeMappingA = TreeUtils.calculateNodeMapping(tracingA.trees, tracingB.trees)
-      (treeMappingA, treeMappingB) = TreeUtils.calculateTreeMappings(tracingA.trees, tracingB.trees)
-      groupMappingA = GroupUtils.calculateTreeGroupMapping(tracingA.treeGroups, tracingB.treeGroups)
+      nodeMappingB = TreeUtils.calculateNodeMapping(tracingA.trees, tracingB.trees)
+      treeMappingB = TreeUtils.calculateTreeMapping(tracingA.trees, tracingB.trees)
+      groupMappingB = GroupUtils.calculateTreeGroupMapping(tracingA.treeGroups, tracingB.treeGroups)
       mergedTrees = TreeUtils.mergeTrees(
         tracingA.trees,
         tracingB.trees,
-        treeMappingA,
         treeMappingB,
-        nodeMappingA,
-        groupMappingA
+        nodeMappingB,
+        groupMappingB
       )
-      mergedGroups = GroupUtils.mergeTreeGroups(tracingA.treeGroups, tracingB.treeGroups, groupMappingA)
+      mergedGroups = GroupUtils.mergeTreeGroups(tracingA.treeGroups, tracingB.treeGroups, groupMappingB)
       mergedBoundingBox = combineBoundingBoxes(tracingA.boundingBox, tracingB.boundingBox)
-      (userBoundingBoxes, bboxIdMapA, bboxIdMapB) = combineUserBoundingBoxes(
+      (userBoundingBoxes, bboxIdMapB) = combineUserBoundingBoxes(
         tracingA.userBoundingBox,
         tracingB.userBoundingBox,
         tracingA.userBoundingBoxes,
@@ -134,10 +133,8 @@ class SkeletonTracingService @Inject() (
       userStates = mergeSkeletonUserStates(
         tracingA.userStates,
         tracingB.userStates,
-        groupMappingA,
-        treeMappingA,
+        groupMappingB,
         treeMappingB,
-        bboxIdMapA,
         bboxIdMapB
       )
     } yield tracingA.copy(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/SkeletonTracingService.scala
@@ -124,7 +124,7 @@ class SkeletonTracingService @Inject() (
       )
       mergedGroups = GroupUtils.mergeTreeGroups(tracingA.treeGroups, tracingB.treeGroups, groupMappingB)
       mergedBoundingBox = combineBoundingBoxes(tracingA.boundingBox, tracingB.boundingBox)
-      (userBoundingBoxes, bboxIdMapB) = combineUserBoundingBoxes(
+      (userBoundingBoxes, bboxIdMapA, bboxIdMapB) = combineUserBoundingBoxes(
         tracingA.userBoundingBox,
         tracingB.userBoundingBox,
         tracingA.userBoundingBoxes,
@@ -135,6 +135,7 @@ class SkeletonTracingService @Inject() (
         tracingB.userStates,
         groupMappingB,
         treeMappingB,
+        bboxIdMapA,
         bboxIdMapB
       )
     } yield tracingA.copy(

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
@@ -5,6 +5,9 @@ import com.scalableminds.webknossos.datastore.SkeletonTracing.Tree
 import scala.util.matching.Regex
 import scala.util.matching.Regex.Match
 
+// Merge convention: tracing A's node/tree ids are left untouched. Tracing B's are densified and
+// offset to continue right after A's, then appended. The same convention applies to tree/segment
+// groups (see GroupUtils) and to segment ids (see MergedVolume) so a merge only ever remaps one side.
 object TreeUtils {
   type FunctionalNodeMapping = Function[Int, Int]
   type FunctionalGroupMapping = Function[Int, Int]
@@ -28,45 +31,44 @@ object TreeUtils {
       nodes.map(_.id).max
   }
 
+  private def maxTreeId(trees: Seq[Tree]): Int = trees.map(_.treeId).maxOption.getOrElse(0)
+
   def mergeTrees(
       treesA: Seq[Tree],
       treesB: Seq[Tree],
-      treeIdMapA: Map[Int, Int],
       treeIdMapB: Map[Int, Int],
-      nodeMappingA: FunctionalNodeMapping,
-      groupMappingA: FunctionalGroupMapping
+      nodeMappingB: FunctionalNodeMapping,
+      groupMappingB: FunctionalGroupMapping
   ): Seq[Tree] = {
-    val nodeIdsA: Set[Int] = treesA.flatMap(_.nodes.map(_.id)).toSet
+    val nodeIdsB: Set[Int] = treesB.flatMap(_.nodes.map(_.id)).toSet
 
-    val mappedTreesA = treesA.map(tree =>
-      applyNodeMapping(tree.withTreeId(treeIdMapA(tree.treeId)), nodeMappingA, nodeIdsA)
-        .copy(groupId = tree.groupId.map(groupMappingA(_)))
+    val mappedTreesB = treesB.map(tree =>
+      applyNodeMapping(tree.withTreeId(treeIdMapB(tree.treeId)), nodeMappingB, nodeIdsB)
+        .copy(groupId = tree.groupId.map(groupMappingB(_)))
     )
 
-    val mappedTreesB = treesB.map(tree => tree.withTreeId(treeIdMapB(tree.treeId)))
-
-    mappedTreesB ++ mappedTreesA
+    treesA ++ mappedTreesB
   }
 
-  private def applyNodeMapping(tree: Tree, nodeMappingA: FunctionalNodeMapping, nodeIdsA: Set[Int]) =
+  private def applyNodeMapping(tree: Tree, nodeMappingB: FunctionalNodeMapping, nodeIdsB: Set[Int]) =
     tree
-      .withNodes(tree.nodes.map(node => node.withId(nodeMappingA(node.id))))
+      .withNodes(tree.nodes.map(node => node.withId(nodeMappingB(node.id))))
       .withEdges(
-        tree.edges.map(edge => edge.withSource(nodeMappingA(edge.source)).withTarget(nodeMappingA(edge.target)))
+        tree.edges.map(edge => edge.withSource(nodeMappingB(edge.source)).withTarget(nodeMappingB(edge.target)))
       )
       .withComments(
         tree.comments.map(comment =>
           comment
-            .withNodeId(nodeMappingA(comment.nodeId))
-            .withContent(updateNodeReferences(comment.content, nodeMappingA, nodeIdsA))
+            .withNodeId(nodeMappingB(comment.nodeId))
+            .withContent(updateNodeReferences(comment.content, nodeMappingB, nodeIdsB))
         )
       )
-      .withBranchPoints(tree.branchPoints.map(bp => bp.withNodeId(nodeMappingA(bp.nodeId))))
+      .withBranchPoints(tree.branchPoints.map(bp => bp.withNodeId(nodeMappingB(bp.nodeId))))
 
-  private def updateNodeReferences(comment: String, nodeMappingA: FunctionalNodeMapping, nodeIdsA: Set[Int]) = {
+  private def updateNodeReferences(comment: String, nodeMappingB: FunctionalNodeMapping, nodeIdsB: Set[Int]) = {
     def replacer(m: Match) = {
       val oldId = m.toString.substring(1).toInt
-      val newId = if (nodeIdsA.contains(oldId)) nodeMappingA(oldId) else oldId
+      val newId = if (nodeIdsB.contains(oldId)) nodeMappingB(oldId) else oldId
       "#" + newId
     }
     nodeIdReferenceRegex.replaceAllIn(comment, m => replacer(m))
@@ -77,11 +79,12 @@ object TreeUtils {
     (nodeId: Int) => nodeId + nodeIdOffset
   }
 
-  def calculateTreeMappings(treesA: Seq[Tree], treesB: Seq[Tree]): (TreeIdMap, TreeIdMap) =
-    (calculateTreeMapping(treesA, treesB.length), calculateTreeMapping(treesB, 0))
+  // A's tree ids are kept as-is; B's are densified (renumbered 1..n) and offset to continue right after A's.
+  def calculateTreeMapping(treesA: Seq[Tree], treesB: Seq[Tree]): TreeIdMap =
+    densifyTreeIds(treesB, maxTreeId(treesA))
 
-  // We’re densifying the tree ids to avoid sparse ids growing too fast
-  private def calculateTreeMapping(trees: Seq[Tree], offset: Int): Map[Int, Int] =
+  // We're densifying the tree ids to avoid sparse ids growing too fast
+  private def densifyTreeIds(trees: Seq[Tree], offset: Int): Map[Int, Int] =
     trees
       .map(_.treeId)
       .sorted
@@ -91,16 +94,16 @@ object TreeUtils {
       }
       .toMap
 
-  // When merging two skeletons, the node ids of skeleton A are remapped by adding this offset
-  // to keep everything unique.
-  // If the existing nodes of A don’t start at 0, their start is subtracted, densifying the ids.
+  // When merging two skeletons, the node ids of skeleton B are remapped by adding this offset
+  // to keep everything unique, continuing right after skeleton A's node ids.
+  // If the existing nodes of B don’t start at 0, their start is subtracted, densifying the ids.
   private def calculateNodeOffset(treesA: Seq[Tree], treesB: Seq[Tree]) =
     if (treesB.isEmpty)
       0
     else {
-      val nodeMaxIdB = maxNodeId(treesB)
-      val nodeMinIdA = minNodeId(treesA)
-      math.max(nodeMaxIdB + 1 - nodeMinIdA, 0)
+      val nodeMaxIdA = maxNodeId(treesA)
+      val nodeMinIdB = minNodeId(treesB)
+      math.max(nodeMaxIdA + 1 - nodeMinIdB, 0)
     }
 
 }

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/skeleton/TreeUtils.scala
@@ -5,12 +5,11 @@ import com.scalableminds.webknossos.datastore.SkeletonTracing.Tree
 import scala.util.matching.Regex
 import scala.util.matching.Regex.Match
 
-// Merge convention: tracing A's node/tree ids are left untouched. Tracing B's are densified and
-// offset to continue right after A's, then appended. The same convention applies to tree/segment
-// groups (see GroupUtils) and to segment ids (see MergedVolume) so a merge only ever remaps one side.
+// Merge convention: tracing A’s node/tree ids are left untouched. Tracing B’s are offset to continue right after A’s.
+// For tree ids, B’s are also densified because sparse tree ids exist in the context of agglomerate trees.
 object TreeUtils {
-  type FunctionalNodeMapping = Function[Int, Int]
-  type FunctionalGroupMapping = Function[Int, Int]
+  private type FunctionalNodeMapping = Function[Int, Int]
+  private type FunctionalGroupMapping = Function[Int, Int]
   type TreeIdMap = Map[Int, Int]
 
   private val nodeIdReferenceRegex: Regex = "#([0-9]+)" r
@@ -79,11 +78,11 @@ object TreeUtils {
     (nodeId: Int) => nodeId + nodeIdOffset
   }
 
-  // A's tree ids are kept as-is; B's are densified (renumbered 1..n) and offset to continue right after A's.
+  // A’s tree ids are kept, B’s are densified and offset to continue right after A’s.
   def calculateTreeMapping(treesA: Seq[Tree], treesB: Seq[Tree]): TreeIdMap =
     densifyTreeIds(treesB, maxTreeId(treesA))
 
-  // We're densifying the tree ids to avoid sparse ids growing too fast
+  // We’re densifying the tree ids to avoid sparse ids growing too fast
   private def densifyTreeIds(trees: Seq[Tree], offset: Int): Map[Int, Int] =
     trees
       .map(_.treeId)
@@ -95,7 +94,7 @@ object TreeUtils {
       .toMap
 
   // When merging two skeletons, the node ids of skeleton B are remapped by adding this offset
-  // to keep everything unique, continuing right after skeleton A's node ids.
+  // to keep everything unique, continuing right after skeleton A’s node ids.
   // If the existing nodes of B don’t start at 0, their start is subtracted, densifying the ids.
   private def calculateNodeOffset(treesA: Seq[Tree], treesB: Seq[Tree]) =
     if (treesB.isEmpty)

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -865,10 +865,11 @@ class VolumeTracingService @Inject() (
     val mergedGroups = GroupUtils.mergeSegmentGroups(tracingA.segmentGroups, tracingB.segmentGroups, groupMappingB)
     val mergedBoundingBox = combineBoundingBoxes(Some(tracingA.boundingBox), Some(tracingB.boundingBox))
     // Tracing A's segment ids are never remapped; tracing B's are (see MergedVolume), matching the
-    // A-fixed/B-remapped convention also used for segment groups, tree/node ids and bounding boxes.
+    // A-fixed/B-remapped convention also used for segment groups and tree/node ids. Bounding boxes are
+    // the exception (see BoundingBoxMerger): both sides may be remapped there.
     val segmentIdMapB =
       if (indexB >= mergedVolumeStats.idMaps.length) Map.empty[Long, Long] else mergedVolumeStats.idMaps(indexB)
-    val (mergedUserBoundingBoxes, bboxIdMapB) = combineUserBoundingBoxes(
+    val (mergedUserBoundingBoxes, bboxIdMapA, bboxIdMapB) = combineUserBoundingBoxes(
       tracingA.userBoundingBox,
       tracingB.userBoundingBox,
       tracingA.userBoundingBoxes,
@@ -880,6 +881,7 @@ class VolumeTracingService @Inject() (
         tracingB.userStates,
         groupMappingB,
         segmentIdMapB,
+        bboxIdMapA,
         bboxIdMapB
       )
     for {

--- a/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
+++ b/webknossos-tracingstore/app/com/scalableminds/webknossos/tracingstore/tracings/volume/VolumeTracingService.scala
@@ -861,12 +861,14 @@ class VolumeTracingService @Inject() (
   ): Box[VolumeTracing] = {
     val largestSegmentId =
       combineLargestSegmentIdsByMaxDefined(tracingA.largestSegmentId, tracingB.largestSegmentId)
-    val groupMappingA = GroupUtils.calculateSegmentGroupMapping(tracingA.segmentGroups, tracingB.segmentGroups)
-    val mergedGroups = GroupUtils.mergeSegmentGroups(tracingA.segmentGroups, tracingB.segmentGroups, groupMappingA)
+    val groupMappingB = GroupUtils.calculateSegmentGroupMapping(tracingA.segmentGroups, tracingB.segmentGroups)
+    val mergedGroups = GroupUtils.mergeSegmentGroups(tracingA.segmentGroups, tracingB.segmentGroups, groupMappingB)
     val mergedBoundingBox = combineBoundingBoxes(Some(tracingA.boundingBox), Some(tracingB.boundingBox))
+    // Tracing A's segment ids are never remapped; tracing B's are (see MergedVolume), matching the
+    // A-fixed/B-remapped convention also used for segment groups, tree/node ids and bounding boxes.
     val segmentIdMapB =
       if (indexB >= mergedVolumeStats.idMaps.length) Map.empty[Long, Long] else mergedVolumeStats.idMaps(indexB)
-    val (mergedUserBoundingBoxes, bboxIdMapA, bboxIdMapB) = combineUserBoundingBoxes(
+    val (mergedUserBoundingBoxes, bboxIdMapB) = combineUserBoundingBoxes(
       tracingA.userBoundingBox,
       tracingB.userBoundingBox,
       tracingA.userBoundingBoxes,
@@ -876,9 +878,8 @@ class VolumeTracingService @Inject() (
       mergeVolumeUserStates(
         tracingA.userStates,
         tracingB.userStates,
-        groupMappingA,
+        groupMappingB,
         segmentIdMapB,
-        bboxIdMapA,
         bboxIdMapB
       )
     for {
@@ -894,8 +895,8 @@ class VolumeTracingService @Inject() (
             )
           }
         }
-      tracingASegments = tracingA.segments.map(s =>
-        s.groupId.map(groupId => s.copy(groupId = Some(groupMappingA(groupId)))).getOrElse(s)
+      tracingBSegmentsMapped = tracingBSegments.map(s =>
+        s.groupId.map(groupId => s.copy(groupId = Some(groupMappingB(groupId)))).getOrElse(s)
       )
     } yield tracingA.copy(
       largestSegmentId = largestSegmentId,
@@ -904,7 +905,7 @@ class VolumeTracingService @Inject() (
           .BoundingBoxProto(com.scalableminds.webknossos.datastore.geometry.Vec3IntProto(0, 0, 0), 0, 0, 0)
       ), // should never be empty for volumes
       userBoundingBoxes = mergedUserBoundingBoxes,
-      segments = (tracingASegments ++ tracingBSegments).distinctBy(_.segmentId),
+      segments = (tracingA.segments ++ tracingBSegmentsMapped).distinctBy(_.segmentId),
       segmentGroups = mergedGroups,
       additionalAxes = AdditionalAxis.toProto(mergedAdditionalAxes),
       userStates = userStates


### PR DESCRIPTION
### Summary

- When merging annotations, the elements from both need to be combined, but their ids need to stay unique. On master, the id remapping was inconsistent (sometimes A’s ids were changed, sometimes B’s). This PR unifies this.
- Not touching A’s ids also means that when merging more than two annotations with foldLeft, the growing accumulator’s Ids don’t have to be rescanned every time, reducing complexity of this step from N² to N, improving perf.
- Special case 1: tree ids need to be densified as well as shifted, because agglomerate skeletons can create large sparse ids, see #8642 This is now done only on B, which should be sufficient.
- Special case 2: bounding boxes are deduplicated *by content* and *across* A and B, this is still the case and not changed in this PR.
- Also added a couple of tests

#### Before

| Element type          | Tracing A’s ids     | Tracing B’s ids     | Densified? | Deduplicated?       |
|-----------------------|---------------------|---------------------|------------|---------------------|
| Node ids              | shifted             | untouched           | no         | no                  |
| Tree ids              | shifted + densified | shifted + densified | yes, A+B   | no                  |
| Groups (tree,segment) | shifted             | untouched           | no         | no                  |
| Segment ids           | untouched           | shifted + densified | yes, B     | no                  |
| Bounding boxes        | may be remapped     | may be remapped     | yes, A+B   | yes, A+B |


#### After

| Element type          | Tracing A’s ids     | Tracing B’s ids     | Densified? | Deduplicated?       | Diff            |
|-----------------------|---------------------|---------------------|------------|---------------------|-----------------|
| Node ids              | untouched           | shifted             | no         | no                  | flipped A/B     |
| Tree ids              | untouched           | shifted + densified | yes, B     | no                  | A now untouched |
| Groups (tree,segment) | untouched           | shifted             | no         | no                  | flipped A/B     |
| Segment ids           | untouched           | shifted + densified | yes, B     | no                  | unchanged       |
| Bounding boxes        | may be remapped     | may be remapped     | yes, A+B   | yes, A+B | unchanged       |


### Steps to test:
- Create some annotations, merge them via merge modal
- Resulting IDs should make sense, no two things should have the same id (in their domain).

### Issues:
- fixes #8670

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
