### PR TITLE
Upgrade react-router from v6 to v7

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -68,6 +68,10 @@
               {
                 "group": ["antd/lib", "antd/lib/**"],
                 "message": "Import from 'antd' or 'antd/es/...'; 'antd/lib' is the CJS build and can duplicate antd modules in the bundle."
+              },
+              {
+                "group": ["react-router-dom", "react-router-dom/**"],
+                "message": "Import from 'react-router' (or 'react-router/dom' for RouterProvider); 'react-router-dom' is a deprecated re-export shim that is removed in react-router v8."
               }
             ]
           }

--- a/frontend/javascripts/admin/account/account_security_view.tsx
+++ b/frontend/javascripts/admin/account/account_security_view.tsx
@@ -6,7 +6,7 @@ import features from "features";
 import Toast from "libs/toast";
 import messages from "messages";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { logoutUserAction } from "viewer/model/actions/user_actions";
 import { SettingsTitle } from "./helpers/settings_title";
 

--- a/frontend/javascripts/admin/account/account_settings_view.tsx
+++ b/frontend/javascripts/admin/account/account_settings_view.tsx
@@ -1,7 +1,7 @@
 import { SafetyOutlined, SettingOutlined, UserOutlined } from "@ant-design/icons";
 import { Breadcrumb, Layout, Menu } from "antd";
 import type { MenuItemGroupType } from "antd/es/menu/interface";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router";
 
 const { Sider, Content } = Layout;
 

--- a/frontend/javascripts/admin/auth/accept_invite_view.tsx
+++ b/frontend/javascripts/admin/auth/accept_invite_view.tsx
@@ -12,7 +12,7 @@ import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
 import { location } from "libs/window";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 const { Content } = Layout;
 

--- a/frontend/javascripts/admin/auth/change_email_view.tsx
+++ b/frontend/javascripts/admin/auth/change_email_view.tsx
@@ -5,7 +5,7 @@ import { Alert, Button, Form, Input, Space } from "antd";
 import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
 import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { logoutUserAction } from "viewer/model/actions/user_actions";
 import { handleResendVerificationEmail } from "./verify_email_view";
 

--- a/frontend/javascripts/admin/auth/finish_reset_password_view.tsx
+++ b/frontend/javascripts/admin/auth/finish_reset_password_view.tsx
@@ -4,7 +4,7 @@ import Request from "libs/request";
 import Toast from "libs/toast";
 import { getUrlParamsObjectFromString } from "libs/utils";
 import messages from "messages";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 const FormItem = Form.Item;
 const { Password } = Input;

--- a/frontend/javascripts/admin/auth/login_form.tsx
+++ b/frontend/javascripts/admin/auth/login_form.tsx
@@ -8,7 +8,7 @@ import features from "features";
 import { getIsInIframe } from "libs/utils";
 import messages from "messages";
 import { useDispatch } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { setActiveOrganizationAction } from "viewer/model/actions/organization_actions";
 import { setActiveUserAction } from "viewer/model/actions/user_actions";
 

--- a/frontend/javascripts/admin/auth/login_view.tsx
+++ b/frontend/javascripts/admin/auth/login_view.tsx
@@ -2,7 +2,7 @@ import { Card, Col, Row, Typography } from "antd";
 import { useWkSelector } from "libs/react_hooks";
 import { getUrlParamValue, hasUrlParam } from "libs/utils";
 import window from "libs/window";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import LoginForm from "./login_form";
 
 type Props = {

--- a/frontend/javascripts/admin/auth/registration_view.tsx
+++ b/frontend/javascripts/admin/auth/registration_view.tsx
@@ -7,7 +7,7 @@ import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
 import messages from "messages";
 import { useEffect, useState } from "react";
-import { Link, Navigate, useNavigate } from "react-router-dom";
+import { Link, Navigate, useNavigate } from "react-router";
 import type { APIOrganization } from "types/api_types";
 
 function RegistrationViewGeneric() {

--- a/frontend/javascripts/admin/auth/start_reset_password_view.tsx
+++ b/frontend/javascripts/admin/auth/start_reset_password_view.tsx
@@ -3,7 +3,7 @@ import { Button, Card, Col, Form, Input, Row, Typography } from "antd";
 import Request from "libs/request";
 import Toast from "libs/toast";
 import messages from "messages";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 
 const FormItem = Form.Item;
 

--- a/frontend/javascripts/admin/auth/verify_email_view.tsx
+++ b/frontend/javascripts/admin/auth/verify_email_view.tsx
@@ -4,7 +4,7 @@ import { extractServerErrorMessage } from "libs/error_handling";
 import { useFetch } from "libs/react_helpers";
 import Toast from "libs/toast";
 import { useEffect } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { Store } from "viewer/singletons";
 
 const VERIFICATION_ERROR_TOAST_KEY = "verificationError";

--- a/frontend/javascripts/admin/dataset/components/post_upload_modal.tsx
+++ b/frontend/javascripts/admin/dataset/components/post_upload_modal.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal, Space, Typography } from "antd";
-import type { useNavigate } from "react-router-dom";
+import type { useNavigate } from "react-router";
 import { ModalWidth } from "theme";
 import { getReadableURLPart, getViewDatasetURL } from "viewer/model/accessors/dataset_accessor";
 import type { DatasetAddType } from "../dataset_add_view";

--- a/frontend/javascripts/admin/dataset/dataset_add_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_view.tsx
@@ -7,7 +7,7 @@ import { Layout, Tabs, type TabsProps } from "antd";
 import { useFetch } from "libs/react_helpers";
 
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import type { APIDataStore } from "types/api_types";
 import PostUploadModal from "./components/post_upload_modal";
 import VoxelyticsBanner from "./components/voxelytics_banner";

--- a/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_upload_view.tsx
@@ -67,7 +67,7 @@ import messages from "messages";
 import React from "react";
 import { type FileWithPath, useDropzone } from "react-dropzone";
 import { connect } from "react-redux";
-import { type BlockerFunction, Link } from "react-router-dom";
+import { type BlockerFunction, Link } from "react-router";
 import {
   type APIDataStore,
   APIJobCommand,

--- a/frontend/javascripts/admin/dataset/dataset_url_import.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_url_import.tsx
@@ -1,7 +1,7 @@
 import DatasetAddRemoteView from "admin/dataset/dataset_add_remote_view";
 import { findDatasetByImportUrl, getDatastores } from "admin/rest_api";
-import type { LoaderFunctionArgs } from "react-router-dom";
-import { redirect, useLoaderData, useNavigate } from "react-router-dom";
+import type { LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, useNavigate } from "react-router";
 import type { APIDataStore } from "types/api_types";
 import { getViewDatasetURL } from "viewer/model/accessors/dataset_accessor";
 

--- a/frontend/javascripts/admin/job/job_list_view.tsx
+++ b/frontend/javascripts/admin/job/job_list_view.tsx
@@ -34,7 +34,7 @@ import {
 import capitalize from "lodash-es/capitalize";
 import type * as React from "react";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { type APIJob, APIJobCommand } from "types/api_types";
 import { getViewDatasetURL } from "viewer/model/accessors/dataset_accessor";
 

--- a/frontend/javascripts/admin/onboarding.tsx
+++ b/frontend/javascripts/admin/onboarding.tsx
@@ -42,7 +42,7 @@ import { useWkSelector } from "libs/react_hooks";
 import Toast from "libs/toast";
 import type React from "react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 import { ModalWidth } from "theme";
 import type { APITeamMembership } from "types/api_types";
 import Store from "viewer/store";

--- a/frontend/javascripts/admin/organization/organization_view.tsx
+++ b/frontend/javascripts/admin/organization/organization_view.tsx
@@ -7,7 +7,7 @@ import {
 } from "@ant-design/icons";
 import { Breadcrumb, Layout, Menu } from "antd";
 import type { MenuItemGroupType } from "antd/es/menu/interface";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router";
 import constants from "viewer/constants";
 
 const { Sider, Content } = Layout;

--- a/frontend/javascripts/admin/project/project_create_view.tsx
+++ b/frontend/javascripts/admin/project/project_create_view.tsx
@@ -10,7 +10,7 @@ import {
 import { Button, Checkbox, Col, Form, Input, InputNumber, Row, Select, theme } from "antd";
 import { useWkSelector } from "libs/react_hooks";
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import type { APITeam, APIUser } from "types/api_types";
 import { enforceActiveUser } from "viewer/model/accessors/user_accessor";
 import { FormItemWithInfo } from "../../dashboard/dataset/helper_components";

--- a/frontend/javascripts/admin/project/project_list_view.tsx
+++ b/frontend/javascripts/admin/project/project_list_view.tsx
@@ -43,7 +43,7 @@ import partial from "lodash-es/partial";
 import uniqBy from "lodash-es/uniqBy";
 import messages from "messages";
 import React, { useState } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router";
 import {
   type APIProject,
   type APIProjectWithStatus,

--- a/frontend/javascripts/admin/scripts/script_create_view.tsx
+++ b/frontend/javascripts/admin/scripts/script_create_view.tsx
@@ -4,7 +4,7 @@ import { createScript, getScript, getTeamManagerOrAdminUsers, updateScript } fro
 import { Button, Col, Form, Input, Row, Select, theme } from "antd";
 import { useWkSelector } from "libs/react_hooks";
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import type { APIUser } from "types/api_types";
 import { enforceActiveUser } from "viewer/model/accessors/user_accessor";
 

--- a/frontend/javascripts/admin/scripts/script_list_view.tsx
+++ b/frontend/javascripts/admin/scripts/script_list_view.tsx
@@ -12,7 +12,7 @@ import partial from "lodash-es/partial";
 import messages from "messages";
 import type React from "react";
 import { Fragment, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIScript, APIUser } from "types/api_types";
 
 const { Column } = Table;

--- a/frontend/javascripts/admin/task/task_create_form_view.tsx
+++ b/frontend/javascripts/admin/task/task_create_form_view.tsx
@@ -43,7 +43,7 @@ import omitBy from "lodash-es/omitBy";
 import uniq from "lodash-es/uniq";
 import messages from "messages";
 import React, { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { ModalWidth } from "theme";
 import type {
   APIDatasetCompact,

--- a/frontend/javascripts/admin/task/task_list_view.tsx
+++ b/frontend/javascripts/admin/task/task_list_view.tsx
@@ -50,7 +50,7 @@ import partial from "lodash-es/partial";
 import messages from "messages";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import type { APITask, APITaskType, TaskStatus } from "types/api_types";
 
 const { Search, TextArea } = Input;

--- a/frontend/javascripts/admin/tasktype/task_type_create_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_create_view.tsx
@@ -23,7 +23,7 @@ import { useFetch } from "libs/react_helpers";
 import { jsonStringify } from "libs/utils";
 import merge from "lodash-es/merge";
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import {
   type APIAllowedMode,
   type APIMagRestrictions,

--- a/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
+++ b/frontend/javascripts/admin/tasktype/task_type_list_view.tsx
@@ -28,7 +28,7 @@ import partial from "lodash-es/partial";
 import messages from "messages";
 import type React from "react";
 import { Fragment, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import type { APITaskType } from "types/api_types";
 
 const { Column } = Table;

--- a/frontend/javascripts/admin/user/user_list_view.tsx
+++ b/frontend/javascripts/admin/user/user_list_view.tsx
@@ -49,7 +49,7 @@ import { location } from "libs/window";
 import keyBy from "lodash-es/keyBy";
 import React, { type Key, useState } from "react";
 import { useDispatch } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APITeamMembership, APIUser, ExperienceMap } from "types/api_types";
 import { enforceActiveOrganization } from "viewer/model/accessors/organization_accessors";
 import { enforceActiveUser } from "viewer/model/accessors/user_accessor";

--- a/frontend/javascripts/admin/voxelytics/ai_model_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/ai_model_list_view.tsx
@@ -30,7 +30,7 @@ import { filterWithSearchQueryAND, scrollToTop } from "libs/utils";
 import uniq from "lodash-es/uniq";
 import type { Key } from "react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { ModalWidth } from "theme";
 import type { AiModel } from "types/api_types";
 import { enforceActiveUser, formatUserName } from "viewer/model/accessors/user_accessor";

--- a/frontend/javascripts/admin/voxelytics/artifacts_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/artifacts_view.tsx
@@ -4,7 +4,7 @@ import { Button, Card, message } from "antd";
 import { copyToClipboard } from "libs/clipboard";
 import { formatCountToDataAmountUnit } from "libs/format_utils";
 import { JSONTree } from "react-json-tree";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { VoxelyticsArtifactConfig } from "types/api_types";
 import { isObjectEmpty, useTheme } from "./utils";
 

--- a/frontend/javascripts/admin/voxelytics/task_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/task_list_view.tsx
@@ -41,7 +41,7 @@ import { useUpdateEvery, useWkSelector } from "libs/react_hooks";
 import { notEmpty } from "libs/utils";
 import MiniSearch from "minisearch";
 import React, { useEffect, useMemo, useState } from "react";
-import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import { Link, useLocation, useNavigate, useParams } from "react-router";
 import { ModalWidth } from "theme";
 import {
   VoxelyticsRunState,

--- a/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_list_view.tsx
@@ -10,7 +10,7 @@ import Toast from "libs/toast";
 import { filterWithSearchQueryAND, scrollToTop } from "libs/utils";
 import type React from "react";
 import { type Key, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   VoxelyticsRunState,
   type VoxelyticsWorkflowListing,

--- a/frontend/javascripts/admin/voxelytics/workflow_view.tsx
+++ b/frontend/javascripts/admin/voxelytics/workflow_view.tsx
@@ -5,7 +5,7 @@ import BrainSpinner, { BrainSpinnerWithError } from "components/brain_spinner";
 import { useSearchParams, useWkSelector } from "libs/react_hooks";
 import sortBy from "lodash-es/sortBy";
 import { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import {
   VoxelyticsRunState,
   type VoxelyticsTaskConfig,

--- a/frontend/javascripts/admin/welcome_ui.tsx
+++ b/frontend/javascripts/admin/welcome_ui.tsx
@@ -10,7 +10,7 @@ import renderIndependently from "libs/render_independently";
 import { isUserAdminOrDatasetManager, isUserAdminOrTeamManager } from "libs/utils";
 import type React from "react";
 import { Fragment } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIUser } from "types/api_types";
 
 type WhatsNextActionProps = {

--- a/frontend/javascripts/components/brain_spinner.tsx
+++ b/frontend/javascripts/components/brain_spinner.tsx
@@ -5,7 +5,7 @@ import { Button, Card, Col, Row, Typography } from "antd";
 import { AsyncButton } from "components/async_clickables";
 import messages from "messages";
 import type * as React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIOrganization } from "types/api_types";
 
 type Props = {

--- a/frontend/javascripts/components/credits_footer.tsx
+++ b/frontend/javascripts/components/credits_footer.tsx
@@ -2,7 +2,7 @@ import maxPlanckGesellschaftLogo from "@images/max-planck-gesellschaft.svg";
 import mpiBrainResearchLogo from "@images/mpi-brain-research.svg";
 import scalablemindsLogo from "@images/scalableminds-logo.svg";
 import { ConfigProvider, Layout, Typography } from "antd";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { getAntdTheme } from "theme";
 
 const { Footer } = Layout;

--- a/frontend/javascripts/components/permission_enforcer.tsx
+++ b/frontend/javascripts/components/permission_enforcer.tsx
@@ -1,5 +1,5 @@
 import { Button, Col, Result, Row } from "antd";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function PageNotAvailableToNormalUser() {
   return (

--- a/frontend/javascripts/components/pricing_enforcers.tsx
+++ b/frontend/javascripts/components/pricing_enforcers.tsx
@@ -21,7 +21,7 @@ import { rgbToHex } from "libs/colors";
 import { useWkSelector } from "libs/react_hooks";
 import noop from "lodash-es/noop";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIOrganization, APIUser } from "types/api_types";
 import { PRIMARY_COLOR } from "viewer/constants";
 import SwitchSetting from "viewer/view/left_border_tabs/components/switch_setting";

--- a/frontend/javascripts/components/redirect.tsx
+++ b/frontend/javascripts/components/redirect.tsx
@@ -1,6 +1,6 @@
 import { useEffectOnlyOnce } from "libs/react_hooks";
 import type React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 type Props = {
   redirectTo: () => Promise<string>;

--- a/frontend/javascripts/components/secured_route.tsx
+++ b/frontend/javascripts/components/secured_route.tsx
@@ -10,7 +10,7 @@ import { useWkSelector } from "libs/react_hooks";
 import { isUserAdminOrManager } from "libs/utils";
 import type React from "react";
 import { memo, useCallback, useEffect, useState } from "react";
-import { useLocation, useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router";
 import { PageNotAvailableToNormalUser } from "./permission_enforcer";
 
 type SecuredRouteProps = {

--- a/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/create_explorative_modal.tsx
@@ -4,7 +4,7 @@ import { Button, Modal, Radio, Spin, Tooltip, Typography } from "antd";
 import { Slider } from "components/slider";
 import { useFetch } from "libs/react_helpers";
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIDataset, APISegmentationLayer } from "types/api_types";
 import {
   doesSupportVolumeWithFallback,

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_action_view.tsx
@@ -20,7 +20,7 @@ import window from "libs/window";
 import messages from "messages";
 import type * as React from "react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIDataset, APIDatasetCompact } from "types/api_types";
 import { getReadableURLPart, getViewDatasetURL } from "viewer/model/accessors/dataset_accessor";
 import { getNoActionsAvailableMenu } from "viewer/view/context_menu/helpers";

--- a/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
+++ b/frontend/javascripts/dashboard/advanced_dataset/dataset_table.tsx
@@ -50,7 +50,7 @@ import type React from "react";
 import { Fragment, PureComponent, useCallback, useContext } from "react";
 import { DndProvider, DragPreviewImage, useDrag } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIDatasetCompact, APIMaybeUnimportedDataset, FolderItem } from "types/api_types";
 import type { EmptyObject } from "types/type_utils";
 import { Unicode } from "viewer/constants";

--- a/frontend/javascripts/dashboard/dashboard_empty_annotations_placeholder.tsx
+++ b/frontend/javascripts/dashboard/dashboard_empty_annotations_placeholder.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, Col, Flex, Row } from "antd";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function DashboardEmptyAnnotationsPlaceholder() {
   return (

--- a/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_task_list_view.tsx
@@ -28,7 +28,7 @@ import { type WithModalProps, withModal } from "libs/with_modal_hoc";
 import messages from "messages";
 import { PureComponent, useContext } from "react";
 import { connect } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIAnnotation, APITaskWithAnnotation, APIUser } from "types/api_types";
 import { getSkeletonDescriptor } from "viewer/model/accessors/skeletontracing_accessor";
 import { enforceActiveUser } from "viewer/model/accessors/user_accessor";

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_delete_tab.tsx
@@ -6,7 +6,7 @@ import { App, Button, Col, Row } from "antd";
 import Toast from "libs/toast";
 import messages from "messages";
 import { useCallback, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useDatasetSettingsContext } from "./dataset_settings_context";
 
 const DatasetSettingsDeleteTab = () => {

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_provider.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_provider.tsx
@@ -17,7 +17,7 @@ import isEqual from "lodash-es/isEqual";
 import size from "lodash-es/size";
 import messages from "messages";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import type { APIDataLayer, APIDataSource, APIDataset, MutableAPIDataset } from "types/api_types";
 import { enforceValidatedDatasetViewConfiguration } from "types/schemas/dataset_view_configuration_defaults";
 import type { DataLayerWithTransformations } from "types/schemas/datasource.types";

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_view.tsx
@@ -15,7 +15,7 @@ import features from "features";
 import messages from "messages";
 import type React from "react";
 import { useCallback } from "react";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router";
 import { getReadableURLPart } from "viewer/model/accessors/dataset_accessor";
 
 const { Sider, Content } = Layout;

--- a/frontend/javascripts/dashboard/dataset/useBeforeUnload_hook.ts
+++ b/frontend/javascripts/dashboard/dataset/useBeforeUnload_hook.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { type BlockerFunction, useBlocker } from "react-router-dom";
+import { type BlockerFunction, useBlocker } from "react-router";
 
 const useBeforeUnload = (hasUnsavedChanges: boolean, message: string) => {
   const beforeUnload = useCallback(

--- a/frontend/javascripts/dashboard/dataset_folder_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_folder_view.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Col, Flex, Row, Space } from "antd";
 import features, { getDemoDatasetUrl } from "features";
 import { filterNullValues, isUserAdminOrDatasetManager, isUserTeamManager } from "libs/utils";
 import React, { useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIDatasetCompact, APIUser, FolderItem } from "types/api_types";
 import { RenderToPortal } from "viewer/view/layouting/portal_utils";
 import DatasetCollectionContextProvider, {

--- a/frontend/javascripts/dashboard/dataset_view.tsx
+++ b/frontend/javascripts/dashboard/dataset_view.tsx
@@ -41,7 +41,7 @@ import { useWkSelector } from "libs/react_hooks";
 import { isUserAdminOrDatasetManager, isUserTeamManager } from "libs/utils";
 import type React from "react";
 import { Fragment, useContext, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   type APIDatasetCompact,
   type APIJob,

--- a/frontend/javascripts/dashboard/explorative_annotations_view.tsx
+++ b/frontend/javascripts/dashboard/explorative_annotations_view.tsx
@@ -46,7 +46,7 @@ import without from "lodash-es/without";
 import messages from "messages";
 import type React from "react";
 import { PureComponent } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import {
   type APIAnnotationInfo,
   type APIUser,

--- a/frontend/javascripts/dashboard/publication_card.tsx
+++ b/frontend/javascripts/dashboard/publication_card.tsx
@@ -6,7 +6,7 @@ import Markdown from "libs/markdown_adapter";
 import { compareBy } from "libs/utils";
 import type React from "react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { APIDataset, APIPublication, APIPublicationAnnotation } from "types/api_types";
 import {
   getDatasetExtentAsString,

--- a/frontend/javascripts/dashboard/publication_details_view.tsx
+++ b/frontend/javascripts/dashboard/publication_details_view.tsx
@@ -5,7 +5,7 @@ import { Button, Flex, Layout, List, Space, Spin, Tooltip } from "antd";
 import PublicationCard from "dashboard/publication_card";
 import { handleGenericError } from "libs/error_handling";
 import { useEffect } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 
 const { Content } = Layout;
 

--- a/frontend/javascripts/libs/react_hooks.ts
+++ b/frontend/javascripts/libs/react_hooks.ts
@@ -8,7 +8,7 @@ import debounce from "lodash-es/debounce";
 import noop from "lodash-es/noop";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type EqualityFn, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import constants from "viewer/constants";
 import type { WebknossosState } from "viewer/store";
 import { bigIntReplacer } from "./bigint_helpers";

--- a/frontend/javascripts/libs/with_blocker_hoc.tsx
+++ b/frontend/javascripts/libs/with_blocker_hoc.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useState } from "react";
-import { type Blocker, type BlockerFunction, useBlocker } from "react-router-dom";
+import { type Blocker, type BlockerFunction, useBlocker } from "react-router";
 
 export type WithBlockerProps = {
   setBlocking: ({ shouldBlock }: { shouldBlock: boolean | BlockerFunction }) => void;

--- a/frontend/javascripts/libs/with_router_hoc.tsx
+++ b/frontend/javascripts/libs/with_router_hoc.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router";
 
 export type RouteComponentProps = {
   location: ReturnType<typeof useLocation>;
@@ -8,11 +8,11 @@ export type RouteComponentProps = {
 };
 
 /**
- * A higher-order component (HOC) that injects React Router v6 hooks
+ * A higher-order component (HOC) that injects React Router hooks
  * (`location`, `navigate`, and `params`) into class-based components
  * via props.
  *
- * React Router v6 has removed the withRouter HOC entirely. This is a workaround for class-based components.
+ * React Router removed the withRouter HOC in v6. This is a workaround for class-based components.
  *
  * @param Component - The class or function component to wrap.
  * @returns A function component that passes router props to the wrapped component.

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -32,7 +32,7 @@ import { checkAnyOrganizationExists, getOrganization } from "admin/api/organizat
 import { CheckCertificateModal } from "components/check_certificate_modal";
 import DisableGenericDnd from "components/disable_generic_dnd";
 import { CheckTermsOfServices } from "components/terms_of_services_check";
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router/dom";
 import router from "router/router";
 import { getThemeFromUser } from "theme";
 import GlobalThemeProvider from "theme_provider";

--- a/frontend/javascripts/navbar.tsx
+++ b/frontend/javascripts/navbar.tsx
@@ -56,7 +56,7 @@ import messages from "messages";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { getAntdTheme } from "theme";
 import type { APIOrganizationCompact, APIUser, APIUserCompact } from "types/api_types";
 import constants from "viewer/constants";

--- a/frontend/javascripts/router/page_not_found_view.tsx
+++ b/frontend/javascripts/router/page_not_found_view.tsx
@@ -1,5 +1,5 @@
 import { Button, Col, Result, Row } from "antd";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 export function PageNotFoundView() {
   return (

--- a/frontend/javascripts/router/route_wrappers.tsx
+++ b/frontend/javascripts/router/route_wrappers.tsx
@@ -15,7 +15,7 @@ import { coalesce, getUrlParamsObjectFromString } from "libs/utils";
 import window from "libs/window";
 import isNumber from "lodash-es/isNumber";
 import { useEffect } from "react";
-import { Navigate, useLocation, useParams } from "react-router-dom";
+import { Navigate, useLocation, useParams } from "react-router";
 import { APICompoundTypeEnum, type APIMagRestrictions, TracingTypeEnum } from "types/api_types";
 import { ControlModeEnum, PerformanceMarkEnum } from "viewer/constants";
 import { getDatasetIdOrNameFromReadableURLPart } from "viewer/model/accessors/dataset_accessor";

--- a/frontend/javascripts/router/router.tsx
+++ b/frontend/javascripts/router/router.tsx
@@ -40,7 +40,7 @@ import {
   Outlet,
   Route,
   redirect,
-} from "react-router-dom";
+} from "react-router";
 import type { EmptyObject } from "types/type_utils";
 import { CommandPalette } from "viewer/view/components/command_palette";
 

--- a/frontend/javascripts/viewer/controller.tsx
+++ b/frontend/javascripts/viewer/controller.tsx
@@ -10,7 +10,7 @@ import { type RouteComponentProps, withRouter } from "libs/with_router_hoc";
 import messages from "messages";
 import { PureComponent } from "react";
 import { connect } from "react-redux";
-import type { BlockerFunction } from "react-router-dom";
+import type { BlockerFunction } from "react-router";
 import type { APIOrganization, APIUser } from "types/api_types";
 import { APIAnnotationTypeEnum, type APICompoundType } from "types/api_types";
 import ApiLoader from "viewer/api/api_loader";

--- a/frontend/javascripts/viewer/view/action_bar_view.tsx
+++ b/frontend/javascripts/viewer/view/action_bar_view.tsx
@@ -11,7 +11,7 @@ import { ArbitraryVectorInput } from "libs/vector_input";
 import type React from "react";
 import { Fragment, PureComponent, useState } from "react";
 import { connect, useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import type { APIDataset, APIOrganization, APISegmentationLayer, APIUser } from "types/api_types";
 import { type AdditionalCoordinate, APIJobCommand } from "types/api_types";
 import constants, {

--- a/frontend/javascripts/viewer/view/ai_jobs/credit_information.tsx
+++ b/frontend/javascripts/viewer/view/ai_jobs/credit_information.tsx
@@ -21,7 +21,7 @@ import { useWkSelector } from "libs/react_hooks";
 import { computeArrayFromBoundingBox, computeVolumeFromBoundingBox } from "libs/utils";
 import type React from "react";
 import { useCallback, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { ColorWKGold } from "theme";
 import { type AiModel, APIJobCommand } from "types/api_types";
 import type { Vector3 } from "viewer/constants";

--- a/frontend/javascripts/viewer/view/components/command_palette.tsx
+++ b/frontend/javascripts/viewer/view/components/command_palette.tsx
@@ -19,7 +19,7 @@ import { getAdministrationSubMenu, getAnalysisSubMenu, switchTo } from "navbar";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactCommandPalette, { type Command } from "react-command-palette";
 import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ColorWKBlue, getSystemColorTheme, getThemeFromUser } from "theme";
 import { WkDevFlags } from "viewer/api/wk_dev";
 import { ViewModeValues } from "viewer/constants";

--- a/frontend/javascripts/viewer/view/right_border_tabs/dataset_info_tab_view.tsx
+++ b/frontend/javascripts/viewer/view/right_border_tabs/dataset_info_tab_view.tsx
@@ -29,7 +29,7 @@ import memoizeOne from "memoize-one";
 import messages from "messages";
 import React, { type CSSProperties } from "react";
 import { connect, useDispatch } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import type { Dispatch } from "redux";
 import type { APIDataset, APIUser, APIUserBase } from "types/api_types";
 import type { EmptyObject } from "types/type_utils";

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "react-json-tree": "0.19.0",
     "react-markdown": "^10.1.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^6.30.1",
+    "react-router": "^7.18.3",
     "react-tooltip": "^5.27.1",
     "react-virtualized-auto-sizer": "^1.0.24",
     "redux": "5.0.1",

--- a/unreleased_changes/9988.md
+++ b/unreleased_changes/9988.md
@@ -1,0 +1,2 @@
+### Changed
+- Upgraded react-router from v6 to v7. The deprecated `react-router-dom` package was replaced by `react-router`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,13 +2418,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.0":
-  version: 1.23.0
-  resolution: "@remix-run/router@npm:1.23.0"
-  checksum: 10c0/eaef5cb46a1e413f7d1019a75990808307e08e53a39d4cf69c339432ddc03143d725decef3d6b9b5071b898da07f72a4a57c4e73f787005fcf10162973d8d7d7
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-android-arm64@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
@@ -5248,7 +5241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.0.2":
+"cookie@npm:^1.0.1, cookie@npm:^1.0.2":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
   checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
@@ -11086,27 +11079,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.30.1":
-  version: 6.30.1
-  resolution: "react-router-dom@npm:6.30.1"
+"react-router@npm:^7.18.3":
+  version: 7.18.3
+  resolution: "react-router@npm:7.18.3"
   dependencies:
-    "@remix-run/router": "npm:1.23.0"
-    react-router: "npm:6.30.1"
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
   peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10c0/e9e1297236b0faa864424ad7d51c392fc6e118595d4dad4cd542fd217c479a81601a81c6266d5801f04f9e154de02d3b094fc22ccb544e755c2eb448fab4ec6b
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.1":
-  version: 6.30.1
-  resolution: "react-router@npm:6.30.1"
-  dependencies:
-    "@remix-run/router": "npm:1.23.0"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/0414326f2d8e0c107fb4603cf4066dacba6a1f6f025c6e273f003e177b2f18888aca3de06d9b5522908f0e41de93be1754c37e82aa97b3a269c4742c08e82539
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/77686cad916f8928e6c4aeafe5f8dc26384e84897849ff7d771ddee67af02b788c103503d029ffa442f7bf42aa47b3779440e70fc1aeae90532120fae4036b0f
   languageName: node
   linkType: hard
 
@@ -11793,6 +11778,13 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
   languageName: node
   linkType: hard
 
@@ -13930,7 +13922,7 @@ __metadata:
     react-json-tree: "npm:0.19.0"
     react-markdown: "npm:^10.1.0"
     react-redux: "npm:^9.2.0"
-    react-router-dom: "npm:^6.30.1"
+    react-router: "npm:^7.18.3"
     react-tooltip: "npm:^5.27.1"
     react-virtualized-auto-sizer: "npm:^1.0.24"
     redux: "npm:5.0.1"


### PR DESCRIPTION
Context: In July [React Router v8 ](https://remix.run/blog/react-router-v8) was released. We are still on v6. Let's slowly update to v7 to not fall behind too much.

### Summary

Upgrades `react-router` from v6.30.1 to v7.18.3 and drops the deprecated `react-router-dom` package. 

The migration surface turned out to be very small. None of the APIs that changed in v7 are used here:

- no `json()` / `defer()` (the two APIs removed in v7)
- no `useFetcher` / `<Form>` / `useNavigation` → `v7_fetcherPersist`, `v7_normalizeFormMethod`, `v7_skipActionErrorRevalidation` are no-ops
- no `fallbackElement` → `v7_partialHydration` is a no-op
- one splat route, root-level `path="*"` → `v7_relativeSplatPath` is a no-op (it only affects multi-segment splats like `dashboard/*`)
- no deep imports, no `MemoryRouter` / `useRoutes` / `matchPath` / `generatePath`

`v7_startTransition` is the only flag with real behavioural effect, and its one precondition — `React.lazy` at module scope — was already satisfied by `libs/lazy_loader` + the module-scope `loadable()` calls in `router.tsx`.

Changes:
- 65 files: `react-router-dom` → `react-router`
- `RouterProvider` now imported from `react-router/dom`
- biome `noRestrictedImports` bans `react-router-dom`, next to the existing `antd/lib` ban, so the old import cannot creep back
- dropped a stale "React Router v6" comment in `with_router_hoc.tsx`

A follow-up PR replaces `createRoutesFromElements` with plain route objects. The v8 bump is deliberately deferred — it needs React ≥19.2.7 and Node ≥22.22.0.

### Steps to test:
- Click through the app; routing should be unchanged.
- Verified locally against a dev server:
  - `/imprint` renders; `/this-route-does-not-exist` hits the splat 404
  - `<Navigate>` redirect: `/login` → `/auth/login`
  - loader `redirect()`: `/publication/42` → `/publications/42`
  - legacy redirect: `/reports/openTasks` → `/reports/availableTasks`
  - client-side navigation via `<Link>` does not full-reload the page
  - no react-router errors or warnings in the console
- `yarn typecheck`, `yarn check-frontend`, `yarn test` (3264 passed), `yarn build` all pass.

### Issues:
- n/a

------
(Please delete unneeded items, merge only when none are left open)
- [x] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)