### PR TITLE
Fix intermittent unhandled rejection in vitest worker mock

### DIFF
--- a/frontend/javascripts/viewer/workers/comlink_wrapper.ts
+++ b/frontend/javascripts/viewer/workers/comlink_wrapper.ts
@@ -39,6 +39,14 @@ export function createWorker<TExposed extends UseCreateWorkerToUseMe<AnyFn> | An
     const workerModulePromise = import(
       /* @vite-ignore */ `./${pathToWorkerWithoutExtension}.worker.ts`
     );
+    // Mark the eager kick-off as handled. Many specs import a module that calls
+    // createWorker() without ever invoking the worker (e.g. because they inject their own
+    // compressor), which leaves nobody to await this promise. If Vitest tears the
+    // environment down while the import is still in flight, the resulting
+    // EnvironmentTeardownError would otherwise be reported as an unhandled rejection and
+    // fail the run. Callers below await `workerModulePromise` itself, so a genuine import
+    // failure still propagates to them.
+    workerModulePromise.catch(() => {});
     return async (...params: Parameters<UnwrapExposedWorkerFn<TExposed>>) => {
       const workerModule = await workerModulePromise;
       return workerModule.default(...params);

--- a/frontend/javascripts/viewer/workers/slow_byte_array_lz4_compression.worker.ts
+++ b/frontend/javascripts/viewer/workers/slow_byte_array_lz4_compression.worker.ts
@@ -2,8 +2,19 @@
  * and is ONLY meant for mocking during tests. This implementation
  * allows to introduce an artificial delay for compression/decompression.
  */
-import { sleep } from "libs/utils";
 import { compress, decompress } from "lz4-wasm";
+
+// `sleep` is inlined rather than imported from libs/utils on purpose. This module is
+// substituted for the real compression worker by a global vi.mock factory (see
+// test/global_mocks.ts), so everything it imports has to be loaded before the mock
+// resolves. libs/utils drags in chalk, dayjs, lodash-es and libs/window for one four-line
+// helper, which widened that window enough to lose a race against Vitest's environment
+// teardown and surface as an intermittent unhandled rejection.
+function sleep(timeout: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}
 
 let isSleepEnabled = false;
 


### PR DESCRIPTION
### Summary

`yarn test` intermittently reported `Errors  1 error` even though every test file and test passed. This reproduces on unmodified `master` and is not caused by any recent change.

```
Error: [vitest] There was an error when mocking a module.
Caused by: EnvironmentTeardownError: Cannot load '/node_modules/chalk/source/index.js'
imported from frontend/javascripts/libs/utils.ts after the environment was torn down.
```

`createWorker()` kicks off the worker's dynamic import eagerly, at call time rather than on first use, so that a late fire-and-forget call cannot trigger the load after teardown. But that promise is only awaited when the worker is actually invoked. Specs that import a module calling `createWorker()` without ever calling the worker — `bucket_snapshot.spec.ts` injects its own `MockCompressor`, so `bucket_compression`'s worker is never used — leave it floating. When Vitest tears the environment down mid-import, the rejection has no handler and fails the run.

The eager kick-off fixed one race and introduced another: the import now always starts, so it can always be in flight at teardown.

Two changes:

- **`comlink_wrapper.ts`** — attach a no-op `catch` to mark the eager kick-off as handled. Callers still `await workerModulePromise` itself, so a genuine import failure is unchanged. This is the fix.
- **`slow_byte_array_lz4_compression.worker.ts`** — inline `sleep`. This module is substituted for the real compression worker by a global `vi.mock` factory, so everything it imports must load before the mock resolves; it pulled in `libs/utils` — and with it chalk, dayjs, lodash-es and `libs/window` — for one four-line helper. Not needed for correctness, but a mock factory that loads that much before resolving is the wrong shape, and it applies to every spec file.

Note that removing chalk — the module the error happens to name — does **not** help. It is one module in a large graph, and shrinking the graph only lowers the odds of losing the race. The missing rejection handler is the defect.

### Steps to test:

Run `yarn test` repeatedly and grep for `Errors  1 error` / `Unhandled Rejection`. Measured on master, ~21 s per suite run, in an isolated worktree:

| variant | flaked |
| --- | --- |
| baseline | 5/40 (12.5%) |
| chalk removed from `libs/utils` | 2/16 — no effect |
| `catch()` only | 0/16 |
| `catch()` + inlined `sleep` | 0/44 |

`yarn typecheck`, `yarn check-frontend` and `yarn build` all pass.

### Issues:
-

------
(Please delete unneeded items, merge only when none are left open)
- [ ] ~~Added changelog entry~~ — not user-facing, test infrastructure only
- [ ] Removed dev-only changes like prints and application.conf edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)