### PR TITLE
Fix segment stats file route response in case of no segment stats file

### DIFF
--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/segmentstatistics/SegmentStatisticsFileService.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/segmentstatistics/SegmentStatisticsFileService.scala
@@ -97,7 +97,7 @@ class SegmentStatisticsFileService @Inject() (
     for {
       attachment <- Box.fromOption(
         dataLayer.attachments.flatMap(_.segmentStatistics)
-      ) ?~> Msg.SegmentStatisticsFile.notFound
+      ) ?-> Msg.SegmentStatisticsFile.notFound
       _ <- Box.fromBool(attachment.path.isAbsolute) ?~> Msg.SegmentStatisticsFile.pathNotAbsolute
     } yield SegmentStatisticsFileKey(
       dataSourceId,


### PR DESCRIPTION
### Summary
In case of no segment stats file this route is supposed to return empty list. To do that, it matches on the Box result of `lookUpSegmentStatisticsFileKey` and distinguishes Empty from Failure. However, the Empty was swallowed by the `?~>`. This PR changes it to `?->` which passes through the Empty.

The symptom was that whenever someone right-clicked a segment (for a dataset without segment stats file, which is most datasets), an error toast appeared.

### Steps to test:
- Open dataset with segmentation layer, right-click a segment
- No error toast should show up. Network tab should show emptylist response for `segmentStatisticsFile` route.

------
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
