### PR TITLE
Fail the build if a web worker bundles main-thread UI code

### DIFF
--- a/frontend/vite/vite-plugin-assert-worker-purity.ts
+++ b/frontend/vite/vite-plugin-assert-worker-purity.ts
@@ -1,0 +1,161 @@
+import path from "node:path";
+import type { Plugin } from "vite";
+
+/**
+ * Fails the production build if a web worker bundles main-thread UI code.
+ *
+ * This is not hypothetical: `async_get_maximum_zoom_for_all_mags.worker` used to ship
+ * ~350 kB of react-dom, antd, @ant-design/cssinjs, stylis and @airbrake/browser - roughly
+ * half its size - pulled in by a single static import edge:
+ *
+ *   worker -> flycam_accessor -> dataset_accessor -> libs/error_handling -> libs/toast -> antd
+ *
+ * Nothing failed and nothing warned. The worker just quietly got five times bigger, and a
+ * pure-math worker paid for a UI framework it can never use (there is no DOM in a worker).
+ *
+ * Registered under `worker.plugins` rather than `plugins` in vite.config.ts, because Vite
+ * bundles workers in a separate rolldown pass that top-level plugins never observe. Every
+ * chunk in that pass belongs to a worker, so this does not need to filter by file name.
+ */
+
+type ForbiddenEntry = readonly [label: string, pattern: RegExp];
+
+const FORBIDDEN_IN_WORKERS: ReadonlyArray<ForbiddenEntry> = [
+  // UI frameworks. `react` is not listed separately: anything that drags in React also
+  // drags in react-dom or antd, while matching bare `react/` would also flag the
+  // react/jsx-runtime that tooling injects into any file containing JSX.
+  ["antd", /node_modules\/(antd|@ant-design|@rc-component)\//],
+  ["react-dom", /node_modules\/react-dom\//],
+  // The repo-side boundary, and what actually leaked. Failing on these names the real
+  // mistake one edge earlier than "somehow antd is in your worker": both modules exist to
+  // show something to a user, so a worker importing either is already wrong.
+  ["libs/toast", /[\\/]libs[\\/]toast\.[jt]sx?$/],
+  ["libs/error_handling", /[\\/]libs[\\/]error_handling\.[jt]sx?$/],
+];
+
+/** Strips the absolute prefix so failures read as repo-relative paths. */
+function shorten(moduleId: string): string {
+  const normalized = moduleId.split(path.sep).join("/");
+  const marker = normalized.lastIndexOf("node_modules/");
+  if (marker !== -1) {
+    return normalized.slice(marker);
+  }
+  const relative = normalized.indexOf("frontend/javascripts/");
+  return relative === -1 ? normalized : normalized.slice(relative);
+}
+
+/**
+ * Walks the static import graph backwards from an offending module to the worker entry
+ * that reaches it. Breadth-first, so the reported chain is the shortest one - which is
+ * both the easiest to read and usually the edge worth cutting.
+ */
+function findImportChain(
+  getModuleInfo: (id: string) => { importers: readonly string[] } | null,
+  offendingModuleId: string,
+): string[] {
+  const queue: string[][] = [[offendingModuleId]];
+  const visited = new Set<string>([offendingModuleId]);
+
+  while (queue.length > 0) {
+    const chain = queue.shift() as string[];
+    const head = chain[0];
+
+    if (/\.worker\.[jt]sx?$/.test(head)) {
+      return chain;
+    }
+
+    for (const importer of getModuleInfo(head)?.importers ?? []) {
+      if (visited.has(importer)) {
+        continue;
+      }
+      visited.add(importer);
+      queue.push([importer, ...chain]);
+    }
+  }
+
+  // No path back to a worker entry (e.g. the module is only dynamically imported).
+  // Reporting the module on its own is still actionable.
+  return [offendingModuleId];
+}
+
+/**
+ * Cuts the chain at the point it first enters the forbidden package. Without this, a leak
+ * of antd reports whichever of its ~500 modules happened to be scanned first, ending in
+ * something like `icons-svg/lib/asn/RightOutlined.js` - technically true, useless to read.
+ */
+function truncateAtBoundary(chain: string[], pattern: RegExp): string[] {
+  const boundary = chain.findIndex((moduleId) => pattern.test(moduleId));
+  return boundary === -1 ? chain : chain.slice(0, boundary + 1);
+}
+
+export default function assertWorkerPurity(): Plugin {
+  return {
+    name: "assert-worker-purity",
+    apply: "build",
+    generateBundle(_options, bundle) {
+      // Grouped per worker per forbidden package: antd alone contributes hundreds of
+      // modules, and repeating the same finding for each of them buries the diagnosis.
+      const matches = new Map<
+        string,
+        { fileName: string; label: string; pattern: RegExp; moduleIds: string[] }
+      >();
+
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== "chunk") {
+          continue;
+        }
+
+        for (const moduleId of chunk.moduleIds) {
+          for (const [label, pattern] of FORBIDDEN_IN_WORKERS) {
+            if (!pattern.test(moduleId)) {
+              continue;
+            }
+
+            const key = `${chunk.fileName}|${label}`;
+            const existing = matches.get(key);
+            if (existing == null) {
+              matches.set(key, { fileName: chunk.fileName, label, pattern, moduleIds: [moduleId] });
+            } else {
+              existing.moduleIds.push(moduleId);
+            }
+          }
+        }
+      }
+
+      const findings = [...matches.values()].map(({ fileName, label, pattern, moduleIds }) => {
+        // Of all the ways into the forbidden package, report the shortest - it is the one
+        // whose edges a reader can actually act on.
+        const chains = moduleIds.map((moduleId) =>
+          truncateAtBoundary(
+            findImportChain((id) => this.getModuleInfo(id), moduleId),
+            pattern,
+          ),
+        );
+        const shortest = chains.reduce((best, chain) =>
+          chain.length < best.length ? chain : best,
+        );
+        return { fileName, label, chain: shortest };
+      });
+
+      // Shallowest first, so the outermost boundary - the edge actually worth cutting -
+      // is the first thing printed rather than the deepest consequence of it.
+      findings.sort((a, b) => a.chain.length - b.chain.length);
+
+      const problems = findings.map(
+        ({ fileName, label, chain }) =>
+          `${fileName} bundles ${label}, imported via:\n      ${chain
+            .map(shorten)
+            .join("\n        -> ")}`,
+      );
+
+      if (problems.length > 0) {
+        this.error(
+          `Web workers must not bundle main-thread UI code.\n\n  ${problems.join("\n\n  ")}\n\n` +
+            "Break the import edge shown above rather than widening the allowlist. If the code " +
+            "is genuinely needed on both sides, split the part the worker needs into its own " +
+            "module - see gpu_capability_check and libs/assertion for two worked examples.",
+        );
+      }
+    },
+  };
+}

--- a/unreleased_changes/9994.md
+++ b/unreleased_changes/9994.md
@@ -1,0 +1,2 @@
+### Added
+- The production build now fails if a web worker bundles main-thread UI code (antd, react-dom, `libs/toast` or `libs/error_handling`), reporting the import chain that pulled it in.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
+import assertWorkerPurity from "./frontend/vite/vite-plugin-assert-worker-purity";
 import viteProtobufPlugin from "./frontend/vite/vite-plugin-protobuf";
 import replaceSvgColorWithCurrentColor from "./frontend/vite/vite-plugin-replace-svg-color";
 
@@ -56,6 +57,9 @@ export const viteConfig = {
   },
   worker: {
     format: "es" as const,
+    // Vite bundles workers in a separate rolldown pass, so plugins that need to inspect
+    // worker chunks have to be registered here rather than in `plugins` above.
+    plugins: () => [assertWorkerPurity()],
   },
   server: {
     port: 9000,


### PR DESCRIPTION
### Summary

Third in the stack, on top of #9991 (which is on top of #9987) — **the base branch is
`bundle-size-tier2-code-splitting`**, so this PR's diff is just the one commit. I'll retarget
it as the ones below land. It is independent of those two in substance, though: it only adds a
guard.

#9987 fixed a worker that was shipping ~350 kB of react-dom, antd, `@ant-design/cssinjs`,
stylis and `@airbrake/browser` — about half its size — reached through a single static import
edge:

```
worker -> flycam_accessor -> dataset_accessor -> libs/error_handling -> libs/toast -> antd
```

Nothing failed and nothing warned. This makes that class of regression a build error.

### How it works

A Vite plugin that inspects each worker chunk's module ids in `generateBundle`, so it reads the
real bundle graph rather than a re-derived one, and reports the shortest import chain into the
forbidden package by walking `ModuleInfo.importers` backwards from the offending module.

**The important detail:** it is registered under `worker.plugins`, not `plugins`. Vite bundles
workers in a **separate rolldown pass** that top-level plugins never observe, so registering it
in `plugins` would silently check nothing — which would have been a guard-shaped no-op, the
worst possible outcome. Because every chunk in that pass belongs to a worker, it needs no
filtering by file name.

The forbidden list is antd and react-dom, plus `libs/toast` and `libs/error_handling`. Including
the repo-side pair is deliberate: they are the actual policy boundary, both exist to show
something to a user, and failing on them names the mistake one edge earlier than "somehow antd
is in your worker".

Two touches that make the failure readable: chains are truncated where they enter the forbidden
package (otherwise an antd leak reports whichever of its ~500 modules was scanned first, ending
somewhere useless like `icons-svg/lib/asn/RightOutlined.js`), and findings are sorted
shallowest-first so the edge worth cutting is printed before the deeper consequences of it.

### Verified in both directions

Passing on a clean tree proves nothing on its own, so I also re-introduced the original
regression (`dataset_accessor` importing `libs/error_handling` again). The build fails with exit
code 1 and:

```
RolldownError: Web workers must not bundle main-thread UI code.

  assets/async_get_maximum_zoom_for_all_mags.worker-CceyeASX.js bundles libs/error_handling, imported via:
      frontend/javascripts/viewer/workers/async_get_maximum_zoom_for_all_mags.worker.ts
        -> frontend/javascripts/viewer/model/accessors/flycam_accessor.ts
        -> frontend/javascripts/viewer/model/accessors/dataset_accessor.ts
        -> frontend/javascripts/libs/error_handling.ts

  assets/async_get_maximum_zoom_for_all_mags.worker-CceyeASX.js bundles libs/toast, imported via:
      ... -> libs/error_handling.ts
        -> frontend/javascripts/libs/toast.tsx

  assets/async_get_maximum_zoom_for_all_mags.worker-CceyeASX.js bundles antd, imported via:
      ... -> libs/toast.tsx
        -> node_modules/antd/es/index.js

  assets/async_get_maximum_zoom_for_all_mags.worker-CceyeASX.js bundles react-dom, imported via:
      ... -> node_modules/antd/es/notification/index.js
        -> node_modules/@rc-component/util/es/Portal.js
        -> node_modules/react-dom/index.js
```

`yarn test` is unaffected (102 files, 3,271 tests): `apply: "build"` keeps this out of the
Vitest path, where workers are imported directly rather than bundled.

### Not included

`build.rolldownOptions.onLog` could similarly turn Vite's `has been externalized for browser
compatibility` warning into an error — that is the warning that let the `url` removal ship a
blank page in #9987. It needs an allowlist first, because the vendored
`libs/DRACOWorker.worker.js` legitimately triggers it for `fs` and `path`. Happy to add it
separately if wanted.

### Steps to test:
- `yarn vite build` should pass unchanged.
- To see the guard fire, add `import Toast from "libs/toast";` (and a use of it) to any module
  reachable from a `*.worker.ts`, e.g. `viewer/model/accessors/dataset_accessor.ts`, and build.
- `yarn test` should be unaffected.

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Added changelog entry (create a `$PR_NUMBER.md` file in `unreleased_changes` or use `./tools/create-changelog-entry.py`)
- [ ] Removed dev-only changes like prints and application.conf edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)