### PR TITLE
Don’t list shared annotations to users who cannot access their datasets

### DIFF
--- a/app/models/annotation/Annotation.scala
+++ b/app/models/annotation/Annotation.scala
@@ -16,6 +16,7 @@ import com.scalableminds.webknossos.tracingstore.tracings.TracingType
 import models.annotation.AnnotationState.AnnotationState
 import models.annotation.CollaborationMode.CollaborationMode
 import models.annotation.AnnotationType.AnnotationType
+import models.dataset.DatasetDAO
 import play.api.libs.json.*
 import slick.jdbc.GetResult
 import slick.jdbc.GetResult.*
@@ -200,8 +201,8 @@ class AnnotationLayerDAO @Inject() (SQLClient: SqlClient)(implicit ec: Execution
     } yield ()
 }
 
-class AnnotationDAO @Inject() (sqlClient: SqlClient, annotationLayerDAO: AnnotationLayerDAO)(implicit
-    ec: ExecutionContext
+class AnnotationDAO @Inject() (sqlClient: SqlClient, annotationLayerDAO: AnnotationLayerDAO, datasetDAO: DatasetDAO)(
+    implicit ec: ExecutionContext
 ) extends SQLDAO[Annotation, AnnotationsRow, Annotations](sqlClient) {
   protected val collection = Annotations
   protected def resultConverter = GetResultAnnotationsRow
@@ -239,7 +240,7 @@ class AnnotationDAO @Inject() (sqlClient: SqlClient, annotationLayerDAO: Annotat
   private def listAccessQ(requestingUserId: ObjectId, prefix: SqlToken): SqlToken =
     q"""
         (
-          _user = $requestingUserId
+          ${prefix}_user = $requestingUserId
           OR (
             (${prefix}visibility = ${AnnotationVisibility.Public} or ${prefix}visibility = ${AnnotationVisibility.Internal})
             AND (
@@ -255,6 +256,12 @@ class AnnotationDAO @Inject() (sqlClient: SqlClient, annotationLayerDAO: Annotat
                 FROM webknossos.annotation_contributors
                 WHERE _user = $requestingUserId
               )
+            )
+            AND EXISTS ( -- user must also still have access to the annotation's dataset
+              SELECT 1
+              FROM webknossos.datasets_ dd
+              WHERE dd._id = ${prefix}_dataset
+              AND (${datasetDAO.readAccessQWithPrefix(requestingUserId, q"dd.")})
             )
           )
         )

--- a/app/models/dataset/Dataset.scala
+++ b/app/models/dataset/Dataset.scala
@@ -200,9 +200,12 @@ class DatasetDAO @Inject() (sqlClient: SqlClient, datasetLayerDAO: DatasetLayerD
   }
 
   override def readAccessQ(requestingUserId: ObjectId): SqlToken =
-    q"""isPublic
+    readAccessQWithPrefix(requestingUserId, q"")
+
+  def readAccessQWithPrefix(requestingUserId: ObjectId, prefix: SqlToken): SqlToken =
+    q"""${prefix}isPublic
         OR ( -- user is matching orga admin or dataset manager
-          _organization IN (
+          ${prefix}_organization IN (
             SELECT _organization
             FROM webknossos.users_
             WHERE _id = $requestingUserId
@@ -210,7 +213,7 @@ class DatasetDAO @Inject() (sqlClient: SqlClient, datasetLayerDAO: DatasetLayerD
           )
         )
         OR ( -- user is in a team that is allowed for the dataset
-          _id IN (
+          ${prefix}_id IN (
             SELECT _dataset
             FROM webknossos.dataset_allowedTeams dt
             JOIN webknossos.user_team_roles utr ON dt._team = utr._team
@@ -218,7 +221,7 @@ class DatasetDAO @Inject() (sqlClient: SqlClient, datasetLayerDAO: DatasetLayerD
           )
         )
         OR ( -- user is in a team that is allowed for the folder or its ancestors
-          _folder IN (
+          ${prefix}_folder IN (
             SELECT fp._descendant
             FROM webknossos.folder_paths fp
             WHERE fp._ancestor IN (

--- a/schema/evolutions/182-annotation-dataset-access-indexes.sql
+++ b/schema/evolutions/182-annotation-dataset-access-indexes.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 181 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+CREATE INDEX ON webknossos.annotations(_dataset);
+CREATE INDEX ON webknossos.annotation_contributors(_user);
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 182;
+
+COMMIT TRANSACTION;

--- a/schema/evolutions/reversions/182-annotation-dataset-access-indexes.sql
+++ b/schema/evolutions/reversions/182-annotation-dataset-access-indexes.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+do $$ begin if (select schemaVersion from webknossos.releaseInformation) <> 182 then raise exception 'Previous schema version mismatch'; end if; end; $$ language plpgsql;
+
+DROP INDEX webknossos.annotations__dataset_idx;
+DROP INDEX webknossos.annotation_contributors__user_idx;
+
+UPDATE webknossos.releaseInformation SET schemaVersion = 181;
+
+COMMIT TRANSACTION;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE webknossos.releaseInformation (
   schemaVersion BIGINT NOT NULL
 );
 
-INSERT INTO webknossos.releaseInformation(schemaVersion) values(181);
+INSERT INTO webknossos.releaseInformation(schemaVersion) values(182);
 COMMIT TRANSACTION;
 
 
@@ -906,6 +906,8 @@ CREATE INDEX ON webknossos.annotations(typ, state, isDeleted);
 CREATE INDEX ON webknossos.annotations(_user, _task, isDeleted);
 CREATE INDEX ON webknossos.annotations(_task, typ, isDeleted);
 CREATE INDEX ON webknossos.annotations(typ, isDeleted);
+CREATE INDEX ON webknossos.annotations(_dataset);
+CREATE INDEX ON webknossos.annotation_contributors(_user);
 CREATE INDEX ON webknossos.datasets(directoryName);
 CREATE INDEX ON webknossos.datasets(_folder);
 CREATE INDEX ON webknossos.tasks(_project);

--- a/unreleased_changes/9965.md
+++ b/unreleased_changes/9965.md
@@ -1,0 +1,5 @@
+### Changed
+- Shared annotations are no longer listed to users who cannot access the underlying dataset.
+
+### Postgres Evolutions
+- [182-annotation-dataset-access-indexes.sql](schema/evolutions/182-annotation-dataset-access-indexes.sql)


### PR DESCRIPTION
### Summary
- If a user cannot view the annotation anyway because they don’t have access to the dataset, hide the annotation in the list
- the user’s own annotations are exempt from this new rule.
- Adds two database indexes to ensure the query stays fast

### Steps to test:
(I tested locally)
- Create an annotation, share it with a team
- As second user in that team, you should not see it in the list
- Now set the dataset to public, or share it with the team too
- As the second user the annotation should now be listed.

### Issues:
- fixes #9083

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
