### PR TITLE
Fix spacing between dashboard header buttons

### DIFF
--- a/frontend/javascripts/dashboard/dataset_folder_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_folder_view.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Col, Flex, Row } from "antd";
+import { Button, Card, Col, Flex, Row, Space } from "antd";
 import features, { getDemoDatasetUrl } from "features";
 import { filterNullValues, isUserAdminOrDatasetManager, isUserTeamManager } from "libs/utils";
 import React, { useEffect, useRef } from "react";
@@ -159,10 +159,10 @@ function DatasetFolderViewInner(props: Props) {
 
     const adminHeader =
       isUserAdminOrDatasetManager(props.user) || isUserTeamManager(props.user) ? (
-        <>
+        <Space>
           <DatasetRefreshButton context={context} />
           <DatasetAddButton context={context} />
-        </>
+        </Space>
       ) : null;
 
     return (

--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -254,9 +254,8 @@ function DatasetView({
   );
 
   const adminHeader = (
-    <Space>
-      {isUserAdminOrDatasetManagerOrTeamManager ? (
-        <Fragment>
+      isUserAdminOrDatasetManagerOrTeamManager ? (
+        <Space>
           <DatasetRefreshButton context={context} />
           <DatasetAddButton context={context} />
           {context.activeFolderId != null && (
@@ -276,11 +275,10 @@ function DatasetView({
             </PricingEnforcedButton>
           )}
           {search}
-        </Fragment>
+        </Space>
       ) : (
         search
-      )}
-    </Space>
+      )
   );
 
   const datasets = context.datasets;

--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -253,32 +253,30 @@ function DatasetView({
     searchBox
   );
 
-  const adminHeader = (
-      isUserAdminOrDatasetManagerOrTeamManager ? (
-        <Space>
-          <DatasetRefreshButton context={context} />
-          <DatasetAddButton context={context} />
-          {context.activeFolderId != null && (
-            <PricingEnforcedButton
-              disabled={folder != null && !folder.isEditable}
-              icon={<PlusOutlined />}
-              onClick={() =>
-                context.activeFolderId != null &&
-                context.setFolderModalState({
-                  mode: "create",
-                  parentFolderId: context.activeFolderId,
-                })
-              }
-              requiredPricingPlan={PricingPlanEnum.Team}
-            >
-              Add Folder
-            </PricingEnforcedButton>
-          )}
-          {search}
-        </Space>
-      ) : (
-        search
-      )
+  const adminHeader = isUserAdminOrDatasetManagerOrTeamManager ? (
+    <Space>
+      <DatasetRefreshButton context={context} />
+      <DatasetAddButton context={context} />
+      {context.activeFolderId != null && (
+        <PricingEnforcedButton
+          disabled={folder != null && !folder.isEditable}
+          icon={<PlusOutlined />}
+          onClick={() =>
+            context.activeFolderId != null &&
+            context.setFolderModalState({
+              mode: "create",
+              parentFolderId: context.activeFolderId,
+            })
+          }
+          requiredPricingPlan={PricingPlanEnum.Team}
+        >
+          Add Folder
+        </PricingEnforcedButton>
+      )}
+      {search}
+    </Space>
+  ) : (
+    search
   );
 
   const datasets = context.datasets;


### PR DESCRIPTION
### Summary
Wraps the refresh/add-dataset buttons (and folder header buttons) in an antd `Space` so they have consistent spacing.

### Steps to test:
- Open the dashboard as an admin/dataset manager and check spacing of the header buttons in both the dataset view and folder view.

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment