### PR TITLE
Fix info route for proxy path neuroglancerPrecomputed datasets

### DIFF
--- a/unreleased_changes/9978.md
+++ b/unreleased_changes/9978.md
@@ -1,0 +1,2 @@
+### Added
+- Added support for neuroglancerPrecomputed datasets opened from the python libs with access_mode PROXY_PATH.

--- a/util/src/main/scala/com/scalableminds/util/Msg.scala
+++ b/util/src/main/scala/com/scalableminds/util/Msg.scala
@@ -479,6 +479,7 @@ object Msg {
     object Layer {
       def notFound(layerName: String): String = s"Could not find layer “$layerName” in dataset."
       def magNotFound(layer: String, mag: String): String = s"Data layer “$layer” does not have mag “$mag”."
+      def zeroMags(layer: String) = s"Data layer “$layer” has zero mags."
       def attachmentNotFound(layer: String, attachment: String): String =
         s"Data layer “$layer” does not have attachment “$attachment”."
       val attachmentSingletonAlreadyFilled: String =

--- a/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataProxyController.scala
+++ b/webknossos-datastore/app/com/scalableminds/webknossos/datastore/controllers/DataProxyController.scala
@@ -4,9 +4,10 @@ import com.google.inject.Inject
 import com.scalableminds.util.Msg
 import com.scalableminds.util.geometry.Vec3Int
 import com.scalableminds.util.objectid.ObjectId
-import com.scalableminds.util.tools.Fox
+import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.dataformats.MagLocator
+import com.scalableminds.webknossos.datastore.datareaders.precomputed.PrecomputedHeader
 import com.scalableminds.webknossos.datastore.datavault.{ByteRange, Encoding}
 import com.scalableminds.webknossos.datastore.datavault.Encoding.Encoding
 import com.scalableminds.webknossos.datastore.helpers.UPath
@@ -46,6 +47,30 @@ class DataProxyController @Inject() (
           (bytes, encoding, rangeHeader) <- requestedPath.readBytesEncodingAndRangeHeader(byteRange)
           headers = buildResponseHeaders(encoding, rangeHeader)
         } yield resultWithStatus(byteRange.successResponseCode, bytes).withHeaders(headers*)
+      }
+    }
+
+  // Readers of neuroglancerPrecomputed mags also request the info header at the *parent* path of each mag.
+  // We have to serve a valid info header at this path.
+  def proxyPrecomputedInfo(datasetId: ObjectId, dataLayerName: String): Action[AnyContent] =
+    Action.fox { implicit request =>
+      accessTokenService.validateAccessFromTokenContext(UserAccessRequest.readDataset(datasetId)) {
+        for {
+          (dataSource, dataLayer) <- datasetCache.getWithLayer(datasetId, dataLayerName) ?~> Msg.Dataset.Layer
+            .notFound(dataLayerName) ~> NOT_FOUND
+          magLocator <- dataLayer.mags.headOption.toFox ?~> Msg.Dataset.Layer.zeroMags(dataLayerName) ~> NOT_FOUND
+          magPath <- dataVaultService.vaultPathFor(magLocator)
+          requestedPath = magPath.parent / PrecomputedHeader.FILENAME_INFO
+          bytes <- requestedPath.readBytes()
+          rootHeader <- JsonHelper.parseAs[PrecomputedHeader](bytes).toFox ?~> "Could not parse array header"
+          rootHeaderAdapted = rootHeader.copy(scales = rootHeader.scales.flatMap { scale =>
+            val matchingMagOpt = dataLayer.mags.find(_.path.exists(_.basename == scale.key))
+            matchingMagOpt match {
+              case Some(matchingMag) => Some(scale.copy(key = matchingMag.mag.toMagLiteral(allowScalar = true)))
+              case None              => None
+            }
+          })
+        } yield Ok(Json.toJson(rootHeaderAdapted))
       }
     }
 

--- a/webknossos-datastore/conf/datastore.latest.routes
+++ b/webknossos-datastore/conf/datastore.latest.routes
@@ -13,6 +13,7 @@ GET           /datasets/:datasetId/layers/:dataLayerName/histogram              
 
 # Read mag and attachment data via proxy
 GET           /datasets/:datasetId/proxy/layers/:dataLayerName/mags/:mag/*path                                        @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyMag(datasetId: ObjectId, dataLayerName: String, mag: String, path: String)
+GET           /datasets/:datasetId/proxy/layers/:dataLayerName/mags/info                                              @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyPrecomputedInfo(datasetId: ObjectId, dataLayerName: String)
 GET           /datasets/:datasetId/proxy/layers/:dataLayerName/attachments/:attachmentType/:attachmentName/*path      @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyAttachment(datasetId: ObjectId, dataLayerName: String, attachmentType: String, attachmentName: String, path: String)
 GET           /datasets/:datasetId/proxy/datasource-properties.json                                                   @com.scalableminds.webknossos.datastore.controllers.DataProxyController.proxyDatasource(datasetId: ObjectId)
 


### PR DESCRIPTION
### Summary
 Readers of neuroglancerPrecomputed mags also request the info header at the *parent* path of each mag. We have to serve a valid info header at this path.

### Steps to test:
- Explore remote neuroglancer dataset
- With the libs, open it with `open_remote("<datasetId>", access_mode=wk.RemoteAccessMode.PROXY_PATH)`
- Try reading from a mag
- Should not fail with `Error opening "neuroglancer_precomputed" driver`. Note: my test dataset still failed with unrelated `assert bbox.axes == CXYZ_AXES`.

### Issues:
- fixes #9975

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [x] Needs datastore update after deployment
