### PR TITLE
Frontend bundle size, part 2: route-level code splitting

### DIFF
--- a/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
@@ -3,10 +3,9 @@ import { isDatasetNameValid, storeRemoteDataset } from "admin/rest_api";
 import { Button, Col, Divider, Flex, Form, type FormInstance, List, Modal, Row } from "antd";
 import BrainSpinner from "components/brain_spinner";
 import type { DatasetSettingsFormData } from "dashboard/dataset/dataset_settings_context";
-import DatasetSettingsDataTab, {
-  TransformationsMode,
-} from "dashboard/dataset/dataset_settings_data_tab";
+import DatasetSettingsDataTab from "dashboard/dataset/dataset_settings_data_tab";
 import { DatasetSettingsProvider } from "dashboard/dataset/dataset_settings_provider";
+import { TransformationsMode } from "dashboard/dataset/dataset_transformations_mode";
 import { FormItemWithInfo, Hideable } from "dashboard/dataset/helper_components";
 import FolderSelection from "dashboard/folders/folder_selection";
 import { useEffectOnlyOnce, useWkSelector } from "libs/react_hooks";

--- a/frontend/javascripts/dashboard/dashboard_tab_keys.ts
+++ b/frontend/javascripts/dashboard/dashboard_tab_keys.ts
@@ -1,0 +1,8 @@
+// Kept out of dashboard_view so that the router can map a URL segment to a tab key without
+// statically importing the (lazily loaded) dashboard itself.
+export const urlTokenToTabKeyMap = {
+  publications: "publications",
+  datasets: "datasets",
+  tasks: "tasks",
+  annotations: "explorativeAnnotations",
+};

--- a/frontend/javascripts/dashboard/dashboard_view.tsx
+++ b/frontend/javascripts/dashboard/dashboard_view.tsx
@@ -4,6 +4,7 @@ import { PlanAboutToExceedAlert, PlanExceededAlert } from "admin/organization/or
 import { getUser, updateNovelUserExperienceInfos } from "admin/rest_api";
 import { WhatsNextHeader } from "admin/welcome_ui";
 import { Spin, Tabs, Typography } from "antd";
+import { urlTokenToTabKeyMap } from "dashboard/dashboard_tab_keys";
 import DashboardTaskListView from "dashboard/dashboard_task_list_view";
 import ExplorativeAnnotationsView from "dashboard/explorative_annotations_view";
 import { PublicationViewWithHeader } from "dashboard/publication_view";
@@ -47,13 +48,6 @@ type State = {
   user: APIUser | null | undefined;
   organization: APIOrganization | null;
   pricingPlanStatus: APIPricingPlanStatus | null;
-};
-
-export const urlTokenToTabKeyMap = {
-  publications: "publications",
-  datasets: "datasets",
-  tasks: "tasks",
-  annotations: "explorativeAnnotations",
 };
 
 function TabBarExtraContent() {

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_context.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_context.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from "react";
 import type { APIDataSource, APIDataset } from "types/api_types";
 import type { DatasetConfiguration } from "viewer/store";
 import type { DatasetRotationAndMirroringSettings } from "./dataset_rotation_form_item";
-import type { TransformationsMode } from "./dataset_settings_data_tab";
+import type { TransformationsMode } from "./dataset_transformations_mode";
 
 export type DatasetSettingsFormData = {
   dataSource: APIDataSource;

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_data_tab.tsx
@@ -37,6 +37,7 @@ import {
   getRotationalTransformation,
 } from "./dataset_rotation_form_item";
 import { useDatasetSettingsContext } from "./dataset_settings_context";
+import { TransformationsMode } from "./dataset_transformations_mode";
 
 export default function DatasetSettingsDataTab() {
   const { dataset, form } = useDatasetSettingsContext();
@@ -138,12 +139,6 @@ function DatasetTransformationSettingsCard({
     default:
       return null;
   }
-}
-
-export enum TransformationsMode {
-  NONE = "none",
-  SIMPLE = "simple",
-  ADVANCED = "advanced",
 }
 
 function SimpleDatasetForm({

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_provider.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_provider.tsx
@@ -33,7 +33,7 @@ import {
   DatasetSettingsContext,
   type DatasetSettingsContextValue,
 } from "./dataset_settings_context";
-import { TransformationsMode } from "./dataset_settings_data_tab";
+import { TransformationsMode } from "./dataset_transformations_mode";
 import { hasFormError } from "./helper_components";
 import useBeforeUnload from "./useBeforeUnload_hook";
 

--- a/frontend/javascripts/dashboard/dataset/dataset_settings_screen.tsx
+++ b/frontend/javascripts/dashboard/dataset/dataset_settings_screen.tsx
@@ -1,0 +1,12 @@
+import { DatasetSettingsProvider } from "dashboard/dataset/dataset_settings_provider";
+import DatasetSettingsView from "dashboard/dataset/dataset_settings_view";
+
+// The provider and the view are loaded as one lazy unit, so that the router does not have to
+// import either of them (nor the dataset-settings tabs they reach) to render its route table.
+export default function DatasetSettingsScreen({ datasetId }: { datasetId: string }) {
+  return (
+    <DatasetSettingsProvider isEditingMode datasetId={datasetId}>
+      <DatasetSettingsView />
+    </DatasetSettingsProvider>
+  );
+}

--- a/frontend/javascripts/dashboard/dataset/dataset_transformations_mode.ts
+++ b/frontend/javascripts/dashboard/dataset/dataset_transformations_mode.ts
@@ -1,0 +1,7 @@
+// Kept out of dataset_settings_data_tab so that the settings provider can reference the enum
+// without statically importing the whole (lazily loaded) tab.
+export enum TransformationsMode {
+  NONE = "none",
+  SIMPLE = "simple",
+  ADVANCED = "advanced",
+}

--- a/frontend/javascripts/main.tsx
+++ b/frontend/javascripts/main.tsx
@@ -17,7 +17,6 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
-import { setupApi } from "viewer/api/internal_api";
 import Model from "viewer/model";
 import { setActiveOrganizationAction } from "viewer/model/actions/organization_actions";
 import { setHasOrganizationsAction, setThemeAction } from "viewer/model/actions/ui_actions";
@@ -43,7 +42,6 @@ window.OlvyConfig = null;
 
 setModel(Model);
 setStore(UnthrottledStore);
-setupApi();
 startSaga(warnIfEmailIsUnverified);
 
 const reactQueryClient = new QueryClient({

--- a/frontend/javascripts/router/route_wrappers.tsx
+++ b/frontend/javascripts/router/route_wrappers.tsx
@@ -18,7 +18,6 @@ import { APICompoundTypeEnum, type APIMagRestrictions, TracingTypeEnum } from "t
 import { ControlModeEnum, PerformanceMarkEnum } from "viewer/constants";
 import { getDatasetIdOrNameFromReadableURLPart } from "viewer/model/accessors/dataset_accessor";
 import { Store } from "viewer/singletons";
-import TracingLayoutView from "viewer/view/layouting/tracing_layout_view";
 import { PageNotFoundView } from "./page_not_found_view";
 
 // Loaded on demand for the same reason as the pages in router.tsx: these are whole
@@ -26,6 +25,10 @@ import { PageNotFoundView } from "./page_not_found_view";
 const Onboarding = loadable(() => import("admin/onboarding"));
 const DashboardView = loadable(() => import("dashboard/dashboard_view"));
 const DatasetSettingsScreen = loadable(() => import("dashboard/dataset/dataset_settings_screen"));
+// The annotation viewer is by far the largest screen in the app - it reaches three.js, the
+// shaders, the geometries and the flexlayout-based layouting. Loading it on demand keeps all
+// of that out of the login screen, the dashboard and every admin page.
+const TracingLayoutView = loadable(() => import("viewer/view/layouting/tracing_layout_view"));
 
 function markTracingViewLoadStartEffect() {
   const markName = PerformanceMarkEnum.TRACING_VIEW_LOAD;

--- a/frontend/javascripts/router/route_wrappers.tsx
+++ b/frontend/javascripts/router/route_wrappers.tsx
@@ -2,14 +2,12 @@ import {
   getDatasetIdFromNameAndOrganization,
   getOrganizationForDataset,
 } from "admin/api/disambiguate_legacy_routes";
-import Onboarding from "admin/onboarding";
 import { createExplorational, getShortLink } from "admin/rest_api";
 import { Typography } from "antd";
 import AsyncRedirect from "components/redirect";
-import DashboardView, { urlTokenToTabKeyMap } from "dashboard/dashboard_view";
-import { DatasetSettingsProvider } from "dashboard/dataset/dataset_settings_provider";
-import DatasetSettingsView from "dashboard/dataset/dataset_settings_view";
+import { urlTokenToTabKeyMap } from "dashboard/dashboard_tab_keys";
 import features from "features";
+import loadable from "libs/lazy_loader";
 import { useWkSelector } from "libs/react_hooks";
 import { coalesce, getUrlParamsObjectFromString } from "libs/utils";
 import window from "libs/window";
@@ -22,6 +20,12 @@ import { getDatasetIdOrNameFromReadableURLPart } from "viewer/model/accessors/da
 import { Store } from "viewer/singletons";
 import TracingLayoutView from "viewer/view/layouting/tracing_layout_view";
 import { PageNotFoundView } from "./page_not_found_view";
+
+// Loaded on demand for the same reason as the pages in router.tsx: these are whole
+// application screens that the initial render never needs.
+const Onboarding = loadable(() => import("admin/onboarding"));
+const DashboardView = loadable(() => import("dashboard/dashboard_view"));
+const DatasetSettingsScreen = loadable(() => import("dashboard/dataset/dataset_settings_screen"));
 
 function markTracingViewLoadStartEffect() {
   const markName = PerformanceMarkEnum.TRACING_VIEW_LOAD;
@@ -106,11 +110,7 @@ export function DatasetSettingsRouteWrapper() {
       />
     );
   }
-  return (
-    <DatasetSettingsProvider isEditingMode datasetId={datasetId || ""}>
-      <DatasetSettingsView />
-    </DatasetSettingsProvider>
-  );
+  return <DatasetSettingsScreen datasetId={datasetId || ""} />;
 }
 
 export function CreateExplorativeRouteWrapper() {

--- a/frontend/javascripts/router/router.tsx
+++ b/frontend/javascripts/router/router.tsx
@@ -13,7 +13,7 @@ import loadable from "libs/lazy_loader";
 import Navbar from "navbar";
 import { createBrowserRouter, Navigate, Outlet, type RouteObject, redirect } from "react-router";
 import type { EmptyObject } from "types/type_utils";
-import { CommandPalette } from "viewer/view/components/command_palette";
+import { CommandPaletteLoader } from "viewer/view/components/command_palette_loader";
 
 const { Content } = Layout;
 
@@ -129,7 +129,7 @@ const AsyncWorkflowListView = loadable<EmptyObject>(
 function RootLayout() {
   return (
     <Layout>
-      <CommandPalette />
+      <CommandPaletteLoader />
       <Navbar />
       <Content>
         <ErrorBoundary>

--- a/frontend/javascripts/router/router.tsx
+++ b/frontend/javascripts/router/router.tsx
@@ -1,36 +1,14 @@
-import AccountSettingsView from "admin/account/account_settings_view";
 import AcceptInviteView from "admin/auth/accept_invite_view";
 import FinishResetPasswordView from "admin/auth/finish_reset_password_view";
 import LoginView from "admin/auth/login_view";
 import RegistrationView from "admin/auth/registration_view";
 import StartResetPasswordView from "admin/auth/start_reset_password_view";
 import VerifyEmailView from "admin/auth/verify_email_view";
-import DatasetAddView from "admin/dataset/dataset_add_view";
-import { DatasetURLImport, datasetURLImportLoader } from "admin/dataset/dataset_url_import";
-import JobListView from "admin/job/job_list_view";
-import OrganizationView from "admin/organization/organization_view";
+import { datasetURLImportLoader } from "admin/dataset/dataset_url_import";
 import { PricingPlanEnum } from "admin/organization/pricing_plan_utils";
-import ProjectCreateView from "admin/project/project_create_view";
-import ProjectListView from "admin/project/project_list_view";
-import ScriptCreateView from "admin/scripts/script_create_view";
-import ScriptListView from "admin/scripts/script_list_view";
-import AvailableTasksReportView from "admin/statistic/available_tasks_report_view";
-import ProjectProgressReportView from "admin/statistic/project_progress_report_view";
-import TimeTrackingOverview from "admin/statistic/time_tracking_overview";
-import TaskCreateFormView from "admin/task/task_create_form_view";
-import TaskCreateView from "admin/task/task_create_view";
-import TaskListView from "admin/task/task_list_view";
-import TaskTypeCreateView from "admin/tasktype/task_type_create_view";
-import TaskTypeListView from "admin/tasktype/task_type_list_view";
-import TeamListView from "admin/team/team_list_view";
-import UserListView from "admin/user/user_list_view";
-import AiModelListView from "admin/voxelytics/ai_model_list_view";
 import { Layout } from "antd";
 import ErrorBoundary from "components/error_boundary";
-import { Imprint, Privacy } from "components/legal";
 import SecuredRoute from "components/secured_route";
-import DashboardView from "dashboard/dashboard_view";
-import PublicationDetailView from "dashboard/publication_details_view";
 import loadable from "libs/lazy_loader";
 import Navbar from "navbar";
 import { createBrowserRouter, Navigate, Outlet, type RouteObject, redirect } from "react-router";
@@ -39,20 +17,6 @@ import { CommandPalette } from "viewer/view/components/command_palette";
 
 const { Content } = Layout;
 
-import AccountAuthTokenView from "admin/account/account_auth_token_view";
-import AccountProfileView from "admin/account/account_profile_view";
-import AccountSecurityView from "admin/account/account_security_view";
-import { OrganizationCreditActivityView } from "admin/organization/organization_credit_activity_view";
-import { OrganizationDangerZoneView } from "admin/organization/organization_danger_zone_view";
-import { OrganizationNotificationsView } from "admin/organization/organization_notifications_view";
-import { OrganizationOverviewView } from "admin/organization/organization_overview_view";
-import { OrganizationPlanActivityView } from "admin/organization/organization_plan_activity_view";
-import DatasetSettingsDataTab from "dashboard/dataset/dataset_settings_data_tab";
-import DatasetSettingsDeleteTab from "dashboard/dataset/dataset_settings_delete_tab";
-import DatasetSettingsMetadataTab from "dashboard/dataset/dataset_settings_metadata_tab";
-import DatasetSettingsSharingTab from "dashboard/dataset/dataset_settings_sharing_tab";
-import DatasetSettingsStorageTab from "dashboard/dataset/dataset_settings_storage_tab";
-import DatasetSettingsViewConfigTab from "dashboard/dataset/dataset_settings_viewconfig_tab";
 import { PageNotFoundView } from "./page_not_found_view";
 import {
   AnnotationsRouteWrapper,
@@ -70,6 +34,92 @@ import {
   TracingViewRouteWrapper,
   UserDetailsRouteWrapper,
 } from "./route_wrappers";
+
+// Admin and dashboard pages are loaded on demand: none of them is needed to render the
+// navbar or the login screen, and together they account for a large part of the entry chunk.
+// loadable() adds the Suspense boundary and the stale-chunk error handling (see libs/lazy_loader).
+const AccountAuthTokenView = loadable(() => import("admin/account/account_auth_token_view"));
+const AccountProfileView = loadable(() => import("admin/account/account_profile_view"));
+const AccountSecurityView = loadable(() => import("admin/account/account_security_view"));
+const AccountSettingsView = loadable(() => import("admin/account/account_settings_view"));
+const AiModelListView = loadable(() => import("admin/voxelytics/ai_model_list_view"));
+const AvailableTasksReportView = loadable(
+  () => import("admin/statistic/available_tasks_report_view"),
+);
+const DashboardView = loadable(() => import("dashboard/dashboard_view"));
+const DatasetAddView = loadable(() => import("admin/dataset/dataset_add_view"));
+const DatasetSettingsDataTab = loadable(
+  () => import("dashboard/dataset/dataset_settings_data_tab"),
+);
+const DatasetSettingsDeleteTab = loadable(
+  () => import("dashboard/dataset/dataset_settings_delete_tab"),
+);
+const DatasetSettingsMetadataTab = loadable(
+  () => import("dashboard/dataset/dataset_settings_metadata_tab"),
+);
+const DatasetSettingsSharingTab = loadable(
+  () => import("dashboard/dataset/dataset_settings_sharing_tab"),
+);
+const DatasetSettingsStorageTab = loadable(
+  () => import("dashboard/dataset/dataset_settings_storage_tab"),
+);
+const DatasetSettingsViewConfigTab = loadable(
+  () => import("dashboard/dataset/dataset_settings_viewconfig_tab"),
+);
+const JobListView = loadable(() => import("admin/job/job_list_view"));
+const OrganizationView = loadable(() => import("admin/organization/organization_view"));
+const ProjectCreateView = loadable(() => import("admin/project/project_create_view"));
+const ProjectListView = loadable(() => import("admin/project/project_list_view"));
+const ProjectProgressReportView = loadable(
+  () => import("admin/statistic/project_progress_report_view"),
+);
+const PublicationDetailView = loadable(() => import("dashboard/publication_details_view"));
+const ScriptCreateView = loadable(() => import("admin/scripts/script_create_view"));
+const ScriptListView = loadable(() => import("admin/scripts/script_list_view"));
+const TaskCreateFormView = loadable(() => import("admin/task/task_create_form_view"));
+const TaskCreateView = loadable(() => import("admin/task/task_create_view"));
+const TaskListView = loadable(() => import("admin/task/task_list_view"));
+const TaskTypeCreateView = loadable(() => import("admin/tasktype/task_type_create_view"));
+const TaskTypeListView = loadable(() => import("admin/tasktype/task_type_list_view"));
+const TeamListView = loadable(() => import("admin/team/team_list_view"));
+const TimeTrackingOverview = loadable(() => import("admin/statistic/time_tracking_overview"));
+const UserListView = loadable(() => import("admin/user/user_list_view"));
+const DatasetURLImport = loadable<EmptyObject>(() =>
+  import("admin/dataset/dataset_url_import").then((module) => ({
+    default: module.DatasetURLImport,
+  })),
+);
+const Imprint = loadable<EmptyObject>(() =>
+  import("components/legal").then((module) => ({ default: module.Imprint })),
+);
+const OrganizationCreditActivityView = loadable<EmptyObject>(() =>
+  import("admin/organization/organization_credit_activity_view").then((module) => ({
+    default: module.OrganizationCreditActivityView,
+  })),
+);
+const OrganizationDangerZoneView = loadable<EmptyObject>(() =>
+  import("admin/organization/organization_danger_zone_view").then((module) => ({
+    default: module.OrganizationDangerZoneView,
+  })),
+);
+const OrganizationNotificationsView = loadable<EmptyObject>(() =>
+  import("admin/organization/organization_notifications_view").then((module) => ({
+    default: module.OrganizationNotificationsView,
+  })),
+);
+const OrganizationOverviewView = loadable<EmptyObject>(() =>
+  import("admin/organization/organization_overview_view").then((module) => ({
+    default: module.OrganizationOverviewView,
+  })),
+);
+const OrganizationPlanActivityView = loadable<EmptyObject>(() =>
+  import("admin/organization/organization_plan_activity_view").then((module) => ({
+    default: module.OrganizationPlanActivityView,
+  })),
+);
+const Privacy = loadable<EmptyObject>(() =>
+  import("components/legal").then((module) => ({ default: module.Privacy })),
+);
 
 const AsyncWorkflowView = loadable<EmptyObject>(() => import("admin/voxelytics/workflow_view"));
 const AsyncWorkflowListView = loadable<EmptyObject>(

--- a/frontend/javascripts/test/components/command_palette_loader.spec.ts
+++ b/frontend/javascripts/test/components/command_palette_loader.spec.ts
@@ -1,0 +1,55 @@
+import { shouldOpenCommandPalette } from "viewer/view/components/command_palette_loader";
+import { describe, expect, it } from "vitest";
+
+const keydown = (overrides: Partial<Parameters<typeof shouldOpenCommandPalette>[0]> = {}) => ({
+  key: "p",
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  shiftKey: false,
+  target: null,
+  ...overrides,
+});
+
+describe("shouldOpenCommandPalette", () => {
+  it("opens on ctrl+p and cmd+p", () => {
+    expect(shouldOpenCommandPalette(keydown({ ctrlKey: true }))).toBe(true);
+    expect(shouldOpenCommandPalette(keydown({ metaKey: true }))).toBe(true);
+  });
+
+  it("is case insensitive, so it still fires when caps lock is on", () => {
+    expect(shouldOpenCommandPalette(keydown({ key: "P", ctrlKey: true }))).toBe(true);
+  });
+
+  it("ignores p without a ctrl or cmd modifier", () => {
+    expect(shouldOpenCommandPalette(keydown())).toBe(false);
+  });
+
+  it("ignores other keys", () => {
+    expect(shouldOpenCommandPalette(keydown({ key: "k", ctrlKey: true }))).toBe(false);
+  });
+
+  it("ignores additional alt or shift modifiers, to avoid stealing other shortcuts", () => {
+    expect(shouldOpenCommandPalette(keydown({ ctrlKey: true, altKey: true }))).toBe(false);
+    expect(shouldOpenCommandPalette(keydown({ ctrlKey: true, shiftKey: true }))).toBe(false);
+  });
+
+  it("does not fire while the user is typing in a form field", () => {
+    for (const tagName of ["INPUT", "SELECT", "TEXTAREA"]) {
+      expect(shouldOpenCommandPalette(keydown({ ctrlKey: true, target: { tagName } as any }))).toBe(
+        false,
+      );
+    }
+    expect(
+      shouldOpenCommandPalette(
+        keydown({ ctrlKey: true, target: { isContentEditable: true } as any }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still fires when the event target is an ordinary element", () => {
+    expect(
+      shouldOpenCommandPalette(keydown({ ctrlKey: true, target: { tagName: "DIV" } as any })),
+    ).toBe(true);
+  });
+});

--- a/frontend/javascripts/viewer/view/components/command_palette.tsx
+++ b/frontend/javascripts/viewer/view/components/command_palette.tsx
@@ -101,7 +101,15 @@ const shortCutDictForTools: Record<string, string> = {
   [AnnotationTool.PROOFREAD.id]: "Ctrl + K, O",
 };
 
-export const CommandPalette = () => {
+export type CommandPaletteProps = {
+  // Forces the palette open as soon as it mounts. Used by CommandPaletteLoader, which mounts
+  // this component in response to the very keypress that should open it. react-command-palette
+  // only reads `open` on mount and on change, so passing a constant true here is safe: the
+  // palette closes normally and its own mousetrap binding handles every later keypress.
+  openOnMount?: boolean;
+};
+
+export const CommandPalette = ({ openOnMount }: CommandPaletteProps) => {
   const dispatch = useDispatch();
 
   const userConfig = useWkSelector((state) => state.userConfiguration);
@@ -472,6 +480,7 @@ export const CommandPalette = () => {
       commands={commandsWithIds}
       key={paletteKey}
       hotKeys={["ctrl+p", "command+p"]}
+      open={openOnMount}
       trigger={null}
       maxDisplayed={100}
       theme={theme === "light" ? commandPaletteLightTheme : commandPaletteDarkTheme}

--- a/frontend/javascripts/viewer/view/components/command_palette_loader.tsx
+++ b/frontend/javascripts/viewer/view/components/command_palette_loader.tsx
@@ -1,0 +1,78 @@
+import loadable from "libs/lazy_loader";
+import { document } from "libs/window";
+import { useEffect, useState } from "react";
+import type { CommandPaletteProps } from "./command_palette";
+
+const LazyCommandPalette = loadable<CommandPaletteProps>(() =>
+  import("./command_palette").then((module) => ({ default: module.CommandPalette })),
+);
+
+// The palette is reachable only through ctrl+p / cmd+p, but react-command-palette, dompurify and
+// the command definitions themselves add well over 100 kB to the bundle, and RootLayout renders
+// the palette on every page. So only the shortcut stays in the initial payload; the palette is
+// fetched the first time it is pressed and mounted with `openOnMount`, so that first press still
+// opens it. From then on the palette binds the shortcut itself and this listener detaches.
+
+type ShortcutEvent = {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  target: EventTarget | null;
+};
+
+/**
+ * Whether a keydown should open the command palette. The form-field check mirrors mousetrap's
+ * default stopCallback, so that ctrl+p keeps its normal meaning while the user is typing -
+ * exactly as it behaved when the palette was still mounted eagerly.
+ */
+export function shouldOpenCommandPalette(event: ShortcutEvent): boolean {
+  const isPaletteShortcut =
+    event.key.toLowerCase() === "p" &&
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey &&
+    !event.shiftKey;
+
+  if (!isPaletteShortcut) {
+    return false;
+  }
+
+  // Duck-typed rather than using instanceof, so this stays testable outside a DOM.
+  const target = event.target as { tagName?: string; isContentEditable?: boolean } | null;
+  if (target?.isContentEditable) {
+    return false;
+  }
+
+  return !["INPUT", "SELECT", "TEXTAREA"].includes(target?.tagName ?? "");
+}
+
+export function CommandPaletteLoader() {
+  const [shouldMountPalette, setShouldMountPalette] = useState(false);
+
+  useEffect(() => {
+    if (shouldMountPalette) {
+      // The palette itself now owns the shortcut.
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!shouldOpenCommandPalette(event)) {
+        return;
+      }
+
+      // Without this, the browser opens its print dialog instead.
+      event.preventDefault();
+      setShouldMountPalette(true);
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [shouldMountPalette]);
+
+  if (!shouldMountPalette) {
+    return null;
+  }
+
+  return <LazyCommandPalette openOnMount />;
+}

--- a/frontend/javascripts/viewer/view/layouting/tracing_layout_view.tsx
+++ b/frontend/javascripts/viewer/view/layouting/tracing_layout_view.tsx
@@ -13,6 +13,7 @@ import type { Dispatch } from "redux";
 import { NavAndStatusBarTheme } from "theme";
 import type { APICompoundType } from "types/api_types";
 import CrossOriginApi from "viewer/api/cross_origin_api";
+import { setupApi } from "viewer/api/internal_api";
 import Constants, { type Vector3 } from "viewer/constants";
 import type { ControllerStatus } from "viewer/controller";
 import WebKnossosController from "viewer/controller";
@@ -58,6 +59,13 @@ import VoxelValueTooltip from "../voxel_pipette_tooltip";
 import { determineLayout } from "./default_layout_configs";
 import FlexLayoutWrapper from "./flex_layout_wrapper";
 import { FloatingMobileControls } from "./floating_mobile_controls";
+
+// The API used to be created in main.tsx, which meant api_latest (and with it three.js and
+// tween.js) was part of the initial payload on every page. It is set up here instead: this
+// module is the lazily loaded entry point of the viewer, so this runs as soon as the viewer
+// chunk is fetched and before any viewer code can read the `api` singleton - the same
+// guarantee main.tsx used to provide, just scoped to the viewer.
+setupApi();
 
 const { Sider } = Layout;
 

--- a/unreleased_changes/9991.md
+++ b/unreleased_changes/9991.md
@@ -1,0 +1,2 @@
+### Changed
+- Admin and dashboard pages, the annotation viewer and the command palette are now loaded on demand instead of upfront. The initial download for any page is about 43% smaller (1763 KB to 1012 KB gzipped), so WEBKNOSSOS starts faster - most noticeably on the login screen and dashboard, which no longer download the 3D annotation viewer.


### PR DESCRIPTION
### Summary

Stacked on #9987 — **please review and merge that one first**; the base branch here is
`bundle-size-tier1-hygiene`, so this PR's diff shows only its own three commits. I'll retarget
it to `master` once #9987 lands.

Where part 1 was hygiene, this is the part that actually shrinks what a user downloads. The app
had almost no code splitting: 2 of ~60 routes were lazy, and `route_wrappers` statically imported
the 3D annotation viewer, so **the login screen downloaded three.js, the shaders, the geometries
and every admin screen**.

| | initial payload (gzip) |
|---|---|
| before (`master`) | 1,763 kB |
| load admin + dashboard pages on demand | 1,640 kB |
| load the command palette on first use | 1,608 kB |
| load the annotation viewer on demand | **999 kB** |

**Initial payload: 1,763 kB → 1,012 kB gzip including CSS, a 43% reduction** (raw: 6,384 kB →
3,220 kB, −50%). Entry chunk: 6,461 kB → 511 kB. Build output excluding sourcemaps: 16.0 MB → 13.3 MB.

#### On measuring this

The entry-chunk number Vite prints is *not* the initial payload once splitting is on. Vite emits
`modulepreload` links for everything statically reachable from the entry, and the browser fetches
all of it upfront. After the first commit the entry chunk had dropped 6,461 → 2,868 kB while the
real initial payload had barely moved, because the still-eager viewer reached most of the shared
dashboard code. All numbers above are measured by summing the entry plus every `modulepreload`
target from the built `index.html`, gzipped.

#### Notes for review

- Everything goes through the existing `loadable()` helper (`libs/lazy_loader`), which supplies the
  Suspense boundary and the stale-chunk-after-deploy handling. The two Voxelytics routes have used it
  for a while — this just extends the established pattern. `Navbar`, the auth views and
  `PageNotFoundView` stay eager, being on the first-paint path.
- Three small extractions were needed because a *value* import from an otherwise lazy module keeps
  that whole module eager: `urlTokenToTabKeyMap` out of `dashboard_view`, the `TransformationsMode`
  enum out of `dataset_settings_data_tab`, and the dataset-settings provider + view wrapped in one
  lazy `dataset_settings_screen`.
- **`setupApi()` moved from `main.tsx` into `tracing_layout_view`.** It builds `window.webknossos`
  via `api_latest`, which value-imports three and tween.js. It runs at that module's top level, so
  it still executes before any viewer module can read the `api` singleton — the same guarantee
  `main.tsx` gave, just scoped to the viewer. Tests call `setupApi()` themselves, so they're unaffected.
- **The command palette needed care.** It self-registers ctrl+p via mousetrap, so lazy-mounting it
  would miss the very keypress meant to open it. `react-command-palette` reads its `open` prop on
  mount, so the loader mounts it with `openOnMount`. The shortcut predicate is extracted as
  `shouldOpenCommandPalette` and unit tested (7 cases), because it has to reproduce mousetrap's
  behaviour: case-insensitive, ignores alt/shift variants, inert while typing in a form field,
  and `preventDefault` so the browser doesn't open its print dialog.

#### What I verified, and what I did not

Verified against the built output served locally with stubbed API responses: the app boots with no
console errors, `/imprint` fetches its chunk on navigation, and ctrl+p fetches and opens the palette
on the first press. `yarn typecheck`, `yarn check-frontend` and `yarn test` (3,271 passing) are green.

I could **not** exercise the annotation viewer itself, which needs a real backend and a dataset —
that is the main thing to check manually, since it is the route that changed most.

#### Still on the table

three.js (497 kB raw) remains in the initial payload. `viewer/constants.ts` value-imports `Euler`
and `Matrix4` and is imported by 267 modules including `navbar`, and `flycam_reducer` reaches three
via the eagerly created Redux store. Splitting those exports out is the next large win and is
deliberately left out of this PR.

### Steps to test:
- Open an annotation and exercise the viewer: 3D viewport, mesh loading, screenshot export, NML
  import/export, volume interpolation, quick-select. Watch for a stuck "Loading..." or a
  chunk-load error toast.
- Press ctrl+p (cmd+p) on the **dashboard**, not just in the viewer, and confirm it opens on the
  first press. Then press it again to confirm the palette's own binding took over. Confirm ctrl+p
  inside a text field still does nothing.
- Click through the admin screens (users, teams, tasks, projects, scripts, organization tabs) and
  the dataset-settings tabs.
- Confirm `window.webknossos.apiReady(3)` still resolves inside an annotation.
- Visit `/workflows` — the two pre-existing lazy routes must still work.

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)