### PR TITLE
Fix updating largestSegmentId in dataset settings view

### DIFF
--- a/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
@@ -49,17 +49,18 @@ export default function DatasetSettingsDataTab() {
   );
 }
 
-function parseAsBigInt(value: string) {
+function parseAsBigInt(value: string | number | bigint | null | undefined): {
+  error: true | null;
+  parsed: bigint | null;
+} {
   if (value == null || value === "") {
     return { error: null, parsed: null };
   }
-  let parsed: bigint;
   try {
-    parsed = BigInt(value);
+    return { error: null, parsed: BigInt(value) };
   } catch {
     return { error: true, parsed: null };
   }
-  return { error: null, parsed };
 }
 
 function copyDatasetID(datasetId: string | null | undefined) {
@@ -645,6 +646,10 @@ function SimpleLayerForm({
                       ? `${layer.largestSegmentId}`
                       : undefined
                   }
+                  getValueFromEvent={(value) => {
+                    const { parsed, error } = parseAsBigInt(value);
+                    return error ? value : (parsed ?? undefined);
+                  }}
                   rules={[
                     {
                       validator: (_rule, value) => {

--- a/unreleased_changes/9977.md
+++ b/unreleased_changes/9977.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed updating the largestSegmentId of segmentation layers on the dataset settings page.


### PR DESCRIPTION
### Summary
 - This field value can be populated with a number or a string, and both need to be converted to bigint before serialization. Especially string values are invalid, the backend rejected any changed largestSegmentId in the updatePartial request.

### Steps to test:
- Update largestSegmentId and save, should work
- Keep it unchanged, change something else and save, should work
- empty the field and save, should work
- on an uint64 segmentation, update it to a large number > 9007199254740991, should also work

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)