### PR TITLE
Move support for non-compact dataset list to legacy API versions only

### DIFF
--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -290,7 +290,7 @@ class DatasetController @Inject() (
       } yield Ok(Json.obj("newDatasetId" -> dataset._id))
     }
 
-  // List all accessible datasets in the compact format (list of json objects, one per dataset)
+  // List all accessible datasets (list of compact json objects, one per dataset)
   def list(
       // Optional filtering: If true, list only active datasets, if false, list only inactive datasets
       isActive: Option[Boolean],

--- a/app/controllers/DatasetController.scala
+++ b/app/controllers/DatasetController.scala
@@ -290,7 +290,7 @@ class DatasetController @Inject() (
       } yield Ok(Json.obj("newDatasetId" -> dataset._id))
     }
 
-  // List all accessible datasets (list of json objects, one per dataset)
+  // List all accessible datasets in the compact format (list of json objects, one per dataset)
   def list(
       // Optional filtering: If true, list only active datasets, if false, list only inactive datasets
       isActive: Option[Boolean],
@@ -309,9 +309,7 @@ class DatasetController @Inject() (
       // Optional filtering: List only datasets with names matching this search query
       searchQuery: Option[String],
       // return only the first n matching datasets.
-      limit: Option[Int],
-      // Change output format to return only a compact list with essential information on the datasets
-      compact: Option[Boolean]
+      limit: Option[Int]
   ): Action[AnyContent] = sil.UserAwareAction.fox { implicit request =>
     for {
       _ <- Fox.successful(())
@@ -320,71 +318,21 @@ class DatasetController @Inject() (
           request.identity.map(_._organization)
         else
           organizationId
-      js <-
-        if (compact.getOrElse(false)) {
-          for {
-            datasetInfos <- datasetDAO.findAllCompactWithSearch(
-              isActive,
-              isUnreported,
-              organizationIdOpt,
-              folderId,
-              uploaderId,
-              searchQuery,
-              request.identity.map(_._id),
-              recursive.getOrElse(false),
-              limitOpt = limit,
-              requestingUserOrga = request.identity.map(_._organization)
-            )
-          } yield Json.toJson(datasetInfos)
-        } else {
-          for {
-            datasets <- datasetDAO.findAllWithSearch(
-              isActive,
-              isUnreported,
-              organizationIdOpt,
-              folderId,
-              uploaderId,
-              searchQuery,
-              recursive.getOrElse(false),
-              limit
-            ) ?~> Msg.Dataset.List.failed
-            js <- listGrouped(datasets, request.identity) ?~> Msg.Dataset.List.groupingFailed
-          } yield Json.toJson(js)
-        }
-      _ = Fox.runOptional(request.identity)(user => userDAO.updateLastActivity(user._id))
-    } yield addRemoteOriginHeaders(Ok(js))
-  }
-
-  private def listGrouped(datasets: List[Dataset], requestingUser: Option[User])(using
-      ctx: DBAccessContext
-  ): Fox[List[JsObject]] =
-    for {
-      requestingUserTeamManagerMemberships <- Fox.runOptional(requestingUser)(user =>
-        userService.teamManagerMembershipsFor(user._id)
+      datasetInfos <- datasetDAO.findAllCompactWithSearch(
+        isActive,
+        isUnreported,
+        organizationIdOpt,
+        folderId,
+        uploaderId,
+        searchQuery,
+        request.identity.map(_._id),
+        recursive.getOrElse(false),
+        limitOpt = limit,
+        requestingUserOrga = request.identity.map(_._organization)
       )
-      groupedByOrga = datasets.groupBy(_._organization).toList
-      js <- Fox.serialCombined(groupedByOrga) { (byOrgaTuple: (String, List[Dataset])) =>
-        for {
-          organization <- organizationDAO.findOne(byOrgaTuple._1)(using GlobalAccessContext) ?~> Msg.Organization
-            .notFound(byOrgaTuple._1)
-          groupedByDataStore = byOrgaTuple._2.groupBy(_._dataStore).toList
-          result <- Fox.serialCombined(groupedByDataStore) { (byDataStoreTuple: (String, List[Dataset])) =>
-            for {
-              dataStore <- dataStoreDAO.findOneByName(byDataStoreTuple._1.trim)(using GlobalAccessContext)
-              resultByDataStore: Seq[JsObject] <- Fox.serialCombined(byDataStoreTuple._2) { d =>
-                datasetService.publicWrites(
-                  d,
-                  requestingUser,
-                  Some(organization),
-                  Some(dataStore),
-                  requestingUserTeamManagerMemberships
-                ) ?~> Msg.Dataset.publicWritesFailed(d._id)
-              }
-            } yield resultByDataStore
-          }
-        } yield result.flatten
-      }
-    } yield js.flatten
+      _ = Fox.runOptional(request.identity)(user => userDAO.updateLastActivity(user._id))
+    } yield addRemoteOriginHeaders(Ok(Json.toJson(datasetInfos)))
+  }
 
   def accessList(datasetId: ObjectId): Action[AnyContent] = sil.SecuredAction.fox { implicit request =>
     for {

--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -2,10 +2,14 @@ package controllers
 
 import com.scalableminds.util.Msg
 import play.silhouette.api.Silhouette
+import play.silhouette.api.actions.UserAwareRequest
+import com.scalableminds.util.accesscontext.{DBAccessContext, GlobalAccessContext}
 import com.scalableminds.util.tools.{Fox, JsonHelper}
 import com.scalableminds.util.tools.Fox.toFox
 import com.scalableminds.webknossos.datastore.helpers.UnsignedLong
-import models.dataset.{DatasetDAO, DatasetService}
+import models.dataset.{DataStoreDAO, Dataset, DatasetDAO, DatasetService}
+import models.organization.OrganizationDAO
+import models.user.{User, UserDAO, UserService}
 
 import javax.inject.Inject
 import play.api.http.HttpEntity
@@ -27,11 +31,43 @@ class LegacyApiController @Inject() (
     datasetController: DatasetController,
     datasetService: DatasetService,
     datasetDAO: DatasetDAO,
+    dataStoreDAO: DataStoreDAO,
+    organizationDAO: OrganizationDAO,
+    userService: UserService,
+    userDAO: UserDAO,
     analyticsService: AnalyticsService,
     sil: Silhouette[WkEnv]
 )(implicit ec: ExecutionContext, bodyParsers: PlayBodyParsers)
     extends Controller
     with MetadataAssertions {
+
+  /* provide v15 */
+
+  def listV15(
+      isActive: Option[Boolean],
+      isUnreported: Option[Boolean],
+      organizationId: Option[String],
+      onlyMyOrganization: Option[Boolean],
+      uploaderId: Option[ObjectId],
+      folderId: Option[ObjectId],
+      includeSubfolders: Option[Boolean],
+      searchQuery: Option[String],
+      limit: Option[Int],
+      compact: Option[Boolean]
+  ): Action[AnyContent] = sil.UserAwareAction.fox { implicit request =>
+    dispatchListByCompact(
+      isActive,
+      isUnreported,
+      organizationId,
+      onlyMyOrganization,
+      uploaderId,
+      folderId,
+      includeSubfolders,
+      searchQuery,
+      limit,
+      compact
+    )
+  }
 
   /* provide v14 */
 
@@ -56,19 +92,17 @@ class LegacyApiController @Inject() (
       compact: Option[Boolean]
   ): Action[AnyContent] = sil.UserAwareAction.fox { implicit request =>
     for {
-      result <- Fox.fromFuture(
-        datasetController.list(
-          isActive,
-          isUnreported,
-          organizationId,
-          onlyMyOrganization,
-          uploaderId,
-          folderId,
-          includeSubfolders,
-          searchQuery,
-          limit,
-          compact
-        )(request)
+      result <- dispatchListByCompact(
+        isActive,
+        isUnreported,
+        organizationId,
+        onlyMyOrganization,
+        uploaderId,
+        folderId,
+        includeSubfolders,
+        searchQuery,
+        limit,
+        compact
       )
       adaptedResult <- replaceInResult(downgradeLargestSegmentIdsIfSafeFox)(result)
     } yield adaptedResult
@@ -146,6 +180,113 @@ class LegacyApiController @Inject() (
     }
 
   /* private helper methods for legacy adaptation */
+
+  // For legacy API versions (v10-v15), replicates the pre-v16 compact-param dispatch that used
+  // to live in DatasetController.list: compact=true uses the (now default) compact format,
+  // anything else uses the old full/grouped format via listFull below.
+  private def dispatchListByCompact(
+      isActive: Option[Boolean],
+      isUnreported: Option[Boolean],
+      organizationId: Option[String],
+      onlyMyOrganization: Option[Boolean],
+      uploaderId: Option[ObjectId],
+      folderId: Option[ObjectId],
+      includeSubfolders: Option[Boolean],
+      searchQuery: Option[String],
+      limit: Option[Int],
+      compact: Option[Boolean]
+  )(implicit request: UserAwareRequest[WkEnv, AnyContent]): Fox[Result] =
+    if (compact.getOrElse(false))
+      Fox.fromFuture(
+        datasetController.list(
+          isActive,
+          isUnreported,
+          organizationId,
+          onlyMyOrganization,
+          uploaderId,
+          folderId,
+          includeSubfolders,
+          searchQuery,
+          limit
+        )(request)
+      )
+    else
+      listFull(
+        isActive,
+        isUnreported,
+        organizationId,
+        onlyMyOrganization,
+        uploaderId,
+        folderId,
+        includeSubfolders,
+        searchQuery,
+        limit
+      )
+
+  // Legacy (pre-v16) full/grouped dataset listing, moved here verbatim from DatasetController.list's
+  // former `else` branch — only reachable via v10-v15 routes now.
+  private def listFull(
+      isActive: Option[Boolean],
+      isUnreported: Option[Boolean],
+      organizationId: Option[String],
+      onlyMyOrganization: Option[Boolean],
+      uploaderId: Option[ObjectId],
+      folderId: Option[ObjectId],
+      recursive: Option[Boolean],
+      searchQuery: Option[String],
+      limit: Option[Int]
+  )(implicit request: UserAwareRequest[WkEnv, AnyContent]): Fox[Result] =
+    for {
+      organizationIdOpt =
+        if (onlyMyOrganization.getOrElse(false))
+          request.identity.map(_._organization)
+        else
+          organizationId
+      datasets <- datasetDAO.findAllWithSearch(
+        isActive,
+        isUnreported,
+        organizationIdOpt,
+        folderId,
+        uploaderId,
+        searchQuery,
+        recursive.getOrElse(false),
+        limit
+      ) ?~> Msg.Dataset.List.failed
+      js <- listGrouped(datasets, request.identity) ?~> Msg.Dataset.List.groupingFailed
+      _ = Fox.runOptional(request.identity)(user => userDAO.updateLastActivity(user._id))
+    } yield addRemoteOriginHeaders(Ok(Json.toJson(js)))
+
+  // Moved verbatim from DatasetController.
+  private def listGrouped(datasets: List[Dataset], requestingUser: Option[User])(using
+      ctx: DBAccessContext
+  ): Fox[List[JsObject]] =
+    for {
+      requestingUserTeamManagerMemberships <- Fox.runOptional(requestingUser)(user =>
+        userService.teamManagerMembershipsFor(user._id)
+      )
+      groupedByOrga = datasets.groupBy(_._organization).toList
+      js <- Fox.serialCombined(groupedByOrga) { (byOrgaTuple: (String, List[Dataset])) =>
+        for {
+          organization <- organizationDAO.findOne(byOrgaTuple._1)(using GlobalAccessContext) ?~> Msg.Organization
+            .notFound(byOrgaTuple._1)
+          groupedByDataStore = byOrgaTuple._2.groupBy(_._dataStore).toList
+          result <- Fox.serialCombined(groupedByDataStore) { (byDataStoreTuple: (String, List[Dataset])) =>
+            for {
+              dataStore <- dataStoreDAO.findOneByName(byDataStoreTuple._1.trim)(using GlobalAccessContext)
+              resultByDataStore: Seq[JsObject] <- Fox.serialCombined(byDataStoreTuple._2) { d =>
+                datasetService.publicWrites(
+                  d,
+                  requestingUser,
+                  Some(organization),
+                  Some(dataStore),
+                  requestingUserTeamManagerMemberships
+                ) ?~> Msg.Dataset.publicWritesFailed(d._id)
+              }
+            } yield resultByDataStore
+          }
+        } yield result.flatten
+      }
+    } yield js.flatten
 
   // For API versions <= 14, largestSegmentId must keep being written as a plain JsNumber
   // whenever that does not lose precision, for backwards compatibility with clients that

--- a/app/controllers/LegacyApiController.scala
+++ b/app/controllers/LegacyApiController.scala
@@ -223,8 +223,6 @@ class LegacyApiController @Inject() (
         limit
       )
 
-  // Legacy (pre-v16) full/grouped dataset listing, moved here verbatim from DatasetController.list's
-  // former `else` branch — only reachable via v10-v15 routes now.
   private def listFull(
       isActive: Option[Boolean],
       isUnreported: Option[Boolean],
@@ -256,7 +254,6 @@ class LegacyApiController @Inject() (
       _ = Fox.runOptional(request.identity)(user => userDAO.updateLastActivity(user._id))
     } yield addRemoteOriginHeaders(Ok(Json.toJson(js)))
 
-  // Moved verbatim from DatasetController.
   private def listGrouped(datasets: List[Dataset], requestingUser: Option[User])(using
       ctx: DBAccessContext
   ): Fox[List[JsObject]] =

--- a/conf/webknossos.latest.routes
+++ b/conf/webknossos.latest.routes
@@ -88,7 +88,7 @@ GET           /teams/:id/projectProgressReport                                  
 # Datasets
 POST          /datasets/:datasetId/createExplorational                                          controllers.AnnotationController.createExplorational(datasetId: ObjectId)
 GET           /datasets/:datasetId/sandbox/:typ                                                 controllers.AnnotationController.getSandbox(datasetId: ObjectId, typ: String, sharingToken: Option[String])
-GET           /datasets                                                                         controllers.DatasetController.list(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
+GET           /datasets                                                                         controllers.DatasetController.list(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int])
 POST          /datasets/exploreRemote                                                           controllers.DatasetController.exploreRemoteDataset()
 POST          /datasets/exploreAndAddRemote                                                     controllers.DatasetController.exploreAndAddRemoteDataset()
 POST          /datasets/addVirtualDataset/:name                                                 controllers.DatasetController.addVirtualDataset(name: String)

--- a/conf/webknossos.versioned.routes
+++ b/conf/webknossos.versioned.routes
@@ -4,6 +4,7 @@
 # Note: keep this in sync with the reported version numbers in the com.scalableminds.util.mvc.ApiVersioning trait
 
 # version log
+ # changed in v16: GET /datasets no longer accepts the compact param; the response is now always in the compact format. Older API versions (v10-v15) keep the old dual-mode behavior.
  # changed in v15: largestSegmentId is now written using a bigint envelope (to support the full uint64 range) for routes that return datasources. Older API versions keep receiving it as a plain number whenever that does not lose precision.
  # changed in v14: Dataset upload routes and parameters have been refactored, introduced upload domain
  # changed in v13: Attachments not mentioned in the dataSource passed to updatePartial will now be deleted.
@@ -19,9 +20,11 @@
  # new in v3: annotation info and finish request now take timestamp
  # new in v2: annotation json contains visibility enum instead of booleans
 
+->       /v16/                                                                webknossos.latest.Routes
+
+GET      /v15/datasets                                                        controllers.LegacyApiController.listV15(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 ->       /v15/                                                                webknossos.latest.Routes
 
-# v14: support changes to v15
 GET      /v14/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v14/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v14/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)
@@ -29,7 +32,6 @@ POST     /v14/datasets/reserveUploadToPaths                                   co
 POST     /v14/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v14/                                                                webknossos.latest.Routes
 
-# v13: support changes to v15
 GET      /v13/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v13/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v13/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV14(datasetId: ObjectId)
@@ -37,7 +39,6 @@ POST     /v13/datasets/reserveUploadToPaths                                   co
 POST     /v13/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v13/                                                                webknossos.latest.Routes
 
-# v12: support changes to v15
 GET      /v12/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v12/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v12/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
@@ -45,7 +46,6 @@ POST     /v12/datasets/reserveUploadToPaths                                   co
 POST     /v12/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v12/                                                                webknossos.latest.Routes
 
-# v11: support changes to v15
 GET      /v11/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v11/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v11/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)
@@ -53,7 +53,6 @@ POST     /v11/datasets/reserveUploadToPaths                                   co
 POST     /v11/datasets/:datasetId/reserveUploadToPathsForPreliminary          controllers.LegacyApiController.reserveUploadToPathsForPreliminaryV14(datasetId: ObjectId)
 ->       /v11/                                                                webknossos.latest.Routes
 
-# v10: support changes to v15
 GET      /v10/datasets/:datasetId                                             controllers.LegacyApiController.readV14(datasetId: ObjectId, sharingToken: Option[String])
 GET      /v10/datasets                                                        controllers.LegacyApiController.listV14(isActive: Option[Boolean], isUnreported: Option[Boolean], organizationId: Option[String], onlyMyOrganization: Option[Boolean], uploaderId: Option[ObjectId], folderId: Option[ObjectId], includeSubfolders: Option[Boolean], searchQuery: Option[String], limit: Option[Int], compact: Option[Boolean])
 PATCH    /v10/datasets/:datasetId/updatePartial                               controllers.LegacyApiController.updatePartialV12(datasetId: ObjectId)

--- a/conf/webknossos.versioned.routes
+++ b/conf/webknossos.versioned.routes
@@ -4,7 +4,7 @@
 # Note: keep this in sync with the reported version numbers in the com.scalableminds.util.mvc.ApiVersioning trait
 
 # version log
- # changed in v16: GET /datasets no longer accepts the compact param; the response is now always in the compact format. Older API versions (v10-v15) keep the old dual-mode behavior.
+ # changed in v16: GET /datasets no longer accepts the compact param; the response is now always in the compact format.
  # changed in v15: largestSegmentId is now written using a bigint envelope (to support the full uint64 range) for routes that return datasources. Older API versions keep receiving it as a plain number whenever that does not lose precision.
  # changed in v14: Dataset upload routes and parameters have been refactored, introduced upload domain
  # changed in v13: Attachments not mentioned in the dataSource passed to updatePartial will now be deleted.

--- a/frontend/javascripts/admin/rest_api.ts
+++ b/frontend/javascripts/admin/rest_api.ts
@@ -1343,8 +1343,6 @@ export async function getDatasets(
     params.set("includeSubfolders", includeSubfolders ? "true" : "false");
   }
 
-  params.set("compact", "true");
-
   const datasets = await Request.receiveJSON(`/api/datasets?${params}`);
   assertResponseLimit(datasets);
   return datasets;

--- a/frontend/javascripts/admin/rest_api.ts
+++ b/frontend/javascripts/admin/rest_api.ts
@@ -1348,8 +1348,8 @@ export async function getDatasets(
   return datasets;
 }
 
-export async function getActiveDatasetsOfMyOrganization(): Promise<Array<APIDataset>> {
-  const datasets: Array<APIDataset> = await Request.receiveJSON(
+export async function getActiveDatasetsOfMyOrganization(): Promise<Array<APIDatasetCompact>> {
+  const datasets: Array<APIDatasetCompact> = await Request.receiveJSON(
     "/api/datasets?isActive=true&onlyMyOrganization=true",
   );
   assertResponseLimit(datasets);

--- a/frontend/javascripts/admin/task/task_create_form_view.tsx
+++ b/frontend/javascripts/admin/task/task_create_form_view.tsx
@@ -44,7 +44,13 @@ import uniq from "lodash-es/uniq";
 import messages from "messages";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import type { APIDataset, APIProject, APIScript, APITask, APITaskType } from "types/api_types";
+import type {
+  APIDatasetCompact,
+  APIProject,
+  APIScript,
+  APITask,
+  APITaskType,
+} from "types/api_types";
 import type { BoundingBoxObject } from "types/bounding_box";
 import type { Vector3, Vector6 } from "viewer/constants";
 import type {
@@ -297,7 +303,7 @@ function TaskCreateFormView({ embedded = false }: { embedded?: boolean }) {
   const { token } = theme.useToken();
   const [form] = Form.useForm<FormValues>();
 
-  const [datasets, setDatasets] = useState<APIDataset[]>([]);
+  const [datasets, setDatasets] = useState<APIDatasetCompact[]>([]);
   const [taskTypes, setTaskTypes] = useState<APITaskType[]>([]);
   const [projects, setProjects] = useState<APIProject[]>([]);
   const [scripts, setScripts] = useState<APIScript[]>([]);
@@ -537,7 +543,7 @@ function TaskCreateFormView({ embedded = false }: { embedded?: boolean }) {
                 style={fullWidth}
                 disabled={isEditingMode || specificationType === SpecificationEnum.BaseAnnotation}
                 loading={isFetchingData}
-                options={datasets.map((dataset: APIDataset) => ({
+                options={datasets.map((dataset: APIDatasetCompact) => ({
                   label: dataset.name,
                   value: dataset.id,
                 }))}

--- a/frontend/javascripts/test/backend_snapshot_tests/__snapshots__/datasets.e2e.ts.snap
+++ b/frontend/javascripts/test/backend_snapshot_tests/__snapshots__/datasets.e2e.ts.snap
@@ -11,85 +11,22 @@ exports[`Dataset API (E2E) > Zarr streaming 2`] = `"AAAAAAAAAAAAAAAAAAAAAAAAAAAA
 exports[`Dataset API (E2E) > getActiveDatasets 1`] = `
 [
   {
-    "allowedTeams": [],
-    "allowedTeamsCumulative": [],
+    "colorLayerNames": [],
     "created": "created",
-    "creationType": "DiskScan",
-    "dataSource": {
-      "dataLayers": [
-        {
-          "boundingBox": {
-            "depth": 100,
-            "height": 100,
-            "topLeft": [
-              50,
-              50,
-              25,
-            ],
-            "width": 100,
-          },
-          "category": "segmentation",
-          "dataFormat": "wkw",
-          "elementClass": "uint32",
-          "largestSegmentId": 176n,
-          "mags": [
-            {
-              "mag": [
-                1,
-                1,
-                1,
-              ],
-              "path": "path",
-            },
-          ],
-          "name": "segmentation",
-          "numChannels": 1,
-          "resolutions": [
-            [
-              1,
-              1,
-              1,
-            ],
-          ],
-        },
-      ],
-      "id": "id",
-      "scale": {
-        "factor": [
-          11.24,
-          11.24,
-          28,
-        ],
-        "unit": "nanometer",
-      },
-    },
-    "dataStore": {
-      "allowsUpload": true,
-      "jobsEnabled": false,
-      "jobsSupportedByAvailableWorkers": [],
-      "name": "localhost",
-      "url": "http://localhost:9000",
-    },
-    "description": null,
     "directoryName": "test-dataset",
     "folderId": "570b9f4e4bb848d0885ea917",
     "id": "id",
     "isActive": true,
     "isEditable": true,
-    "isPublic": false,
     "isUnreported": false,
-    "isVirtual": false,
     "lastUsedByUser": 0,
-    "logoUrl": "/images/mpi-logos.svg",
-    "metadata": [],
-    "mirrorPath": null,
     "name": "test-dataset",
     "owningOrganization": "Organization_X",
-    "rootPath": "rootPath",
-    "rootRealPath": "rootRealPath",
-    "sortingKey": "sortingKey",
+    "segmentationLayerNames": [
+      "segmentation",
+    ],
+    "status": "",
     "tags": [],
-    "uploaderFullName": null,
     "usedStorageBytes": 0,
   },
 ]

--- a/frontend/javascripts/test/backend_snapshot_tests/datasets.e2e.ts
+++ b/frontend/javascripts/test/backend_snapshot_tests/datasets.e2e.ts
@@ -26,9 +26,9 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 async function getFirstDataset(): Promise<APIDataset> {
   const datasets = await getActiveDatasetsOfMyOrganization();
-  const dataset = sortBy(datasets, (d) => d.name)[0];
+  const compactDataset = sortBy(datasets, (d) => d.name)[0];
 
-  return dataset;
+  return getDataset(compactDataset.id);
 }
 
 describe("Dataset API (E2E)", () => {

--- a/unreleased_changes/9980.md
+++ b/unreleased_changes/9980.md
@@ -1,0 +1,2 @@
+### Changed
+- New HTTP API version 16: GET /datasets no longer accepts the compact param; the response is now always in the compact format.

--- a/util/src/main/scala/com/scalableminds/util/mvc/ApiVersioning.scala
+++ b/util/src/main/scala/com/scalableminds/util/mvc/ApiVersioning.scala
@@ -5,7 +5,7 @@ import play.api.mvc.RequestHeader
 
 trait ApiVersioning {
 
-  protected val CURRENT_API_VERSION: Int = 15
+  protected val CURRENT_API_VERSION: Int = 16
   protected val OLDEST_SUPPORTED_API_VERSION: Int = 10
 
   protected lazy val apiVersioningInfo: JsObject =

--- a/webknossos-datastore/conf/datastore.versioned.routes
+++ b/webknossos-datastore/conf/datastore.versioned.routes
@@ -1,6 +1,7 @@
 # Note: keep this in sync with the reported version numbers in the com.scalableminds.util.mvc.ApiVersioning trait
 # Version log in webknossos.versioned.routes
 
+->  /v16/ datastore.latest.Routes
 ->  /v15/ datastore.latest.Routes
 
 GET           /v14/datasets/:datasetId/proxy/datasource-properties.json                                                                                  @com.scalableminds.webknossos.datastore.controllers.DSLegacyApiController.proxyDatasourceV14(datasetId: ObjectId)

--- a/webknossos-tracingstore/conf/tracingstore.versioned.routes
+++ b/webknossos-tracingstore/conf/tracingstore.versioned.routes
@@ -1,6 +1,7 @@
 # Note: keep this in sync with the reported version numbers in the com.scalableminds.util.mvc.ApiVersioning trait
 # Version log in webknossos.versioned.routes
 
+->  /v16/ tracingstore.latest.Routes
 ->  /v15/ tracingstore.latest.Routes
 ->  /v14/ tracingstore.latest.Routes
 ->  /v13/ tracingstore.latest.Routes


### PR DESCRIPTION
### Summary
- New HTTP API version 16: GET /datasets no longer accepts the compact param; the response is now always in the compact format.
- Corresponding libs PR: https://github.com/scalableminds/webknossos-libs/pull/1535

### Steps to test:
- Dashboard should still list datasets correctly
- libs `RemoteDataset.list` should still work


### Issues:
- fixes #6862

------
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [x] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change - Corresponding libs PR: https://github.com/scalableminds/webknossos-libs/pull/1535
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
