### PR TITLE
Define routes as objects instead of JSX

### DIFF
--- a/frontend/javascripts/router/router.tsx
+++ b/frontend/javascripts/router/router.tsx
@@ -33,14 +33,7 @@ import DashboardView from "dashboard/dashboard_view";
 import PublicationDetailView from "dashboard/publication_details_view";
 import loadable from "libs/lazy_loader";
 import Navbar from "navbar";
-import {
-  createBrowserRouter,
-  createRoutesFromElements,
-  Navigate,
-  Outlet,
-  Route,
-  redirect,
-} from "react-router";
+import { createBrowserRouter, Navigate, Outlet, type RouteObject, redirect } from "react-router";
 import type { EmptyObject } from "types/type_utils";
 import { CommandPalette } from "viewer/view/components/command_palette";
 
@@ -97,410 +90,405 @@ function RootLayout() {
   );
 }
 
-const routes = createRoutesFromElements(
-  <Route element={<RootLayout />}>
-    <Route path="/" element={<RootRouteWrapper />} />
-    <Route
-      path="/dashboard/:tab"
-      element={
-        <SecuredRoute>
-          <DashboardRouteWrapper />
-        </SecuredRoute>
-      }
-    />
+const routes: RouteObject[] = [
+  {
+    element: <RootLayout />,
+    children: [
+      { path: "/", element: <RootRouteWrapper /> },
+      {
+        path: "/dashboard/:tab",
+        element: (
+          <SecuredRoute>
+            <DashboardRouteWrapper />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/dashboard/datasets/:folderIdWithName",
+        element: (
+          <SecuredRoute>
+            <DashboardView userId={null} isAdminView={false} initialTabKey={"datasets"} />
+          </SecuredRoute>
+        ),
+      },
+      { path: "/dashboard", element: <DashboardRouteRootWrapper /> },
+      {
+        path: "/users/:userId/details",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <UserDetailsRouteWrapper />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/users",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <UserListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/import",
+        loader: datasetURLImportLoader,
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <DatasetURLImport />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/teams",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <TeamListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/timetracking",
+        element: (
+          <SecuredRoute>
+            <TimeTrackingOverview />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/reports/projectProgress",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <ProjectProgressReportView />
+          </SecuredRoute>
+        ),
+      },
+      { path: "/reports/openTasks", element: <Navigate to="/reports/availableTasks" replace /> },
+      {
+        path: "/reports/availableTasks",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <AvailableTasksReportView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/tasks",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/tasks/create",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskCreateView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/tasks/:taskId/edit",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskCreateFormView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/tasks/:taskId",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/projects",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <ProjectListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/projects/create",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <ProjectCreateView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/projects/:projectId/tasks",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/projects/:projectId/edit",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <ProjectCreateView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/annotations/:type/:id",
+        element: (
+          <SecuredRoute checkIfResourceIsPublic>
+            <AnnotationsRouteWrapper />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/annotations/:id",
+        element: (
+          <SecuredRoute checkIfResourceIsPublic>
+            <TracingViewRouteWrapper />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/datasets/upload",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <DatasetAddView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/datasets/:datasetNameAndId/edit",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <DatasetSettingsRouteWrapper />
+          </SecuredRoute>
+        ),
+        children: [
+          { index: true, element: <Navigate to="data" replace /> },
+          { path: "data", element: <DatasetSettingsDataTab /> },
+          { path: "sharing", element: <DatasetSettingsSharingTab /> },
+          { path: "metadata", element: <DatasetSettingsMetadataTab /> },
+          { path: "defaultConfig", element: <DatasetSettingsViewConfigTab /> },
+          { path: "storage", element: <DatasetSettingsStorageTab /> },
+          { path: "delete", element: <DatasetSettingsDeleteTab /> },
+        ],
+      },
+      {
+        path: "/taskTypes",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <TaskTypeListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/taskTypes/create",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskTypeCreateView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/taskTypes/:taskTypeId/edit",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskTypeCreateView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/taskTypes/:taskTypeId/tasks",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <TaskListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/taskTypes/:taskTypeId/projects",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
+            <ProjectListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/scripts/create",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <ScriptCreateView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/scripts/:scriptId/edit",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <ScriptCreateView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/scripts",
+        element: (
+          <SecuredRoute requiresAdminOrManagerRole>
+            <ScriptListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/jobs",
+        element: (
+          <SecuredRoute>
+            <JobListView />
+          </SecuredRoute>
+        ),
+      },
+      { path: "/organizations/:organizationId", element: <Navigate to="/organization" replace /> },
+      {
+        path: "/organization",
+        element: (
+          <SecuredRoute>
+            <OrganizationView />
+          </SecuredRoute>
+        ),
+        children: [
+          { index: true, element: <Navigate to="overview" replace /> },
+          { path: "overview", element: <OrganizationOverviewView /> },
+          { path: "notifications", element: <OrganizationNotificationsView /> },
+          { path: "credit-activity", element: <OrganizationCreditActivityView /> },
+          { path: "planupdates", element: <OrganizationPlanActivityView /> },
+          { path: "delete", element: <OrganizationDangerZoneView /> },
+        ],
+      },
+      {
+        path: "/help/keyboardshortcuts",
+        loader: () => redirect("https://docs.webknossos.org/webknossos/ui/keyboard_shortcuts.html"),
+      },
+      // Backwards compatibility for old auth token URLs
+      { path: "/auth/token", element: <Navigate to="/account/token" replace /> },
+      // Backwards compatibility for old password change URLs
+      { path: "/auth/changePassword", element: <Navigate to="/account/security" replace /> },
+      { path: "/account/password", element: <Navigate to="/account/security" replace /> },
+      { path: "/login", element: <Navigate to="/auth/login" replace /> },
 
-    <Route
-      path="/dashboard/datasets/:folderIdWithName"
-      element={
-        <SecuredRoute>
-          <DashboardView userId={null} isAdminView={false} initialTabKey={"datasets"} />
-        </SecuredRoute>
-      }
-    />
+      { path: "/invite/:token", element: <AcceptInviteView /> },
 
-    <Route path="/dashboard" element={<DashboardRouteRootWrapper />} />
-    <Route
-      path="/users/:userId/details"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <UserDetailsRouteWrapper />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/users"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <UserListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/import"
-      loader={datasetURLImportLoader}
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <DatasetURLImport />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/teams"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <TeamListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/timetracking"
-      element={
-        <SecuredRoute>
-          <TimeTrackingOverview />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/reports/projectProgress"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <ProjectProgressReportView />
-        </SecuredRoute>
-      }
-    />
-    <Route path="/reports/openTasks" element={<Navigate to="/reports/availableTasks" replace />} />
-    <Route
-      path="/reports/availableTasks"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <AvailableTasksReportView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/tasks"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/tasks/create"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskCreateView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/tasks/:taskId/edit"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskCreateFormView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/tasks/:taskId"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/projects"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <ProjectListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/projects/create"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <ProjectCreateView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/projects/:projectId/tasks"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/projects/:projectId/edit"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <ProjectCreateView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/annotations/:type/:id"
-      element={
-        <SecuredRoute checkIfResourceIsPublic>
-          <AnnotationsRouteWrapper />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/annotations/:id"
-      element={
-        <SecuredRoute checkIfResourceIsPublic>
-          <TracingViewRouteWrapper />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/datasets/upload"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <DatasetAddView />
-        </SecuredRoute>
-      }
-    />
+      { path: "/verifyEmail/:token", element: <VerifyEmailView /> },
+      // Backwards compatibility for signup URLs
+      { path: "/signup", element: <Navigate to="/auth/signup" replace /> },
+      // Backwards compatibility for register URLs
+      { path: "/register", element: <Navigate to="/auth/signup" replace /> },
+      // Backwards compatibility for register URLs
+      { path: "/auth/register", element: <Navigate to="/auth/signup" replace /> },
+      { path: "/auth/login", element: <LoginView /> },
+      { path: "/auth/signup", element: <RegistrationView /> },
 
-    <Route
-      path="/datasets/:datasetNameAndId/edit"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <DatasetSettingsRouteWrapper />
-        </SecuredRoute>
-      }
-    >
-      <Route index element={<Navigate to="data" replace />} />
-      <Route path="data" element={<DatasetSettingsDataTab />} />
-      <Route path="sharing" element={<DatasetSettingsSharingTab />} />
-      <Route path="metadata" element={<DatasetSettingsMetadataTab />} />
-      <Route path="defaultConfig" element={<DatasetSettingsViewConfigTab />} />
-      <Route path="storage" element={<DatasetSettingsStorageTab />} />
-      <Route path="delete" element={<DatasetSettingsDeleteTab />} />
-    </Route>
-    <Route
-      path="/taskTypes"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <TaskTypeListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/taskTypes/create"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskTypeCreateView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/taskTypes/:taskTypeId/edit"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskTypeCreateView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/taskTypes/:taskTypeId/tasks"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <TaskListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/taskTypes/:taskTypeId/projects"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={PricingPlanEnum.Team}>
-          <ProjectListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/scripts/create"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <ScriptCreateView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/scripts/:scriptId/edit"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <ScriptCreateView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/scripts"
-      element={
-        <SecuredRoute requiresAdminOrManagerRole>
-          <ScriptListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/jobs"
-      element={
-        <SecuredRoute>
-          <JobListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/organizations/:organizationId"
-      element={<Navigate to="/organization" replace />}
-    />
-    <Route
-      path="/organization"
-      element={
-        <SecuredRoute>
-          <OrganizationView />
-        </SecuredRoute>
-      }
-    >
-      <Route index element={<Navigate to="overview" replace />} />
-      <Route path="overview" element={<OrganizationOverviewView />} />
-      <Route path="notifications" element={<OrganizationNotificationsView />} />
-      <Route path="credit-activity" element={<OrganizationCreditActivityView />} />
-      <Route path="planupdates" element={<OrganizationPlanActivityView />} />
-      <Route path="delete" element={<OrganizationDangerZoneView />} />
-    </Route>
-    <Route
-      path="/help/keyboardshortcuts"
-      loader={() => redirect("https://docs.webknossos.org/webknossos/ui/keyboard_shortcuts.html")}
-    />
-    {/* Backwards compatibility for old auth token URLs */}
-    <Route path="/auth/token" element={<Navigate to="/account/token" replace />} />
-    {/* Backwards compatibility for old password change URLs */}
-    <Route path="/auth/changePassword" element={<Navigate to="/account/security" replace />} />
-    <Route path="/account/password" element={<Navigate to="/account/security" replace />} />
-    <Route path="/login" element={<Navigate to="/auth/login" replace />} />
+      { path: "/auth/resetPassword", element: <StartResetPasswordView /> },
+      { path: "/auth/finishResetPassword", element: <FinishResetPasswordView /> },
+      // legacy view mode route
+      {
+        path: "/datasets/:organizationId/:datasetName/view",
+        element: <TracingViewModeLegacyWrapper />,
+      },
+      { path: "/datasets/:datasetNameAndId/view", element: <TracingViewModeRouteWrapper /> },
+      {
+        path: "/datasets/:datasetNameAndId/sandbox/:type",
+        element: <TracingSandboxRouteWrapper />,
+      },
+      // legacy sandbox route
+      {
+        path: "/datasets/:organizationId/:datasetName/sandbox/:type",
+        element: <TracingSandboxLegacyRouteWrapper />,
+      },
+      {
+        path: "/datasets/:datasetId/createExplorative/:type",
+        element: (
+          <SecuredRoute>
+            <CreateExplorativeRouteWrapper />
+          </SecuredRoute>
+        ),
+      },
+      // Note that the following two routes have to be beneath all others sharing the same prefix,
+      // to avoid url mismatching.
+      // legacy view mode route
+      { path: "/datasets/:organizationId/:datasetName", element: <TracingViewModeLegacyWrapper /> },
+      { path: "/datasets/:datasetNameAndId", element: <TracingViewModeRouteWrapper /> },
+      { path: "/publications/:id", element: <PublicationDetailView /> },
+      {
+        path: "/publication/:id",
+        loader: ({ params }) => redirect(`/publications/${params.id}`),
+      },
+      {
+        path: "/workflows",
+        element: (
+          <SecuredRoute>
+            <AsyncWorkflowListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/aiModels",
+        element: (
+          <SecuredRoute>
+            <AiModelListView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/workflows/:workflowHash",
+        loader: ({ params, request }) => {
+          const url = new URL(request.url);
+          const runId = url.searchParams.get("runId");
+          if (runId) {
+            url.searchParams.delete("runId");
+            const search = url.searchParams.toString();
 
-    <Route path="/invite/:token" element={<AcceptInviteView />} />
-
-    <Route path="/verifyEmail/:token" element={<VerifyEmailView />} />
-    {/* Backwards compatibility for signup URLs */}
-    <Route path="/signup" element={<Navigate to="/auth/signup" replace />} />
-    {/* Backwards compatibility for register URLs */}
-    <Route path="/register" element={<Navigate to="/auth/signup" replace />} />
-    {/* Backwards compatibility for register URLs */}
-    <Route path="/auth/register" element={<Navigate to="/auth/signup" replace />} />
-    <Route path="/auth/login" element={<LoginView />} />
-    <Route path="/auth/signup" element={<RegistrationView />} />
-
-    <Route path="/auth/resetPassword" element={<StartResetPasswordView />} />
-    <Route path="/auth/finishResetPassword" element={<FinishResetPasswordView />} />
-    {/* legacy view mode route */}
-    <Route
-      path="/datasets/:organizationId/:datasetName/view"
-      element={<TracingViewModeLegacyWrapper />}
-    />
-    <Route path="/datasets/:datasetNameAndId/view" element={<TracingViewModeRouteWrapper />} />
-    <Route
-      path="/datasets/:datasetNameAndId/sandbox/:type"
-      element={<TracingSandboxRouteWrapper />}
-    />
-    {/* legacy sandbox route */}
-    <Route
-      path="/datasets/:organizationId/:datasetName/sandbox/:type"
-      element={<TracingSandboxLegacyRouteWrapper />}
-    />
-    <Route
-      path="/datasets/:datasetId/createExplorative/:type"
-      element={
-        <SecuredRoute>
-          <CreateExplorativeRouteWrapper />
-        </SecuredRoute>
-      }
-    />
-    {
-      // Note that this route has to be beneath all others sharing the same prefix,
-      // to avoid url mismatching
-    }
-    {/*legacy view mode route */}
-    <Route
-      path="/datasets/:organizationId/:datasetName"
-      element={<TracingViewModeLegacyWrapper />}
-    />
-    <Route path="/datasets/:datasetNameAndId" element={<TracingViewModeRouteWrapper />} />
-    <Route path="/publications/:id" element={<PublicationDetailView />} />
-    <Route
-      path="/publication/:id"
-      loader={({ params }) => redirect(`/publications/${params.id}`)}
-    />
-    <Route
-      path="/workflows"
-      element={
-        <SecuredRoute>
-          <AsyncWorkflowListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/aiModels"
-      element={
-        <SecuredRoute>
-          <AiModelListView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/workflows/:workflowHash"
-      loader={({ params, request }) => {
-        const url = new URL(request.url);
-        const runId = url.searchParams.get("runId");
-        if (runId) {
-          url.searchParams.delete("runId");
-          const search = url.searchParams.toString();
-
-          return redirect(
-            `/workflows/${params.workflowHash}/run/${encodeURIComponent(runId)}${search ? `?${search}` : ""}`,
-          );
-        }
-        return null;
-      }}
-      element={
-        <SecuredRoute>
-          <AsyncWorkflowView />
-        </SecuredRoute>
-      }
-    />
-    <Route
-      path="/workflows/:workflowHash/run/:runId"
-      element={
-        <SecuredRoute>
-          <AsyncWorkflowView />
-        </SecuredRoute>
-      }
-    />
-    <Route path="/imprint" element={<Imprint />} />
-    <Route path="/privacy" element={<Privacy />} />
-    <Route path="/links/:key" element={<ShortLinksRouteWrapper />} />
-    <Route path="/onboarding" element={<OnboardingRouteWrapper />} />
-    <Route
-      path="/account"
-      element={
-        <SecuredRoute>
-          <AccountSettingsView />
-        </SecuredRoute>
-      }
-    >
-      <Route index element={<Navigate to="profile" replace />} />
-      <Route path="profile" element={<AccountProfileView />} />
-      <Route path="security" element={<AccountSecurityView />} />
-      <Route path="token" element={<AccountAuthTokenView />} />
-    </Route>
-    <Route path="*" element={<PageNotFoundView />} />
-  </Route>,
-);
+            return redirect(
+              `/workflows/${params.workflowHash}/run/${encodeURIComponent(runId)}${search ? `?${search}` : ""}`,
+            );
+          }
+          return null;
+        },
+        element: (
+          <SecuredRoute>
+            <AsyncWorkflowView />
+          </SecuredRoute>
+        ),
+      },
+      {
+        path: "/workflows/:workflowHash/run/:runId",
+        element: (
+          <SecuredRoute>
+            <AsyncWorkflowView />
+          </SecuredRoute>
+        ),
+      },
+      { path: "/imprint", element: <Imprint /> },
+      { path: "/privacy", element: <Privacy /> },
+      { path: "/links/:key", element: <ShortLinksRouteWrapper /> },
+      { path: "/onboarding", element: <OnboardingRouteWrapper /> },
+      {
+        path: "/account",
+        element: (
+          <SecuredRoute>
+            <AccountSettingsView />
+          </SecuredRoute>
+        ),
+        children: [
+          { index: true, element: <Navigate to="profile" replace /> },
+          { path: "profile", element: <AccountProfileView /> },
+          { path: "security", element: <AccountSecurityView /> },
+          { path: "token", element: <AccountAuthTokenView /> },
+        ],
+      },
+      { path: "*", element: <PageNotFoundView /> },
+    ],
+  },
+];
 
 const router = createBrowserRouter(routes);
 export default router;


### PR DESCRIPTION
> Stacked on #9988 — please merge that one first. The base will retarget to `master` automatically.

### Summary

Replaces `createRoutesFromElements` with a plain `RouteObject[]` in `router/router.tsx`.

The JSX form was only an authoring helper: react-router converted those `<Route>` elements into exactly this object shape at startup. Writing the objects directly drops that conversion step and lets the config be typed as `RouteObject[]`, so route properties (`loader` signatures, `index` vs `path`, `children`) are checked directly rather than through the JSX element props.

Route `element`s are left exactly as they were — this is a structural change only.

### Steps to test:
No behaviour change is intended, so the main check is that routing is unchanged. Verified mechanically that the old and new configs are equivalent:

- **Ordered route list is identical** — 85 entries, same order, diffed programmatically against the previous file.
- **Nesting is identical** — pathless root layout wrapping all 85; `/datasets/:datasetNameAndId/edit` → 7 children; `/organization` → 6; `/account` → 4.
- **Loaders are identical** — same 4, on `/import`, `/help/keyboardshortcuts`, `/publication/:id`, `/workflows/:workflowHash`.

And against a dev server:
- nested routes match: `/datasets/upload`, `/organization/overview`, `/account/security`, `/datasets/:id/edit/sharing`
- `<Navigate>` redirect: `/login` → `/auth/login`
- loader redirect: `/publication/42` → `/publications/42`
- loader + query rewrite: `/workflows/abc123?runId=xyz` → `/workflows/abc123/run/xyz`
- splat 404 still renders `PageNotFoundView`
- no react-router errors or warnings in the console

`yarn typecheck`, `yarn check-frontend`, `yarn test` (3264 passed), `yarn build` all pass.

### Possible follow-up
The object form makes the `<SecuredRoute requiresAdminOrManagerRole requiredPricingPlan={...}>` repetition (~30 occurrences) more visible. It could collapse into shared parent routes with `children`, but that changes the route tree, so it is deliberately not part of this PR.

### Issues:
- n/a

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`) — internal refactor, no user-facing change
- [ ] Added migration guide entry if applicable (edit the same file as for the changelog)
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [x] Removed dev-only changes like prints and application.conf edits
- [x] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)